### PR TITLE
Override user-agent

### DIFF
--- a/fastly/config.go
+++ b/fastly/config.go
@@ -3,6 +3,7 @@ package fastly
 import (
 	"fmt"
 
+	"github.com/hashicorp/terraform/terraform"
 	gofastly "github.com/sethvargo/go-fastly/fastly"
 )
 
@@ -21,6 +22,7 @@ func (c *Config) Client() (interface{}, error) {
 		return nil, fmt.Errorf("[Err] No API key for Fastly")
 	}
 
+	gofastly.UserAgent = terraform.UserAgentString()
 	fconn, err := gofastly.NewClient(c.ApiKey)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Hi!

@sethvargo in #42 you were talking about using just "terraform" as a user agent. I saw that there's a more standard user agent inside the terraform package so I used that. Let me know if that fits what you had in mind.

Thanks
Joseph

Closes #42 