### PR TITLE
Add validation for condition type attribute

### DIFF
--- a/fastly/resource_fastly_service_v1.go
+++ b/fastly/resource_fastly_service_v1.go
@@ -94,9 +94,10 @@ func resourceServiceV1() *schema.Resource {
 							Description: "A number used to determine the order in which multiple conditions execute. Lower numbers execute first",
 						},
 						"type": {
-							Type:        schema.TypeString,
-							Required:    true,
-							Description: "Type of the condition, either `REQUEST`, `RESPONSE`, or `CACHE`",
+							Type:         schema.TypeString,
+							Required:     true,
+							Description:  "Type of the condition, either `REQUEST`, `RESPONSE`, or `CACHE`",
+							ValidateFunc: validateConditionType(),
 						},
 					},
 				},

--- a/fastly/validators.go
+++ b/fastly/validators.go
@@ -1,6 +1,11 @@
 package fastly
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
+)
 
 func validateLoggingFormatVersion(v interface{}, k string) (ws []string, errors []error) {
 	value := uint(v.(int))
@@ -59,4 +64,12 @@ func validateDirectorType(v interface{}, k string) (ws []string, errors []error)
 			"%q must be one of ['1' (random), '3' (hash), '4' (client)]", k))
 	}
 	return
+}
+
+func validateConditionType() schema.SchemaValidateFunc {
+	return validation.StringInSlice([]string{
+		"REQUEST",
+		"RESPONSE",
+		"CACHE",
+	}, false)
 }

--- a/fastly/validators_test.go
+++ b/fastly/validators_test.go
@@ -105,3 +105,28 @@ func TestValidateDirectorType(t *testing.T) {
 		}
 	}
 }
+
+func TestValidateConditionType(t *testing.T) {
+	for _, ctvt := range []struct {
+		value          string
+		expectedWarns  int
+		expectedErrors int
+	}{
+		{"REQUEST", 0, 0},
+		{"RESPONSE", 0, 0},
+		{"CACHE", 0, 0},
+		{"request", 0, 1},
+		{"response", 0, 1},
+		{"cache", 0, 1},
+	} {
+		t.Run(ctvt.value, func(t *testing.T) {
+			actualWarns, actualErrors := validateConditionType()(ctvt.value, "type")
+			if len(actualWarns) != ctvt.expectedWarns {
+				t.Errorf("expected %d warnings, actual %d ", ctvt.expectedWarns, len(actualWarns))
+			}
+			if len(actualErrors) != ctvt.expectedErrors {
+				t.Errorf("expected %d errors, actual %d ", ctvt.expectedErrors, len(actualErrors))
+			}
+		})
+	}
+}

--- a/vendor/github.com/hashicorp/terraform/helper/structure/expand_json.go
+++ b/vendor/github.com/hashicorp/terraform/helper/structure/expand_json.go
@@ -1,0 +1,11 @@
+package structure
+
+import "encoding/json"
+
+func ExpandJsonFromString(jsonString string) (map[string]interface{}, error) {
+	var result map[string]interface{}
+
+	err := json.Unmarshal([]byte(jsonString), &result)
+
+	return result, err
+}

--- a/vendor/github.com/hashicorp/terraform/helper/structure/flatten_json.go
+++ b/vendor/github.com/hashicorp/terraform/helper/structure/flatten_json.go
@@ -1,0 +1,16 @@
+package structure
+
+import "encoding/json"
+
+func FlattenJsonToString(input map[string]interface{}) (string, error) {
+	if len(input) == 0 {
+		return "", nil
+	}
+
+	result, err := json.Marshal(input)
+	if err != nil {
+		return "", err
+	}
+
+	return string(result), nil
+}

--- a/vendor/github.com/hashicorp/terraform/helper/structure/normalize_json.go
+++ b/vendor/github.com/hashicorp/terraform/helper/structure/normalize_json.go
@@ -1,0 +1,24 @@
+package structure
+
+import "encoding/json"
+
+// Takes a value containing JSON string and passes it through
+// the JSON parser to normalize it, returns either a parsing
+// error or normalized JSON string.
+func NormalizeJsonString(jsonString interface{}) (string, error) {
+	var j interface{}
+
+	if jsonString == nil || jsonString.(string) == "" {
+		return "", nil
+	}
+
+	s := jsonString.(string)
+
+	err := json.Unmarshal([]byte(s), &j)
+	if err != nil {
+		return s, err
+	}
+
+	bytes, _ := json.Marshal(j)
+	return string(bytes[:]), nil
+}

