### PR TITLE
fix base_url implementation

### DIFF
--- a/fastly/config.go
+++ b/fastly/config.go
@@ -23,10 +23,6 @@ func (c *Config) Client() (interface{}, error) {
 		return nil, fmt.Errorf("[Err] No API key for Fastly")
 	}
 
-	if c.BaseURL == "" {
-		c.BaseURL = gofastly.DefaultEndpoint
-	}
-
 	gofastly.UserAgent = terraform.UserAgentString()
 
 	fconn, err := gofastly.NewClientForEndpoint(c.ApiKey, c.BaseURL)

--- a/fastly/provider.go
+++ b/fastly/provider.go
@@ -3,6 +3,7 @@ package fastly
 import (
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
+	gofastly "github.com/sethvargo/go-fastly/fastly"
 )
 
 // Provider returns a terraform.ResourceProvider.
@@ -16,6 +17,14 @@ func Provider() terraform.ResourceProvider {
 					"FASTLY_API_KEY",
 				}, nil),
 				Description: "Fastly API Key from https://app.fastly.com/#account",
+			},
+			"base_url": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				DefaultFunc: schema.MultiEnvDefaultFunc([]string{
+					"FASTLY_API_URL",
+				}, gofastly.DefaultEndpoint),
+				Description: "Fastly API URL",
 			},
 		},
 		DataSourcesMap: map[string]*schema.Resource{

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -89,4 +89,5 @@ The following arguments are supported in the `provider` block:
 
 * `base_url` - (Optional) This is the API server hostname. It is required
   if using a private instance of the API and otherwise defaults to the
-  public Fastly production service.
+  public Fastly production service. It can also be sourced from the
+  `FASTLY_API_URL` environment variable


### PR DESCRIPTION
this adds base_url to the resource schema to avoid acceptance test
failures

this also makes it so that the base_url can be configured using an
environment variable `FASTLY_API_URL`