### PR TITLE
Fix the description for tls_ca_cert.

### DIFF
--- a/fastly/resource_fastly_service_v1.go
+++ b/fastly/resource_fastly_service_v1.go
@@ -809,7 +809,7 @@ func resourceServiceV1() *schema.Resource {
 							Type:        schema.TypeString,
 							Optional:    true,
 							Default:     "",
-							Description: "The Hostname used to verify the server's certificate",
+							Description: "A secure certificate to authenticate the server with.",
 						},
 						"response_condition": {
 							Type:        schema.TypeString,


### PR DESCRIPTION
Fixed `tls_ca_cert` argument description, which was clearly mis-copied from `tls_hostname`.