### PR TITLE
update to s3 logging block for `format_version`

### DIFF
--- a/website/docs/r/service_v1.html.markdown
+++ b/website/docs/r/service_v1.html.markdown
@@ -317,6 +317,7 @@ seconds. Default `3600`.
 compression. `1` is fastest and least compressed, `9` is slowest and most
 compressed. Default `0`.
 * `format` - (Optional) Apache-style string or VCL variables to use for log formatting. Defaults to Apache Common Log format (`%h %l %u %t %r %>s`)
+* `format_version` - (Optional) The format version of Fastly's custom log formats. Defaults to Version 1. More information on [Custom log formats](https://docs.fastly.com/guides/streaming-logs/custom-log-formats)
 * `message_type` - (Optional) How the message should be formatted; one of: `classic`, `loggly`, `logplex` or `blank`.  Default `classic`.
 * `timestamp_format` - (Optional) `strftime` specified timestamp formatting (default `%Y-%m-%dT%H:%M:%S.000`).
 * `redundancy` - (Optional) The S3 redundancy level. Should be formatted; one of: `standard`, `reduced_redundancy` or null. Default `null`.


### PR DESCRIPTION
the default format_version is version 1. This causes a message in the console recommending that you upgrade to version 2. While looking though the provider code, this funtionality exist, but it not documented. Adding `format_version = 2` to my terraform configuration worked.