### PR TITLE
Remove default stale_ttl on cache_setting

### DIFF
--- a/fastly/resource_fastly_service_v1.go
+++ b/fastly/resource_fastly_service_v1.go
@@ -358,7 +358,6 @@ func resourceServiceV1() *schema.Resource {
 							Type:        schema.TypeInt,
 							Optional:    true,
 							Description: "Max 'Time To Live' for stale (unreachable) objects.",
-							Default:     300,
 						},
 						"ttl": {
 							Type:        schema.TypeInt,

--- a/website/docs/r/service_v1.html.markdown
+++ b/website/docs/r/service_v1.html.markdown
@@ -221,7 +221,6 @@ The `cache_setting` block supports:
 on Fastly's documentation under ["Caching action descriptions"](https://docs.fastly.com/guides/performance-tuning/controlling-caching#caching-action-descriptions).
 * `cache_condition` - (Optional) Name of already defined `condition` used to test whether this settings object should be used. This `condition` must be of type `CACHE`.
 * `stale_ttl` - (Optional) Max "Time To Live" for stale (unreachable) objects.
-Default `300`.
 * `ttl` - (Optional) The Time-To-Live (TTL) for the object.
 
 The `gzip` block supports:


### PR DESCRIPTION
- Fastly does not currently have a default

See attached screenshot from Fastly UI. `stale_ttl` is not set/does not have a default
![screen shot 2017-10-09 at 8 03 36 pm](https://user-images.githubusercontent.com/4970083/31367646-86b6a2d4-ad2d-11e7-8146-16a288f7187a.png)

