### PR TITLE
Add ssl_ca_cert option to backend

### DIFF
--- a/fastly/resource_fastly_service_v1.go
+++ b/fastly/resource_fastly_service_v1.go
@@ -271,6 +271,12 @@ func resourceServiceV1() *schema.Resource {
 							Description: "SSL certificate hostname",
 							Deprecated:  "Use ssl_cert_hostname and ssl_sni_hostname instead.",
 						},
+						"ssl_ca_cert": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Default:     "",
+							Description: "CA certificate attached to origin.",
+						},
 						"ssl_cert_hostname": {
 							Type:        schema.TypeString,
 							Optional:    true,
@@ -1206,6 +1212,7 @@ func resourceServiceV1Update(d *schema.ResourceData, meta interface{}) error {
 					AutoLoadbalance:     gofastly.CBool(df["auto_loadbalance"].(bool)),
 					SSLCheckCert:        gofastly.CBool(df["ssl_check_cert"].(bool)),
 					SSLHostname:         df["ssl_hostname"].(string),
+					SSLCACert:           df["ssl_ca_cert"].(string),
 					SSLCertHostname:     df["ssl_cert_hostname"].(string),
 					SSLSNIHostname:      df["ssl_sni_hostname"].(string),
 					Shield:              df["shield"].(string),
@@ -2194,6 +2201,7 @@ func flattenBackends(backendList []*gofastly.Backend) []map[string]interface{} {
 			"shield":                b.Shield,
 			"ssl_check_cert":        b.SSLCheckCert,
 			"ssl_hostname":          b.SSLHostname,
+			"ssl_ca_cert":           b.SSLCACert,
 			"ssl_cert_hostname":     b.SSLCertHostname,
 			"ssl_sni_hostname":      b.SSLSNIHostname,
 			"weight":                int(b.Weight),

--- a/fastly/resource_fastly_service_v1_test.go
+++ b/fastly/resource_fastly_service_v1_test.go
@@ -95,6 +95,7 @@ func TestResourceFastlyFlattenBackend(t *testing.T) {
 					"healthcheck":           "",
 					"ssl_check_cert":        true,
 					"ssl_hostname":          "",
+					"ssl_ca_cert":           "",
 					"ssl_cert_hostname":     "",
 					"ssl_sni_hostname":      "",
 					"shield":                "New York",


### PR DESCRIPTION
Make it possible to configure the CA cert used to verify the backend
for a Fastly service.