### PR TITLE
Outsource and refactor validators

### DIFF
--- a/fastly/resource_fastly_service_v1.go
+++ b/fastly/resource_fastly_service_v1.go
@@ -94,9 +94,10 @@ func resourceServiceV1() *schema.Resource {
 							Description: "A number used to determine the order in which multiple conditions execute. Lower numbers execute first",
 						},
 						"type": {
-							Type:        schema.TypeString,
-							Required:    true,
-							Description: "Type of the condition, either `REQUEST`, `RESPONSE`, or `CACHE`",
+							Type:         schema.TypeString,
+							Required:     true,
+							Description:  "Type of the condition, either `REQUEST`, `RESPONSE`, or `CACHE`",
+							ValidateFunc: validateConditionType(),
 						},
 					},
 				},

--- a/fastly/resource_fastly_service_v1.go
+++ b/fastly/resource_fastly_service_v1.go
@@ -1239,22 +1239,10 @@ func resourceServiceV1() *schema.Resource {
 							Description: "A unique name to refer to this VCL snippet",
 						},
 						"type": {
-							Type:        schema.TypeString,
-							Required:    true,
-							Description: "One of init, recv, hit, miss, pass, fetch, error, deliver, log, none",
-							ValidateFunc: func(v interface{}, k string) (ws []string, es []error) {
-								var found bool
-								for _, t := range []string{"init", "recv", "hit", "miss", "pass", "fetch", "error", "deliver", "log", "none"} {
-									if v.(string) == t {
-										found = true
-									}
-								}
-								if !found {
-									es = append(es, fmt.Errorf(
-										"Fastly VCL snippet location is case sensitive and must be one of 'init', 'recv', 'hit', 'miss', 'pass', 'fetch', 'error', 'deliver', 'log' or 'none'; found: %s", v.(string)))
-								}
-								return
-							},
+							Type:         schema.TypeString,
+							Required:     true,
+							Description:  "One of init, recv, hit, miss, pass, fetch, error, deliver, log, none",
+							ValidateFunc: validateSnippetType,
 						},
 						"content": {
 							Type:        schema.TypeString,

--- a/fastly/resource_fastly_service_v1.go
+++ b/fastly/resource_fastly_service_v1.go
@@ -499,22 +499,10 @@ func resourceServiceV1() *schema.Resource {
 							ValidateFunc: validateHeaderAction,
 						},
 						"type": {
-							Type:        schema.TypeString,
-							Required:    true,
-							Description: "Type to manipulate: request, fetch, cache, response",
-							ValidateFunc: func(v interface{}, k string) (ws []string, es []error) {
-								var found bool
-								for _, t := range []string{"request", "fetch", "cache", "response"} {
-									if v.(string) == t {
-										found = true
-									}
-								}
-								if !found {
-									es = append(es, fmt.Errorf(
-										"Fastly Header type is case sensitive and must be one of 'request', 'fetch', 'cache', or 'response'; found: %s", v.(string)))
-								}
-								return
-							},
+							Type:         schema.TypeString,
+							Required:     true,
+							Description:  "Type to manipulate: request, fetch, cache, response",
+							ValidateFunc: validateHeaderType,
 						},
 						"destination": {
 							Type:        schema.TypeString,

--- a/fastly/resource_fastly_service_v1.go
+++ b/fastly/resource_fastly_service_v1.go
@@ -493,22 +493,10 @@ func resourceServiceV1() *schema.Resource {
 							Description: "A name to refer to this Header object",
 						},
 						"action": {
-							Type:        schema.TypeString,
-							Required:    true,
-							Description: "One of set, append, delete, regex, or regex_repeat",
-							ValidateFunc: func(v interface{}, k string) (ws []string, es []error) {
-								var found bool
-								for _, t := range []string{"set", "append", "delete", "regex", "regex_repeat"} {
-									if v.(string) == t {
-										found = true
-									}
-								}
-								if !found {
-									es = append(es, fmt.Errorf(
-										"Fastly Header action is case sensitive and must be one of 'set', 'append', 'delete', 'regex', or 'regex_repeat'; found: %s", v.(string)))
-								}
-								return
-							},
+							Type:         schema.TypeString,
+							Required:     true,
+							Description:  "One of set, append, delete, regex, or regex_repeat",
+							ValidateFunc: validateHeaderAction,
 						},
 						"type": {
 							Type:        schema.TypeString,

--- a/fastly/resource_fastly_service_v1.go
+++ b/fastly/resource_fastly_service_v1.go
@@ -382,16 +382,11 @@ func resourceServiceV1() *schema.Resource {
 							Description: "Selected POP to serve as a 'shield' for origin servers.",
 						},
 						"quorum": {
-							Type:        schema.TypeInt,
-							Optional:    true,
-							Default:     75,
-							Description: "Percentage of capacity that needs to be up for the director itself to be considered up",
-							ValidateFunc: func(v interface{}, k string) (ws []string, es []error) {
-								if v.(int) < 0 || v.(int) > 100 {
-									es = append(es, fmt.Errorf("Fastly Director quorum should be a percentage between 0 and 100; found %d", v.(int)))
-								}
-								return
-							},
+							Type:         schema.TypeInt,
+							Optional:     true,
+							Default:      75,
+							Description:  "Percentage of capacity that needs to be up for the director itself to be considered up",
+							ValidateFunc: validateDirectorQuorum,
 						},
 						"type": {
 							Type:         schema.TypeInt,

--- a/fastly/validators.go
+++ b/fastly/validators.go
@@ -154,3 +154,19 @@ func validateHeaderAction(v interface{}, k string) (ws []string, errors []error)
 	}
 	return
 }
+
+func validateHeaderType(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	validTypes := map[string]struct{}{
+		"request":  {},
+		"fetch":    {},
+		"cache":    {},
+		"response": {},
+	}
+
+	if _, ok := validTypes[value]; !ok {
+		errors = append(errors, fmt.Errorf(
+			"%q must be one of ['request', 'fetch', 'cache', 'response']", k))
+	}
+	return
+}

--- a/fastly/validators.go
+++ b/fastly/validators.go
@@ -137,3 +137,20 @@ func validateSnippetType(v interface{}, k string) (ws []string, errors []error) 
 	}
 	return
 }
