### PR TITLE
add log placement support

### DIFF
--- a/fastly/resource_fastly_service_v1.go
+++ b/fastly/resource_fastly_service_v1.go
@@ -680,10 +680,10 @@ func resourceServiceV1() *schema.Resource {
 							Description: "The S3 redundancy level.",
 						},
 						"placement": {
-						Type:        schema.TypeString,
-						Optional:    true,
-						Description: "The placement for the logging endpoint. Can be ",
-					},
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "The placement for the logging endpoint. Can be ",
+						},
 						"response_condition": {
 							Type:        schema.TypeString,
 							Optional:    true,
@@ -697,11 +697,6 @@ func resourceServiceV1() *schema.Resource {
 							Description:  "How the message should be formatted.",
 							ValidateFunc: validateLoggingMessageType,
 						},
-
-
-
-
-
 					},
 				},
 			},
@@ -735,10 +730,10 @@ func resourceServiceV1() *schema.Resource {
 							Description: "Apache-style string or VCL variables to use for log formatting",
 						},
 						"placement": {
-						Type:        schema.TypeString,
-						Optional:    true,
-						Description: "The placement for the logging endpoint. Can be ",
-					},
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "The placement for the logging endpoint. Can be ",
+						},
 						"response_condition": {
 							Type:        schema.TypeString,
 							Optional:    true,
@@ -780,10 +775,10 @@ func resourceServiceV1() *schema.Resource {
 							ValidateFunc: validateLoggingFormatVersion,
 						},
 						"placement": {
-						Type:        schema.TypeString,
-						Optional:    true,
-						Description: "The placement for the logging endpoint. Can be ",
-					},
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "The placement for the logging endpoint. Can be ",
+						},
 						"response_condition": {
 							Type:        schema.TypeString,
 							Optional:    true,
@@ -856,10 +851,10 @@ func resourceServiceV1() *schema.Resource {
 						},
 
 						"placement": {
-						Type:        schema.TypeString,
-						Optional:    true,
-						Description: "The placement for the logging endpoint. Can be ",
-					},
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "The placement for the logging endpoint. Can be ",
+						},
 						"timestamp_format": {
 							Type:        schema.TypeString,
 							Optional:    true,
@@ -930,10 +925,10 @@ func resourceServiceV1() *schema.Resource {
 							Default:     "%h %l %u %t \"%r\" %>s %b",
 						},
 						"placement": {
-						Type:        schema.TypeString,
-						Optional:    true,
-						Description: "The placement for the logging endpoint. Can be ",
-					},
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "The placement for the logging endpoint. Can be ",
+						},
 						"response_condition": {
 							Type:        schema.TypeString,
 							Optional:    true,
@@ -1959,7 +1954,7 @@ func resourceServiceV1Update(d *schema.ResourceData, meta interface{}) error {
 					TimestampFormat:   sf["timestamp_format"].(string),
 					ResponseCondition: sf["response_condition"].(string),
 					MessageType:       sf["message_type"].(string),
-					Placement: 		   sf["placement"].(string),
+					Placement:         sf["placement"].(string),
 				}
 
 				redundancy := strings.ToLower(sf["redundancy"].(string))
@@ -2025,7 +2020,7 @@ func resourceServiceV1Update(d *schema.ResourceData, meta interface{}) error {
 					Port:              uint(pf["port"].(int)),
 					Format:            pf["format"].(string),
 					ResponseCondition: pf["response_condition"].(string),
-					Placement: 		   pf["placement"].(string),
+					Placement:         pf["placement"].(string),
 				}
 
 				log.Printf("[DEBUG] Create Papertrail Opts: %#v", opts)
@@ -2083,7 +2078,7 @@ func resourceServiceV1Update(d *schema.ResourceData, meta interface{}) error {
 					FormatVersion:     sf["format_version"].(int),
 					ResponseCondition: sf["response_condition"].(string),
 					MessageType:       sf["message_type"].(string),
-					Placement: 		   sf["placement"].(string),
+					Placement:         sf["placement"].(string),
 				}
 
 				log.Printf("[DEBUG] Create Sumologic Opts: %#v", opts)
@@ -2146,7 +2141,7 @@ func resourceServiceV1Update(d *schema.ResourceData, meta interface{}) error {
 					TimestampFormat:   sf["timestamp_format"].(string),
 					MessageType:       sf["message_type"].(string),
 					ResponseCondition: sf["response_condition"].(string),
-					Placement: 		   sf["placement"].(string),
+					Placement:         sf["placement"].(string),
 				}
 
 				log.Printf("[DEBUG] Create GCS Opts: %#v", opts)
@@ -2334,7 +2329,7 @@ func resourceServiceV1Update(d *schema.ResourceData, meta interface{}) error {
 					Format:            slf["format"].(string),
 					FormatVersion:     uint(slf["format_version"].(int)),
 					ResponseCondition: slf["response_condition"].(string),
-					Placement: 		   slf["placement"].(string),
+					Placement:         slf["placement"].(string),
 				}
 
 				log.Printf("[DEBUG] Create Logentries Opts: %#v", opts)
@@ -3581,7 +3576,7 @@ func flattenLogentries(logentriesList []*gofastly.Logentries) []map[string]inter
 			"format":             currentLE.Format,
 			"format_version":     currentLE.FormatVersion,
 			"response_condition": currentLE.ResponseCondition,
-			"placement": currentLE.Placement,
+			"placement":          currentLE.Placement,
 		}
 
 		// prune any empty values that come from the default string value in structs

