### PR TITLE
Default message type

### DIFF
--- a/fastly/resource_fastly_service_v1.go
+++ b/fastly/resource_fastly_service_v1.go
@@ -750,7 +750,7 @@ func resourceServiceV1() *schema.Resource {
 						"message_type": {
 							Type:        schema.TypeString,
 							Optional:    true,
-							Default:     "",
+							Default:     "classic",
 							Description: "The log message type per the fastly docs: https://docs.fastly.com/api/logging#logging_gcs",
 						},
 					},

--- a/website/docs/r/service_v1.html.markdown
+++ b/website/docs/r/service_v1.html.markdown
@@ -336,7 +336,7 @@ The `sumologic` block supports:
 * `format` - (Optional) Apache-style string or VCL variables to use for log formatting. Defaults to Apache Common Log format (`%h %l %u %t %r %>s`)
 * `format_version` - (Optional) The version of the custom logging format used for the configured endpoint. Can be either 1 (the default, version 1 log format) or 2 (the version 2 log format).
 * `response_condition` - (Optional) Name of already defined `condition` to apply. This `condition` must be of type `RESPONSE`. For detailed information about Conditionals, see [Fastly's Documentation on Conditionals][fastly-conditionals].
-* `message_type` - (Optional) How the message should be formatted. One of: classic, loggly, logplex, blank. See [Fastly's Documentation on Sumologic][fastly-sumologic]
+* `message_type` - (Optional) How the message should be formatted; one of: `classic`, `loggly`, `logplex` or `blank`. Default `classic`. See [Fastly's Documentation on Sumologic][fastly-sumologic]
 
 The `gcslogging` block supports:
 
@@ -353,7 +353,7 @@ compression. `1` is fastest and least compressed, `9` is slowest and most
 compressed. Default `0`.
 * `format` - (Optional) Apache-style string or VCL variables to use for log formatting. Defaults to Apache Common Log format (`%h %l %u %t %r %>s`)
 * `response_condition` - (Optional) Name of already defined `condition` to apply. This `condition` must be of type `RESPONSE`. For detailed information about Conditionals, see [Fastly's Documentation on Conditionals][fastly-conditionals].
-* `message_type` - (Optional) Message type (classic, loggly, logplex, blank) default is classic. [Fastly Documentation](https://docs.fastly.com/api/logging#logging_gcs)
+* `message_type` - (Optional) How the message should be formatted; one of: `classic`, `loggly`, `logplex` or `blank`. Default `classic`. [Fastly Documentation](https://docs.fastly.com/api/logging#logging_gcs)
 
 The `syslog` block supports:
 


### PR DESCRIPTION
Fixes #54 

```
% TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccFastlyServiceV1_gcslogging -timeout 120m
?   	github.com/terraform-providers/terraform-provider-fastly	[no test files]
=== RUN   TestAccFastlyServiceV1_gcslogging
--- PASS: TestAccFastlyServiceV1_gcslogging (24.43s)
=== RUN   TestAccFastlyServiceV1_gcslogging_env
--- PASS: TestAccFastlyServiceV1_gcslogging_env (22.89s)
PASS
ok  	github.com/terraform-providers/terraform-provider-fastly/fastly	47.440s
```

Also, updates the docs for `message_type` to be the same across resources.

