### PR TITLE
provider: Enable request/response logging

### DIFF
--- a/fastly/config.go
+++ b/fastly/config.go
@@ -3,6 +3,7 @@ package fastly
 import (
 	"fmt"
 
+	"github.com/hashicorp/terraform/helper/logging"
 	"github.com/hashicorp/terraform/terraform"
 	gofastly "github.com/sethvargo/go-fastly/fastly"
 )
@@ -25,12 +26,13 @@ func (c *Config) Client() (interface{}, error) {
 
 	gofastly.UserAgent = terraform.UserAgentString()
 
-	fconn, err := gofastly.NewClientForEndpoint(c.ApiKey, c.BaseURL)
-
+	fastlyClient, err := gofastly.NewClientForEndpoint(c.ApiKey, c.BaseURL)
 	if err != nil {
 		return nil, err
 	}
 
-	client.conn = fconn
+	fastlyClient.HTTPClient.Transport = logging.NewTransport("Fastly", fastlyClient.HTTPClient.Transport)
+
+	client.conn = fastlyClient
 	return &client, nil
 }


### PR DESCRIPTION
This will allow anyone to debug any potential provider issues more easily.

The exact same mechanism is already in use in number of other providers (e.g. GCP or GitHub).

Here's an example from log (when compiled with this patch):

```
2019-01-24T10:13:04.971Z [DEBUG] plugin.terraform-provider-fastly: 2019/01/24 10:13:04 [DEBUG] Fastly API Request Details:
2019-01-24T10:13:04.971Z [DEBUG] plugin.terraform-provider-fastly: ---[ REQUEST ]---------------------------------------
2019-01-24T10:13:04.972Z [DEBUG] plugin.terraform-provider-fastly: GET /service HTTP/1.1
2019-01-24T10:13:04.972Z [DEBUG] plugin.terraform-provider-fastly: Host: api.fastly.com
2019-01-24T10:13:04.972Z [DEBUG] plugin.terraform-provider-fastly: User-Agent: Terraform 0.10.0-dev (go1.11.4)
2019-01-24T10:13:04.972Z [DEBUG] plugin.terraform-provider-fastly: Fastly-Key: REDACTED
2019-01-24T10:13:04.972Z [DEBUG] plugin.terraform-provider-fastly: Accept-Encoding: gzip
2019-01-24T10:13:04.972Z [DEBUG] plugin.terraform-provider-fastly: 
2019-01-24T10:13:04.972Z [DEBUG] plugin.terraform-provider-fastly: 
2019-01-24T10:13:04.972Z [DEBUG] plugin.terraform-provider-fastly: -----------------------------------------------------
2019-01-24T10:13:05.585Z [DEBUG] plugin.terraform-provider-fastly: 2019/01/24 10:13:05 [DEBUG] Fastly API Response Details:
2019-01-24T10:13:05.585Z [DEBUG] plugin.terraform-provider-fastly: ---[ RESPONSE ]--------------------------------------
2019-01-24T10:13:05.585Z [DEBUG] plugin.terraform-provider-fastly: HTTP/2.0 200 OK
2019-01-24T10:13:05.585Z [DEBUG] plugin.terraform-provider-fastly: Accept-Ranges: bytes
2019-01-24T10:13:05.585Z [DEBUG] plugin.terraform-provider-fastly: Accept-Ranges: bytes
2019-01-24T10:13:05.585Z [DEBUG] plugin.terraform-provider-fastly: Accept-Ranges: bytes
2019-01-24T10:13:05.585Z [DEBUG] plugin.terraform-provider-fastly: Age: 0
2019-01-24T10:13:05.585Z [DEBUG] plugin.terraform-provider-fastly: Cache-Control: no-cache
2019-01-24T10:13:05.585Z [DEBUG] plugin.terraform-provider-fastly: Content-Type: application/json
2019-01-24T10:13:05.585Z [DEBUG] plugin.terraform-provider-fastly: Date: Thu, 24 Jan 2019 10:13:05 GMT
2019-01-24T10:13:05.585Z [DEBUG] plugin.terraform-provider-fastly: Status: 200 OK
2019-01-24T10:13:05.585Z [DEBUG] plugin.terraform-provider-fastly: Strict-Transport-Security: max-age=31536000
2019-01-24T10:13:05.585Z [DEBUG] plugin.terraform-provider-fastly: Vary: Accept-Encoding
2019-01-24T10:13:05.586Z [DEBUG] plugin.terraform-provider-fastly: Via: 1.1 varnish
2019-01-24T10:13:05.586Z [DEBUG] plugin.terraform-provider-fastly: Via: 1.1 varnish
2019-01-24T10:13:05.586Z [DEBUG] plugin.terraform-provider-fastly: X-Cache: MISS, MISS
2019-01-24T10:13:05.586Z [DEBUG] plugin.terraform-provider-fastly: X-Cache-Hits: 0, 0
2019-01-24T10:13:05.586Z [DEBUG] plugin.terraform-provider-fastly: X-Served-By: cache-control-slwdc9035-CONTROL-SLWDC, cache-lhr6336-LHR
2019-01-24T10:13:05.586Z [DEBUG] plugin.terraform-provider-fastly: X-Timer: S1548324785.316178,VS0,VE501
2019-01-24T10:13:05.586Z [DEBUG] plugin.terraform-provider-fastly: 
2019-01-24T10:13:05.586Z [DEBUG] plugin.terraform-provider-fastly: [{"version":1,"name":"demofastly","created_at":"2019-01-24T09:33:34Z","versions":[{"testing":false,"locked":false,"number":1,"active":false,"service_id":"5srJUOiwy7cUNt6KiqlRaC","staging":false,"created_at":"2019-01-24T09:33:34Z","deleted_at":null,"comment":"","updated_at":"2019-01-24T09:33:34Z","deployed":false}],"comment":"Managed by Terraform","customer_id":"lTexZLRvnZ9mVAhIwJqIs","updated_at":"2019-01-24T09:33:34Z","id":"5srJUOiwy7cUNt6KiqlRaC"}]
2019-01-24T10:13:05.586Z [DEBUG] plugin.terraform-provider-fastly: -----------------------------------------------------
```

Request headers may (will) contain the API key, but we generally expect sensitive data in the debug log and expect such log to be handled with caution.