### PR TITLE
Return full string content for VCL state

### DIFF
--- a/fastly/resource_fastly_service_v1.go
+++ b/fastly/resource_fastly_service_v1.go
@@ -1239,8 +1239,7 @@ func resourceServiceV1() *schema.Resource {
 							StateFunc: func(v interface{}) string {
 								switch v.(type) {
 								case string:
-									hash := sha1.Sum([]byte(v.(string)))
-									return hex.EncodeToString(hash[:])
+									return v.(string)
 								default:
 									return ""
 								}


### PR DESCRIPTION
When comparing vcl after import, only the checksum of the file would be printed. This allows for comparing the full content of the VCL. 

Closes #140.

Another resolution would have been to use the SHA on import but this prevents accurate comparison of the differences upon applying. 