### PR TITLE
update list of exported attributes

### DIFF
--- a/website/docs/r/service_v1.html.markdown
+++ b/website/docs/r/service_v1.html.markdown
@@ -482,32 +482,10 @@ marked as the main block. Default is `false`.
 
 ## Attributes Reference
 
-The following attributes are exported:
+In addition to the arguments listed above, the following attributes are exported:
 
 * `id` – The ID of the Service.
 * `active_version` – The currently active version of your Fastly Service.
-* `backend` – Set of Backends. See above for details.
-* `bigquerylogging` – Set of Google BigQuery configurations. See above for details.
-* `cache_setting` – Set of Cache Setting configurations. See above for details.
-* `condition` – Set of Condition configurations. See above for details.
-* `default_host` – Default host specified.
-* `default_ttl` – Default TTL.
-* `director` – Set of Directors. See above for details.
-* `domain` – Set of Domains. See above for details.
-* `gcslogging` – Set of Google Cloud Storage configurations. See above for details.
-* `gzip` – Set of Gzip configurations. See above for details.
-* `header` – Set of Headers. See above for details.
-* `healthcheck` – Set of Health Check configurations. See above for details.
-* `logentries` – Set of Logentries configurations. See above for details.
-* `name` – Name of this service.
-* `papertrail` – Set of Papertrail configurations. See above for details.
-* `request_setting` – Set of Request Setting configurations. See above for details.
-* `response_object` – Set of Response Object configurations. See above for details.
-* `s3logging` – Set of S3 Logging configurations. See above for details.
-* `snippet` – Set of Snippet configurations. See above for details.
-* `sumologic` – Set of Sumologic configurations. See above for details.
-* `syslog` – Set of Syslog configurations. See above for details.
-* `vcl` – Set of custom VCL configurations. See above for details.
 
 [fastly-s3]: https://docs.fastly.com/guides/integrations/amazon-s3
 [fastly-cname]: https://docs.fastly.com/guides/basic-setup/adding-cname-records


### PR DESCRIPTION
Terraform automatically export all arguments as attributes. Therefore, the list should only contain the attributes which aren't listed in the arguments section. We should avoid duplicating the list of arguments in the list of attributes.