--- a/fastly/resource_fastly_service_v1.go
+++ b/fastly/resource_fastly_service_v1.go
@@ -679,6 +679,11 @@ func resourceServiceV1() *schema.Resource {
 							Optional:    true,
 							Description: "The S3 redundancy level.",
 						},
+						"placement": {
+						Type:        schema.TypeString,
+						Optional:    true,
+						Description: "The placement for the logging endpoint. Can be ",
+					},
 						"response_condition": {
 							Type:        schema.TypeString,
 							Optional:    true,
@@ -692,6 +697,11 @@ func resourceServiceV1() *schema.Resource {
 							Description:  "How the message should be formatted.",
 							ValidateFunc: validateLoggingMessageType,
 						},
+
+
+
+
+
 					},
 				},
 			},
@@ -724,6 +734,11 @@ func resourceServiceV1() *schema.Resource {
 							Default:     "%h %l %u %t %r %>s",
 							Description: "Apache-style string or VCL variables to use for log formatting",
 						},
+						"placement": {
+						Type:        schema.TypeString,
+						Optional:    true,
+						Description: "The placement for the logging endpoint. Can be ",
+					},
 						"response_condition": {
 							Type:        schema.TypeString,
 							Optional:    true,
@@ -764,6 +779,11 @@ func resourceServiceV1() *schema.Resource {
 							Description:  "The version of the custom logging format used for the configured endpoint. Can be either 1 or 2. (Default: 1)",
 							ValidateFunc: validateLoggingFormatVersion,
 						},
+						"placement": {
+						Type:        schema.TypeString,
+						Optional:    true,
+						Description: "The placement for the logging endpoint. Can be ",
+					},
 						"response_condition": {
 							Type:        schema.TypeString,
 							Optional:    true,
@@ -834,6 +854,12 @@ func resourceServiceV1() *schema.Resource {
 							Default:     "%h %l %u %t %r %>s",
 							Description: "Apache-style string or VCL variables to use for log formatting",
 						},
+
+						"placement": {
+						Type:        schema.TypeString,
+						Optional:    true,
+						Description: "The placement for the logging endpoint. Can be ",
+					},
 						"timestamp_format": {
 							Type:        schema.TypeString,
 							Optional:    true,
@@ -903,6 +929,11 @@ func resourceServiceV1() *schema.Resource {
 							Description: "The logging format desired.",
 							Default:     "%h %l %u %t \"%r\" %>s %b",
 						},
+						"placement": {
+						Type:        schema.TypeString,
+						Optional:    true,
+						Description: "The placement for the logging endpoint. Can be ",
+					},
 						"response_condition": {
 							Type:        schema.TypeString,
 							Optional:    true,
@@ -992,6 +1023,11 @@ func resourceServiceV1() *schema.Resource {
 							Description:  "How the message should be formatted.",
 							ValidateFunc: validateLoggingMessageType,
 						},
+						"placement": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "The placement for the logging endpoint. Can be ",
+						},
 					},
 				},
 			},
