### PR TITLE
Support for "redundancy" in s3logging

### DIFF
--- a/fastly/resource_fastly_service_v1.go
+++ b/fastly/resource_fastly_service_v1.go
@@ -612,6 +612,11 @@ func resourceServiceV1() *schema.Resource {
 							Default:     "%Y-%m-%dT%H:%M:%S.000",
 							Description: "specified timestamp formatting (default `%Y-%m-%dT%H:%M:%S.000`)",
 						},
+						"redundancy": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "The S3 redundancy level.",
+						},
 						"response_condition": {
 							Type:        schema.TypeString,
 							Optional:    true,
@@ -1615,6 +1620,14 @@ func resourceServiceV1Update(d *schema.ResourceData, meta interface{}) error {
 					TimestampFormat:   sf["timestamp_format"].(string),
 					ResponseCondition: sf["response_condition"].(string),
 					MessageType:       sf["message_type"].(string),
+				}
+
+				redundancy := strings.ToLower(sf["redundancy"].(string))
+				switch redundancy {
+				case "standard":
+					opts.Redundancy = gofastly.S3RedundancyStandard
+				case "reduced_redundancy":
+					opts.Redundancy = gofastly.S3RedundancyReduced
 				}
 
 				log.Printf("[DEBUG] Create S3 Logging Opts: %#v", opts)
@@ -2793,6 +2806,7 @@ func flattenS3s(s3List []*gofastly.S3) []map[string]interface{} {
 			"format":             s.Format,
 			"format_version":     s.FormatVersion,
 			"timestamp_format":   s.TimestampFormat,
+			"redundancy":         s.Redundancy,
 			"response_condition": s.ResponseCondition,
 			"message_type":       s.MessageType,
 		}

--- a/fastly/resource_fastly_service_v1_s3logging_test.go
+++ b/fastly/resource_fastly_service_v1_s3logging_test.go
@@ -45,6 +45,7 @@ func TestAccFastlyServiceV1_s3logging_basic(t *testing.T) {
 		Format:            "%h %l %u %t %r %>s",
 		FormatVersion:     1,
 		MessageType:       "blank",
+		Redundancy:        "reduced_redundancy",
 		TimestampFormat:   "%Y-%m-%dT%H:%M:%S.000",
 		ResponseCondition: "response_condition_test",
 	}
@@ -365,6 +366,7 @@ resource "fastly_service_v1" "foo" {
     s3_secret_key      = "somesecret"
     response_condition = "response_condition_test"
     message_type       = "blank"
+    redundancy         = "reduced_redundancy"
   }
 
   s3logging {

--- a/website/docs/r/service_v1.html.markdown
+++ b/website/docs/r/service_v1.html.markdown
@@ -319,6 +319,7 @@ compressed. Default `0`.
 * `format` - (Optional) Apache-style string or VCL variables to use for log formatting. Defaults to Apache Common Log format (`%h %l %u %t %r %>s`)
 * `message_type` - (Optional) How the message should be formatted; one of: `classic`, `loggly`, `logplex` or `blank`.  Default `classic`.
 * `timestamp_format` - (Optional) `strftime` specified timestamp formatting (default `%Y-%m-%dT%H:%M:%S.000`).
+* `redundancy` - (Optional) The S3 redundancy level. Should be formatted; one of: `standard`, `reduced_redundancy` or null. Default `null`.
 * `response_condition` - (Optional) Name of already defined `condition` to apply. This `condition` must be of type `RESPONSE`. For detailed information about Conditionals,
 see [Fastly's Documentation on Conditionals][fastly-conditionals].
 


### PR DESCRIPTION
Terraform Fastly provider was missing `redundancy` option for s3logging.

Fastly API: https://docs.fastly.com/api/logging#logging_s3
Go Fastly: https://github.com/sethvargo/go-fastly/blob/master/fastly/s3.go#L34