### PR TITLE
Support message_type attribute for s3logging

### DIFF
--- a/fastly/resource_fastly_service_v1.go
+++ b/fastly/resource_fastly_service_v1.go
@@ -562,6 +562,13 @@ func resourceServiceV1() *schema.Resource {
 							Default:     "",
 							Description: "Name of a condition to apply this logging.",
 						},
+						"message_type": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							Default:      "classic",
+							Description:  "How the message should be formatted.",
+							ValidateFunc: validateLoggingMessageType,
+						},
 					},
 				},
 			},
@@ -1405,6 +1412,7 @@ func resourceServiceV1Update(d *schema.ResourceData, meta interface{}) error {
 					FormatVersion:     uint(sf["format_version"].(int)),
 					TimestampFormat:   sf["timestamp_format"].(string),
 					ResponseCondition: sf["response_condition"].(string),
+					MessageType:       sf["message_type"].(string),
 				}
 
 				log.Printf("[DEBUG] Create S3 Logging Opts: %#v", opts)
@@ -2424,6 +2432,7 @@ func flattenS3s(s3List []*gofastly.S3) []map[string]interface{} {
 			"format_version":     s.FormatVersion,
 			"timestamp_format":   s.TimestampFormat,
 			"response_condition": s.ResponseCondition,
+			"message_type":       s.MessageType,
 		}
 
 		// prune any empty values that come from the default string value in structs

--- a/vendor/github.com/sethvargo/go-fastly/s3.go
+++ b/vendor/github.com/sethvargo/go-fastly/s3.go
@@ -29,6 +29,7 @@ type S3 struct {
 	Format            string       `mapstructure:"format"`
 	FormatVersion     uint         `mapstructure:"format_version"`
 	ResponseCondition string       `mapstructure:"response_condition"`
+	MessageType       string       `mapstructure:"message_type"`
 	TimestampFormat   string       `mapstructure:"timestamp_format"`
 	Redundancy        S3Redundancy `mapstructure:"redundancy"`
 	CreatedAt         *time.Time   `mapstructure:"created_at"`
@@ -95,6 +96,7 @@ type CreateS3Input struct {
 	Period            uint         `form:"period,omitempty"`
 	GzipLevel         uint         `form:"gzip_level,omitempty"`
 	Format            string       `form:"format,omitempty"`
+	MessageType       string       `form:"message_type,omitempty"`
 	FormatVersion     uint         `form:"format_version,omitempty"`
 	ResponseCondition string       `form:"response_condition,omitempty"`
 	TimestampFormat   string       `form:"timestamp_format,omitempty"`
@@ -183,6 +185,7 @@ type UpdateS3Input struct {
 	Format            string       `form:"format,omitempty"`
 	FormatVersion     uint         `form:"format_version,omitempty"`
 	ResponseCondition string       `form:"response_condition,omitempty"`
+	MessageType       string       `form:"message_type,omitempty"`
 	TimestampFormat   string       `form:"timestamp_format,omitempty"`
 	Redundancy        S3Redundancy `form:"redundancy,omitempty"`
 }


### PR DESCRIPTION
It'd be really useful to be able to specify `message_type` attribute on s3 logging configuration.  This will allow us to eg. log to s3 in JSON format (if we set `message_type` to `blank` we can then build JSON structure using `format`).

Default value for `message_type` will be set to `classic` which will not change the default behaviour of Fastly - as per [[1]](https://docs.fastly.com/api/logging) - if not specified, `message_type` defaults to `classic`.

[[1]](https://docs.fastly.com/api/logging)