### PR TITLE
Remove default max_stale_age on request_setting

### DIFF
--- a/fastly/resource_fastly_service_v1.go
+++ b/fastly/resource_fastly_service_v1.go
@@ -947,7 +947,6 @@ func resourceServiceV1() *schema.Resource {
 						"max_stale_age": {
 							Type:        schema.TypeInt,
 							Optional:    true,
-							Default:     60,
 							Description: "How old an object is allowed to be, in seconds. Default `60`",
 						},
 						"force_miss": {

--- a/website/docs/r/service_v1.html.markdown
+++ b/website/docs/r/service_v1.html.markdown
@@ -276,7 +276,7 @@ defining behavior that should change based on a predefined `condition`:
 * `request_condition` - (Optional) Name of already defined `condition` to
 determine if this request setting should be applied.
 * `max_stale_age` - (Optional) How old an object is allowed to be to serve
-`stale-if-error` or `stale-while-revalidate`, in seconds. Default `60`.
+`stale-if-error` or `stale-while-revalidate`, in seconds.
 * `force_miss` - (Optional) Force a cache miss for the request. If specified,
 can be `true` or `false`.
 * `force_ssl` - (Optional) Forces the request to use SSL (Redirects a non-SSL request to SSL).


### PR DESCRIPTION
- Fastly does not currently have a default

See attached screenshot from Fastly UI. `max_stale_age` is in the Advanced Options and not set/does not have a default
![screen shot 2017-10-09 at 3 16 27 pm](https://user-images.githubusercontent.com/4970083/31367610-499111c8-ad2d-11e7-8cd0-e7dc97b9d1cf.png)
