### PR TITLE
Add missing healthcheck argument for backend configuration - Fixes #18

### DIFF
--- a/website/docs/r/service_v1.html.markdown
+++ b/website/docs/r/service_v1.html.markdown
@@ -189,6 +189,7 @@ Default `200`.
 * `ssl_sni_hostname` - (Optional) Overrides ssl_hostname, but only for SNI in the handshake. Does not affect cert validation at all.
 * `shield` - (Optional) The POP of the shield designated to reduce inbound load.
 * `weight` - (Optional) The [portion of traffic](https://docs.fastly.com/guides/performance-tuning/load-balancing-configuration.html#how-weight-affects-load-balancing) to send to this Backend. Each Backend receives `weight / total` of the traffic. Default `100`.
+* `healthcheck` - (Optional) Name of a defined `healthcheck` to assign to this backend.
 
 The `condition` block supports allows you to add logic to any basic configuration
 object in a service. See Fastly's documentation


### PR DESCRIPTION
This change adds missing documentation for the `healthcheck` argument added to the `backend`  configuration block in https://github.com/hashicorp/terraform/commit/d5207e17ed8b3cfad288ea858e3613883ad9b403.

Fixes #18 