+
+func validateHeaderAction(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	validActions := map[string]struct{}{
+		"set":          {},
+		"append":       {},
+		"delete":       {},
+		"regex":        {},
+		"regex_repeat": {},
+	}
+
+	if _, ok := validActions[value]; !ok {
+		errors = append(errors, fmt.Errorf(
+			"%q must be one of ['set', 'append', 'delete', 'regex', 'regex_repeat']", k))
+	}
+	return
+}

--- a/fastly/validators.go
+++ b/fastly/validators.go
@@ -1,6 +1,11 @@
 package fastly
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
+)
 
 func validateLoggingFormatVersion(v interface{}, k string) (ws []string, errors []error) {
 	value := uint(v.(int))
@@ -34,29 +39,101 @@ func validateLoggingMessageType(v interface{}, k string) (ws []string, errors []
 
 func validateLoggingPlacement(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
-	validTypes := map[string]struct{}{
+	validPlacements := map[string]struct{}{
 		"none":      {},
 		"waf_debug": {},
 	}
 
-	if _, ok := validTypes[value]; !ok {
+	if _, ok := validPlacements[value]; !ok {
 		errors = append(errors, fmt.Errorf(
 			"%q must be one of ['none', 'waf_debug']", k))
 	}
 	return
 }
 
+func validateDirectorQuorum(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(int)
+	if value < 0 || value > 100 {
+		errors = append(errors, fmt.Errorf(
+			"%q must be a percentage between 0 and 100", k))
+	}
+	return
+}
+
 func validateDirectorType(v interface{}, k string) (ws []string, errors []error) {
 	value := uint(v.(int))
-	validVersions := map[uint]struct{}{
+	validTypes := map[uint]struct{}{
 		1: {},
 		3: {},
 		4: {},
 	}
 
-	if _, ok := validVersions[value]; !ok {
+	if _, ok := validTypes[value]; !ok {
 		errors = append(errors, fmt.Errorf(
 			"%q must be one of ['1' (random), '3' (hash), '4' (client)]", k))
+	}
+	return
+}
+
+func validateConditionType() schema.SchemaValidateFunc {
+	return validation.StringInSlice([]string{
+		"REQUEST",
+		"RESPONSE",
+		"CACHE",
+	}, false)
+}
+
+func validateHeaderAction(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	validActions := map[string]struct{}{
+		"set":          {},
+		"append":       {},
+		"delete":       {},
+		"regex":        {},
+		"regex_repeat": {},
+	}
+
+	if _, ok := validActions[value]; !ok {
+		errors = append(errors, fmt.Errorf(
+			"%q must be one of ['set', 'append', 'delete', 'regex', 'regex_repeat']", k))
+	}
+	return
+}
+
+func validateHeaderType(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	validTypes := map[string]struct{}{
+		"request":  {},
+		"fetch":    {},
+		"cache":    {},
+		"response": {},
+	}
+
+	if _, ok := validTypes[value]; !ok {
+		errors = append(errors, fmt.Errorf(
+			"%q must be one of ['request', 'fetch', 'cache', 'response']", k))
+	}
+	return
+}
+
+func validateSnippetType(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	validTypes := map[string]struct{}{
+		"init":    {},
+		"recv":    {},
+		"hit":     {},
+		"miss":    {},
+		"pass":    {},
+		"fetch":   {},
+		"error":   {},
+		"deliver": {},
+		"log":     {},
+		"none":    {},
+	}
+
+	if _, ok := validTypes[value]; !ok {
+		errors = append(errors, fmt.Errorf(
+			"%q must be one of ['init', 'recv', 'hit', 'miss', 'pass', 'fetch', 'error', 'deliver', 'log', 'none']", k))
 	}
 	return
 }

--- a/fastly/validators.go
+++ b/fastly/validators.go
@@ -170,3 +170,25 @@ func validateHeaderType(v interface{}, k string) (ws []string, errors []error) {
 	}
 	return
 }
+
+func validateSnippetType(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	validTypes := map[string]struct{}{
+		"init":    {},
+		"recv":    {},
+		"hit":     {},
+		"miss":    {},
+		"pass":    {},
+		"fetch":   {},
+		"error":   {},
+		"deliver": {},
+		"log":     {},
+		"none":    {},
+	}
+
+	if _, ok := validTypes[value]; !ok {
+		errors = append(errors, fmt.Errorf(
+			"%q must be one of ['init', 'recv', 'hit', 'miss', 'pass', 'fetch', 'error', 'deliver', 'log', 'none']", k))
+	}
+	return
+}

--- a/fastly/validators_test.go
+++ b/fastly/validators_test.go
@@ -186,3 +186,29 @@ func TestValidateHeaderAction(t *testing.T) {
 		}
 	}
 }
+
+func TestValidateHeaderType(t *testing.T) {
+	validTypes := []string{
+		"request",
+		"fetch",
+		"cache",
+		"response",
+	}
+	for _, v := range validTypes {
+		_, errors := validateHeaderType(v, "type")
+		if len(errors) != 0 {
+			t.Fatalf("%q should be a valid header type: %q", v, errors)
+		}
+	}
+
+	invalidTypes := []string{
+		"invalid_type_1",
+		"invalid_type_2",
+	}
+	for _, v := range invalidTypes {
+		_, errors := validateHeaderType(v, "type")
+		if len(errors) != 1 {
+			t.Fatalf("%q should not be a valid header type", v)
+		}
+	}
+}

--- a/fastly/validators_test.go
+++ b/fastly/validators_test.go
@@ -78,6 +78,35 @@ func TestValidateLoggingPlacement(t *testing.T) {
 	}
 }
 
+func TestValidateDirectorQuorum(t *testing.T) {
+	validQuorums := []int{
+		0,
+		9,
+		55,
+		83,
+		100,
+	}
+	for _, v := range validQuorums {
+		_, errors := validateDirectorQuorum(v, "quorum")
+		if len(errors) != 0 {
+			t.Fatalf("%q should be a valid director quorum: %q", v, errors)
+		}
+	}
+
+	invalidQuorums := []int{
+		-1,
+		-50,
+		101,
+		150,
+	}
+	for _, v := range invalidQuorums {
+		_, errors := validateDirectorQuorum(v, "quorum")
+		if len(errors) != 1 {
+			t.Fatalf("%q should not be a valid director quorum", v)
+		}
+	}
+}
+
 func TestValidateDirectorType(t *testing.T) {
 	validVersions := []int{
 		1,

--- a/fastly/validators_test.go
+++ b/fastly/validators_test.go
@@ -212,3 +212,35 @@ func TestValidateHeaderType(t *testing.T) {
 		}
 	}
 }
+
+func TestValidateSnippetType(t *testing.T) {
+	validTypes := []string{
+		"init",
+		"recv",
+		"hit",
+		"miss",
+		"pass",
+		"fetch",
+		"error",
+		"deliver",
+		"log",
+		"none",
+	}
+	for _, v := range validTypes {
+		_, errors := validateSnippetType(v, "type")
+		if len(errors) != 0 {
+			t.Fatalf("%q should be a valid snippet type: %q", v, errors)
+		}
+	}
+
+	invalidTypes := []string{
+		"invalid_type_1",
+		"invalid_type_2",
+	}
+	for _, v := range invalidTypes {
+		_, errors := validateSnippetType(v, "type")
+		if len(errors) != 1 {
+			t.Fatalf("%q should not be a valid snippet type", v)
+		}
+	}
+}

--- a/fastly/validators_test.go
+++ b/fastly/validators_test.go
@@ -62,7 +62,7 @@ func TestValidateLoggingPlacement(t *testing.T) {
 	for _, v := range validPlacements {
 		_, errors := validateLoggingPlacement(v, "placement")
 		if len(errors) != 0 {
-			t.Fatalf("%q should be a valid placement", v)
+			t.Fatalf("%q should be a valid placement: %q", v, errors)
 		}
 	}
 
@@ -108,26 +108,26 @@ func TestValidateDirectorQuorum(t *testing.T) {
 }
 
 func TestValidateDirectorType(t *testing.T) {
-	validVersions := []int{
+	validTypes := []int{
 		1,
 		3,
 		4,
 	}
-	for _, v := range validVersions {
+	for _, v := range validTypes {
 		_, errors := validateDirectorType(v, "type")
 		if len(errors) != 0 {
 			t.Fatalf("%q should be a valid director type: %q", v, errors)
 		}
 	}
 
-	invalidVersions := []int{
+	invalidTypes := []int{
 		0,
 		-1,
 		2,
 		5,
 		6,
 	}
-	for _, v := range invalidVersions {
+	for _, v := range invalidTypes {
 		_, errors := validateDirectorType(v, "type")
 		if len(errors) != 1 {
 			t.Fatalf("%q should not be a valid director type", v)

--- a/fastly/validators_test.go
+++ b/fastly/validators_test.go
@@ -159,3 +159,30 @@ func TestValidateConditionType(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateHeaderAction(t *testing.T) {
+	validActions := []string{
+		"set",
+		"append",
+		"delete",
+		"regex",
+		"regex_repeat",
+	}
+	for _, v := range validActions {
+		_, errors := validateHeaderAction(v, "action")
+		if len(errors) != 0 {
+			t.Fatalf("%q should be a valid header action: %q", v, errors)
+		}
+	}
+
+	invalidActions := []string{
+		"invalid_action_1",
+		"invalid_action_2",
+	}
+	for _, v := range invalidActions {
+		_, errors := validateHeaderAction(v, "action")
+		if len(errors) != 1 {
+			t.Fatalf("%q should not be a valid header action", v)
+		}
+	}
+}

--- a/fastly/validators_test.go
+++ b/fastly/validators_test.go
@@ -105,3 +105,28 @@ func TestValidateDirectorType(t *testing.T) {
 		}
 	}
 }
+
+func TestValidateConditionType(t *testing.T) {
+	for _, ctvt := range []struct {
+		value          string
+		expectedWarns  int
+		expectedErrors int
+	}{
+		{"REQUEST", 0, 0},
+		{"RESPONSE", 0, 0},
+		{"CACHE", 0, 0},
+		{"request", 0, 1},
+		{"response", 0, 1},
+		{"cache", 0, 1},
+	} {
+		t.Run(ctvt.value, func(t *testing.T) {
+			actualWarns, actualErrors := validateConditionType()(ctvt.value, "type")
+			if len(actualWarns) != ctvt.expectedWarns {
+				t.Errorf("expected %d warnings, actual %d ", ctvt.expectedWarns, len(actualWarns))
+			}
+			if len(actualErrors) != ctvt.expectedErrors {
+				t.Errorf("expected %d errors, actual %d ", ctvt.expectedErrors, len(actualErrors))
+			}
+		})
+	}
+}

--- a/vendor/github.com/hashicorp/terraform/helper/structure/expand_json.go
+++ b/vendor/github.com/hashicorp/terraform/helper/structure/expand_json.go
@@ -1,0 +1,11 @@
+package structure
+
+import "encoding/json"
+
+func ExpandJsonFromString(jsonString string) (map[string]interface{}, error) {
+	var result map[string]interface{}
+
+	err := json.Unmarshal([]byte(jsonString), &result)
+
+	return result, err
+}

--- a/vendor/github.com/hashicorp/terraform/helper/structure/flatten_json.go
+++ b/vendor/github.com/hashicorp/terraform/helper/structure/flatten_json.go
@@ -1,0 +1,16 @@
+package structure
+
+import "encoding/json"
+
+func FlattenJsonToString(input map[string]interface{}) (string, error) {
+	if len(input) == 0 {
+		return "", nil
+	}
+
+	result, err := json.Marshal(input)
+	if err != nil {
+		return "", err
+	}
+
+	return string(result), nil
+}

--- a/vendor/github.com/hashicorp/terraform/helper/structure/normalize_json.go
+++ b/vendor/github.com/hashicorp/terraform/helper/structure/normalize_json.go
@@ -1,0 +1,24 @@
+package structure
+
+import "encoding/json"
+
+// Takes a value containing JSON string and passes it through
+// the JSON parser to normalize it, returns either a parsing
+// error or normalized JSON string.
+func NormalizeJsonString(jsonString interface{}) (string, error) {
+	var j interface{}
+
+	if jsonString == nil || jsonString.(string) == "" {
+		return "", nil
+	}
+
+	s := jsonString.(string)
+
+	err := json.Unmarshal([]byte(s), &j)
+	if err != nil {
+		return s, err
+	}
+
+	bytes, _ := json.Marshal(j)
+	return string(bytes[:]), nil
+}

--- a/vendor/github.com/hashicorp/terraform/helper/structure/suppress_json_diff.go
+++ b/vendor/github.com/hashicorp/terraform/helper/structure/suppress_json_diff.go
@@ -1,0 +1,21 @@
+package structure
+
+import (
+	"reflect"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func SuppressJsonDiff(k, old, new string, d *schema.ResourceData) bool {
+	oldMap, err := ExpandJsonFromString(old)
+	if err != nil {
+		return false
+	}
+
+	newMap, err := ExpandJsonFromString(new)
+	if err != nil {
+		return false
+	}
+
+	return reflect.DeepEqual(oldMap, newMap)
+}

--- a/vendor/github.com/hashicorp/terraform/helper/validation/validation.go
+++ b/vendor/github.com/hashicorp/terraform/helper/validation/validation.go
@@ -1,0 +1,322 @@
+package validation
+
+import (
+	"bytes"
+	"fmt"
+	"net"
+	"reflect"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/structure"
+)
+
+// All returns a SchemaValidateFunc which tests if the provided value
+// passes all provided SchemaValidateFunc
+func All(validators ...schema.SchemaValidateFunc) schema.SchemaValidateFunc {
+	return func(i interface{}, k string) ([]string, []error) {
+		var allErrors []error
+		var allWarnings []string
+		for _, validator := range validators {
+			validatorWarnings, validatorErrors := validator(i, k)
+			allWarnings = append(allWarnings, validatorWarnings...)
+			allErrors = append(allErrors, validatorErrors...)
+		}
+		return allWarnings, allErrors
+	}
+}
+
+// Any returns a SchemaValidateFunc which tests if the provided value
+// passes any of the provided SchemaValidateFunc
+func Any(validators ...schema.SchemaValidateFunc) schema.SchemaValidateFunc {
+	return func(i interface{}, k string) ([]string, []error) {
+		var allErrors []error
+		var allWarnings []string
+		for _, validator := range validators {
+			validatorWarnings, validatorErrors := validator(i, k)
+			if len(validatorWarnings) == 0 && len(validatorErrors) == 0 {
+				return []string{}, []error{}
+			}
+			allWarnings = append(allWarnings, validatorWarnings...)
+			allErrors = append(allErrors, validatorErrors...)
+		}
+		return allWarnings, allErrors
+	}
+}
+
+// IntBetween returns a SchemaValidateFunc which tests if the provided value
+// is of type int and is between min and max (inclusive)
+func IntBetween(min, max int) schema.SchemaValidateFunc {
+	return func(i interface{}, k string) (s []string, es []error) {
+		v, ok := i.(int)
+		if !ok {
+			es = append(es, fmt.Errorf("expected type of %s to be int", k))
+			return
+		}
+
+		if v < min || v > max {
+			es = append(es, fmt.Errorf("expected %s to be in the range (%d - %d), got %d", k, min, max, v))
+			return
+		}
+
+		return
+	}
+}
+
+// IntAtLeast returns a SchemaValidateFunc which tests if the provided value
+// is of type int and is at least min (inclusive)
+func IntAtLeast(min int) schema.SchemaValidateFunc {
+	return func(i interface{}, k string) (s []string, es []error) {
+		v, ok := i.(int)
+		if !ok {
+			es = append(es, fmt.Errorf("expected type of %s to be int", k))
+			return
+		}
+
+		if v < min {
+			es = append(es, fmt.Errorf("expected %s to be at least (%d), got %d", k, min, v))
+			return
+		}
+
+		return
+	}
+}
+
+// IntAtMost returns a SchemaValidateFunc which tests if the provided value
+// is of type int and is at most max (inclusive)
+func IntAtMost(max int) schema.SchemaValidateFunc {
+	return func(i interface{}, k string) (s []string, es []error) {
+		v, ok := i.(int)
+		if !ok {
+			es = append(es, fmt.Errorf("expected type of %s to be int", k))
+			return
+		}
+
+		if v > max {
+			es = append(es, fmt.Errorf("expected %s to be at most (%d), got %d", k, max, v))
+			return
+		}
+
+		return
+	}
+}
+
+// IntInSlice returns a SchemaValidateFunc which tests if the provided value
+// is of type int and matches the value of an element in the valid slice
+func IntInSlice(valid []int) schema.SchemaValidateFunc {
+	return func(i interface{}, k string) (s []string, es []error) {
+		v, ok := i.(int)
+		if !ok {
+			es = append(es, fmt.Errorf("expected type of %s to be an integer", k))
+			return
+		}
+
+		for _, validInt := range valid {
+			if v == validInt {
+				return
+			}
+		}
+
+		es = append(es, fmt.Errorf("expected %s to be one of %v, got %d", k, valid, v))
+		return
+	}
+}
+
+// StringInSlice returns a SchemaValidateFunc which tests if the provided value
+// is of type string and matches the value of an element in the valid slice
+// will test with in lower case if ignoreCase is true
+func StringInSlice(valid []string, ignoreCase bool) schema.SchemaValidateFunc {
+	return func(i interface{}, k string) (s []string, es []error) {
+		v, ok := i.(string)
+		if !ok {
+			es = append(es, fmt.Errorf("expected type of %s to be string", k))
+			return
+		}
+
+		for _, str := range valid {
+			if v == str || (ignoreCase && strings.ToLower(v) == strings.ToLower(str)) {
+				return
+			}
+		}
+
+		es = append(es, fmt.Errorf("expected %s to be one of %v, got %s", k, valid, v))
+		return
+	}
+}
+
+// StringLenBetween returns a SchemaValidateFunc which tests if the provided value
+// is of type string and has length between min and max (inclusive)
+func StringLenBetween(min, max int) schema.SchemaValidateFunc {
+	return func(i interface{}, k string) (s []string, es []error) {
+		v, ok := i.(string)
+		if !ok {
+			es = append(es, fmt.Errorf("expected type of %s to be string", k))
+			return
+		}
+		if len(v) < min || len(v) > max {
+			es = append(es, fmt.Errorf("expected length of %s to be in the range (%d - %d), got %s", k, min, max, v))
+		}
+		return
+	}
+}
+
+// StringMatch returns a SchemaValidateFunc which tests if the provided value
+// matches a given regexp. Optionally an error message can be provided to
+// return something friendlier than "must match some globby regexp".
+func StringMatch(r *regexp.Regexp, message string) schema.SchemaValidateFunc {
+	return func(i interface{}, k string) ([]string, []error) {
+		v, ok := i.(string)
+		if !ok {
+			return nil, []error{fmt.Errorf("expected type of %s to be string", k)}
+		}
+
+		if ok := r.MatchString(v); !ok {
+			if message != "" {
+				return nil, []error{fmt.Errorf("invalid value for %s (%s)", k, message)}
+
+			}
+			return nil, []error{fmt.Errorf("expected value of %s to match regular expression %q", k, r)}
+		}
+		return nil, nil
+	}
+}
+
+// NoZeroValues is a SchemaValidateFunc which tests if the provided value is
+// not a zero value. It's useful in situations where you want to catch
+// explicit zero values on things like required fields during validation.
+func NoZeroValues(i interface{}, k string) (s []string, es []error) {
+	if reflect.ValueOf(i).Interface() == reflect.Zero(reflect.TypeOf(i)).Interface() {
+		switch reflect.TypeOf(i).Kind() {
+		case reflect.String:
+			es = append(es, fmt.Errorf("%s must not be empty", k))
+		case reflect.Int, reflect.Float64:
+			es = append(es, fmt.Errorf("%s must not be zero", k))
+		default:
+			// this validator should only ever be applied to TypeString, TypeInt and TypeFloat
+			panic(fmt.Errorf("can't use NoZeroValues with %T attribute %s", i, k))
+		}
+	}
+	return
+}
+
+// CIDRNetwork returns a SchemaValidateFunc which tests if the provided value
+// is of type string, is in valid CIDR network notation, and has significant bits between min and max (inclusive)
+func CIDRNetwork(min, max int) schema.SchemaValidateFunc {
+	return func(i interface{}, k string) (s []string, es []error) {
+		v, ok := i.(string)
+		if !ok {
+			es = append(es, fmt.Errorf("expected type of %s to be string", k))
+			return
+		}
+
+		_, ipnet, err := net.ParseCIDR(v)
+		if err != nil {
+			es = append(es, fmt.Errorf(
+				"expected %s to contain a valid CIDR, got: %s with err: %s", k, v, err))
+			return
+		}
+
+		if ipnet == nil || v != ipnet.String() {
+			es = append(es, fmt.Errorf(
+				"expected %s to contain a valid network CIDR, expected %s, got %s",
+				k, ipnet, v))
+		}
+
+		sigbits, _ := ipnet.Mask.Size()
+		if sigbits < min || sigbits > max {
+			es = append(es, fmt.Errorf(
+				"expected %q to contain a network CIDR with between %d and %d significant bits, got: %d",
+				k, min, max, sigbits))
+		}
+
+		return
+	}
+}
+
+// SingleIP returns a SchemaValidateFunc which tests if the provided value
+// is of type string, and in valid single IP notation
+func SingleIP() schema.SchemaValidateFunc {
+	return func(i interface{}, k string) (s []string, es []error) {
+		v, ok := i.(string)
+		if !ok {
+			es = append(es, fmt.Errorf("expected type of %s to be string", k))
+			return
+		}
+
+		ip := net.ParseIP(v)
+		if ip == nil {
+			es = append(es, fmt.Errorf(
+				"expected %s to contain a valid IP, got: %s", k, v))
+		}
+		return
+	}
+}
+
+// IPRange returns a SchemaValidateFunc which tests if the provided value
+// is of type string, and in valid IP range notation
+func IPRange() schema.SchemaValidateFunc {
+	return func(i interface{}, k string) (s []string, es []error) {
+		v, ok := i.(string)
+		if !ok {
+			es = append(es, fmt.Errorf("expected type of %s to be string", k))
+			return
+		}
+
+		ips := strings.Split(v, "-")
+		if len(ips) != 2 {
+			es = append(es, fmt.Errorf(
+				"expected %s to contain a valid IP range, got: %s", k, v))
+			return
+		}
+		ip1 := net.ParseIP(ips[0])
+		ip2 := net.ParseIP(ips[1])
+		if ip1 == nil || ip2 == nil || bytes.Compare(ip1, ip2) > 0 {
+			es = append(es, fmt.Errorf(
+				"expected %s to contain a valid IP range, got: %s", k, v))
+		}
+		return
+	}
+}
+
+// ValidateJsonString is a SchemaValidateFunc which tests to make sure the
+// supplied string is valid JSON.
+func ValidateJsonString(v interface{}, k string) (ws []string, errors []error) {
+	if _, err := structure.NormalizeJsonString(v); err != nil {
+		errors = append(errors, fmt.Errorf("%q contains an invalid JSON: %s", k, err))
+	}
+	return
+}
+
+// ValidateListUniqueStrings is a ValidateFunc that ensures a list has no
+// duplicate items in it. It's useful for when a list is needed over a set
+// because order matters, yet the items still need to be unique.
+func ValidateListUniqueStrings(v interface{}, k string) (ws []string, errors []error) {
+	for n1, v1 := range v.([]interface{}) {
+		for n2, v2 := range v.([]interface{}) {
+			if v1.(string) == v2.(string) && n1 != n2 {
+				errors = append(errors, fmt.Errorf("%q: duplicate entry - %s", k, v1.(string)))
+			}
+		}
+	}
+	return
+}
+
+// ValidateRegexp returns a SchemaValidateFunc which tests to make sure the
+// supplied string is a valid regular expression.
+func ValidateRegexp(v interface{}, k string) (ws []string, errors []error) {
+	if _, err := regexp.Compile(v.(string)); err != nil {
+		errors = append(errors, fmt.Errorf("%q: %s", k, err))
+	}
+	return
+}
+
+// ValidateRFC3339TimeString is a ValidateFunc that ensures a string parses
+// as time.RFC3339 format
+func ValidateRFC3339TimeString(v interface{}, k string) (ws []string, errors []error) {
+	if _, err := time.Parse(time.RFC3339, v.(string)); err != nil {
+		errors = append(errors, fmt.Errorf("%q: invalid RFC3339 timestamp", k))
+	}
+	return
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -108,10 +108,12 @@ github.com/hashicorp/terraform/plugin
 github.com/hashicorp/terraform/helper/hashcode
 github.com/hashicorp/terraform/helper/logging
 github.com/hashicorp/terraform/helper/schema
+github.com/hashicorp/terraform/helper/validation
 github.com/hashicorp/terraform/terraform
 github.com/hashicorp/terraform/plugin/discovery
 github.com/hashicorp/terraform/config
 github.com/hashicorp/terraform/config/configschema
+github.com/hashicorp/terraform/helper/structure
 github.com/hashicorp/terraform/config/module
 github.com/hashicorp/terraform/dag
 github.com/hashicorp/terraform/flatmap


### PR DESCRIPTION
👋 This PR moves all remaining validators out of `resource_fastly_service_v1.go` into `validators.go`.

Unit tests:
```
==> Checking that code complies with gofmt requirements...
go test -i $(go list ./... |grep -v 'vendor') || exit 1
echo $(go list ./... |grep -v 'vendor') | \
		xargs -t -n4 go test  -timeout=30s -parallel=4
go test -timeout=30s -parallel=4 github.com/terraform-providers/terraform-provider-fastly github.com/terraform-providers/terraform-provider-fastly/fastly
?   	github.com/terraform-providers/terraform-provider-fastly	[no test files]
ok  	github.com/terraform-providers/terraform-provider-fastly/fastly	0.021s
```