@@ -1037,6 +1073,11 @@ func resourceServiceV1() *schema.Resource {
 							Default:      1,
 							Description:  "The version of the custom logging format used for the configured endpoint. Can be either 1 or 2. (Default: 1)",
 							ValidateFunc: validateLoggingFormatVersion,
+						},
+						"placement": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "The placement for the logging endpoint. Can be ",
 						},
 						"response_condition": {
 							Type:        schema.TypeString,
@@ -1918,6 +1959,7 @@ func resourceServiceV1Update(d *schema.ResourceData, meta interface{}) error {
 					TimestampFormat:   sf["timestamp_format"].(string),
 					ResponseCondition: sf["response_condition"].(string),
 					MessageType:       sf["message_type"].(string),
+					Placement: 		   sf["placement"].(string),
 				}
 
 				redundancy := strings.ToLower(sf["redundancy"].(string))
@@ -1983,6 +2025,7 @@ func resourceServiceV1Update(d *schema.ResourceData, meta interface{}) error {
 					Port:              uint(pf["port"].(int)),
 					Format:            pf["format"].(string),
 					ResponseCondition: pf["response_condition"].(string),
+					Placement: 		   pf["placement"].(string),
 				}
 
 				log.Printf("[DEBUG] Create Papertrail Opts: %#v", opts)
@@ -2040,6 +2083,7 @@ func resourceServiceV1Update(d *schema.ResourceData, meta interface{}) error {
 					FormatVersion:     sf["format_version"].(int),
 					ResponseCondition: sf["response_condition"].(string),
 					MessageType:       sf["message_type"].(string),
+					Placement: 		   sf["placement"].(string),
 				}
 
 				log.Printf("[DEBUG] Create Sumologic Opts: %#v", opts)
@@ -2102,6 +2146,7 @@ func resourceServiceV1Update(d *schema.ResourceData, meta interface{}) error {
 					TimestampFormat:   sf["timestamp_format"].(string),
 					MessageType:       sf["message_type"].(string),
 					ResponseCondition: sf["response_condition"].(string),
+					Placement: 		   sf["placement"].(string),
 				}
 
 				log.Printf("[DEBUG] Create GCS Opts: %#v", opts)
@@ -2161,6 +2206,7 @@ func resourceServiceV1Update(d *schema.ResourceData, meta interface{}) error {
 					SecretKey:         sf["secret_key"].(string),
 					ResponseCondition: sf["response_condition"].(string),
 					Template:          sf["template"].(string),
+					Placement:         sf["placement"].(string),
 				}
 
 				if sf["format"].(string) != "" {
@@ -2222,6 +2268,7 @@ func resourceServiceV1Update(d *schema.ResourceData, meta interface{}) error {
 					Port:              uint(slf["port"].(int)),
 					Format:            slf["format"].(string),
 					FormatVersion:     uint(slf["format_version"].(int)),
+					Placement:         slf["placement"].(string),
 					Token:             slf["token"].(string),
 					UseTLS:            gofastly.CBool(slf["use_tls"].(bool)),
 					TLSHostname:       slf["tls_hostname"].(string),
@@ -2287,6 +2334,7 @@ func resourceServiceV1Update(d *schema.ResourceData, meta interface{}) error {
 					Format:            slf["format"].(string),
 					FormatVersion:     uint(slf["format_version"].(int)),
 					ResponseCondition: slf["response_condition"].(string),
+					Placement: 		   slf["placement"].(string),
 				}
 
 				log.Printf("[DEBUG] Create Logentries Opts: %#v", opts)
@@ -3533,6 +3581,7 @@ func flattenLogentries(logentriesList []*gofastly.Logentries) []map[string]inter
 			"format":             currentLE.Format,
 			"format_version":     currentLE.FormatVersion,
 			"response_condition": currentLE.ResponseCondition,
+			"placement": currentLE.Placement,
 		}
 
 		// prune any empty values that come from the default string value in structs

--- a/vendor/github.com/sethvargo/go-fastly/CHANGELOG.md
+++ b/vendor/github.com/sethvargo/go-fastly/CHANGELOG.md
@@ -1,8 +1,15 @@
 # go-fastly CHANGELOG
 
-## v0.4.1.dev (Unreleased)
+## v0.4.3 (Unreleased)
+
+- Add WAF methods for fetching status of rules, both one at a time and in filtered lists
+- Add WAF methods for modifying the status of rules, both one at a time and based on tags
+- Rename `UpdateWafRuleSets` function to `UpdateWAFRuleSets` to match other names
+
+## v0.4.2 (September 5, 2017)
 
 - Add support for specifying `message_type` in GCS [GH-52]
+- Add support for WAF [GH-35, GH-55]
 
 ## v0.4.1 (August 7, 2017)
 
@@ -12,7 +19,7 @@
 
 FEATURES:
 
-  - Add support for real-time stats [GH-48]
+- Add support for real-time stats [GH-48]
 
 ## v0.3.0 (July 19, 2017)
 

--- a/vendor/github.com/sethvargo/go-fastly/Gopkg.lock
+++ b/vendor/github.com/sethvargo/go-fastly/Gopkg.lock
@@ -14,6 +14,12 @@
   revision = "87d4990451a858cc210399285be976e63bc3c364"
 
 [[projects]]
+  name = "github.com/google/jsonapi"
+  packages = ["."]
+  revision = "46d3ced0434461be12e555852e2f1a9ed382e139"
+  version = "1.0.0"
+
+[[projects]]
   branch = "master"
   name = "github.com/hashicorp/go-cleanhttp"
   packages = ["."]
@@ -29,11 +35,11 @@
   branch = "v2"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
-  revision = "3b4ad1db5b2a649883ff3782f5f9f6fb52be71af"
+  revision = "eb3733d160e74a9c7e442f435eb3bea458e1d19f"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "868da49a356a7aab20b6fa8bfe2e3e3f776cefe09a33aef1a896f2ab0a998e39"
+  inputs-digest = "03e647bbda0583bbdd216cfd709d083ee4eaaf54ac9547aa9ba81151a79eebb0"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/vendor/github.com/sethvargo/go-fastly/README.md
+++ b/vendor/github.com/sethvargo/go-fastly/README.md
@@ -83,7 +83,7 @@ if err != nil {
 fmt.Println(domain.Name)
 
 // Now we can validate that our version is valid.
-valid, err := client.ValidateVersion(&fastly.ValidateVersionInput{
+valid, _, err := client.ValidateVersion(&fastly.ValidateVersionInput{
   Service: serviceID,
   Version: version.Number,
 })

--- a/vendor/github.com/sethvargo/go-fastly/fastly/gcs.go
+++ b/vendor/github.com/sethvargo/go-fastly/fastly/gcs.go
@@ -84,6 +84,7 @@ type CreateGCSInput struct {
 	MessageType       string `form:"message_type,omitempty"`
 	ResponseCondition string `form:"response_condition,omitempty"`
 	TimestampFormat   string `form:"timestamp_format,omitempty"`
+	Placement         string `form:"placement,omitempty"`
 }
 
 // CreateGCS creates a new Fastly GCS.

--- a/vendor/github.com/sethvargo/go-fastly/fastly/s3.go
+++ b/vendor/github.com/sethvargo/go-fastly/fastly/s3.go
@@ -101,7 +101,7 @@ type CreateS3Input struct {
 	ResponseCondition string       `form:"response_condition,omitempty"`
 	TimestampFormat   string       `form:"timestamp_format,omitempty"`
 	Redundancy        S3Redundancy `form:"redundancy,omitempty"`
-        Placement         string       `form:"placement,omitempty"`
+	Placement         string       `form:"placement,omitempty"`
 }
 
 // CreateS3 creates a new Fastly S3.

--- a/vendor/github.com/sethvargo/go-fastly/fastly/sumologic.go
+++ b/vendor/github.com/sethvargo/go-fastly/fastly/sumologic.go
@@ -21,6 +21,7 @@ type Sumologic struct {
 	CreatedAt         *time.Time `mapstructure:"created_at"`
 	UpdatedAt         *time.Time `mapstructure:"updated_at"`
 	DeletedAt         *time.Time `mapstructure:"deleted_at"`
+
 }
 
 // sumologicsByName is a sortable list of sumologics.

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -576,9 +576,9 @@
 			"revisionTime": "2016-09-27T10:08:44Z"
 		},
 		{
-			"checksumSHA1": "+mAkrZAT0A8eQAIf+ZD/DWWTa+c=",
+			"checksumSHA1": "H6CINrQ0S6NJ3HSVzdejuZng7B0=",
 			"path": "github.com/sethvargo/go-fastly",
-			"revision": "8d3144bdefbc73b225ac176671978d102d31862a",
+			"revision": "16e557cdd5fed48d0fd4f68b6360c900f9e2407a",
 			"revisionTime": "2017-08-25T22:07:33Z"
 		},
 		{


### PR DESCRIPTION
The Fastly WAF uses the placement functionality to determine if the logging endpoint is a WAF logging endpoint or not. A WAF logging endpoint is unique in the fact that has unique fields like waf.logdata and waf.rule available to log for one or many WAF event in a single request.  

You can find out more information how placement is used for WAF at: https://docs.fastly.com/guides/web-application-firewall/fastly-waf-logging#waf_debug_log

I am not 100% sure if I should update testing for other endpoints, please advice. Also updated the go-fastly library to have the underlying calls for the logging integration also understand placement. Some already supported it but not all, see: https://github.com/sethvargo/go-fastly/pull/88 for details. Thank you