### PR TITLE
Add support for version comment field

### DIFF
--- a/fastly/resource_fastly_service_v1.go
+++ b/fastly/resource_fastly_service_v1.go
@@ -33,6 +33,13 @@ func resourceServiceV1() *schema.Resource {
 				Description: "Unique name for this Service",
 			},
 
+			"comment": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Default:     "Managed by Terraform",
+				Description: "A personal freeform descriptive note",
+			},
+
 			// Active Version represents the currently activated version in Fastly. In
 			// Terraform, we abstract this number away from the users and manage
 			// creating and activating. It's used internally, but also exported for
@@ -1319,7 +1326,7 @@ func resourceServiceV1Create(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*FastlyClient).conn
 	service, err := conn.CreateService(&gofastly.CreateServiceInput{
 		Name:    d.Get("name").(string),
-		Comment: "Managed by Terraform",
+		Comment: d.Get("name").(string),
 	})
 
 	if err != nil {
@@ -1337,11 +1344,12 @@ func resourceServiceV1Update(d *schema.ResourceData, meta interface{}) error {
 
 	conn := meta.(*FastlyClient).conn
 
-	// Update Name. No new verions is required for this
-	if d.HasChange("name") {
+	// Update Name and/or Comment. No new verions is required for this
+	if d.HasChange("name") || d.HasChange("comment") {
 		_, err := conn.UpdateService(&gofastly.UpdateServiceInput{
-			ID:   d.Id(),
-			Name: d.Get("name").(string),
+			ID:      d.Id(),
+			Name:    d.Get("name").(string),
+			Comment: d.Get("comment").(string),
 		})
 		if err != nil {
 			return err
@@ -2711,6 +2719,7 @@ func resourceServiceV1Read(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	d.Set("name", s.Name)
+	d.Set("comment", s.Comment)
 	d.Set("active_version", s.ActiveVersion.Number)
 
 	// If CreateService succeeds, but initial updates to the Service fail, we'll

--- a/fastly/resource_fastly_service_v1_test.go
+++ b/fastly/resource_fastly_service_v1_test.go
@@ -245,7 +245,9 @@ func TestAccFastlyServiceV1_updateInvalidBackend(t *testing.T) {
 func TestAccFastlyServiceV1_basic(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
-	domainName := fmt.Sprintf("tf-acc-test-%s.com", acctest.RandString(10))
+	comment := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	domainName1 := fmt.Sprintf("tf-acc-test-%s.com", acctest.RandString(10))
+	domainName2 := fmt.Sprintf("tf-acc-test-%s.com", acctest.RandString(10))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -253,16 +255,36 @@ func TestAccFastlyServiceV1_basic(t *testing.T) {
 		CheckDestroy: testAccCheckServiceV1Destroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccServiceV1Config(name, domainName),
+				Config: testAccServiceV1Config(name, domainName1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
-					testAccCheckFastlyServiceV1Attributes(&service, name, []string{domainName}),
 					resource.TestCheckResourceAttr(
 						"fastly_service_v1.foo", "name", name),
+					resource.TestCheckResourceAttr(
+						"fastly_service_v1.foo", "comment", "Managed by Terraform"),
 					resource.TestCheckResourceAttr(
 						"fastly_service_v1.foo", "active_version", "1"),
 					resource.TestCheckResourceAttr(
 						"fastly_service_v1.foo", "domain.#", "1"),
+					resource.TestCheckResourceAttr(
+						"fastly_service_v1.foo", "backend.#", "1"),
+				),
+			},
+
+			{
+				Config: testAccServiceV1Config_basicUpdate(name, comment, domainName2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
+					resource.TestCheckResourceAttr(
+						"fastly_service_v1.foo", "name", name),
+					resource.TestCheckResourceAttr(
+						"fastly_service_v1.foo", "comment", comment),
+					resource.TestCheckResourceAttr(
+						"fastly_service_v1.foo", "active_version", "2"),
+					resource.TestCheckResourceAttr(
+						"fastly_service_v1.foo", "domain.#", "1"),
+					resource.TestCheckResourceAttr(
+						"fastly_service_v1.foo", "backend.#", "1"),
 				),
 			},
 		},
@@ -498,6 +520,26 @@ resource "fastly_service_v1" "foo" {
 
   force_destroy = true
 }`, name, domain)
+}
+
+func testAccServiceV1Config_basicUpdate(name, comment, domain string) string {
+	return fmt.Sprintf(`
+resource "fastly_service_v1" "foo" {
+  name    = "%s"
+  comment = "%s"
+
+  domain {
+    name    = "%s"
+    comment = "tf-testing-domain"
+  }
+
+  backend {
+    address = "aws.amazon.com"
+    name    = "amazon docs"
+  }
+
+  force_destroy = true
+}`, name, comment, domain)
 }
 
 func testAccServiceV1Config_domainUpdate(name, domain1, domain2 string) string {

--- a/fastly/resource_fastly_service_v1_test.go
+++ b/fastly/resource_fastly_service_v1_test.go
@@ -246,6 +246,7 @@ func TestAccFastlyServiceV1_basic(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	comment := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	version_comment := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	domainName1 := fmt.Sprintf("tf-acc-test-%s.com", acctest.RandString(10))
 	domainName2 := fmt.Sprintf("tf-acc-test-%s.com", acctest.RandString(10))
 
@@ -263,6 +264,8 @@ func TestAccFastlyServiceV1_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"fastly_service_v1.foo", "comment", "Managed by Terraform"),
 					resource.TestCheckResourceAttr(
+						"fastly_service_v1.foo", "version_comment", ""),
+					resource.TestCheckResourceAttr(
 						"fastly_service_v1.foo", "active_version", "1"),
 					resource.TestCheckResourceAttr(
 						"fastly_service_v1.foo", "domain.#", "1"),
@@ -272,13 +275,15 @@ func TestAccFastlyServiceV1_basic(t *testing.T) {
 			},
 
 			{
-				Config: testAccServiceV1Config_basicUpdate(name, comment, domainName2),
+				Config: testAccServiceV1Config_basicUpdate(name, comment, version_comment, domainName2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
 					resource.TestCheckResourceAttr(
 						"fastly_service_v1.foo", "name", name),
 					resource.TestCheckResourceAttr(
 						"fastly_service_v1.foo", "comment", comment),
+					resource.TestCheckResourceAttr(
+						"fastly_service_v1.foo", "version_comment", version_comment),
 					resource.TestCheckResourceAttr(
 						"fastly_service_v1.foo", "active_version", "2"),
 					resource.TestCheckResourceAttr(
@@ -522,11 +527,12 @@ resource "fastly_service_v1" "foo" {
 }`, name, domain)
 }
 
-func testAccServiceV1Config_basicUpdate(name, comment, domain string) string {
+func testAccServiceV1Config_basicUpdate(name, comment, version_comment, domain string) string {
 	return fmt.Sprintf(`
 resource "fastly_service_v1" "foo" {
-  name    = "%s"
-  comment = "%s"
+  name            = "%s"
+  comment         = "%s"
+  version_comment = "%s"
 
   domain {
     name    = "%s"
@@ -539,7 +545,7 @@ resource "fastly_service_v1" "foo" {
   }
 
   force_destroy = true
-}`, name, comment, domain)
+}`, name, comment, version_comment, domain)
 }
 
 func testAccServiceV1Config_domainUpdate(name, domain1, domain2 string) string {

--- a/website/docs/r/service_v1.html.markdown
+++ b/website/docs/r/service_v1.html.markdown
@@ -164,6 +164,7 @@ The following arguments are supported:
 
 * `activate` - (Optional) Conditionally prevents the Service from being activated. The apply step will continue to create a new draft version but will not activate it if this is set to false. Default true.
 * `name` - (Required) The unique name for the Service to create.
+* `comment` - (Optional) Description field for the service. Default `Managed by Terraform`.
 * `domain` - (Required) A set of Domain names to serve as entry points for your
 Service. Defined below.
 * `backend` - (Optional) A set of Backends to service requests from your Domains.

--- a/website/docs/r/service_v1.html.markdown
+++ b/website/docs/r/service_v1.html.markdown
@@ -165,6 +165,7 @@ The following arguments are supported:
 * `activate` - (Optional) Conditionally prevents the Service from being activated. The apply step will continue to create a new draft version but will not activate it if this is set to false. Default true.
 * `name` - (Required) The unique name for the Service to create.
 * `comment` - (Optional) Description field for the service. Default `Managed by Terraform`.
+* `version_comment` - (Optional) Description field for the version.
 * `domain` - (Required) A set of Domain names to serve as entry points for your
 Service. Defined below.
 * `backend` - (Optional) A set of Backends to service requests from your Domains.


### PR DESCRIPTION
This solves #126.

Acceptance tests:

```
=== RUN   TestAccFastlyServiceV1_updateDomain
--- PASS: TestAccFastlyServiceV1_updateDomain (87.91s)
=== RUN   TestAccFastlyServiceV1_updateBackend
--- PASS: TestAccFastlyServiceV1_updateBackend (89.50s)
=== RUN   TestAccFastlyServiceV1_updateInvalidBackend
--- PASS: TestAccFastlyServiceV1_updateInvalidBackend (45.57s)
=== RUN   TestAccFastlyServiceV1_basic
--- PASS: TestAccFastlyServiceV1_basic (89.08s)
=== RUN   TestAccFastlyServiceV1_disappears
--- PASS: TestAccFastlyServiceV1_disappears (18.04s)
=== RUN   TestAccFastlyServiceV1_defaultTTL
--- PASS: TestAccFastlyServiceV1_defaultTTL (132.99s)
```