### PR TITLE
Add explanation for importing service

### DIFF
--- a/website/docs/r/service_v1.html.markdown
+++ b/website/docs/r/service_v1.html.markdown
@@ -439,3 +439,11 @@ Service.
 [fastly-conditionals]: https://docs.fastly.com/guides/conditions/using-conditions
 [fastly-sumologic]: https://docs.fastly.com/api/logging#logging_sumologic
 [fastly-gcs]: https://docs.fastly.com/api/logging#logging_gcs
+
+## Import
+
+Fastly Service can be imported using their service ID, e.g.
+
+```
+$ terraform import fastly_service_v1.demo xxxxxxxxxxxxxxxxxxxx
+```


### PR DESCRIPTION
Although terraform import works for fastly service, it is not documented.
I think it's nice to have explanations for importing.