### PR TITLE
add support for the placement field to all logging providers

### DIFF
--- a/fastly/resource_fastly_service_v1.go
+++ b/fastly/resource_fastly_service_v1.go
@@ -692,6 +692,12 @@ func resourceServiceV1() *schema.Resource {
 							Description:  "How the message should be formatted.",
 							ValidateFunc: validateLoggingMessageType,
 						},
+						"placement": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							Description:  "Where in the generated VCL the logging call should be placed.",
+							ValidateFunc: validateLoggingPlacement,
+						},
 					},
 				},
 			},
@@ -729,6 +735,12 @@ func resourceServiceV1() *schema.Resource {
 							Optional:    true,
 							Default:     "",
 							Description: "Name of a condition to apply this logging",
+						},
+						"placement": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							Description:  "Where in the generated VCL the logging call should be placed.",
+							ValidateFunc: validateLoggingPlacement,
 						},
 					},
 				},
@@ -776,6 +788,12 @@ func resourceServiceV1() *schema.Resource {
 							Default:      "classic",
 							Description:  "How the message should be formatted.",
 							ValidateFunc: validateLoggingMessageType,
+						},
+						"placement": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							Description:  "Where in the generated VCL the logging call should be placed.",
+							ValidateFunc: validateLoggingPlacement,
 						},
 					},
 				},
@@ -852,6 +870,12 @@ func resourceServiceV1() *schema.Resource {
 							Default:     "classic",
 							Description: "The log message type per the fastly docs: https://docs.fastly.com/api/logging#logging_gcs",
 						},
+						"placement": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							Description:  "Where in the generated VCL the logging call should be placed.",
+							ValidateFunc: validateLoggingPlacement,
+						},
 					},
 				},
 			},
@@ -914,6 +938,12 @@ func resourceServiceV1() *schema.Resource {
 							Optional:    true,
 							Default:     "",
 							Description: "Big query table name suffix template",
+						},
+						"placement": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							Description:  "Where in the generated VCL the logging call should be placed.",
+							ValidateFunc: validateLoggingPlacement,
 						},
 					},
 				},
@@ -992,6 +1022,12 @@ func resourceServiceV1() *schema.Resource {
 							Description:  "How the message should be formatted.",
 							ValidateFunc: validateLoggingMessageType,
 						},
+						"placement": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							Description:  "Where in the generated VCL the logging call should be placed.",
+							ValidateFunc: validateLoggingPlacement,
+						},
 					},
 				},
 			},
@@ -1043,6 +1079,12 @@ func resourceServiceV1() *schema.Resource {
 							Optional:    true,
 							Default:     "",
 							Description: "Name of a condition to apply this logging.",
+						},
+						"placement": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							Description:  "Where in the generated VCL the logging call should be placed.",
+							ValidateFunc: validateLoggingPlacement,
 						},
 					},
 				},
@@ -1918,6 +1960,7 @@ func resourceServiceV1Update(d *schema.ResourceData, meta interface{}) error {
 					TimestampFormat:   sf["timestamp_format"].(string),
 					ResponseCondition: sf["response_condition"].(string),
 					MessageType:       sf["message_type"].(string),
+					Placement:         sf["placement"].(string),
 				}
 
 				redundancy := strings.ToLower(sf["redundancy"].(string))
@@ -1983,6 +2026,7 @@ func resourceServiceV1Update(d *schema.ResourceData, meta interface{}) error {
 					Port:              uint(pf["port"].(int)),
 					Format:            pf["format"].(string),
 					ResponseCondition: pf["response_condition"].(string),
+					Placement:         pf["placement"].(string),
 				}
 
 				log.Printf("[DEBUG] Create Papertrail Opts: %#v", opts)
@@ -2040,6 +2084,7 @@ func resourceServiceV1Update(d *schema.ResourceData, meta interface{}) error {
 					FormatVersion:     sf["format_version"].(int),
 					ResponseCondition: sf["response_condition"].(string),
 					MessageType:       sf["message_type"].(string),
+					Placement:         sf["placement"].(string),
 				}
 
 				log.Printf("[DEBUG] Create Sumologic Opts: %#v", opts)
