### PR TITLE
Expand documentation of GCS secret key

### DIFF
--- a/website/docs/r/service_v1.html.markdown
+++ b/website/docs/r/service_v1.html.markdown
@@ -346,7 +346,7 @@ The `gcslogging` block supports:
 * `name` - (Required) A unique name to identify this GCS endpoint.
 * `email` - (Required) The email address associated with the target GCS bucket on your account. You may optionally provide this secret via an environment variable, `FASTLY_GCS_EMAIL`.
 * `bucket_name` - (Required) The name of the bucket in which to store the logs.
-* `secret_key` - (Required) The secret key associated with the target gcs bucket on your account. You may optionally provide this secret via an environment variable, `FASTLY_GCS_SECRET_KEY`.
+* `secret_key` - (Required) The secret key associated with the target gcs bucket on your account. You may optionally provide this secret via an environment variable, `FASTLY_GCS_SECRET_KEY`. A typical format for the key is PEM format, containing actual newline characters where required.
 * `path` - (Optional) Path to store the files. Must end with a trailing slash.
 If this field is left empty, the files will be saved in the bucket's root path.
 * `period` - (Optional) How frequently the logs should be transferred, in


### PR DESCRIPTION
Keys are particularly difficult to troubleshoot due to the sensitive nature of their values. Google Cloud Platform usually releases credentials in JSON strings whereas specifying them as an environment variable [requires unusual encodings](https://stackoverflow.com/a/36439943/91590). How to pass credentials in is out of scope for this documentation, but I'd like a more precise explanation of what is required.