### PR TITLE
Add argument reference for bigquerylogging

### DIFF
--- a/website/docs/r/service_v1.html.markdown
+++ b/website/docs/r/service_v1.html.markdown
@@ -192,6 +192,8 @@ Defined below.
 Defined below.
 * `gcslogging` - (Optional) A gcs endpoint to send streaming logs too.
 Defined below.
+* `bigquerylogging` - (Optional) A BigQuery endpoint to send streaming logs too.
+Defined below.
 * `syslog` - (Optional) A syslog endpoint to send streaming logs too.
 Defined below.
 * `logentries` - (Optional) A logentries endpoint to send streaming logs too.


### PR DESCRIPTION
`bigquerylogging` option is missing from "Argument Reference" in the doc.