@@ -2102,6 +2147,7 @@ func resourceServiceV1Update(d *schema.ResourceData, meta interface{}) error {
 					TimestampFormat:   sf["timestamp_format"].(string),
 					MessageType:       sf["message_type"].(string),
 					ResponseCondition: sf["response_condition"].(string),
+					Placement:         sf["placement"].(string),
 				}
 
 				log.Printf("[DEBUG] Create GCS Opts: %#v", opts)
@@ -2161,6 +2207,7 @@ func resourceServiceV1Update(d *schema.ResourceData, meta interface{}) error {
 					SecretKey:         sf["secret_key"].(string),
 					ResponseCondition: sf["response_condition"].(string),
 					Template:          sf["template"].(string),
+					Placement:         sf["placement"].(string),
 				}
 
 				if sf["format"].(string) != "" {
@@ -2228,6 +2275,7 @@ func resourceServiceV1Update(d *schema.ResourceData, meta interface{}) error {
 					TLSCACert:         slf["tls_ca_cert"].(string),
 					ResponseCondition: slf["response_condition"].(string),
 					MessageType:       slf["message_type"].(string),
+					Placement:         slf["placement"].(string),
 				}
 
 				log.Printf("[DEBUG] Create Syslog Opts: %#v", opts)
@@ -2287,6 +2335,7 @@ func resourceServiceV1Update(d *schema.ResourceData, meta interface{}) error {
 					Format:            slf["format"].(string),
 					FormatVersion:     uint(slf["format_version"].(int)),
 					ResponseCondition: slf["response_condition"].(string),
+					Placement:         slf["placement"].(string),
 				}
 
 				log.Printf("[DEBUG] Create Logentries Opts: %#v", opts)
@@ -3364,6 +3413,7 @@ func flattenS3s(s3List []*gofastly.S3) []map[string]interface{} {
 			"redundancy":         s.Redundancy,
 			"response_condition": s.ResponseCondition,
 			"message_type":       s.MessageType,
+			"placement":          s.Placement,
 		}
 
 		// prune any empty values that come from the default string value in structs
@@ -3389,6 +3439,7 @@ func flattenPapertrails(papertrailList []*gofastly.Papertrail) []map[string]inte
 			"port":               p.Port,
 			"format":             p.Format,
 			"response_condition": p.ResponseCondition,
+			"placement":          p.Placement,
 		}
 
 		// prune any empty values that come from the default string value in structs
@@ -3415,6 +3466,7 @@ func flattenSumologics(sumologicList []*gofastly.Sumologic) []map[string]interfa
 			"response_condition": p.ResponseCondition,
 			"message_type":       p.MessageType,
 			"format_version":     int(p.FormatVersion),
+			"placement":          p.Placement,
 		}
 
 		// prune any empty values that come from the default string value in structs
@@ -3446,6 +3498,7 @@ func flattenGCS(gcsList []*gofastly.GCS) []map[string]interface{} {
 			"message_type":       currentGCS.MessageType,
 			"format":             currentGCS.Format,
 			"timestamp_format":   currentGCS.TimestampFormat,
+			"placement":          currentGCS.Placement,
 		}
 
 		// prune any empty values that come from the default string value in structs
@@ -3475,6 +3528,7 @@ func flattenBigQuery(bqList []*gofastly.BigQuery) []map[string]interface{} {
 			"table":              currentBQ.Table,
 			"response_condition": currentBQ.ResponseCondition,
 			"template":           currentBQ.Template,
+			"placement":          currentBQ.Placement,
 		}
 
 		// prune any empty values that come from the default string value in structs
@@ -3506,6 +3560,7 @@ func flattenSyslogs(syslogList []*gofastly.Syslog) []map[string]interface{} {
 			"tls_ca_cert":        p.TLSCACert,
 			"response_condition": p.ResponseCondition,
 			"message_type":       p.MessageType,
+			"placement":          p.Placement,
 		}
 
 		// prune any empty values that come from the default string value in structs
@@ -3533,6 +3588,7 @@ func flattenLogentries(logentriesList []*gofastly.Logentries) []map[string]inter
 			"format":             currentLE.Format,
 			"format_version":     currentLE.FormatVersion,
 			"response_condition": currentLE.ResponseCondition,
+			"placement":          currentLE.Placement,
 		}
 
 		// prune any empty values that come from the default string value in structs

