### PR TITLE
Implement all of the fastly SSL backend configuration

### DIFF
--- a/fastly/resource_fastly_service_v1.go
+++ b/fastly/resource_fastly_service_v1.go
@@ -258,6 +258,18 @@ func resourceServiceV1() *schema.Resource {
 							Default:     "",
 							Description: "The POP of the shield designated to reduce inbound load.",
 						},
+						"use_ssl": {
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Default:     false,
+							Description: "Whether or not to use SSL to reach the Backend",
+						},
+						"ssl_ciphers": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Default:     "",
+							Description: "Comma sepparated list of ciphers",
+						},
 						"ssl_check_cert": {
 							Type:        schema.TypeBool,
 							Optional:    true,
@@ -289,15 +301,21 @@ func resourceServiceV1() *schema.Resource {
 							Default:     "",
 							Description: "SSL certificate hostname for SNI verification",
 						},
-						// UseSSL is something we want to support in the future, but
-						// requires SSL setup we don't yet have
-						// TODO: Provide all SSL fields from https://docs.fastly.com/api/config#backend
-						// "use_ssl": &schema.Schema{
-						// 	Type:        schema.TypeBool,
-						// 	Optional:    true,
-						// 	Default:     false,
-						// 	Description: "Whether or not to use SSL to reach the Backend",
-						// },
+						"ssl_client_cert": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Default:     "",
+							Description: "SSL certificate file for client connections to the backend.",
+							Sensitive:   true,
+						},
+						"ssl_client_key": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Default:     "",
+							Description: "SSL key file for client connections to backend.",
+							Sensitive:   true,
+						},
+
 						"weight": {
 							Type:        schema.TypeInt,
 							Optional:    true,
@@ -1350,6 +1368,10 @@ func resourceServiceV1Update(d *schema.ResourceData, meta interface{}) error {
 					SSLCACert:           df["ssl_ca_cert"].(string),
 					SSLCertHostname:     df["ssl_cert_hostname"].(string),
 					SSLSNIHostname:      df["ssl_sni_hostname"].(string),
+					UseSSL:              gofastly.CBool(df["use_ssl"].(bool)),
+					SSLClientKey:        df["ssl_client_key"].(string),
+					SSLClientCert:       df["ssl_client_cert"].(string),
+					SSLCiphers:          strings.Split(df["ssl_ciphers"].(string), ","),
 					Shield:              df["shield"].(string),
 					Port:                uint(df["port"].(int)),
 					BetweenBytesTimeout: uint(df["between_bytes_timeout"].(int)),
@@ -2485,6 +2507,10 @@ func flattenBackends(backendList []*gofastly.Backend) []map[string]interface{} {
 			"ssl_check_cert":        b.SSLCheckCert,
 			"ssl_hostname":          b.SSLHostname,
 			"ssl_ca_cert":           b.SSLCACert,
+			"ssl_client_key":        b.SSLClientKey,
+			"ssl_client_cert":       b.SSLClientCert,
+			"ssl_ciphers":           strings.Join(b.SSLCiphers, ","),
+			"use_ssl":               b.UseSSL,
 			"ssl_cert_hostname":     b.SSLCertHostname,
 			"ssl_sni_hostname":      b.SSLSNIHostname,
 			"weight":                int(b.Weight),

--- a/fastly/resource_fastly_service_v1_test.go
+++ b/fastly/resource_fastly_service_v1_test.go
@@ -72,10 +72,15 @@ func TestResourceFastlyFlattenBackend(t *testing.T) {
 					MaxConn:             uint(200),
 					RequestCondition:    "",
 					HealthCheck:         "",
+					UseSSL:              false,
 					SSLCheckCert:        true,
 					SSLHostname:         "",
+					SSLCACert:           "",
 					SSLCertHostname:     "",
 					SSLSNIHostname:      "",
+					SSLClientKey:        "",
+					SSLClientCert:       "",
+					SSLCiphers:          []string{"foo", "bar", "baz"},
 					Shield:              "New York",
 					Weight:              uint(100),
 				},
@@ -93,11 +98,15 @@ func TestResourceFastlyFlattenBackend(t *testing.T) {
 					"max_conn":              200,
 					"request_condition":     "",
 					"healthcheck":           "",
+					"use_ssl":               false,
 					"ssl_check_cert":        true,
 					"ssl_hostname":          "",
 					"ssl_ca_cert":           "",
 					"ssl_cert_hostname":     "",
 					"ssl_sni_hostname":      "",
+					"ssl_client_key":        "",
+					"ssl_client_cert":       "",
+					"ssl_ciphers":           "foo,bar,baz",
 					"shield":                "New York",
 					"weight":                100,
 				},
@@ -108,7 +117,7 @@ func TestResourceFastlyFlattenBackend(t *testing.T) {
 	for _, c := range cases {
 		out := flattenBackends(c.remote)
 		if !reflect.DeepEqual(out, c.local) {
-			t.Fatalf("Error matching:\nexpected: %#v\ngot: %#v", c.local, out)
+			t.Fatalf("Error matching:\nexpected: %#v\n     got: %#v", c.local, out)
 		}
 	}
 }

--- a/website/docs/r/service_v1.html.markdown
+++ b/website/docs/r/service_v1.html.markdown
@@ -187,6 +187,11 @@ Default `1000`
 Default `200`.
 * `port` - (Optional) The port number on which the Backend responds. Default `80`.
 * `request_condition` - (Optional, string) Name of already defined `condition`, which if met, will select this backend during a request.
+* `use_ssl` - (Optional) Whether or not to use SSL to reach the backend. Default `false`.
+* `ssl_ciphers` - (Optional) Comma separated list of OpenSSL Ciphers to try when negotiating to the backend.
+* `ssl_ca_cert` - (Optional) CA certificate attached to origin.
+* `ssl_client_cert` - (Optional) Client certificate attached to origin. Used when connecting to the backend.
+* `ssl_client_key` - (Optional) Client key attached to origin. Used when connecting to the backend.
 * `ssl_check_cert` - (Optional) Be strict about checking SSL certs. Default `true`.
 * `ssl_hostname` - (Optional, deprecated by Fastly) Used for both SNI during the TLS handshake and to validate the cert.
 * `ssl_cert_hostname` - (Optional) Overrides ssl_hostname, but only for cert verification. Does not affect SNI at all.


### PR DESCRIPTION
Adds all backend ssl configurations that were missing from the
provider.

Unfortunately this will conflict with #39 that implements
a subset of these. We had started this work before that was
opened up.