### PR TITLE
Configurable base url

### DIFF
--- a/fastly/config.go
+++ b/fastly/config.go
@@ -7,7 +7,8 @@ import (
 )
 
 type Config struct {
-	ApiKey string
+	ApiKey  string
+	BaseURL string
 }
 
 type FastlyClient struct {
@@ -21,7 +22,11 @@ func (c *Config) Client() (interface{}, error) {
 		return nil, fmt.Errorf("[Err] No API key for Fastly")
 	}
 
-	fconn, err := gofastly.NewClient(c.ApiKey)
+	if c.BaseURL == "" {
+		c.BaseURL = gofastly.DefaultEndpoint
+	}
+
+	fconn, err := gofastly.NewClientForEndpoint(c.ApiKey, c.BaseURL)
 	if err != nil {
 		return nil, err
 	}

--- a/fastly/provider.go
+++ b/fastly/provider.go
@@ -31,7 +31,8 @@ func Provider() terraform.ResourceProvider {
 
 func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	config := Config{
-		ApiKey: d.Get("api_key").(string),
+		ApiKey:  d.Get("api_key").(string),
+		BaseURL: d.Get("base_url").(string),
 	}
 	return config.Client()
 }

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -86,3 +86,7 @@ The following arguments are supported in the `provider` block:
 
 * `api_key` - (Optional) This is the API key. It must be provided, but
   it can also be sourced from the `FASTLY_API_KEY` environment variable
+
+* `base_url` - (Optional) This is the API server hostname. It is required
+  if using a private instance of the API and otherwise defaults to the
+  public Fastly production service.


### PR DESCRIPTION
This helps us with internal testing to be able to connect to alternate api hosts. This was enabled by https://github.com/sethvargo/go-fastly/pull/38.