### PR TITLE
Add support for format_version for Logentries logs

### DIFF
--- a/fastly/resource_fastly_service_v1.go
+++ b/fastly/resource_fastly_service_v1.go
@@ -839,6 +839,13 @@ func resourceServiceV1() *schema.Resource {
 							Default:     "%h %l %u %t %r %>s",
 							Description: "Apache-style string or VCL variables to use for log formatting",
 						},
+						"format_version": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							Default:      1,
+							Description:  "The version of the custom logging format used for the configured endpoint. Can be either 1 or 2. (Default: 1)",
+							ValidateFunc: validateLoggingFormatVersion,
+						},
 						"response_condition": {
 							Type:        schema.TypeString,
 							Optional:    true,
@@ -1811,6 +1818,7 @@ func resourceServiceV1Update(d *schema.ResourceData, meta interface{}) error {
 					UseTLS:            gofastly.CBool(slf["use_tls"].(bool)),
 					Token:             slf["token"].(string),
 					Format:            slf["format"].(string),
+					FormatVersion:     uint(slf["format_version"].(int)),
 					ResponseCondition: slf["response_condition"].(string),
 				}
 
@@ -2843,6 +2851,7 @@ func flattenLogentries(logentriesList []*gofastly.Logentries) []map[string]inter
 			"use_tls":            currentLE.UseTLS,
 			"token":              currentLE.Token,
 			"format":             currentLE.Format,
+			"format_version":     currentLE.FormatVersion,
 			"response_condition": currentLE.ResponseCondition,
 		}
 

--- a/vendor/github.com/sethvargo/go-fastly/fastly/logentries.go
+++ b/vendor/github.com/sethvargo/go-fastly/fastly/logentries.go
@@ -16,6 +16,7 @@ type Logentries struct {
 	UseTLS            bool       `mapstructure:"use_tls"`
 	Token             string     `mapstructure:"token"`
 	Format            string     `mapstructure:"format"`
+	FormatVersion     uint       `mapstructure:"format_version"`
 	ResponseCondition string     `mapstructure:"response_condition"`
 	CreatedAt         *time.Time `mapstructure:"created_at"`
 	UpdatedAt         *time.Time `mapstructure:"updated_at"`
@@ -77,6 +78,7 @@ type CreateLogentriesInput struct {
 	UseTLS            *Compatibool `form:"use_tls,omitempty"`
 	Token             string       `form:"token,omitempty"`
 	Format            string       `form:"format,omitempty"`
+	FormatVersion     uint         `form:"format_version,omitempty"`
 	ResponseCondition string       `form:"response_condition,omitempty"`
 }
 
@@ -156,6 +158,7 @@ type UpdateLogentriesInput struct {
 	UseTLS            *Compatibool `form:"use_tls,omitempty"`
 	Token             string       `form:"token,omitempty"`
 	Format            string       `form:"format,omitempty"`
+	FormatVersion     uint         `form:"format_version,omitempty"`
 	ResponseCondition string       `form:"response_condition,omitempty"`
 }
 

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -570,10 +570,10 @@
 			"revisionTime": "2016-09-27T10:08:44Z"
 		},
 		{
-			"checksumSHA1": "PifM63ho+0T4ETbMftdMDbuPFu8=",
+			"checksumSHA1": "BUMwyjUY3xepJP0uEdNjC1F1stI=",
 			"path": "github.com/sethvargo/go-fastly/fastly",
-			"revision": "2b863da88fc1033a68538ccdc5c9dc82fa52681f",
-			"revisionTime": "2017-08-07T16:33:08Z"
+			"revision": "1675d78c897707a0092f16567de49fffb21ed363",
+			"revisionTime": "2017-08-09T15:58:00Z"
 		},
 		{
 			"checksumSHA1": "vE43s37+4CJ2CDU6TlOUOYE0K9c=",

--- a/website/docs/r/service_v1.html.markdown
+++ b/website/docs/r/service_v1.html.markdown
@@ -371,6 +371,7 @@ The `logentries` block supports:
 * `port` - (Optional) The port number configured in Logentries to send logs to. Defaults to `20000`.
 * `use_tls` - (Optional) Whether to use TLS for secure logging. Defaults to `true`
 * `format` - (Optional) Apache-style string or VCL variables to use for log formatting. Defaults to Apache Common Log format (`%h %l %u %t %r %>s`).
+* `format_version` - (Optional) The version of the custom logging format used for the configured endpoint. Can be either 1 (the default, version 1 log format) or 2 (the version 2 log format).
 * `response_condition` - (Optional) Name of already defined `condition` to apply. This `condition` must be of type `RESPONSE`. For detailed information about Conditionals, see [Fastly's Documentation on Conditionals][fastly-conditionals].
 
 


### PR DESCRIPTION
We'd like to be able to use version 2 of Fastly's custom log formats in Fastly's Real-Time Log Streaming feature.

This commits adds support for format_version, documentation around it and acceptance test to verify we can set `format_version`.

Also - updated `go-fastly` as the latest version includes support for setting `format_version` on Logentries logs integration.