### PR TITLE
s3logging: default S3 domain to s3.amazonaws.com to match api default

### DIFF
--- a/fastly/resource_fastly_service_v1.go
+++ b/fastly/resource_fastly_service_v1.go
@@ -524,6 +524,7 @@ func resourceServiceV1() *schema.Resource {
 							Type:        schema.TypeString,
 							Optional:    true,
 							Description: "Bucket endpoint",
+							Default:     "s3.amazonaws.com",
 						},
 						"gzip_level": {
 							Type:        schema.TypeInt,

--- a/fastly/resource_fastly_service_v1_s3logging_test.go
+++ b/fastly/resource_fastly_service_v1_s3logging_test.go
@@ -112,6 +112,8 @@ func TestAccFastlyServiceV1_s3logging_domain_default(t *testing.T) {
 						"fastly_service_v1.foo", "name", name),
 					resource.TestCheckResourceAttr(
 						"fastly_service_v1.foo", "s3logging.#", "1"),
+					resource.TestCheckResourceAttr(
+						"fastly_service_v1.foo", "s3logging.910866243.domain", "s3.amazonaws.com"),
 				),
 			},
 		},


### PR DESCRIPTION
Set default value for the `domain` attribute in the `s3logging` block. Right now if it's not in us-east-1, you need to specify a value, but it seems now that the API will provide a default of `s3.amazonaws.com` so we need to match it.

Users specifying any valid value are unaffected, and users without a value are seeing a perpetual diff, so this should be fine in terms of backwards compatibility regarding the struct hash. 

All our existing tests supplied a value here, so I add a new test with that uses the default.

```
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./fastly -v -run=TestAccFastlyServiceV1_s3logging -timeout 120m
=== RUN   TestAccFastlyServiceV1_s3logging_basic
--- PASS: TestAccFastlyServiceV1_s3logging_basic (33.43s)
=== RUN   TestAccFastlyServiceV1_s3logging_domain_default
--- PASS: TestAccFastlyServiceV1_s3logging_domain_default (15.20s)
=== RUN   TestAccFastlyServiceV1_s3logging_s3_env
--- PASS: TestAccFastlyServiceV1_s3logging_s3_env (16.60s)
=== RUN   TestAccFastlyServiceV1_s3logging_formatVersion
--- PASS: TestAccFastlyServiceV1_s3logging_formatVersion (14.53s)
PASS
ok      github.com/terraform-providers/terraform-provider-fastly/fastly 79.774s
```

Should fix #10 /cc @DanielRussell