### PR TITLE
Set condition priority to optional with default 10

### DIFF
--- a/fastly/resource_fastly_service_v1.go
+++ b/fastly/resource_fastly_service_v1.go
@@ -81,7 +81,8 @@ func resourceServiceV1() *schema.Resource {
 						},
 						"priority": {
 							Type:        schema.TypeInt,
-							Required:    true,
+							Optional:    true,
+							Default:     10,
 							Description: "A number used to determine the order in which multiple conditions execute. Lower numbers execute first",
 						},
 						"type": {

--- a/website/docs/r/service_v1.html.markdown
+++ b/website/docs/r/service_v1.html.markdown
@@ -209,10 +209,10 @@ used in the `request_condition`, `response_condition`, or
 
 * `name` - (Required) The unique name for the condition.
 * `statement` - (Required) The statement used to determine if the condition is met.
-* `priority` - (Required) A number used to determine the order in which multiple
-conditions execute. Lower numbers execute first.
 * `type` - (Required) Type of condition, either `REQUEST` (req), `RESPONSE`
 (req, resp), or `CACHE` (req, beresp).
+* `priority` - (Optional) A number used to determine the order in which multiple
+conditions execute. Lower numbers execute first. Default `10`.
 
 The `cache_setting` block supports:
 


### PR DESCRIPTION
- this is how it is in Fastly

- change docs to say it's optional and the default
  - move to below the required configurations

See attached screenshot from Fastly UI. `priority` is in the Advanced Options and is set to 10 by default
![screen shot 2017-10-09 at 1 53 17 pm](https://user-images.githubusercontent.com/4970083/31367665-b80f69e2-ad2d-11e7-98ab-54260841612a.png)
