### PR TITLE
Increase default health check interval

### DIFF
--- a/fastly/resource_fastly_service_v1.go
+++ b/fastly/resource_fastly_service_v1.go
@@ -141,7 +141,7 @@ func resourceServiceV1() *schema.Resource {
 						"check_interval": {
 							Type:        schema.TypeInt,
 							Optional:    true,
-							Default:     5000,
+							Default:     60000,
 							Description: "How often to run the healthcheck in milliseconds",
 						},
 						"expected_response": {


### PR DESCRIPTION
Health checks are run from every one of Fastly's ~60 POPs, so an interval if 5s results in 20/s for each POP, or roughly 1200 requests per minute. A more "sane" default would be once per minute.