### PR TITLE
Add support for splunk logging

### DIFF
--- a/fastly/resource_fastly_service_v1.go
+++ b/fastly/resource_fastly_service_v1.go
@@ -1069,6 +1069,67 @@ func resourceServiceV1() *schema.Resource {
 				},
 			},
 
+			"splunk": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						// Required fields
+						"name": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "The unique name of the Splunk logging endpoint",
+						},
+						"url": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "The Splunk URL to stream logs to",
+						},
+						"token": {
+							Type:        schema.TypeString,
+							Required:    true,
+							DefaultFunc: schema.EnvDefaultFunc("FASTLY_SPLUNK_TOKEN", ""),
+							Description: "The Splunk token to be used for authentication",
+							Sensitive:   true,
+							StateFunc: func(v interface{}) string {
+								switch v.(type) {
+								case string:
+									hash := sha512.Sum512([]byte(v.(string)))
+									return hex.EncodeToString(hash[:])
+								default:
+									return ""
+								}
+							},
+						},
+						// Optional fields
+						"format": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Default:     "%h %l %u %t \"%r\" %>s %b",
+							Description: "Apache-style string or VCL variables to use for log formatting (default: `%h %l %u %t \"%r\" %>s %b`)",
+						},
+						"format_version": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							Default:      2,
+							Description:  "The version of the custom logging format used for the configured endpoint. Can be either 1 or 2. (default: 2)",
+							ValidateFunc: validateLoggingFormatVersion(),
+						},
+						"placement": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							Description:  "Where in the generated VCL the logging call should be placed",
+							ValidateFunc: validateLoggingPlacement(),
+						},
+						"response_condition": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "The name of the condition to apply",
+						},
+					},
+				},
+			},
+
 			"response_object": {
 				Type:     schema.TypeSet,
 				Optional: true,
@@ -1329,6 +1390,7 @@ func resourceServiceV1Update(d *schema.ResourceData, meta interface{}) error {
 		"syslog",
 		"sumologic",
 		"logentries",
+		"splunk",
 		"response_object",
 		"condition",
 		"request_setting",
@@ -2313,6 +2375,65 @@ func resourceServiceV1Update(d *schema.ResourceData, meta interface{}) error {
 			}
 		}
 
+		// find difference in Splunk logging configurations
+		if d.HasChange("splunk") {
+			os, ns := d.GetChange("splunk")
+			if os == nil {
+				os = new(schema.Set)
+			}
+			if ns == nil {
+				ns = new(schema.Set)
+			}
+
+			oss := os.(*schema.Set)
+			nss := ns.(*schema.Set)
+
+			remove := oss.Difference(nss).List()
+			add := nss.Difference(oss).List()
+
+			// DELETE old Splunk logging configurations
+			for _, sRaw := range remove {
+				sf := sRaw.(map[string]interface{})
+				opts := gofastly.DeleteSplunkInput{
+					Service: d.Id(),
+					Version: latestVersion,
+					Name:    sf["name"].(string),
+				}
+
+				log.Printf("[DEBUG] Splunk removal opts: %#v", opts)
+				err := conn.DeleteSplunk(&opts)
+				if errRes, ok := err.(*gofastly.HTTPError); ok {
+					if errRes.StatusCode != 404 {
+						return err
+					}
+				} else if err != nil {
+					return err
+				}
+			}
+
+			// POST new/updated Splunk configurations
+			for _, sRaw := range add {
+				sf := sRaw.(map[string]interface{})
+				opts := gofastly.CreateSplunkInput{
+					Service:           d.Id(),
+					Version:           latestVersion,
+					Name:              sf["name"].(string),
+					URL:               sf["url"].(string),
+					Format:            sf["format"].(string),
+					FormatVersion:     uint(sf["format_version"].(int)),
+					ResponseCondition: sf["response_condition"].(string),
+					Placement:         sf["placement"].(string),
+					Token:             sf["token"].(string),
+				}
+
+				log.Printf("[DEBUG] Splunk create opts: %#v", opts)
+				_, err := conn.CreateSplunk(&opts)
+				if err != nil {
+					return err
+				}
+			}
+		}
+
 		// find difference in Response Object
 		if d.HasChange("response_object") {
 			or, nr := d.GetChange("response_object")
@@ -2924,6 +3045,23 @@ func resourceServiceV1Read(d *schema.ResourceData, meta interface{}) error {
 
 		if err := d.Set("logentries", lel); err != nil {
 			log.Printf("[WARN] Error setting Logentries for (%s): %s", d.Id(), err)
+		}
+
+		// refresh Splunk Logging
+		log.Printf("[DEBUG] Refreshing Splunks for (%s)", d.Id())
+		splunkList, err := conn.ListSplunks(&gofastly.ListSplunksInput{
+			Service: d.Id(),
+			Version: s.ActiveVersion.Number,
+		})
+
+		if err != nil {
+			return fmt.Errorf("[ERR] Error looking up Splunks for (%s), version (%v): %s", d.Id(), s.ActiveVersion.Number, err)
+		}
+
+		spl := flattenSplunks(splunkList)
+
+		if err := d.Set("splunk", spl); err != nil {
+			log.Printf("[WARN] Error setting Splunks for (%s): %s", d.Id(), err)
 		}
 
 		// refresh Response Objects
@@ -3577,6 +3715,33 @@ func flattenLogentries(logentriesList []*gofastly.Logentries) []map[string]inter
 	}
 
 	return LEList
+}
+
+func flattenSplunks(splunkList []*gofastly.Splunk) []map[string]interface{} {
+	var sl []map[string]interface{}
+	for _, s := range splunkList {
+		// Convert Splunk to a map for saving to state.
+		nbs := map[string]interface{}{
+			"name":               s.Name,
+			"url":                s.URL,
+			"format":             s.Format,
+			"format_version":     s.FormatVersion,
+			"response_condition": s.ResponseCondition,
+			"placement":          s.Placement,
+			"token":              s.Token,
+		}
+
+		// prune any empty values that come from the default string value in structs
+		for k, v := range nbs {
+			if v == "" {
+				delete(nbs, k)
+			}
+		}
+
+		sl = append(sl, nbs)
+	}
+
+	return sl
 }
 
 func flattenResponseObjects(responseObjectList []*gofastly.ResponseObject) []map[string]interface{} {

--- a/fastly/resource_fastly_service_v1_splunk_test.go
+++ b/fastly/resource_fastly_service_v1_splunk_test.go
@@ -1,0 +1,404 @@
+package fastly
+
+import (
+	"fmt"
+	"os"
+	"reflect"
+	"testing"
+
+	gofastly "github.com/fastly/go-fastly/fastly"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestResourceFastlyFlattenSplunk(t *testing.T) {
+	cases := []struct {
+		remote []*gofastly.Splunk
+		local  []map[string]interface{}
+	}{
+		{
+			remote: []*gofastly.Splunk{
+				{
+					Name:              "test-splunk",
+					URL:               "https://mysplunkendpoint.example.com/services/collector/event",
+					Format:            "%h %l %u %t \"%r\" %>s %b",
+					FormatVersion:     1,
+					ResponseCondition: "error_response",
+					Placement:         "waf_debug",
+					Token:             "test-token",
+				},
+			},
+			local: []map[string]interface{}{
+				{
+					"name":               "test-splunk",
+					"url":                "https://mysplunkendpoint.example.com/services/collector/event",
+					"format":             "%h %l %u %t \"%r\" %>s %b",
+					"format_version":     uint(1),
+					"response_condition": "error_response",
+					"placement":          "waf_debug",
+					"token":              "test-token",
+				},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		out := flattenSplunks(c.remote)
+		if !reflect.DeepEqual(out, c.local) {
+			t.Fatalf("Error matching:\nexpected: %#v\ngot: %#v", c.local, out)
+		}
+	}
+}
+
+func TestAccFastlyServiceV1_splunk_basic(t *testing.T) {
+	var service gofastly.ServiceDetail
+	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+
+	splunkLogOne := gofastly.Splunk{
+		Name:              "test-splunk-1",
+		URL:               "https://mysplunkendpoint.example.com/services/collector/event",
+		Token:             "test-token",
+		Format:            "%h %l %u %t \"%r\" %>s %b",
+		FormatVersion:     1,
+		Placement:         "waf_debug",
+		ResponseCondition: "error_response_5XX",
+	}
+
+	splunkLogOneUpdated := gofastly.Splunk{
+		Name:              "test-splunk-1",
+		URL:               "https://mysplunkendpoint.example.com/services/collector/event",
+		Token:             "test-token",
+		Format:            "%h %l %u %{now}V %{req.method}V %{req.url}V %>s %{resp.http.Content-Length}V",
+		FormatVersion:     2,
+		Placement:         "waf_debug",
+		ResponseCondition: "error_response_5XX",
+	}
+
+	splunkLogTwo := gofastly.Splunk{
+		Name:              "test-splunk-2",
+		URL:               "https://mysplunkendpoint.example.com/services/collector/event",
+		Token:             "test-token",
+		Format:            "%h %l %u %{now}V %{req.method}V %{req.url}V %>s %{resp.http.Content-Length}V",
+		FormatVersion:     2,
+		Placement:         "waf_debug",
+		ResponseCondition: "ok_response_2XX",
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckServiceV1Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServiceV1SplunkConfig_complete(serviceName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
+					testAccCheckFastlyServiceV1SplunkAttributes(&service, []*gofastly.Splunk{&splunkLogOne}),
+					resource.TestCheckResourceAttr(
+						"fastly_service_v1.foo", "name", serviceName),
+					resource.TestCheckResourceAttr(
+						"fastly_service_v1.foo", "splunk.#", "1"),
+				),
+			},
+
+			{
+				Config: testAccServiceV1SplunkConfig_update(serviceName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
+					testAccCheckFastlyServiceV1SplunkAttributes(&service, []*gofastly.Splunk{&splunkLogOneUpdated, &splunkLogTwo}),
+					resource.TestCheckResourceAttr(
+						"fastly_service_v1.foo", "name", serviceName),
+					resource.TestCheckResourceAttr(
+						"fastly_service_v1.foo", "splunk.#", "2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccFastlyServiceV1_splunk_default(t *testing.T) {
+	var service gofastly.ServiceDetail
+	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+
+	splunkLog := gofastly.Splunk{
+		Name:          "test-splunk",
+		URL:           "https://mysplunkendpoint.example.com/services/collector/event",
+		Token:         "test-token",
+		Format:        "%h %l %u %t \"%r\" %>s %b",
+		FormatVersion: 2,
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckServiceV1Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServiceV1SplunkConfig_default(serviceName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
+					testAccCheckFastlyServiceV1SplunkAttributes(&service, []*gofastly.Splunk{&splunkLog}),
+					resource.TestCheckResourceAttr(
+						"fastly_service_v1.foo", "name", serviceName),
+					resource.TestCheckResourceAttr(
+						"fastly_service_v1.foo", "splunk.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccFastlyServiceV1_splunk_env(t *testing.T) {
+	var service gofastly.ServiceDetail
+	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+
+	// set env variable to something we expect
+	resetEnv := setSplunkEnv("test-token", t)
+	defer resetEnv()
+
+	splunkLog := gofastly.Splunk{
+		Name:          "test-splunk",
+		URL:           "https://mysplunkendpoint.example.com/services/collector/event",
+		Token:         "test-token",
+		Format:        "%h %l %u %t \"%r\" %>s %b",
+		FormatVersion: 2,
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckServiceV1Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServiceV1SplunkConfig_env(serviceName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
+					testAccCheckFastlyServiceV1SplunkAttributes(&service, []*gofastly.Splunk{&splunkLog}),
+					resource.TestCheckResourceAttr(
+						"fastly_service_v1.foo", "name", serviceName),
+					resource.TestCheckResourceAttr(
+						"fastly_service_v1.foo", "splunk.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckFastlyServiceV1SplunkAttributes(service *gofastly.ServiceDetail, localSplunkList []*gofastly.Splunk) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+
+		conn := testAccProvider.Meta().(*FastlyClient).conn
+		remoteSplunkList, err := conn.ListSplunks(&gofastly.ListSplunksInput{
+			Service: service.ID,
+			Version: service.ActiveVersion.Number,
+		})
+
+		if err != nil {
+			return fmt.Errorf("[ERR] Error looking up Splunk for (%s), version (%v): %s", service.Name, service.ActiveVersion.Number, err)
+		}
+
+		if len(remoteSplunkList) != len(localSplunkList) {
+			return fmt.Errorf("Splunk List count mismatch, expected (%d), got (%d)", len(localSplunkList), len(remoteSplunkList))
+		}
+
+		var found int
+		for _, ls := range localSplunkList {
+			for _, rs := range remoteSplunkList {
+				if ls.Name == rs.Name {
+					// we don't know these things ahead of time, so populate them now
+					ls.ServiceID = service.ID
+					ls.Version = service.ActiveVersion.Number
+					// We don't track these, so clear them out because we also wont know
+					// these ahead of time
+					rs.CreatedAt = nil
+					rs.UpdatedAt = nil
+					if !reflect.DeepEqual(ls, rs) {
+						return fmt.Errorf("Bad match Splunk logging match, expected (%#v), got (%#v)", ls, rs)
+					}
+					found++
+				}
+			}
+		}
+
+		if found != len(localSplunkList) {
+			return fmt.Errorf("Error matching Splunk rules")
+		}
+
+		return nil
+	}
+}
+
+func testAccServiceV1SplunkConfig_complete(serviceName string) string {
+	domainName := fmt.Sprintf("fastly-test.tf-%s.com", acctest.RandString(10))
+
+	return fmt.Sprintf(`
+resource "fastly_service_v1" "foo" {
+  name = "%s"
+
+  domain {
+    name    = "%s"
+    comment = "tf-testing-domain"
+  }
+
+  backend {
+    address = "aws.amazon.com"
+    name    = "tf-test-backend"
+  }
+
+  condition {
+    name      = "error_response_5XX"
+    statement = "resp.status >= 500 && resp.status < 600"
+    priority  = 10
+    type      = "RESPONSE"
+  }
+
+  splunk {
+    name               = "test-splunk-1"
+    url                = "https://mysplunkendpoint.example.com/services/collector/event"
+    token              = "test-token"
+    format             = "%%h %%l %%u %%t \"%%r\" %%>s %%b"
+    format_version     = 1
+    placement          = "waf_debug"
+    response_condition = "error_response_5XX"
+  }
+
+  force_destroy = true
+}`, serviceName, domainName)
+}
+
+func testAccServiceV1SplunkConfig_update(serviceName string) string {
+	domainName := fmt.Sprintf("fastly-test.tf-%s.com", acctest.RandString(10))
+
+	return fmt.Sprintf(`
+resource "fastly_service_v1" "foo" {
+  name = "%s"
+
+  domain {
+    name    = "%s"
+    comment = "tf-testing-domain"
+  }
+
+  backend {
+    address = "aws.amazon.com"
+    name    = "tf-test-backend"
+  }
+
+  condition {
+    name      = "error_response_5XX"
+    statement = "resp.status >= 500 && resp.status < 600"
+    priority  = 10
+    type      = "RESPONSE"
+  }
+
+  condition {
+    name      = "ok_response_2XX"
+    statement = "resp.status >= 200 && resp.status < 300"
+    priority  = 10
+    type      = "RESPONSE"
+  }
+
+  splunk {
+    name               = "test-splunk-1"
+    url                = "https://mysplunkendpoint.example.com/services/collector/event"
+    token              = "test-token"
+    format             = "%%h %%l %%u %%{now}V %%{req.method}V %%{req.url}V %%>s %%{resp.http.Content-Length}V"
+    format_version     = 2
+    placement          = "waf_debug"
+    response_condition = "error_response_5XX"
+  }
+
+  splunk {
+    name               = "test-splunk-2"
+    url                = "https://mysplunkendpoint.example.com/services/collector/event"
+    token              = "test-token"
+    format             = "%%h %%l %%u %%{now}V %%{req.method}V %%{req.url}V %%>s %%{resp.http.Content-Length}V"
+    format_version     = 2
+    placement          = "waf_debug"
+    response_condition = "ok_response_2XX"
+  }
+
+  force_destroy = true
+}`, serviceName, domainName)
+}
+
+func testAccServiceV1SplunkConfig_default(serviceName string) string {
+	domainName := fmt.Sprintf("fastly-test.tf-%s.com", acctest.RandString(10))
+
+	return fmt.Sprintf(`
+resource "fastly_service_v1" "foo" {
+  name = "%s"
+
+  domain {
+    name    = "%s"
+    comment = "tf-testing-domain"
+  }
+
+  backend {
+    address = "aws.amazon.com"
+    name    = "tf-test-backend"
+  }
+
+  splunk {
+    name  = "test-splunk"
+    url   = "https://mysplunkendpoint.example.com/services/collector/event"
+    token = "test-token"
+  }
+
+  force_destroy = true
+}`, serviceName, domainName)
+}
+
+func testAccServiceV1SplunkConfig_env(serviceName string) string {
+	domainName := fmt.Sprintf("fastly-test.tf-%s.com", acctest.RandString(10))
+
+	return fmt.Sprintf(`
+resource "fastly_service_v1" "foo" {
+  name = "%s"
+
+  domain {
+    name    = "%s"
+    comment = "tf-testing-domain"
+  }
+
+  backend {
+    address = "aws.amazon.com"
+    name    = "tf-test-backend"
+  }
+
+  splunk {
+    name = "test-splunk"
+    url  = "https://mysplunkendpoint.example.com/services/collector/event"
+  }
+
+  force_destroy = true
+}`, serviceName, domainName)
+}
+
+func setSplunkEnv(token string, t *testing.T) func() {
+	e := getSplunkEnv()
+	// Set all the envs to a dummy value
+	if err := os.Setenv("FASTLY_SPLUNK_TOKEN", token); err != nil {
+		t.Fatalf("Error setting env var FASTLY_SPLUNK_TOKEN: %s", err)
+	}
+
+	return func() {
+		// re-set all the envs we unset above
+		if err := os.Setenv("FASTLY_SPLUNK_TOKEN", e.Token); err != nil {
+			t.Fatalf("Error resetting env var FASTLY_SPLUNK_TOKEN: %s", err)
+		}
+	}
+}
+
+// struct to preserve the current environment
+type currentSplunkEnv struct {
+	Token string
+}
+
+func getSplunkEnv() *currentSplunkEnv {
+	// Grab the existing Fastly Splunk token and preserve, in the off chance
+	// they're actually set in the enviornment
+	return &currentSplunkEnv{
+		Token: os.Getenv("FASTLY_SPLUNK_TOKEN"),
+	}
+}

--- a/website/docs/r/service_v1.html.markdown
+++ b/website/docs/r/service_v1.html.markdown
@@ -199,6 +199,8 @@ Defined below.
 Defined below.
 * `logentries` - (Optional) A logentries endpoint to send streaming logs too.
 Defined below.
+* `splunk` - (Optional) A Splunk endpoint to send streaming logs too.
+Defined below.
 * `response_object` - (Optional) Allows you to create synthetic responses that exist entirely on the varnish machine. Useful for creating error or maintenance pages that exists outside the scope of your datacenter. Best when used with Condition objects.
 * `snippet` - (Optional) A set of custom, "regular" (non-dynamic) VCL Snippet configuration blocks.  Defined below.
 * `vcl` - (Optional) A set of custom VCL configuration blocks. The
@@ -453,6 +455,15 @@ The `logentries` block supports:
 * `response_condition` - (Optional) Name of already defined `condition` to apply. This `condition` must be of type `RESPONSE`. For detailed information about Conditionals, see [Fastly's Documentation on Conditionals][fastly-conditionals].
 * `placement` - (Optional) Where in the generated VCL the logging call should be placed; one of: `none` or `waf_debug`.
 
+The `splunk` block supports:
+
+* `name` - (Required) A unique name to identify the Splunk endpoint.
+* `url` - (Required) The Splunk URL to stream logs to.
+* `token` - (Required) The Splunk token to be used for authentication.
+* `format` - (Optional) Apache-style string or VCL variables to use for log formatting. Default `%h %l %u %t \"%r\" %>s %b`.
+* `format_version` - (Optional) The version of the custom logging format used for the configured endpoint. Can be either `1` or `2`. The logging call gets placed by default in `vcl_log` if `format_version` is set to `2` and in `vcl_deliver` if `format_version` is set to `1`. Default `2`.
+* `placement` - (Optional) Where in the generated VCL the logging call should be placed, overriding any `format_version` default. Can be either `none` or `waf_debug`.
+* `response_condition` - (Optional) The name of the `condition` to apply. If empty, always execute.
 
 The `response_object` block supports:
 


### PR DESCRIPTION
Closes #130.

Acceptance tests:

```
=== RUN   TestResourceFastlyFlattenSplunk
--- PASS: TestResourceFastlyFlattenSplunk (0.00s)
=== RUN   TestAccFastlyServiceV1_splunk_basic
--- PASS: TestAccFastlyServiceV1_splunk_basic (90.82s)
=== RUN   TestAccFastlyServiceV1_splunk_default
--- PASS: TestAccFastlyServiceV1_splunk_default (46.54s)
=== RUN   TestAccFastlyServiceV1_splunk_env
--- PASS: TestAccFastlyServiceV1_splunk_env (47.41s)
```