### PR TITLE
Add support for service comment field

### DIFF
--- a/website/docs/r/service_v1.html.markdown
+++ b/website/docs/r/service_v1.html.markdown
@@ -164,6 +164,7 @@ The following arguments are supported:
 
 * `activate` - (Optional) Conditionally prevents the Service from being activated. The apply step will continue to create a new draft version but will not activate it if this is set to false. Default true.
 * `name` - (Required) The unique name for the Service to create.
+* `comment` - (Optional) Description field for the service. Default `Managed by Terraform`.
 * `domain` - (Required) A set of Domain names to serve as entry points for your
 Service. Defined below.
 * `backend` - (Optional) A set of Backends to service requests from your Domains.


### PR DESCRIPTION
This solves #70.

Acceptance tests:

```
=== RUN   TestAccFastlyServiceV1_updateDomain
--- PASS: TestAccFastlyServiceV1_updateDomain (68.71s)
=== RUN   TestAccFastlyServiceV1_updateBackend
--- PASS: TestAccFastlyServiceV1_updateBackend (74.12s)
=== RUN   TestAccFastlyServiceV1_updateInvalidBackend
--- PASS: TestAccFastlyServiceV1_updateInvalidBackend (37.48s)
=== RUN   TestAccFastlyServiceV1_basic
--- PASS: TestAccFastlyServiceV1_basic (73.70s)
=== RUN   TestAccFastlyServiceV1_disappears
--- PASS: TestAccFastlyServiceV1_disappears (16.65s)
=== RUN   TestAccFastlyServiceV1_defaultTTL
--- PASS: TestAccFastlyServiceV1_defaultTTL (110.87s)
``` 