--- a/fastly/validators.go
+++ b/fastly/validators.go
@@ -32,6 +32,20 @@ func validateLoggingMessageType(v interface{}, k string) (ws []string, errors []
 	return
 }
 
+func validateLoggingPlacement(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	validTypes := map[string]struct{}{
+		"none":      {},
+		"waf_debug": {},
+	}
+
+	if _, ok := validTypes[value]; !ok {
+		errors = append(errors, fmt.Errorf(
+			"%q must be one of ['none', 'waf_debug']", k))
+	}
+	return
+}
+
 func validateDirectorType(v interface{}, k string) (ws []string, errors []error) {
 	value := uint(v.(int))
 	validVersions := map[uint]struct{}{

--- a/fastly/validators_test.go
+++ b/fastly/validators_test.go
@@ -54,6 +54,30 @@ func TestValidateLoggingMessageType(t *testing.T) {
 	}
 }
 
+func TestValidateLoggingPlacement(t *testing.T) {
+	validPlacements := []string{
+		"none",
+		"waf_debug",
+	}
+	for _, v := range validPlacements {
+		_, errors := validateLoggingPlacement(v, "placement")
+		if len(errors) != 0 {
+			t.Fatalf("%q should be a valid placement", v)
+		}
+	}
+
+	invalidPlacements := []string{
+		"invalid_placement_1",
+		"invalid_placement_2",
+	}
+	for _, v := range invalidPlacements {
+		_, errors := validateLoggingPlacement(v, "placement")
+		if len(errors) != 1 {
+			t.Fatalf("%q should not be a valid placement", v)
+		}
+	}
+}
+
 func TestValidateDirectorType(t *testing.T) {
 	validVersions := []int{
 		1,

--- a/vendor/github.com/sethvargo/go-fastly/fastly/bigquery.go
+++ b/vendor/github.com/sethvargo/go-fastly/fastly/bigquery.go
@@ -19,6 +19,7 @@ type BigQuery struct {
 	UpdatedAt         string `mapstructure:"updated_at"`
 	DeletedAt         string `mapstructure:"deleted_at"`
 	ResponseCondition string `mapstructure:"response_condition"`
+	Placement         string `mapstructure:"placement"`
 }
 
 // GetBigQueryInput is used as input to the GetBigQuery function.
@@ -89,6 +90,10 @@ type CreateBigQueryInput struct {
 	// ResponseCondition allows you to attach a response condition to your BigQuery logging endpoint.
 	// Optional.
 	ResponseCondition string
+
+	// Placement is the log placement desired for your BigQuery logging endpoint.
+	// Optional.
+	Placement string
 }
 
 // CreateBigQuery creates a new Fastly BigQuery logging endpoint.
@@ -140,6 +145,10 @@ func (c *Client) CreateBigQuery(i *CreateBigQueryInput) (*BigQuery, error) {
 	}
 	if i.Template != "" {
 		params["template_suffix"] = i.Template
+	}
+
+	if i.Placement != "" {
+		params["placement"] = i.Placement
 	}
 
 	path := fmt.Sprintf("/service/%s/version/%d/logging/bigquery", i.Service, i.Version)
@@ -202,6 +211,10 @@ type UpdateBigQueryInput struct {
 	// ResponseCondition allows you to attach a response condition to your BigQuery logging endpoint.
 	// Optional.
 	ResponseCondition string
+
+	// Placement is the log placement desired for your BigQuery logging endpoint.
+	// Optional.
+	Placement string
 }
 
 // UpdateBigQuery updates a BigQuery logging endpoint.
@@ -247,6 +260,10 @@ func (c *Client) UpdateBigQuery(i *UpdateBigQueryInput) (*BigQuery, error) {
 	}
 	if i.ResponseCondition != "" {
 		params["response_condition"] = i.ResponseCondition
+	}
+
+	if i.Placement != "" {
+		params["placement"] = i.Placement
 	}
 
 	path := fmt.Sprintf("/service/%s/version/%d/logging/bigquery/%s", i.Service, i.Version, i.Name)

--- a/vendor/github.com/sethvargo/go-fastly/fastly/ftp.go
+++ b/vendor/github.com/sethvargo/go-fastly/fastly/ftp.go
@@ -22,6 +22,7 @@ type FTP struct {
 	Format            string     `mapstructure:"format"`
 	ResponseCondition string     `mapstructure:"response_condition"`
 	TimestampFormat   string     `mapstructure:"timestamp_format"`
+	Placement         string     `mapstructure:"placement"`
 	CreatedAt         *time.Time `mapstructure:"created_at"`
 	UpdatedAt         *time.Time `mapstructure:"updated_at"`
 	DeletedAt         *time.Time `mapstructure:"deleted_at"`
@@ -88,6 +89,7 @@ type CreateFTPInput struct {
 	Format            string `form:"format,omitempty"`
 	ResponseCondition string `form:"response_condition,omitempty"`
 	TimestampFormat   string `form:"timestamp_format,omitempty"`
+	Placement         string `form:"placement,omitempty"`
 }
 
 // CreateFTP creates a new Fastly FTP.
@@ -172,6 +174,7 @@ type UpdateFTPInput struct {
 	Format            string `form:"format,omitempty"`
 	ResponseCondition string `form:"response_condition,omitempty"`
 	TimestampFormat   string `form:"timestamp_format,omitempty"`
+	Placement         string `form:"placement,omitempty"`
 }
 
 // UpdateFTP updates a specific FTP.

--- a/vendor/github.com/sethvargo/go-fastly/fastly/gcs.go
+++ b/vendor/github.com/sethvargo/go-fastly/fastly/gcs.go
@@ -21,6 +21,7 @@ type GCS struct {
 	MessageType       string `mapstructure:"message_type"`
 	ResponseCondition string `mapstructure:"response_condition"`
 	TimestampFormat   string `mapstructure:"timestamp_format"`
+	Placement         string `mapstructure:"placement"`
 }
 
 // gcsesByName is a sortable list of gcses.
@@ -84,6 +85,7 @@ type CreateGCSInput struct {
 	MessageType       string `form:"message_type,omitempty"`
 	ResponseCondition string `form:"response_condition,omitempty"`
 	TimestampFormat   string `form:"timestamp_format,omitempty"`
+	Placement         string `form:"placement,omitempty"`
 }
 
 // CreateGCS creates a new Fastly GCS.
@@ -167,6 +169,7 @@ type UpdateGCSInput struct {
 	Format            string `form:"format,omitempty"`
 	ResponseCondition string `form:"response_condition,omitempty"`
 	TimestampFormat   string `form:"timestamp_format,omitempty"`
+	Placement         string `form:"placement,omitempty"`
 }
 
 // UpdateGCS updates a specific GCS.

--- a/vendor/github.com/sethvargo/go-fastly/fastly/logentries.go
+++ b/vendor/github.com/sethvargo/go-fastly/fastly/logentries.go
@@ -21,6 +21,7 @@ type Logentries struct {
 	CreatedAt         *time.Time `mapstructure:"created_at"`
 	UpdatedAt         *time.Time `mapstructure:"updated_at"`
 	DeletedAt         *time.Time `mapstructure:"deleted_at"`
+	Placement         string     `mapstructure:"placement"`
 }
 
 // logentriesByName is a sortable list of logentries.
@@ -161,6 +162,7 @@ type UpdateLogentriesInput struct {
 	Format            string       `form:"format,omitempty"`
 	FormatVersion     uint         `form:"format_version,omitempty"`
 	ResponseCondition string       `form:"response_condition,omitempty"`
+	Placement         string       `form:"placement,omitempty"`
 }
 
 // UpdateLogentries updates a specific logentries.

--- a/vendor/github.com/sethvargo/go-fastly/fastly/papertrail.go
+++ b/vendor/github.com/sethvargo/go-fastly/fastly/papertrail.go
@@ -19,6 +19,7 @@ type Papertrail struct {
 	CreatedAt         *time.Time `mapstructure:"created_at"`
 	UpdatedAt         *time.Time `mapstructure:"updated_at"`
 	DeletedAt         *time.Time `mapstructure:"deleted_at"`
+	Placement         string     `mapstructure:"placement"`
 }
 
 // papertrailsByName is a sortable list of papertrails.
@@ -161,6 +162,7 @@ type UpdatePapertrailInput struct {
 	CreatedAt         *time.Time `form:"created_at,omitempty"`
 	UpdatedAt         *time.Time `form:"updated_at,omitempty"`
 	DeletedAt         *time.Time `form:"deleted_at,omitempty"`
+	Placement         string     `form:"placement,omitempty"`
 }
 
 // UpdatePapertrail updates a specific papertrail.

--- a/vendor/github.com/sethvargo/go-fastly/fastly/s3.go
+++ b/vendor/github.com/sethvargo/go-fastly/fastly/s3.go
@@ -31,6 +31,7 @@ type S3 struct {
 	ResponseCondition string       `mapstructure:"response_condition"`
 	MessageType       string       `mapstructure:"message_type"`
 	TimestampFormat   string       `mapstructure:"timestamp_format"`
+	Placement         string       `mapstructure:"placement"`
 	Redundancy        S3Redundancy `mapstructure:"redundancy"`
 	CreatedAt         *time.Time   `mapstructure:"created_at"`
 	UpdatedAt         *time.Time   `mapstructure:"updated_at"`
@@ -101,7 +102,7 @@ type CreateS3Input struct {
 	ResponseCondition string       `form:"response_condition,omitempty"`
 	TimestampFormat   string       `form:"timestamp_format,omitempty"`
 	Redundancy        S3Redundancy `form:"redundancy,omitempty"`
-        Placement         string       `form:"placement,omitempty"`
+	Placement         string       `form:"placement,omitempty"`
 }
 
 // CreateS3 creates a new Fastly S3.
@@ -189,6 +190,7 @@ type UpdateS3Input struct {
 	MessageType       string       `form:"message_type,omitempty"`
 	TimestampFormat   string       `form:"timestamp_format,omitempty"`
 	Redundancy        S3Redundancy `form:"redundancy,omitempty"`
+	Placement         string       `form:"placement,omitempty"`
 }
 
 // UpdateS3 updates a specific S3.

--- a/vendor/github.com/sethvargo/go-fastly/fastly/service.go
+++ b/vendor/github.com/sethvargo/go-fastly/fastly/service.go
@@ -3,6 +3,7 @@ package fastly
 import (
 	"fmt"
 	"sort"
+	"time"
 )
 
 // Service represents a single service for the Fastly account.
@@ -27,6 +28,18 @@ type ServiceDetail struct {
 	Version       Version    `mapstructure:"version"`
 	Versions      []*Version `mapstructure:"versions"`
 }
+
+type ServiceDomain struct {
+	Locked    bool       `mapstructure:"locked"`
+	Version   int64      `mapstructure:"version"`
+	Name      string     `mapstructure:"name"`
+	DeletedAt *time.Time `mapstructure:"deleted_at"`
+	ServiceID string     `mapstructure: "service_id"`
+	CreatedAt time.Time  `mapstructure: "created_at"`
+	Comment   string     `mapstructure:"comment"`
+	UpdatedAt time.Time  `mapstructure:"updated_at"`
+}
+type ServiceDomainsList []*ServiceDomain
 
 // servicesByName is a sortable list of services.
 type servicesByName []*Service
@@ -205,4 +218,28 @@ func (c *Client) SearchService(i *SearchServiceInput) (*Service, error) {
 	}
 
 	return s, nil
+}
+
+type ListServiceDomainInput struct {
+	ID string
+}
+
+// ListServiceDomains lists all domains associated with a given service
+func (c *Client) ListServiceDomains(i *ListServiceDomainInput) (ServiceDomainsList, error) {
+	if i.ID == "" {
+		return nil, ErrMissingID
+	}
+	path := fmt.Sprintf("/service/%s/domain", i.ID)
+	resp, err := c.Get(path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var ds ServiceDomainsList
+
+	if err := decodeJSON(&ds, resp.Body); err != nil {
+		return nil, err
+	}
+
+	return ds, nil
 }

--- a/vendor/github.com/sethvargo/go-fastly/fastly/sumologic.go
+++ b/vendor/github.com/sethvargo/go-fastly/fastly/sumologic.go
@@ -21,6 +21,7 @@ type Sumologic struct {
 	CreatedAt         *time.Time `mapstructure:"created_at"`
 	UpdatedAt         *time.Time `mapstructure:"updated_at"`
 	DeletedAt         *time.Time `mapstructure:"deleted_at"`
+	Placement         string     `mapstructure:"placement"`
 }
 
 // sumologicsByName is a sortable list of sumologics.
@@ -161,6 +162,7 @@ type UpdateSumologicInput struct {
 	ResponseCondition string `form:"response_condition,omitempty"`
 	MessageType       string `form:"message_type,omitempty"`
 	FormatVersion     int    `form:"format_version,omitempty"`
+	Placement         string `form:"placement,omitempty"`
 }
 
 // UpdateSumologic updates a specific sumologic.

--- a/vendor/github.com/sethvargo/go-fastly/fastly/syslog.go
+++ b/vendor/github.com/sethvargo/go-fastly/fastly/syslog.go
@@ -24,6 +24,7 @@ type Syslog struct {
 	FormatVersion     uint       `mapstructure:"format_version"`
 	MessageType       string     `mapstructure:"message_type"`
 	ResponseCondition string     `mapstructure:"response_condition"`
+	Placement         string     `mapstructure:"placement"`
 	CreatedAt         *time.Time `mapstructure:"created_at"`
 	UpdatedAt         *time.Time `mapstructure:"updated_at"`
 	DeletedAt         *time.Time `mapstructure:"deleted_at"`
@@ -179,6 +180,7 @@ type UpdateSyslogInput struct {
 	FormatVersion     uint         `form:"format_version,omitempty"`
 	MessageType       string       `form:"message_type,omitempty"`
 	ResponseCondition string       `form:"response_condition,omitempty"`
+	Placement         string       `form:"placement,omitempty"`
 }
 
 // UpdateSyslog updates a specific syslog.

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -582,10 +582,10 @@
 			"revisionTime": "2017-08-25T22:07:33Z"
 		},
 		{
-			"checksumSHA1": "nS4YWuLdoRejuuQJ0z/6iYmX/BE=",
+			"checksumSHA1": "VSwxQ4aSJCNf7VPkSw8LCRpBnXg=",
 			"path": "github.com/sethvargo/go-fastly/fastly",
-			"revision": "7d947bfd93efa873f3874f7c6c27331372a865a9",
-			"revisionTime": "2018-09-12T23:57:25Z"
+			"revision": "c9e8e74a07f00a96780a3de424fdc32293c5a757",
+			"revisionTime": "2018-12-08T16:52:00Z"
 		},
 		{
 			"checksumSHA1": "vE43s37+4CJ2CDU6TlOUOYE0K9c=",

--- a/website/docs/r/service_v1.html.markdown
+++ b/website/docs/r/service_v1.html.markdown
@@ -372,6 +372,7 @@ compressed. Default `0`.
 * `redundancy` - (Optional) The S3 redundancy level. Should be formatted; one of: `standard`, `reduced_redundancy` or null. Default `null`.
 * `response_condition` - (Optional) Name of already defined `condition` to apply. This `condition` must be of type `RESPONSE`. For detailed information about Conditionals,
 see [Fastly's Documentation on Conditionals][fastly-conditionals].
+* `placement` - (Optional) Where in the generated VCL the logging call should be placed; one of: `none` or `waf_debug`.
 
 The `papertrail` block supports:
 
@@ -381,6 +382,7 @@ The `papertrail` block supports:
 * `format` - (Optional) Apache-style string or VCL variables to use for log formatting. Defaults to Apache Common Log format (`%h %l %u %t %r %>s`)
 * `response_condition` - (Optional) Name of already defined `condition` to apply. This `condition` must be of type `RESPONSE`. For detailed information about Conditionals,
 see [Fastly's Documentation on Conditionals][fastly-conditionals].
+* `placement` - (Optional) Where in the generated VCL the logging call should be placed; one of: `none` or `waf_debug`.
 
 The `sumologic` block supports:
 
@@ -390,6 +392,7 @@ The `sumologic` block supports:
 * `format_version` - (Optional) The version of the custom logging format used for the configured endpoint. Can be either 1 (the default, version 1 log format) or 2 (the version 2 log format).
 * `response_condition` - (Optional) Name of already defined `condition` to apply. This `condition` must be of type `RESPONSE`. For detailed information about Conditionals, see [Fastly's Documentation on Conditionals][fastly-conditionals].
 * `message_type` - (Optional) How the message should be formatted; one of: `classic`, `loggly`, `logplex` or `blank`. Default `classic`. See [Fastly's Documentation on Sumologic][fastly-sumologic]
+* `placement` - (Optional) Where in the generated VCL the logging call should be placed; one of: `none` or `waf_debug`.
 
 The `gcslogging` block supports:
 
@@ -407,6 +410,7 @@ compressed. Default `0`.
 * `format` - (Optional) Apache-style string or VCL variables to use for log formatting. Defaults to Apache Common Log format (`%h %l %u %t %r %>s`)
 * `response_condition` - (Optional) Name of already defined `condition` to apply. This `condition` must be of type `RESPONSE`. For detailed information about Conditionals, see [Fastly's Documentation on Conditionals][fastly-conditionals].
 * `message_type` - (Optional) How the message should be formatted; one of: `classic`, `loggly`, `logplex` or `blank`. Default `classic`. [Fastly Documentation](https://docs.fastly.com/api/logging#logging_gcs)
+* `placement` - (Optional) Where in the generated VCL the logging call should be placed; one of: `none` or `waf_debug`.
 
 The `bigquerylogging` block supports:
 
@@ -419,6 +423,7 @@ The `bigquerylogging` block supports:
 * `format` - (Optional) Apache style log formatting. Must produce JSON that matches the schema of your BigQuery table.
 * `response_condition` - (Optional) Name of already defined `condition` to apply. This `condition` must be of type `RESPONSE`. For detailed information about Conditionals, see [Fastly's Documentation on Conditionals][fastly-conditionals].
 * `template` - (Optional) Big query table name suffix template. If set will be interpreted as a strftime compatible string and used as the [Template Suffix for your table](https://cloud.google.com/bigquery/streaming-data-into-bigquery#template-tables).
+* `placement` - (Optional) Where in the generated VCL the logging call should be placed; one of: `none` or `waf_debug`.
 
 The `syslog` block supports:
 
@@ -434,6 +439,7 @@ The `syslog` block supports:
 * `response_condition` - (Optional) Name of already defined `condition` to apply. This `condition` must be of type `RESPONSE`. For detailed information about Conditionals,
 see [Fastly's Documentation on Conditionals][fastly-conditionals].
 * `message_type` - (Optional) How the message should be formatted; one of: `classic`, `loggly`, `logplex` or `blank`.  Default `classic`.
+* `placement` - (Optional) Where in the generated VCL the logging call should be placed; one of: `none` or `waf_debug`.
 
 The `logentries` block supports:
 
@@ -444,6 +450,7 @@ The `logentries` block supports:
 * `format` - (Optional) Apache-style string or VCL variables to use for log formatting. Defaults to Apache Common Log format (`%h %l %u %t %r %>s`).
 * `format_version` - (Optional) The version of the custom logging format used for the configured endpoint. Can be either 1 (the default, version 1 log format) or 2 (the version 2 log format).
 * `response_condition` - (Optional) Name of already defined `condition` to apply. This `condition` must be of type `RESPONSE`. For detailed information about Conditionals, see [Fastly's Documentation on Conditionals][fastly-conditionals].
+* `placement` - (Optional) Where in the generated VCL the logging call should be placed; one of: `none` or `waf_debug`.
 
 
 The `response_object` block supports:


### PR DESCRIPTION
Currently, none of the logging providers support the `placement` field in order to be able to place the logging call in a specific VCL subroutine.

At the moment Fastly provides two different values for the `placement` field:

1. `none` - doesn't place the logging call in any VCL subroutine
2. `waf_debug` - places the logging call in the VCL `waf_debug_log` subroutine

There is already a [PR (#96)](https://github.com/terraform-providers/terraform-provider-fastly/pull/96) for adding the `placement` field to the logging providers. However, this one covers all providers and has better validation. Also, this one updates the docs with the proper descriptions.

The build is currently failing because `go-fastly` needs to be updated in order to support the `placement` field. For the work of [PR (#96)](https://github.com/terraform-providers/terraform-provider-fastly/pull/96) there have been already opened and merged two PRs:

1. [Added log placement support for integrations that were missing it #88](https://github.com/sethvargo/go-fastly/pull/88)
2. [Add log placement #89](https://github.com/sethvargo/go-fastly/pull/89)

The problem with these two PRs is that only the `response` struct or the `request` struct has been updated in order to accept the `placement` field. The PR [add placement field to all missing providers #92)](https://github.com/sethvargo/go-fastly/pull/92) for the `go-fastly` client adds the `placement` field to the remaining structs in order to pass the build.