### PR TITLE
Document s3logging `bucket_name` as required

### DIFF
--- a/website/docs/r/service_v1.html.markdown
+++ b/website/docs/r/service_v1.html.markdown
@@ -348,7 +348,7 @@ Fastly-Geo-Region into the request headers.
 The `s3logging` block supports:
 
 * `name` - (Required) A unique name to identify this S3 Logging Bucket.
-* `bucket_name` - (Optional) An optional comment about the Domain.
+* `bucket_name` - (Required) The name of the bucket in which to store the logs.
 * `s3_access_key` - (Required) AWS Access Key of an account with the required
 permissions to post logs. It is **strongly** recommended you create a separate
 IAM user with permissions to only operate on this Bucket. This key will be


### PR DESCRIPTION
`Error: fastly_service_v1.abcd: "s3logging.0.bucket_name": required field is not set`

Mark as required in docs, and update description from Fastly UI.

marked as required here: https://github.com/terraform-providers/terraform-provider-fastly/blob/522875e9e85677e96cb443b9308f08650b5db2b0/fastly/resource_fastly_service_v1.go#L606