--- a/vendor/github.com/hashicorp/terraform/helper/structure/suppress_json_diff.go
+++ b/vendor/github.com/hashicorp/terraform/helper/structure/suppress_json_diff.go
@@ -1,0 +1,21 @@
+package structure
+
+import (
+	"reflect"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func SuppressJsonDiff(k, old, new string, d *schema.ResourceData) bool {
+	oldMap, err := ExpandJsonFromString(old)
+	if err != nil {
+		return false
+	}
+
+	newMap, err := ExpandJsonFromString(new)
+	if err != nil {
+		return false
+	}
+
+	return reflect.DeepEqual(oldMap, newMap)
+}

--- a/vendor/github.com/hashicorp/terraform/helper/validation/validation.go
+++ b/vendor/github.com/hashicorp/terraform/helper/validation/validation.go
@@ -1,0 +1,322 @@
+package validation
+
+import (
+	"bytes"
+	"fmt"
+	"net"
+	"reflect"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/structure"
+)
+
+// All returns a SchemaValidateFunc which tests if the provided value
+// passes all provided SchemaValidateFunc
+func All(validators ...schema.SchemaValidateFunc) schema.SchemaValidateFunc {
+	return func(i interface{}, k string) ([]string, []error) {
+		var allErrors []error
+		var allWarnings []string
+		for _, validator := range validators {
+			validatorWarnings, validatorErrors := validator(i, k)
+			allWarnings = append(allWarnings, validatorWarnings...)
+			allErrors = append(allErrors, validatorErrors...)
+		}
+		return allWarnings, allErrors
+	}
+}
+
+// Any returns a SchemaValidateFunc which tests if the provided value
+// passes any of the provided SchemaValidateFunc
+func Any(validators ...schema.SchemaValidateFunc) schema.SchemaValidateFunc {
+	return func(i interface{}, k string) ([]string, []error) {
+		var allErrors []error
+		var allWarnings []string
+		for _, validator := range validators {
+			validatorWarnings, validatorErrors := validator(i, k)
+			if len(validatorWarnings) == 0 && len(validatorErrors) == 0 {
+				return []string{}, []error{}
+			}
+			allWarnings = append(allWarnings, validatorWarnings...)
+			allErrors = append(allErrors, validatorErrors...)
+		}
+		return allWarnings, allErrors
+	}
+}
+
+// IntBetween returns a SchemaValidateFunc which tests if the provided value
+// is of type int and is between min and max (inclusive)
+func IntBetween(min, max int) schema.SchemaValidateFunc {
+	return func(i interface{}, k string) (s []string, es []error) {
+		v, ok := i.(int)
+		if !ok {
+			es = append(es, fmt.Errorf("expected type of %s to be int", k))
+			return
+		}
+
+		if v < min || v > max {
+			es = append(es, fmt.Errorf("expected %s to be in the range (%d - %d), got %d", k, min, max, v))
+			return
+		}
+
+		return
+	}
+}
+
+// IntAtLeast returns a SchemaValidateFunc which tests if the provided value
+// is of type int and is at least min (inclusive)
+func IntAtLeast(min int) schema.SchemaValidateFunc {
+	return func(i interface{}, k string) (s []string, es []error) {
+		v, ok := i.(int)
+		if !ok {
+			es = append(es, fmt.Errorf("expected type of %s to be int", k))
+			return
+		}
+
+		if v < min {
+			es = append(es, fmt.Errorf("expected %s to be at least (%d), got %d", k, min, v))
+			return
+		}
+
+		return
+	}
+}
+
+// IntAtMost returns a SchemaValidateFunc which tests if the provided value
+// is of type int and is at most max (inclusive)
+func IntAtMost(max int) schema.SchemaValidateFunc {
+	return func(i interface{}, k string) (s []string, es []error) {
+		v, ok := i.(int)
+		if !ok {
+			es = append(es, fmt.Errorf("expected type of %s to be int", k))
+			return
+		}
+
+		if v > max {
+			es = append(es, fmt.Errorf("expected %s to be at most (%d), got %d", k, max, v))
+			return
+		}
+
+		return
+	}
+}
+
+// IntInSlice returns a SchemaValidateFunc which tests if the provided value
+// is of type int and matches the value of an element in the valid slice
+func IntInSlice(valid []int) schema.SchemaValidateFunc {
+	return func(i interface{}, k string) (s []string, es []error) {
+		v, ok := i.(int)
+		if !ok {
+			es = append(es, fmt.Errorf("expected type of %s to be an integer", k))
+			return
+		}
+
+		for _, validInt := range valid {
+			if v == validInt {
+				return
+			}
+		}
+
+		es = append(es, fmt.Errorf("expected %s to be one of %v, got %d", k, valid, v))
+		return
+	}
+}
+
+// StringInSlice returns a SchemaValidateFunc which tests if the provided value
+// is of type string and matches the value of an element in the valid slice
+// will test with in lower case if ignoreCase is true
+func StringInSlice(valid []string, ignoreCase bool) schema.SchemaValidateFunc {
+	return func(i interface{}, k string) (s []string, es []error) {
+		v, ok := i.(string)
+		if !ok {
+			es = append(es, fmt.Errorf("expected type of %s to be string", k))
+			return
+		}
+
+		for _, str := range valid {
+			if v == str || (ignoreCase && strings.ToLower(v) == strings.ToLower(str)) {
+				return
+			}
+		}
+
+		es = append(es, fmt.Errorf("expected %s to be one of %v, got %s", k, valid, v))
+		return
+	}
+}
+
+// StringLenBetween returns a SchemaValidateFunc which tests if the provided value
+// is of type string and has length between min and max (inclusive)
+func StringLenBetween(min, max int) schema.SchemaValidateFunc {
+	return func(i interface{}, k string) (s []string, es []error) {
+		v, ok := i.(string)
+		if !ok {
+			es = append(es, fmt.Errorf("expected type of %s to be string", k))
+			return
+		}
+		if len(v) < min || len(v) > max {
+			es = append(es, fmt.Errorf("expected length of %s to be in the range (%d - %d), got %s", k, min, max, v))
+		}
+		return
+	}
+}
+
+// StringMatch returns a SchemaValidateFunc which tests if the provided value
+// matches a given regexp. Optionally an error message can be provided to
+// return something friendlier than "must match some globby regexp".
+func StringMatch(r *regexp.Regexp, message string) schema.SchemaValidateFunc {
+	return func(i interface{}, k string) ([]string, []error) {
+		v, ok := i.(string)
+		if !ok {
+			return nil, []error{fmt.Errorf("expected type of %s to be string", k)}
+		}
+
+		if ok := r.MatchString(v); !ok {
+			if message != "" {
+				return nil, []error{fmt.Errorf("invalid value for %s (%s)", k, message)}
+
+			}
+			return nil, []error{fmt.Errorf("expected value of %s to match regular expression %q", k, r)}
+		}
+		return nil, nil
+	}
+}
+
+// NoZeroValues is a SchemaValidateFunc which tests if the provided value is
+// not a zero value. It's useful in situations where you want to catch
+// explicit zero values on things like required fields during validation.
+func NoZeroValues(i interface{}, k string) (s []string, es []error) {
+	if reflect.ValueOf(i).Interface() == reflect.Zero(reflect.TypeOf(i)).Interface() {
+		switch reflect.TypeOf(i).Kind() {
+		case reflect.String:
+			es = append(es, fmt.Errorf("%s must not be empty", k))
+		case reflect.Int, reflect.Float64:
+			es = append(es, fmt.Errorf("%s must not be zero", k))
+		default:
+			// this validator should only ever be applied to TypeString, TypeInt and TypeFloat
+			panic(fmt.Errorf("can't use NoZeroValues with %T attribute %s", i, k))
+		}
+	}
+	return
+}
+
+// CIDRNetwork returns a SchemaValidateFunc which tests if the provided value
+// is of type string, is in valid CIDR network notation, and has significant bits between min and max (inclusive)
+func CIDRNetwork(min, max int) schema.SchemaValidateFunc {
+	return func(i interface{}, k string) (s []string, es []error) {
+		v, ok := i.(string)
+		if !ok {
+			es = append(es, fmt.Errorf("expected type of %s to be string", k))
+			return
+		}
+
+		_, ipnet, err := net.ParseCIDR(v)
+		if err != nil {
+			es = append(es, fmt.Errorf(
+				"expected %s to contain a valid CIDR, got: %s with err: %s", k, v, err))
+			return
+		}
+
+		if ipnet == nil || v != ipnet.String() {
+			es = append(es, fmt.Errorf(
+				"expected %s to contain a valid network CIDR, expected %s, got %s",
+				k, ipnet, v))
+		}
+
+		sigbits, _ := ipnet.Mask.Size()
+		if sigbits < min || sigbits > max {
+			es = append(es, fmt.Errorf(
+				"expected %q to contain a network CIDR with between %d and %d significant bits, got: %d",
+				k, min, max, sigbits))
+		}
+
+		return
+	}
+}
+
+// SingleIP returns a SchemaValidateFunc which tests if the provided value
+// is of type string, and in valid single IP notation
+func SingleIP() schema.SchemaValidateFunc {
+	return func(i interface{}, k string) (s []string, es []error) {
+		v, ok := i.(string)
+		if !ok {
+			es = append(es, fmt.Errorf("expected type of %s to be string", k))
+			return
+		}
+
+		ip := net.ParseIP(v)
+		if ip == nil {
+			es = append(es, fmt.Errorf(
+				"expected %s to contain a valid IP, got: %s", k, v))
+		}
+		return
+	}
+}
+
+// IPRange returns a SchemaValidateFunc which tests if the provided value
+// is of type string, and in valid IP range notation
+func IPRange() schema.SchemaValidateFunc {
+	return func(i interface{}, k string) (s []string, es []error) {
+		v, ok := i.(string)
+		if !ok {
+			es = append(es, fmt.Errorf("expected type of %s to be string", k))
+			return
+		}
+
+		ips := strings.Split(v, "-")
+		if len(ips) != 2 {
+			es = append(es, fmt.Errorf(
+				"expected %s to contain a valid IP range, got: %s", k, v))
+			return
+		}
+		ip1 := net.ParseIP(ips[0])
+		ip2 := net.ParseIP(ips[1])
+		if ip1 == nil || ip2 == nil || bytes.Compare(ip1, ip2) > 0 {
+			es = append(es, fmt.Errorf(
+				"expected %s to contain a valid IP range, got: %s", k, v))
+		}
+		return
+	}
+}
+
+// ValidateJsonString is a SchemaValidateFunc which tests to make sure the
+// supplied string is valid JSON.
+func ValidateJsonString(v interface{}, k string) (ws []string, errors []error) {
+	if _, err := structure.NormalizeJsonString(v); err != nil {
+		errors = append(errors, fmt.Errorf("%q contains an invalid JSON: %s", k, err))
+	}
+	return
+}
+
+// ValidateListUniqueStrings is a ValidateFunc that ensures a list has no
+// duplicate items in it. It's useful for when a list is needed over a set
+// because order matters, yet the items still need to be unique.
+func ValidateListUniqueStrings(v interface{}, k string) (ws []string, errors []error) {
+	for n1, v1 := range v.([]interface{}) {
+		for n2, v2 := range v.([]interface{}) {
+			if v1.(string) == v2.(string) && n1 != n2 {
+				errors = append(errors, fmt.Errorf("%q: duplicate entry - %s", k, v1.(string)))
+			}
+		}
+	}
+	return
+}
+
+// ValidateRegexp returns a SchemaValidateFunc which tests to make sure the
+// supplied string is a valid regular expression.
+func ValidateRegexp(v interface{}, k string) (ws []string, errors []error) {
+	if _, err := regexp.Compile(v.(string)); err != nil {
+		errors = append(errors, fmt.Errorf("%q: %s", k, err))
+	}
+	return
+}
+
+// ValidateRFC3339TimeString is a ValidateFunc that ensures a string parses
+// as time.RFC3339 format
+func ValidateRFC3339TimeString(v interface{}, k string) (ws []string, errors []error) {
+	if _, err := time.Parse(time.RFC3339, v.(string)); err != nil {
+		errors = append(errors, fmt.Errorf("%q: invalid RFC3339 timestamp", k))
+	}
+	return
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -106,10 +106,12 @@ github.com/hashicorp/terraform/plugin
 github.com/hashicorp/terraform/helper/hashcode
 github.com/hashicorp/terraform/helper/logging
 github.com/hashicorp/terraform/helper/schema
+github.com/hashicorp/terraform/helper/validation
 github.com/hashicorp/terraform/terraform
 github.com/hashicorp/terraform/plugin/discovery
 github.com/hashicorp/terraform/config
 github.com/hashicorp/terraform/config/configschema
+github.com/hashicorp/terraform/helper/structure
 github.com/hashicorp/terraform/config/module
 github.com/hashicorp/terraform/dag
 github.com/hashicorp/terraform/flatmap


### PR DESCRIPTION
Closes #148.

Since conditions are supported the type must be either `REQUEST`, `RESPONSE`, or `CACHE`. The `go-fastly` HTTP client and the Fastly API allow lower-case values for the type attribute! However, the Fastly API always returns an upper-case value for the type attribute. Therefore, a `plan` output always detects changes for a condition if the type attribute in the Terraform definition is lower-case because it compares a lower-case with an upper-case value! This validation prevents the Terraform definition from being different from what the Fastly API returns. **This is not a breaking change!**

Unit tests:

```
==> Checking that code complies with gofmt requirements...
go test -i $(go list ./... |grep -v 'vendor') || exit 1
echo $(go list ./... |grep -v 'vendor') | \
		xargs -t -n4 go test  -timeout=30s -parallel=4
go test -timeout=30s -parallel=4 github.com/terraform-providers/terraform-provider-fastly github.com/terraform-providers/terraform-provider-fastly/fastly
?   	github.com/terraform-providers/terraform-provider-fastly	[no test files]
ok  	github.com/terraform-providers/terraform-provider-fastly/fastly	0.020s
```