### PR TITLE
Fix imports for logentries test

### DIFF
--- a/fastly/resource_fastly_service_v1_logentries_test.go
+++ b/fastly/resource_fastly_service_v1_logentries_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
-	gofastly "github.com/sethvargo/go-fastly"
+	gofastly "github.com/sethvargo/go-fastly/fastly"
 )
 
 func TestAccFastlyServiceV1_logentries_basic(t *testing.T) {


### PR DESCRIPTION
```
$ make test
==> Checking that code complies with gofmt requirements...
go test -i $(go list ./... |grep -v 'vendor') || exit 1
echo $(go list ./... |grep -v 'vendor') | \
	xargs -t -n4 go test  -timeout=30s -parallel=4
go test -timeout=30s -parallel=4 github.com/terraform-providers/terraform-provider-fastly github.com/terraform-providers/terraform-provider-fastly/fastly 
?   	github.com/terraform-providers/terraform-provider-fastly	[no test files]
ok  	github.com/terraform-providers/terraform-provider-fastly/fastly	0.008s
```