### PR TITLE
skip any dynamic snippets in #flattenSnippets

### DIFF
--- a/fastly/resource_fastly_service_v1.go
+++ b/fastly/resource_fastly_service_v1.go
@@ -3757,6 +3757,11 @@ func buildSnippet(snippetMap interface{}) (*gofastly.CreateSnippetInput, error) 
 func flattenSnippets(snippetList []*gofastly.Snippet) []map[string]interface{} {
 	var sl []map[string]interface{}
 	for _, snippet := range snippetList {
+		// Skip dynamic snippets
+		if snippet.Dynamic == 1 {
+			continue
+		}
+
 		// Convert VCLs to a map for saving to state.
 		snippetMap := map[string]interface{}{
 			"name":     snippet.Name,


### PR DESCRIPTION
fix #98 

To fix this issue there is no need to add the `dynamic` field to the `snippet` schema like proposed in https://github.com/hynd/terraform-provider-fastly/commit/9bfd203b3be5989b70e2ebbe5f677248d3081ed9. It's only necessary to prevent adding `dynamic` snippets to the list of all snippets. That way `dynamic` snippets will be ignored if there are any changes in the pipeline.

I wanted to avoid having any references to `dynamic` snippets in the source code because the provider only supports `regular` snippets. This won't change until the Fastly API provides the `content` for `dynamic` snippets.