### PR TITLE
fastly_service_v1 documentation fixes

### DIFF
--- a/website/docs/r/service_v1.html.markdown
+++ b/website/docs/r/service_v1.html.markdown
@@ -248,7 +248,7 @@ see [Fastly's Documentation on Conditionals][fastly-conditionals].
 The `healthcheck` block supports:
 
 * `name` - (Required) A unique name to identify this Healthcheck.
-* `host` - (Required) Address of the host to check.
+* `host` - (Required) The Host header to send for this Healthcheck.
 * `path` - (Required) The path to check.
 * `check_interval` - (Optional) How often to run the Healthcheck in milliseconds. Default `5000`.
 * `expected_response` - (Optional) The status code expected from the host. Default `200`.

--- a/website/fastly.erb
+++ b/website/fastly.erb
@@ -24,7 +24,7 @@
 
                     <ul class="nav nav-visible">
                         <li<%= sidebar_current("docs-fastly-resource-service-v1") %>>
-                            <a href="/docs/providers/fastly/r/service_v1.html">service_v1</a>
+                            <a href="/docs/providers/fastly/r/service_v1.html">fastly_service_v1</a>
                         </li>
                     </ul>
 


### PR DESCRIPTION
These changes fix two documentation issues:

* The documentation sidebar incorrectly lists the `fastly_service_v1` resource as `service_v1`.
* The `host` argument for the `healthcheck` block does not match the Fastly configuration interface, nor it's actual behavior. (This may be why issue #18 exists as the author misunderstood the host argument's usage.)
