### PR TITLE
Update test domains to be more unique

### DIFF
--- a/fastly/resource_fastly_service_v1_cache_setting_test.go
+++ b/fastly/resource_fastly_service_v1_cache_setting_test.go
@@ -14,7 +14,7 @@ import (
 func TestAccFastlyServiceV1CacheSetting_basic(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
-	domainName1 := fmt.Sprintf("%s.notadomain.com", acctest.RandString(10))
+	domainName1 := fmt.Sprintf("fastly-test.tf-%s.com", acctest.RandString(10))
 
 	cq1 := gofastly.CacheSetting{
 		Name:           "alt_backend",

--- a/fastly/resource_fastly_service_v1_conditionals_test.go
+++ b/fastly/resource_fastly_service_v1_conditionals_test.go
@@ -14,7 +14,7 @@ import (
 func TestAccFastlyServiceV1_conditional_basic(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
-	domainName1 := fmt.Sprintf("%s.notadomain.com", acctest.RandString(10))
+	domainName1 := fmt.Sprintf("fastly-test.tf-%s.com", acctest.RandString(10))
 
 	con1 := gofastly.Condition{
 		Name:      "some amz condition",

--- a/fastly/resource_fastly_service_v1_gcslogging_test.go
+++ b/fastly/resource_fastly_service_v1_gcslogging_test.go
@@ -128,13 +128,14 @@ func testAccCheckFastlyServiceV1Attributes_gcs(service *gofastly.ServiceDetail, 
 
 func testAccServiceV1Config_gcs(name, gcsName string) string {
 	backendName := fmt.Sprintf("%s.aws.amazon.com", acctest.RandString(3))
+	domainName := fmt.Sprintf("fastly-test.tf-%s.com", acctest.RandString(10))
 
 	return fmt.Sprintf(`
 resource "fastly_service_v1" "foo" {
   name = "%s"
 
   domain {
-    name    = "test.notadomain.com"
+    name    = "%s"
     comment = "tf-testing-domain"
   }
 
@@ -153,18 +154,19 @@ resource "fastly_service_v1" "foo" {
 	}
 
   force_destroy = true
-}`, name, backendName, gcsName)
+}`, name, domainName, backendName, gcsName)
 }
 
 func testAccServiceV1Config_gcs_env(name, gcsName string) string {
 	backendName := fmt.Sprintf("%s.aws.amazon.com", acctest.RandString(3))
+	domainName := fmt.Sprintf("fastly-test.tf-%s.com", acctest.RandString(10))
 
 	return fmt.Sprintf(`
 resource "fastly_service_v1" "foo" {
   name = "%s"
 
   domain {
-    name    = "test.notadomain.com"
+    name    = "%s"
     comment = "tf-testing-domain"
   }
 
@@ -181,7 +183,7 @@ resource "fastly_service_v1" "foo" {
 	}
 
   force_destroy = true
-}`, name, backendName, gcsName)
+}`, name, domainName, backendName, gcsName)
 }
 
 func setGcsEnv(s string, t *testing.T) func() {

--- a/fastly/resource_fastly_service_v1_gzip_test.go
+++ b/fastly/resource_fastly_service_v1_gzip_test.go
@@ -105,7 +105,7 @@ func TestFastlyServiceV1_FlattenGzips(t *testing.T) {
 func TestAccFastlyServiceV1_gzips_basic(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
-	domainName1 := fmt.Sprintf("%s.notadomain.com", acctest.RandString(10))
+	domainName1 := fmt.Sprintf("fastly-test.tf-%s.com", acctest.RandString(10))
 
 	log1 := gofastly.Gzip{
 		Version:        1,

--- a/fastly/resource_fastly_service_v1_headers_test.go
+++ b/fastly/resource_fastly_service_v1_headers_test.go
@@ -78,7 +78,7 @@ func TestFastlyServiceV1_BuildHeaders(t *testing.T) {
 func TestAccFastlyServiceV1_headers_basic(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
-	domainName1 := fmt.Sprintf("%s.notadomain.com", acctest.RandString(10))
+	domainName1 := fmt.Sprintf("fastly-test.tf-%s.com", acctest.RandString(10))
 
 	log1 := gofastly.Header{
 		Version:     1,

--- a/fastly/resource_fastly_service_v1_healthcheck_test.go
+++ b/fastly/resource_fastly_service_v1_healthcheck_test.go
@@ -14,7 +14,7 @@ import (
 func TestAccFastlyServiceV1_healthcheck_basic(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
-	domainName := fmt.Sprintf("%s.notadomain.com", acctest.RandString(10))
+	domainName := fmt.Sprintf("fastly-test.tf-%s.com", acctest.RandString(10))
 
 	log1 := gofastly.HealthCheck{
 		Version:          1,

--- a/fastly/resource_fastly_service_v1_papertrail_test.go
+++ b/fastly/resource_fastly_service_v1_papertrail_test.go
@@ -14,7 +14,7 @@ import (
 func TestAccFastlyServiceV1_papertrail_basic(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
-	domainName1 := fmt.Sprintf("%s.notadomain.com", acctest.RandString(10))
+	domainName1 := fmt.Sprintf("fastly-test.tf-%s.com", acctest.RandString(10))
 
 	log1 := gofastly.Papertrail{
 		Version:           1,

--- a/fastly/resource_fastly_service_v1_request_setting_test.go
+++ b/fastly/resource_fastly_service_v1_request_setting_test.go
@@ -14,7 +14,7 @@ import (
 func TestAccFastlyServiceV1RequestSetting_basic(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
-	domainName1 := fmt.Sprintf("%s.notadomain.com", acctest.RandString(10))
+	domainName1 := fmt.Sprintf("fastly-test.tf-%s.com", acctest.RandString(10))
 
 	rq1 := gofastly.RequestSetting{
 		Name:             "alt_backend",

--- a/fastly/resource_fastly_service_v1_response_object_test.go
+++ b/fastly/resource_fastly_service_v1_response_object_test.go
@@ -14,7 +14,7 @@ import (
 func TestAccFastlyServiceV1_response_object_basic(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
-	domainName1 := fmt.Sprintf("%s.notadomain.com", acctest.RandString(10))
+	domainName1 := fmt.Sprintf("fastly-test.tf-%s.com", acctest.RandString(10))
 
 	log1 := gofastly.ResponseObject{
 		Version:          1,

--- a/fastly/resource_fastly_service_v1_s3logging_test.go
+++ b/fastly/resource_fastly_service_v1_s3logging_test.go
@@ -15,7 +15,7 @@ import (
 func TestAccFastlyServiceV1_s3logging_basic(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
-	domainName1 := fmt.Sprintf("%s.notadomain.com", acctest.RandString(10))
+	domainName1 := fmt.Sprintf("fastly-test.tf-%s.com", acctest.RandString(10))
 
 	log1 := gofastly.S3{
 		Version:           1,
@@ -81,7 +81,7 @@ func TestAccFastlyServiceV1_s3logging_basic(t *testing.T) {
 func TestAccFastlyServiceV1_s3logging_domain_default(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
-	domainName1 := fmt.Sprintf("%s.notadomain.com", acctest.RandString(10))
+	domainName1 := fmt.Sprintf("fastly-test.tf-%s.com", acctest.RandString(10))
 
 	log1 := gofastly.S3{
 		Version:           1,
@@ -124,7 +124,7 @@ func TestAccFastlyServiceV1_s3logging_domain_default(t *testing.T) {
 func TestAccFastlyServiceV1_s3logging_s3_env(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
-	domainName1 := fmt.Sprintf("%s.notadomain.com", acctest.RandString(10))
+	domainName1 := fmt.Sprintf("fastly-test.tf-%s.com", acctest.RandString(10))
 
 	// set env Vars to something we expect
 	resetEnv := setEnv("someEnv", t)
@@ -167,7 +167,7 @@ func TestAccFastlyServiceV1_s3logging_s3_env(t *testing.T) {
 func TestAccFastlyServiceV1_s3logging_formatVersion(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
-	domainName1 := fmt.Sprintf("%s.notadomain.com", acctest.RandString(10))
+	domainName1 := fmt.Sprintf("fastly-test.tf-%s.com", acctest.RandString(10))
 
 	log1 := gofastly.S3{
 		Version:         1,

--- a/fastly/resource_fastly_service_v1_sumologic_test.go
+++ b/fastly/resource_fastly_service_v1_sumologic_test.go
@@ -100,13 +100,14 @@ func testAccCheckFastlyServiceV1Attributes_sumologic(service *gofastly.ServiceDe
 
 func testAccServiceV1Config_sumologic(name, sumologic string) string {
 	backendName := fmt.Sprintf("%s.aws.amazon.com", acctest.RandString(3))
+	domainName := fmt.Sprintf("fastly-test.tf-%s.com", acctest.RandString(10))
 
 	return fmt.Sprintf(`
 resource "fastly_service_v1" "foo" {
   name = "%s"
 
   domain {
-    name    = "test.notadomain.com"
+    name    = "%s"
     comment = "tf-testing-domain"
   }
 
@@ -122,5 +123,5 @@ resource "fastly_service_v1" "foo" {
   }
 
   force_destroy = true
-}`, name, backendName, sumologic)
+}`, name, domainName, backendName, sumologic)
 }

--- a/fastly/resource_fastly_service_v1_test.go
+++ b/fastly/resource_fastly_service_v1_test.go
@@ -117,8 +117,8 @@ func TestAccFastlyServiceV1_updateDomain(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	nameUpdate := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
-	domainName1 := fmt.Sprintf("%s.notadomain.com", acctest.RandString(10))
-	domainName2 := fmt.Sprintf("%s.notadomain.com", acctest.RandString(10))
+	domainName1 := fmt.Sprintf("fastly-test.tf-%s.com", acctest.RandString(10))
+	domainName2 := fmt.Sprintf("fastly-test.tf-%s.com", acctest.RandString(10))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/fastly/resource_fastly_service_v1_vcl_test.go
+++ b/fastly/resource_fastly_service_v1_vcl_test.go
@@ -13,7 +13,7 @@ import (
 func TestAccFastlyServiceV1_VCL_basic(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
-	domainName1 := fmt.Sprintf("%s.notadomain.com", acctest.RandString(10))
+	domainName1 := fmt.Sprintf("fastly-test.tf-%s.com", acctest.RandString(10))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },


### PR DESCRIPTION
Addresses #21 

Updates the domains in the acceptance tests to be more unique. The domains are constructed as `fastly-test.tf-randString(10).com` so there should be less collisions.

Tests results:

```
% make testacc                                                                                                                                                                                                                                                             2 ↵ ✹
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v  -timeout 120m
?   	github.com/terraform-providers/terraform-provider-fastly	[no test files]
=== RUN   TestAccFastlyIPRanges
--- PASS: TestAccFastlyIPRanges (0.73s)
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestAccFastlyServiceV1CacheSetting_basic
--- PASS: TestAccFastlyServiceV1CacheSetting_basic (42.05s)
=== RUN   TestAccFastlyServiceV1_conditional_basic
--- PASS: TestAccFastlyServiceV1_conditional_basic (19.22s)
=== RUN   TestResourceFastlyFlattenGCS
--- PASS: TestResourceFastlyFlattenGCS (0.00s)
=== RUN   TestAccFastlyServiceV1_gcslogging
--- PASS: TestAccFastlyServiceV1_gcslogging (18.45s)
=== RUN   TestAccFastlyServiceV1_gcslogging_env
--- PASS: TestAccFastlyServiceV1_gcslogging_env (19.89s)
=== RUN   TestFastlyServiceV1_FlattenGzips
--- PASS: TestFastlyServiceV1_FlattenGzips (0.00s)
=== RUN   TestAccFastlyServiceV1_gzips_basic
--- PASS: TestAccFastlyServiceV1_gzips_basic (40.07s)
=== RUN   TestFastlyServiceV1_BuildHeaders
--- PASS: TestFastlyServiceV1_BuildHeaders (0.00s)
=== RUN   TestAccFastlyServiceV1_headers_basic
--- PASS: TestAccFastlyServiceV1_headers_basic (41.68s)
=== RUN   TestAccFastlyServiceV1_healthcheck_basic
--- PASS: TestAccFastlyServiceV1_healthcheck_basic (41.22s)
=== RUN   TestAccFastlyServiceV1_papertrail_basic
--- PASS: TestAccFastlyServiceV1_papertrail_basic (40.10s)
=== RUN   TestAccFastlyServiceV1RequestSetting_basic
--- PASS: TestAccFastlyServiceV1RequestSetting_basic (20.29s)
=== RUN   TestAccFastlyServiceV1_response_object_basic
--- PASS: TestAccFastlyServiceV1_response_object_basic (41.88s)
=== RUN   TestAccFastlyServiceV1_s3logging_basic
--- PASS: TestAccFastlyServiceV1_s3logging_basic (40.81s)
=== RUN   TestAccFastlyServiceV1_s3logging_domain_default
--- PASS: TestAccFastlyServiceV1_s3logging_domain_default (20.10s)
=== RUN   TestAccFastlyServiceV1_s3logging_s3_env
--- PASS: TestAccFastlyServiceV1_s3logging_s3_env (19.03s)
=== RUN   TestAccFastlyServiceV1_s3logging_formatVersion
--- PASS: TestAccFastlyServiceV1_s3logging_formatVersion (19.23s)
=== RUN   TestResourceFastlyFlattenSumologic
--- PASS: TestResourceFastlyFlattenSumologic (0.00s)
=== RUN   TestAccFastlyServiceV1_sumologic
--- PASS: TestAccFastlyServiceV1_sumologic (19.41s)
=== RUN   TestResourceFastlyFlattenDomains
--- PASS: TestResourceFastlyFlattenDomains (0.00s)
=== RUN   TestResourceFastlyFlattenBackend
--- PASS: TestResourceFastlyFlattenBackend (0.00s)
=== RUN   TestAccFastlyServiceV1_updateDomain
--- PASS: TestAccFastlyServiceV1_updateDomain (41.48s)
=== RUN   TestAccFastlyServiceV1_updateBackend
--- PASS: TestAccFastlyServiceV1_updateBackend (43.09s)
=== RUN   TestAccFastlyServiceV1_basic
--- PASS: TestAccFastlyServiceV1_basic (18.78s)
=== RUN   TestAccFastlyServiceV1_disappears
--- PASS: TestAccFastlyServiceV1_disappears (9.17s)
=== RUN   TestAccFastlyServiceV1_defaultTTL
--- PASS: TestAccFastlyServiceV1_defaultTTL (75.14s)
=== RUN   TestAccFastlyServiceV1_VCL_basic
--- PASS: TestAccFastlyServiceV1_VCL_basic (43.17s)
=== RUN   TestValidateLoggingFormatVersion
--- PASS: TestValidateLoggingFormatVersion (0.00s)
=== RUN   TestValidateLoggingMessageType
--- PASS: TestValidateLoggingMessageType (0.00s)
PASS
ok  	github.com/terraform-providers/terraform-provider-fastly/fastly	675.082s
```