### PR TITLE
Add support for Logentries logging

### DIFF
--- a/fastly/resource_fastly_service_v1.go
+++ b/fastly/resource_fastly_service_v1.go
@@ -797,6 +797,51 @@ func resourceServiceV1() *schema.Resource {
 				},
 			},
 
+			"logentries": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						// Required fields
+						"name": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "Unique name to refer to this logging setup",
+						},
+						"token": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "Use token based authentication (https://logentries.com/doc/input-token/)",
+						},
+						// Optional
+						"port": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Default:     20000,
+							Description: "The port number configured in Logentries",
+						},
+						"use_tls": {
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Default:     true,
+							Description: "Whether to use TLS for secure logging",
+						},
+						"format": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Default:     "%h %l %u %t %r %>s",
+							Description: "Apache-style string or VCL variables to use for log formatting",
+						},
+						"response_condition": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Default:     "",
+							Description: "Name of a condition to apply this logging.",
+						},
+					},
+				},
+			},
+
 			"response_object": {
 				Type:     schema.TypeSet,
 				Optional: true,
@@ -1012,6 +1057,7 @@ func resourceServiceV1Update(d *schema.ResourceData, meta interface{}) error {
 		"s3logging",
 		"papertrail",
 		"syslog",
+		"logentries",
 		"response_object",
 		"condition",
 		"request_setting",
@@ -1714,6 +1760,60 @@ func resourceServiceV1Update(d *schema.ResourceData, meta interface{}) error {
 			}
 		}
 
+		// find difference in Logentries
+		if d.HasChange("logentries") {
+			os, ns := d.GetChange("logentries")
+			if os == nil {
+				os = new(schema.Set)
+			}
+			if ns == nil {
+				ns = new(schema.Set)
+			}
+
+			oss := os.(*schema.Set)
+			nss := ns.(*schema.Set)
+			removeLogentries := oss.Difference(nss).List()
+			addLogentries := nss.Difference(oss).List()
+
+			// DELETE old logentries configurations
+			for _, pRaw := range removeLogentries {
+				slf := pRaw.(map[string]interface{})
+				opts := gofastly.DeleteLogentriesInput{
+					Service: d.Id(),
+					Version: latestVersion,
+					Name:    slf["name"].(string),
+				}
+
+				log.Printf("[DEBUG] Fastly Logentries removal opts: %#v", opts)
+				err := conn.DeleteLogentries(&opts)
+				if err != nil {
+					return err
+				}
+			}
+
+			// POST new/updated Logentries
+			for _, pRaw := range addLogentries {
+				slf := pRaw.(map[string]interface{})
+
+				opts := gofastly.CreateLogentriesInput{
+					Service:           d.Id(),
+					Version:           latestVersion,
+					Name:              slf["name"].(string),
+					Port:              uint(slf["port"].(int)),
+					UseTLS:            gofastly.CBool(slf["use_tls"].(bool)),
+					Token:             slf["token"].(string),
+					Format:            slf["format"].(string),
+					ResponseCondition: slf["response_condition"].(string),
+				}
+
+				log.Printf("[DEBUG] Create Logentries Opts: %#v", opts)
+				_, err := conn.CreateLogentries(&opts)
+				if err != nil {
+					return err
+				}
+			}
+		}
+
 		// find difference in Response Object
 		if d.HasChange("response_object") {
 			or, nr := d.GetChange("response_object")
@@ -2178,6 +2278,23 @@ func resourceServiceV1Read(d *schema.ResourceData, meta interface{}) error {
 
 		if err := d.Set("syslog", sll); err != nil {
 			log.Printf("[WARN] Error setting Syslog for (%s): %s", d.Id(), err)
+		}
+
+		// refresh Logentries Logging
+		log.Printf("[DEBUG] Refreshing Logentries for (%s)", d.Id())
+		logentriesList, err := conn.ListLogentries(&gofastly.ListLogentriesInput{
+			Service: d.Id(),
+			Version: s.ActiveVersion.Number,
+		})
+
+		if err != nil {
+			return fmt.Errorf("[ERR] Error looking up Logentries for (%s), version (%d): %s", d.Id(), s.ActiveVersion.Number, err)
+		}
+
+		lel := flattenLogentries(logentriesList)
+
+		if err := d.Set("logentries", lel); err != nil {
+			log.Printf("[WARN] Error setting Logentries for (%s): %s", d.Id(), err)
 		}
 
 		// refresh Response Objects
@@ -2705,6 +2822,32 @@ func flattenSyslogs(syslogList []*gofastly.Syslog) []map[string]interface{} {
 	}
 
 	return pl
+}
+
+func flattenLogentries(logentriesList []*gofastly.Logentries) []map[string]interface{} {
+	var LEList []map[string]interface{}
+	for _, currentLE := range logentriesList {
+		// Convert Logentries to a map for saving to state.
+		LEMapString := map[string]interface{}{
+			"name":               currentLE.Name,
+			"port":               currentLE.Port,
+			"use_tls":            currentLE.UseTLS,
+			"token":              currentLE.Token,
+			"format":             currentLE.Format,
+			"response_condition": currentLE.ResponseCondition,
+		}
+
+		// prune any empty values that come from the default string value in structs
+		for k, v := range LEMapString {
+			if v == "" {
+				delete(LEMapString, k)
+			}
+		}
+
+		LEList = append(LEList, LEMapString)
+	}
+
+	return LEList
 }
 
 func flattenResponseObjects(responseObjectList []*gofastly.ResponseObject) []map[string]interface{} {

--- a/fastly/resource_fastly_service_v1_logentries_test.go
+++ b/fastly/resource_fastly_service_v1_logentries_test.go
@@ -1,0 +1,178 @@
+package fastly
+
+import (
+	"fmt"
+	"log"
+	"reflect"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	gofastly "github.com/sethvargo/go-fastly"
+)
+
+func TestAccFastlyServiceV1_logentries_basic(t *testing.T) {
+	var service gofastly.ServiceDetail
+	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	domainName1 := fmt.Sprintf("fastly-test.tf-%s.com", acctest.RandString(10))
+
+	log1 := gofastly.Logentries{
+		Version:           1,
+		Name:              "somelogentriesname",
+		Port:              uint(20000),
+		UseTLS:            true,
+		Token:             "token",
+		Format:            "%h %l %u %t %r %>s",
+		ResponseCondition: "response_condition_test",
+	}
+
+	log2 := gofastly.Logentries{
+		Version:           1,
+		Name:              "somelogentriesanothername",
+		Port:              uint(10000),
+		UseTLS:            false,
+		Token:             "newtoken",
+		Format:            "%h %u %t %r %>s",
+		ResponseCondition: "response_condition_test",
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckServiceV1Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServiceV1LogentriesConfig(name, domainName1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
+					testAccCheckFastlyServiceV1LogentriesAttributes(&service, []*gofastly.Logentries{&log1}),
+					resource.TestCheckResourceAttr(
+						"fastly_service_v1.foo", "name", name),
+					resource.TestCheckResourceAttr(
+						"fastly_service_v1.foo", "logentries.#", "1"),
+				),
+			},
+
+			{
+				Config: testAccServiceV1LogentriesConfig_update(name, domainName1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
+					testAccCheckFastlyServiceV1LogentriesAttributes(&service, []*gofastly.Logentries{&log1, &log2}),
+					resource.TestCheckResourceAttr(
+						"fastly_service_v1.foo", "name", name),
+					resource.TestCheckResourceAttr(
+						"fastly_service_v1.foo", "logentries.#", "2"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckFastlyServiceV1LogentriesAttributes(service *gofastly.ServiceDetail, logentriess []*gofastly.Logentries) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+
+		conn := testAccProvider.Meta().(*FastlyClient).conn
+		logentriesList, err := conn.ListLogentries(&gofastly.ListLogentriesInput{
+			Service: service.ID,
+			Version: service.ActiveVersion.Number,
+		})
+
+		if err != nil {
+			return fmt.Errorf("[ERR] Error looking up Logentries Logging for (%s), version (%d): %s", service.Name, service.ActiveVersion.Number, err)
+		}
+
+		if len(logentriesList) != len(logentriess) {
+			return fmt.Errorf("Logentries List count mismatch, expected (%d), got (%d)", len(logentriess), len(logentriesList))
+		}
+
+		log.Printf("[DEBUG] logentriesList = %+v\n", logentriesList)
+
+		var found int
+		for _, s := range logentriess {
+			for _, ls := range logentriesList {
+				if s.Name == ls.Name {
+					// we don't know these things ahead of time, so populate them now
+					s.ServiceID = service.ID
+					s.Version = service.ActiveVersion.Number
+					// We don't track these, so clear them out because we also wont know
+					// these ahead of time
+					ls.CreatedAt = nil
+					ls.UpdatedAt = nil
+					if !reflect.DeepEqual(s, ls) {
+						return fmt.Errorf("Bad match Logentries logging match,\nexpected:\n(%#v),\ngot:\n(%#v)", s, ls)
+					}
+					found++
+				}
+			}
+		}
+
+		if found != len(logentriess) {
+			return fmt.Errorf("Error matching Logentries Logging rules")
+		}
+
+		return nil
+	}
+}
+
+func testAccServiceV1LogentriesConfig(name, domain string) string {
+	return fmt.Sprintf(`
+resource "fastly_service_v1" "foo" {
+  name = "%s"
+  domain {
+    name    = "%s"
+    comment = "tf-testing-domain"
+  }
+  backend {
+    address = "aws.amazon.com"
+    name    = "amazon docs"
+  }
+  condition {
+    name      = "response_condition_test"
+    type      = "RESPONSE"
+    priority  = 8
+    statement = "resp.status == 418"
+  }
+  logentries {
+    name               = "somelogentriesname"
+    token              = "token"
+    response_condition = "response_condition_test"
+  }
+  force_destroy = true
+}`, name, domain)
+}
+
+func testAccServiceV1LogentriesConfig_update(name, domain string) string {
+	return fmt.Sprintf(`
+resource "fastly_service_v1" "foo" {
+  name = "%s"
+  domain {
+    name    = "%s"
+    comment = "tf-testing-domain"
+  }
+  backend {
+    address = "aws.amazon.com"
+    name    = "amazon docs"
+  }
+  condition {
+    name      = "response_condition_test"
+    type      = "RESPONSE"
+    priority  = 8
+    statement = "resp.status == 418"
+  }
+  logentries {
+    name               = "somelogentriesname"
+    token              = "token"
+    response_condition = "response_condition_test"
+  }
+  logentries {
+    name               = "somelogentriesanothername"
+    port               = "10000"
+    use_tls            = "false"
+    token              = "newtoken"
+    format             = "%%h %%u %%t %%r %%>s"
+    response_condition = "response_condition_test"
+  }
+  force_destroy = true
+}`, name, domain)
+}

--- a/website/docs/r/service_v1.html.markdown
+++ b/website/docs/r/service_v1.html.markdown
@@ -159,6 +159,8 @@ Defined below.
 Defined below.
 * `syslog` - (Optional) A syslog endpoint to send streaming logs too.
 Defined below.
+* `logentries` - (Optional) A logentries endpoint to send streaming logs too.
+Defined below.
 * `response_object` - (Optional) Allows you to create synthetic responses that exist entirely on the varnish machine. Useful for creating error or maintenance pages that exists outside the scope of your datacenter. Best when used with Condition objects.
 * `vcl` - (Optional) A set of custom VCL configuration blocks. The
 ability to upload custom VCL code is not enabled by default for new Fastly
@@ -360,6 +362,16 @@ The `syslog` block supports:
 * `tls_ca_cert` - (Optional) A secure certificate to authenticate the server with.
 * `response_condition` - (Optional) Name of already defined `condition` to apply. This `condition` must be of type `RESPONSE`. For detailed information about Conditionals,
 see [Fastly's Documentation on Conditionals][fastly-conditionals].
+
+The `logentries` block supports:
+
+* `name` - (Required) A unique name to identify this GCS endpoint.
+* `token` - (Required) Logentries Token to be used for authentication (https://logentries.com/doc/input-token/).
+* `port` - (Optional) The port number configured in Logentries to send logs to. Defaults to `20000`.
+* `use_tls` - (Optional) Whether to use TLS for secure logging. Defaults to `true`
+* `format` - (Optional) Apache-style string or VCL variables to use for log formatting. Defaults to Apache Common Log format (`%h %l %u %t %r %>s`).
+* `response_condition` - (Optional) Name of already defined `condition` to apply. This `condition` must be of type `RESPONSE`. For detailed information about Conditionals, see [Fastly's Documentation on Conditionals][fastly-conditionals].
+
 
 The `response_object` block supports:
 


### PR DESCRIPTION
As per [1] and [2] Fastly supports Real-Time Log Streaming to Logentries.  The `go-fastly` library has got support to configure Logentries as a logging target.

This commit wires the `go-fastly` support to Terraform Fastly provider so no we're able to configure Logentries as a target for Real-Time Log Streaming.  Tests coverage and documentation included as well.

[1] https://docs.logentries.com/v1.0/docs/fastly/
[2] https://docs.fastly.com/guides/streaming-logs/log-streaming-logentries