### PR TITLE
Add tls_hostname support for syslog.

### DIFF
--- a/fastly/resource_fastly_service_v1.go
+++ b/fastly/resource_fastly_service_v1.go
@@ -805,6 +805,12 @@ func resourceServiceV1() *schema.Resource {
 							Default:     false,
 							Description: "Use TLS for secure logging",
 						},
+						"tls_hostname": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Default:     "",
+							Description: "Used during the TLS handshake to validate the certificate.",
+						},
 						"tls_ca_cert": {
 							Type:        schema.TypeString,
 							Optional:    true,
@@ -1795,6 +1801,7 @@ func resourceServiceV1Update(d *schema.ResourceData, meta interface{}) error {
 					FormatVersion:     uint(slf["format_version"].(int)),
 					Token:             slf["token"].(string),
 					UseTLS:            gofastly.CBool(slf["use_tls"].(bool)),
+					TLSHostname:       slf["tls_hostname"].(string),
 					TLSCACert:         slf["tls_ca_cert"].(string),
 					ResponseCondition: slf["response_condition"].(string),
 					MessageType:       slf["message_type"].(string),
@@ -2862,6 +2869,7 @@ func flattenSyslogs(syslogList []*gofastly.Syslog) []map[string]interface{} {
 			"format_version":     p.FormatVersion,
 			"token":              p.Token,
 			"use_tls":            p.UseTLS,
+			"tls_hostname":       p.TLSHostname,
 			"tls_ca_cert":        p.TLSCACert,
 			"response_condition": p.ResponseCondition,
 			"message_type":       p.MessageType,

--- a/website/docs/r/service_v1.html.markdown
+++ b/website/docs/r/service_v1.html.markdown
@@ -364,6 +364,7 @@ The `syslog` block supports:
 * `format_version` - (Optional) The version of the custom logging format used for the configured endpoint. Can be either 1 (the default, version 1 log format) or 2 (the version 2 log format).
 * `token` - (Optional) Whether to prepend each message with a specific token.
 * `use_tls` - (Optional) Whether to use TLS for secure logging. Default `false`.
+* `tls_hostname` - (Optional) Used during the TLS handshake to validate the certificate.
 * `tls_ca_cert` - (Optional) A secure certificate to authenticate the server with.
 * `response_condition` - (Optional) Name of already defined `condition` to apply. This `condition` must be of type `RESPONSE`. For detailed information about Conditionals,
 see [Fastly's Documentation on Conditionals][fastly-conditionals].


### PR DESCRIPTION
Add support for `tls_hostname` in syslog block. 

Simply passing the value to the vendor'd go-fastly `TLSHostname`.