### PR TITLE
add `activate` argument

### DIFF
--- a/fastly/resource_fastly_service_v1.go
+++ b/fastly/resource_fastly_service_v1.go
@@ -2675,7 +2675,10 @@ func resourceServiceV1Update(d *schema.ResourceData, meta interface{}) error {
 			// This prevents us from getting stuck in cloning an invalid version
 			d.Set("active_version", latestVersion)
 		} else {
-			log.Printf("[DEBUG] Skipping activation of Fastly Service (%s), Version (%v)", d.Id(), latestVersion)
+			log.Printf("[INFO] Skipping activation of Fastly Service (%s), Version (%v)", d.Id(), latestVersion)
+			log.Print("[INFO] The Terraform definition is explicitly specified to not activate the changes on Fastly")
+			log.Printf("[INFO] Version (%v) has been pushed and validated", latestVersion)
+			log.Printf("[INFO] Visit https://manage.fastly.com/configure/services/%s/versions/%v and activate it manually", d.Id(), latestVersion)
 		}
 	}
 

--- a/website/docs/r/service_v1.html.markdown
+++ b/website/docs/r/service_v1.html.markdown
@@ -162,6 +162,7 @@ Fastly documentation on [Amazon S3][fastly-s3].
 
 The following arguments are supported:
 
+* `activate` - (Optional) Conditionally prevents the Service from being activated. The apply step will continue to create a new draft version but will not activate it if this is set to false. Default true.
 * `name` - (Required) The unique name for the Service to create.
 * `domain` - (Required) A set of Domain names to serve as entry points for your
 Service. Defined below.


### PR DESCRIPTION
This new argument conditionally prevents the service from being activated. By default
it maintains the previous activation behavior.

### todo

- [x] add documentation