### PR TITLE
Introduce and rename flatten function unit tests.

### DIFF
--- a/fastly/provider_test.go
+++ b/fastly/provider_test.go
@@ -1,6 +1,10 @@
 package fastly
 
 import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
 	"os"
 	"testing"
 
@@ -16,6 +20,24 @@ func init() {
 	testAccProviders = map[string]terraform.ResourceProvider{
 		"fastly": testAccProvider,
 	}
+}
+
+func generateKey() (string, error) {
+	reader := rand.Reader
+	bitSize := 2048
+
+	key, err := rsa.GenerateKey(reader, bitSize)
+	if err != nil {
+		return "", err
+	}
+	var privateKey = &pem.Block{
+		Type:  "PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(key),
+	}
+
+	bytes := pem.EncodeToMemory(privateKey)
+
+	return string(bytes), nil
 }
 
 func TestProvider(t *testing.T) {

--- a/fastly/resource_fastly_service_v1_bigquerylogging_test.go
+++ b/fastly/resource_fastly_service_v1_bigquerylogging_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
+var secretKey, _ = generateKey()
+
 var flattenBigQueryTests = []struct {
 	name     string
 	in       []*gofastly.BigQuery
@@ -23,14 +25,14 @@ var flattenBigQueryTests = []struct {
 			{
 				Name: "bigquery-example", User: "email@example.com",
 				ProjectID: "example-gcp-project", Dataset: "example-bq-dataset",
-				Table: "example-bq-table", SecretKey: "secretKey",
+				Table: "example-bq-table", SecretKey: secretKey,
 			},
 		},
 		expected: []map[string]interface{}{
 			{
 				"name": "bigquery-example", "email": "email@example.com",
 				"project_id": "example-gcp-project", "dataset": "example-bq-dataset",
-				"table": "example-bq-table", "secret_key": "secretKey",
+				"table": "example-bq-table", "secret_key": secretKey,
 			},
 		},
 	},
@@ -54,6 +56,10 @@ func TestAccFastlyServiceV1_bigquerylogging(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	bqName := fmt.Sprintf("bq %s", acctest.RandString(10))
+	secretKey, err := generateKey()
+	if err != nil {
+		t.Errorf("Failed to generate key: %s", err)
+	}
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -61,7 +67,7 @@ func TestAccFastlyServiceV1_bigquerylogging(t *testing.T) {
 		CheckDestroy: testAccCheckServiceV1Destroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccServiceV1Config_bigquery(name, bqName),
+				Config: testAccServiceV1Config_bigquery(name, bqName, secretKey),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
 					testAccCheckFastlyServiceV1Attributes_bq(&service, name, bqName),
@@ -75,9 +81,13 @@ func TestAccFastlyServiceV1_bigquerylogging_env(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	bqName := fmt.Sprintf("bq %s", acctest.RandString(10))
+	secretKey, err := generateKey()
+	if err != nil {
+		t.Errorf("Failed to generate key: %s", err)
+	}
 
 	// set env Vars to something we expect
-	resetEnv := setBQEnv("someEnv", t)
+	resetEnv := setBQEnv("someEnv", secretKey, t)
 	defer resetEnv()
 
 	resource.Test(t, resource.TestCase{
@@ -125,7 +135,7 @@ func testAccCheckFastlyServiceV1Attributes_bq(service *gofastly.ServiceDetail, n
 	}
 }
 
-func testAccServiceV1Config_bigquery(name, gcsName string) string {
+func testAccServiceV1Config_bigquery(name, gcsName, secretKey string) string {
 	backendName := fmt.Sprintf("%s.aws.amazon.com", acctest.RandString(3))
 	domainName := fmt.Sprintf("fastly-test.tf-%s.com", acctest.RandString(10))
 
@@ -146,14 +156,14 @@ resource "fastly_service_v1" "foo" {
   bigquerylogging {
     name       = "%s"
     email      = "email@example.com",
-    secret_key = "secretKey",
+    secret_key = %q,
     project_id = "example-gcp-project"
-    dataset    = "example-bq-dataset"
-    table      = "example-bq-table"
+    dataset    = "example_bq_dataset"
+    table      = "example_bq_table"
   }
 
   force_destroy = true
-}`, name, domainName, backendName, gcsName)
+}`, name, domainName, backendName, gcsName, secretKey)
 }
 
 func testAccServiceV1Config_bigquery_env(name, gcsName string) string {
@@ -177,21 +187,21 @@ resource "fastly_service_v1" "foo" {
   bigquerylogging {
     name       = "%s"
     project_id = "example-gcp-project"
-    dataset    = "example-bq-dataset"
-    table      = "example-bq-table"
+    dataset    = "example_bq_dataset"
+    table      = "example_bq_table"
   }
 
   force_destroy = true
 }`, name, domainName, backendName, gcsName)
 }
 
-func setBQEnv(s string, t *testing.T) func() {
+func setBQEnv(email, secretKey string, t *testing.T) func() {
 	e := getBQEnv()
 	// Set all the envs to a dummy value
-	if err := os.Setenv("FASTLY_BQ_EMAIL", s); err != nil {
+	if err := os.Setenv("FASTLY_BQ_EMAIL", email); err != nil {
 		t.Fatalf("Error setting env var FASTLY_BQ_EMAIL: %s", err)
 	}
-	if err := os.Setenv("FASTLY_BQ_SECRET_KEY", s); err != nil {
+	if err := os.Setenv("FASTLY_BQ_SECRET_KEY", secretKey); err != nil {
 		t.Fatalf("Error setting env var FASTLY_BQ_SECRET_KEY: %s", err)
 	}
 

--- a/fastly/resource_fastly_service_v1_bigquerylogging_test.go
+++ b/fastly/resource_fastly_service_v1_bigquerylogging_test.go
@@ -12,40 +12,41 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestResourceFastlyFlattenBigQuery(t *testing.T) {
-	cases := []struct {
-		remote []*gofastly.BigQuery
-		local  []map[string]interface{}
-	}{
-		{
-			remote: []*gofastly.BigQuery{
-				{
-					Name:      "bigquery-example",
-					User:      "email@example.com",
-					ProjectID: "example-gcp-project",
-					Dataset:   "example-bq-dataset",
-					Table:     "example-bq-table",
-					SecretKey: "secretKey",
-				},
-			},
-			local: []map[string]interface{}{
-				{
-					"name":       "bigquery-example",
-					"email":      "email@example.com",
-					"project_id": "example-gcp-project",
-					"dataset":    "example-bq-dataset",
-					"table":      "example-bq-table",
-					"secret_key": "secretKey",
-				},
+var flattenBigQueryTests = []struct {
+	name     string
+	in       []*gofastly.BigQuery
+	expected []map[string]interface{}
+}{
+	{
+		name: "basic flatten",
+		in: []*gofastly.BigQuery{
+			{
+				Name: "bigquery-example", User: "email@example.com",
+				ProjectID: "example-gcp-project", Dataset: "example-bq-dataset",
+				Table: "example-bq-table", SecretKey: "secretKey",
 			},
 		},
-	}
+		expected: []map[string]interface{}{
+			{
+				"name": "bigquery-example", "email": "email@example.com",
+				"project_id": "example-gcp-project", "dataset": "example-bq-dataset",
+				"table": "example-bq-table", "secret_key": "secretKey",
+			},
+		},
+	},
+}
 
-	for _, c := range cases {
-		out := flattenBigQuery(c.remote)
-		if !reflect.DeepEqual(out, c.local) {
-			t.Fatalf("Error matching:\nexpected: %#v\ngot: %#v", c.local, out)
-		}
+func TestResourceFastlyFlattenBigQuery(t *testing.T) {
+
+	for _, tt := range flattenBigQueryTests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			actual := flattenBigQuery(tt.in)
+
+			if !reflect.DeepEqual(actual, tt.expected) {
+				t.Fatalf("Error matching:\nexpected: %#v\ngot: %#v", tt.expected, actual)
+			}
+		})
 	}
 }
 

--- a/fastly/resource_fastly_service_v1_bigquerylogging_test.go
+++ b/fastly/resource_fastly_service_v1_bigquerylogging_test.go
@@ -44,7 +44,7 @@ func TestResourceFastlyFlattenBigQuery(t *testing.T) {
 			actual := flattenBigQuery(tt.in)
 
 			if !reflect.DeepEqual(actual, tt.expected) {
-				t.Fatalf("Error matching:\nexpected: %#v\ngot: %#v", tt.expected, actual)
+				t.Errorf("Error matching:\nexpected: %#v\ngot: %#v", tt.expected, actual)
 			}
 		})
 	}

--- a/fastly/resource_fastly_service_v1_cache_setting_test.go
+++ b/fastly/resource_fastly_service_v1_cache_setting_test.go
@@ -11,6 +11,43 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
+func TestResourceFastlyFlattenCacheSettings(t *testing.T) {
+
+	cases := []struct {
+		remote []*gofastly.CacheSetting
+		local  []map[string]interface{}
+	}{
+		{
+			remote: []*gofastly.CacheSetting{
+				{
+					Name:           "alt_backend",
+					Action:         gofastly.CacheSettingActionPass,
+					StaleTTL:       3600,
+					CacheCondition: "serve_alt_backend",
+					TTL:            300,
+				},
+			},
+			local: []map[string]interface{}{
+				{
+					"name":            "alt_backend",
+					"action":          gofastly.CacheSettingActionPass,
+					"cache_condition": "serve_alt_backend",
+					"stale_ttl":       uint(3600),
+					"ttl":             uint(300),
+				},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		out := flattenCacheSettings(c.remote)
+		if !reflect.DeepEqual(out, c.local) {
+			t.Fatalf("Error matching:\nexpected: %#v\n got: %#v", c.local, out)
+		}
+	}
+
+}
+
 func TestAccFastlyServiceV1CacheSetting_basic(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))

--- a/fastly/resource_fastly_service_v1_cache_setting_test.go
+++ b/fastly/resource_fastly_service_v1_cache_setting_test.go
@@ -43,7 +43,7 @@ func TestResourceFastlyFlattenCacheSettings(t *testing.T) {
 			actual := flattenCacheSettings(tt.in)
 
 			if !reflect.DeepEqual(actual, tt.expected) {
-				t.Fatalf("Error matching:\nexpected: %#v\ngot: %#v", tt.expected, actual)
+				t.Errorf("Error matching:\nexpected: %#v\ngot: %#v", tt.expected, actual)
 			}
 		})
 	}

--- a/fastly/resource_fastly_service_v1_conditionals_test.go
+++ b/fastly/resource_fastly_service_v1_conditionals_test.go
@@ -43,7 +43,7 @@ func TestResourceFastlyFlattenConditions(t *testing.T) {
 			actual := flattenConditions(tt.in)
 
 			if !reflect.DeepEqual(actual, tt.expected) {
-				t.Fatalf("Error matching:\nexpected: %#v\ngot: %#v", tt.expected, actual)
+				t.Errorf("Error matching:\nexpected: %#v\ngot: %#v", tt.expected, actual)
 			}
 		})
 	}

--- a/fastly/resource_fastly_service_v1_conditionals_test.go
+++ b/fastly/resource_fastly_service_v1_conditionals_test.go
@@ -11,6 +11,41 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
+func TestResourceFastlyFlattenConditions(t *testing.T) {
+
+	cases := []struct {
+		remote []*gofastly.Condition
+		local  []map[string]interface{}
+	}{
+		{
+			remote: []*gofastly.Condition{
+				{
+					Name:      "some amz condition",
+					Priority:  10,
+					Type:      "REQUEST",
+					Statement: `req.url ~ "^/yolo/"`,
+				},
+			},
+			local: []map[string]interface{}{
+				{
+					"name":      "some amz condition",
+					"priority":  10,
+					"type":      "REQUEST",
+					"statement": "req.url ~ \"^/yolo/\"",
+				},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		out := flattenConditions(c.remote)
+		if !reflect.DeepEqual(out, c.local) {
+			t.Fatalf("Error matching:\nexpected: %#v\n got: %#v", c.local, out)
+		}
+	}
+
+}
+
 func TestAccFastlyServiceV1_conditional_basic(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))

--- a/fastly/resource_fastly_service_v1_conditionals_test.go
+++ b/fastly/resource_fastly_service_v1_conditionals_test.go
@@ -11,39 +11,42 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestResourceFastlyFlattenConditions(t *testing.T) {
-
-	cases := []struct {
-		remote []*gofastly.Condition
-		local  []map[string]interface{}
-	}{
-		{
-			remote: []*gofastly.Condition{
-				{
-					Name:      "some amz condition",
-					Priority:  10,
-					Type:      "REQUEST",
-					Statement: `req.url ~ "^/yolo/"`,
-				},
-			},
-			local: []map[string]interface{}{
-				{
-					"name":      "some amz condition",
-					"priority":  10,
-					"type":      "REQUEST",
-					"statement": "req.url ~ \"^/yolo/\"",
-				},
+var flattenConditionTests = []struct {
+	name     string
+	in       []*gofastly.Condition
+	expected []map[string]interface{}
+}{
+	{
+		name: "basic flatten",
+		in: []*gofastly.Condition{
+			{
+				Name: "some amz condition", Priority: 10,
+				Type: "REQUEST", Statement: `req.url ~ "^/yolo/"`,
 			},
 		},
-	}
+		expected: []map[string]interface{}{
+			{
+				"name":      "some amz condition",
+				"priority":  10,
+				"type":      "REQUEST",
+				"statement": "req.url ~ \"^/yolo/\"",
+			},
+		},
+	},
+}
 
-	for _, c := range cases {
-		out := flattenConditions(c.remote)
-		if !reflect.DeepEqual(out, c.local) {
-			t.Fatalf("Error matching:\nexpected: %#v\n got: %#v", c.local, out)
-		}
-	}
+func TestResourceFastlyFlattenConditions(t *testing.T) {
 
+	for _, tt := range flattenConditionTests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			actual := flattenConditions(tt.in)
+
+			if !reflect.DeepEqual(actual, tt.expected) {
+				t.Fatalf("Error matching:\nexpected: %#v\ngot: %#v", tt.expected, actual)
+			}
+		})
+	}
 }
 
 func TestAccFastlyServiceV1_conditional_basic(t *testing.T) {

--- a/fastly/resource_fastly_service_v1_director_test.go
+++ b/fastly/resource_fastly_service_v1_director_test.go
@@ -90,14 +90,14 @@ func TestResourceFastlyFlattenDirectors(t *testing.T) {
 					if o["name"].(string) == l["name"].(string) {
 						found++
 						if o["backends"] == nil && l["backends"] != nil {
-							t.Fatalf("output backends are nil, local are not")
+							t.Errorf("output backends are nil, local are not")
 						}
 
 						if o["backends"] != nil {
 							oex := o["backends"].(*schema.Set)
 							lex := l["backends"].(*schema.Set)
 							if !oex.Equal(lex) {
-								t.Fatalf("Backends don't match, expected: %#v, got: %#v", lex, oex)
+								t.Errorf("Backends don't match, expected: %#v, got: %#v", lex, oex)
 							}
 						}
 					}
@@ -105,7 +105,7 @@ func TestResourceFastlyFlattenDirectors(t *testing.T) {
 			}
 
 			if found != expectedCount {
-				t.Fatalf("Found and expected mismatch: %d / %d", found, expectedCount)
+				t.Errorf("Found and expected mismatch: %d / %d", found, expectedCount)
 			}
 		})
 	}

--- a/fastly/resource_fastly_service_v1_director_test.go
+++ b/fastly/resource_fastly_service_v1_director_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestFastlyServiceV1_FlattenDirectors(t *testing.T) {
+func TestResourceFastlyFlattenDirectors(t *testing.T) {
 	cases := []struct {
 		remote_director        []*gofastly.Director
 		remote_directorbackend []*gofastly.DirectorBackend

--- a/fastly/resource_fastly_service_v1_gcslogging_test.go
+++ b/fastly/resource_fastly_service_v1_gcslogging_test.go
@@ -12,42 +12,43 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestResourceFastlyFlattenGCS(t *testing.T) {
-	cases := []struct {
-		remote []*gofastly.GCS
-		local  []map[string]interface{}
-	}{
-		{
-			remote: []*gofastly.GCS{
-				{
-					Name:      "GCS collector",
-					User:      "email@example.com",
-					Bucket:    "bucketName",
-					SecretKey: "secretKey",
-					Format:    "log format",
-					Period:    3600,
-					GzipLevel: 0,
-				},
-			},
-			local: []map[string]interface{}{
-				{
-					"name":        "GCS collector",
-					"email":       "email@example.com",
-					"bucket_name": "bucketName",
-					"secret_key":  "secretKey",
-					"format":      "log format",
-					"period":      3600,
-					"gzip_level":  0,
-				},
+var flattenGCSTests = []struct {
+	name     string
+	in       []*gofastly.GCS
+	expected []map[string]interface{}
+}{
+	{
+		name: "basic flatten",
+		in: []*gofastly.GCS{
+			{
+				Name: "GCS collector", User: "email@example.com",
+				Bucket: "bucketName", SecretKey: "secretKey",
+				Format: "log format", Period: 3600,
+				GzipLevel: 0,
 			},
 		},
-	}
+		expected: []map[string]interface{}{
+			{
+				"name": "GCS collector", "email": "email@example.com",
+				"bucket_name": "bucketName", "secret_key": "secretKey",
+				"format": "log format", "period": 3600,
+				"gzip_level": 0,
+			},
+		},
+	},
+}
 
-	for _, c := range cases {
-		out := flattenGCS(c.remote)
-		if !reflect.DeepEqual(out, c.local) {
-			t.Fatalf("Error matching:\nexpected: %#v\ngot: %#v", c.local, out)
-		}
+func TestResourceFastlyFlattenGCS(t *testing.T) {
+
+	for _, tt := range flattenGCSTests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			actual := flattenGCS(tt.in)
+
+			if !reflect.DeepEqual(actual, tt.expected) {
+				t.Fatalf("Error matching:\nexpected: %#v\ngot: %#v", tt.expected, actual)
+			}
+		})
 	}
 }
 

--- a/fastly/resource_fastly_service_v1_gcslogging_test.go
+++ b/fastly/resource_fastly_service_v1_gcslogging_test.go
@@ -46,7 +46,7 @@ func TestResourceFastlyFlattenGCS(t *testing.T) {
 			actual := flattenGCS(tt.in)
 
 			if !reflect.DeepEqual(actual, tt.expected) {
-				t.Fatalf("Error matching:\nexpected: %#v\ngot: %#v", tt.expected, actual)
+				t.Errorf("Error matching:\nexpected: %#v\ngot: %#v", tt.expected, actual)
 			}
 		})
 	}

--- a/fastly/resource_fastly_service_v1_gcslogging_test.go
+++ b/fastly/resource_fastly_service_v1_gcslogging_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
+var secretKey, _ = generateKey()
+
 var flattenGCSTests = []struct {
 	name     string
 	in       []*gofastly.GCS
@@ -22,7 +24,7 @@ var flattenGCSTests = []struct {
 		in: []*gofastly.GCS{
 			{
 				Name: "GCS collector", User: "email@example.com",
-				Bucket: "bucketName", SecretKey: "secretKey",
+				Bucket: "bucketName", SecretKey: secretKey,
 				Format: "log format", Period: 3600,
 				GzipLevel: 0,
 			},
@@ -30,7 +32,7 @@ var flattenGCSTests = []struct {
 		expected: []map[string]interface{}{
 			{
 				"name": "GCS collector", "email": "email@example.com",
-				"bucket_name": "bucketName", "secret_key": "secretKey",
+				"bucket_name": "bucketName", "secret_key": secretKey,
 				"format": "log format", "period": 3600,
 				"gzip_level": 0,
 			},
@@ -56,6 +58,10 @@ func TestAccFastlyServiceV1_gcslogging(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	gcsName := fmt.Sprintf("gcs %s", acctest.RandString(10))
+	secretKey, err := generateKey()
+	if err != nil {
+		t.Errorf("Failed to generate key: %s", err)
+	}
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -63,7 +69,7 @@ func TestAccFastlyServiceV1_gcslogging(t *testing.T) {
 		CheckDestroy: testAccCheckServiceV1Destroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccServiceV1Config_gcs(name, gcsName),
+				Config: testAccServiceV1Config_gcs(name, gcsName, secretKey),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
 					testAccCheckFastlyServiceV1Attributes_gcs(&service, name, gcsName),
@@ -77,9 +83,13 @@ func TestAccFastlyServiceV1_gcslogging_env(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	gcsName := fmt.Sprintf("gcs %s", acctest.RandString(10))
+	secretKey, err := generateKey()
+	if err != nil {
+		t.Errorf("Failed to generate key: %s", err)
+	}
 
 	// set env Vars to something we expect
-	resetEnv := setGcsEnv("someEnv", t)
+	resetEnv := setGcsEnv("someEnv", secretKey, t)
 	defer resetEnv()
 
 	resource.Test(t, resource.TestCase{
@@ -127,7 +137,7 @@ func testAccCheckFastlyServiceV1Attributes_gcs(service *gofastly.ServiceDetail, 
 	}
 }
 
-func testAccServiceV1Config_gcs(name, gcsName string) string {
+func testAccServiceV1Config_gcs(name, gcsName, secretKey string) string {
 	backendName := fmt.Sprintf("%s.aws.amazon.com", acctest.RandString(3))
 	domainName := fmt.Sprintf("fastly-test.tf-%s.com", acctest.RandString(10))
 
@@ -148,14 +158,14 @@ resource "fastly_service_v1" "foo" {
 	gcslogging {
 	  name =  "%s"
 		email = "email@example.com",
-		bucket_name = "bucketName",
-		secret_key = "secretKey",
+		bucket_name = "bucketname",
+		secret_key = %q,
 		format = "log format",
 		response_condition = "",
 	}
 
   force_destroy = true
-}`, name, domainName, backendName, gcsName)
+}`, name, domainName, backendName, gcsName, secretKey)
 }
 
 func testAccServiceV1Config_gcs_env(name, gcsName string) string {
@@ -178,7 +188,7 @@ resource "fastly_service_v1" "foo" {
 
 	gcslogging {
 	  name =  "%s"
-		bucket_name = "bucketName",
+		bucket_name = "bucketname",
 		format = "log format",
 		response_condition = "",
 	}
@@ -187,13 +197,13 @@ resource "fastly_service_v1" "foo" {
 }`, name, domainName, backendName, gcsName)
 }
 
-func setGcsEnv(s string, t *testing.T) func() {
+func setGcsEnv(email, secretKey string, t *testing.T) func() {
 	e := getGcsEnv()
 	// Set all the envs to a dummy value
-	if err := os.Setenv("FASTLY_GCS_EMAIL", s); err != nil {
+	if err := os.Setenv("FASTLY_GCS_EMAIL", email); err != nil {
 		t.Fatalf("Error setting env var FASTLY_GCS_EMAIL: %s", err)
 	}
-	if err := os.Setenv("FASTLY_GCS_SECRET_KEY", s); err != nil {
+	if err := os.Setenv("FASTLY_GCS_SECRET_KEY", secretKey); err != nil {
 		t.Fatalf("Error setting env var FASTLY_GCS_SECRET_KEY: %s", err)
 	}
 

--- a/fastly/resource_fastly_service_v1_gzip_test.go
+++ b/fastly/resource_fastly_service_v1_gzip_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestFastlyServiceV1_FlattenGzips(t *testing.T) {
+func TestResourceFastlyFlattenGzips(t *testing.T) {
 	cases := []struct {
 		remote []*gofastly.Gzip
 		local  []map[string]interface{}

--- a/fastly/resource_fastly_service_v1_gzip_test.go
+++ b/fastly/resource_fastly_service_v1_gzip_test.go
@@ -71,26 +71,26 @@ func TestResourceFastlyFlattenGzips(t *testing.T) {
 					if o["name"].(string) == l["name"].(string) {
 						found++
 						if o["extensions"] == nil && l["extensions"] != nil {
-							t.Fatalf("output extensions are nil, local are not")
+							t.Errorf("output extensions are nil, local are not")
 						}
 
 						if o["extensions"] != nil {
 							oex := o["extensions"].(*schema.Set)
 							lex := l["extensions"].(*schema.Set)
 							if !oex.Equal(lex) {
-								t.Fatalf("Extensions don't match, expected: %#v, got: %#v", lex, oex)
+								t.Errorf("Extensions don't match, expected: %#v, got: %#v", lex, oex)
 							}
 						}
 
 						if o["content_types"] == nil && l["content_types"] != nil {
-							t.Fatalf("output content types are nil, local are not")
+							t.Errorf("output content types are nil, local are not")
 						}
 
 						if o["content_types"] != nil {
 							oct := o["content_types"].(*schema.Set)
 							lct := l["content_types"].(*schema.Set)
 							if !oct.Equal(lct) {
-								t.Fatalf("ContentTypes don't match, expected: %#v, got: %#v", lct, oct)
+								t.Errorf("ContentTypes don't match, expected: %#v, got: %#v", lct, oct)
 							}
 						}
 
@@ -99,7 +99,7 @@ func TestResourceFastlyFlattenGzips(t *testing.T) {
 			}
 
 			if found != expectedCount {
-				t.Fatalf("Found and expected mismatch: %d / %d", found, expectedCount)
+				t.Errorf("Found and expected mismatch: %d / %d", found, expectedCount)
 			}
 		})
 	}

--- a/fastly/resource_fastly_service_v1_headers_test.go
+++ b/fastly/resource_fastly_service_v1_headers_test.go
@@ -11,49 +11,48 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestResourceFastlyFlattenHeaders(t *testing.T) {
-
-	cases := []struct {
-		remote []*gofastly.Header
-		local  []map[string]interface{}
-	}{
-		{
-			remote: []*gofastly.Header{
-				{
-					Name:              "myheader",
-					Action:            "delete",
-					IgnoreIfSet:       true,
-					Type:              "cache",
-					Destination:       "http.aws-id",
-					Source:            "",
-					Regex:             "",
-					Substitution:      "",
-					Priority:          100,
-					RequestCondition:  "",
-					CacheCondition:    "",
-					ResponseCondition: "",
-				},
-			},
-			local: []map[string]interface{}{
-				{
-					"name":          "myheader",
-					"action":        gofastly.HeaderActionDelete,
-					"ignore_if_set": true,
-					"type":          gofastly.HeaderTypeCache,
-					"destination":   "http.aws-id",
-					"priority":      int(100),
-				},
+var flattenHeadersTests = []struct {
+	name     string
+	in       []*gofastly.Header
+	expected []map[string]interface{}
+}{
+	{
+		name: "basic flatten",
+		in: []*gofastly.Header{
+			{
+				Name: "myheader", Action: "delete",
+				IgnoreIfSet: true, Type: "cache",
+				Destination: "http.aws-id", Source: "",
+				Regex: "", Substitution: "",
+				Priority: 100, RequestCondition: "",
+				CacheCondition: "", ResponseCondition: "",
 			},
 		},
-	}
+		expected: []map[string]interface{}{
+			{
+				"name":          "myheader",
+				"action":        gofastly.HeaderActionDelete,
+				"ignore_if_set": true,
+				"type":          gofastly.HeaderTypeCache,
+				"destination":   "http.aws-id",
+				"priority":      int(100),
+			},
+		},
+	},
+}
 
-	for _, c := range cases {
-		out := flattenHeaders(c.remote)
-		if !reflect.DeepEqual(out, c.local) {
-			t.Fatalf("Error matching:\nexpected: %#v\n got: %#v", c.local, out)
-		}
-	}
+func TestResourceFastlyFlattenHeaders(t *testing.T) {
 
+	for _, tt := range flattenHeadersTests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			actual := flattenHeaders(tt.in)
+
+			if !reflect.DeepEqual(actual, tt.expected) {
+				t.Fatalf("Error matching:\nexpected: %#v\ngot: %#v", tt.expected, actual)
+			}
+		})
+	}
 }
 
 func TestFastlyServiceV1_BuildHeaders(t *testing.T) {

--- a/fastly/resource_fastly_service_v1_headers_test.go
+++ b/fastly/resource_fastly_service_v1_headers_test.go
@@ -49,7 +49,7 @@ func TestResourceFastlyFlattenHeaders(t *testing.T) {
 			actual := flattenHeaders(tt.in)
 
 			if !reflect.DeepEqual(actual, tt.expected) {
-				t.Fatalf("Error matching:\nexpected: %#v\ngot: %#v", tt.expected, actual)
+				t.Errorf("Error matching:\nexpected: %#v\ngot: %#v", tt.expected, actual)
 			}
 		})
 	}

--- a/fastly/resource_fastly_service_v1_headers_test.go
+++ b/fastly/resource_fastly_service_v1_headers_test.go
@@ -11,6 +11,51 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
+func TestResourceFastlyFlattenHeaders(t *testing.T) {
+
+	cases := []struct {
+		remote []*gofastly.Header
+		local  []map[string]interface{}
+	}{
+		{
+			remote: []*gofastly.Header{
+				{
+					Name:              "myheader",
+					Action:            "delete",
+					IgnoreIfSet:       true,
+					Type:              "cache",
+					Destination:       "http.aws-id",
+					Source:            "",
+					Regex:             "",
+					Substitution:      "",
+					Priority:          100,
+					RequestCondition:  "",
+					CacheCondition:    "",
+					ResponseCondition: "",
+				},
+			},
+			local: []map[string]interface{}{
+				{
+					"name":          "myheader",
+					"action":        gofastly.HeaderActionDelete,
+					"ignore_if_set": true,
+					"type":          gofastly.HeaderTypeCache,
+					"destination":   "http.aws-id",
+					"priority":      int(100),
+				},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		out := flattenHeaders(c.remote)
+		if !reflect.DeepEqual(out, c.local) {
+			t.Fatalf("Error matching:\nexpected: %#v\n got: %#v", c.local, out)
+		}
+	}
+
+}
+
 func TestFastlyServiceV1_BuildHeaders(t *testing.T) {
 	cases := []struct {
 		remote *gofastly.CreateHeaderInput

--- a/fastly/resource_fastly_service_v1_healthcheck_test.go
+++ b/fastly/resource_fastly_service_v1_healthcheck_test.go
@@ -11,6 +11,56 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
+func TestResourceFastlyFlattenHealthChecks(t *testing.T) {
+
+	cases := []struct {
+		remote []*gofastly.HealthCheck
+		local  []map[string]interface{}
+	}{
+		{
+			remote: []*gofastly.HealthCheck{
+				{
+					Version:          1,
+					Name:             "myhealthcheck",
+					Host:             "example1.com",
+					Path:             "/test1.txt",
+					CheckInterval:    4000,
+					ExpectedResponse: 200,
+					HTTPVersion:      "1.1",
+					Initial:          2,
+					Method:           "HEAD",
+					Threshold:        3,
+					Timeout:          5000,
+					Window:           5,
+				},
+			},
+			local: []map[string]interface{}{
+				{
+					"name":              "myhealthcheck",
+					"host":              "example1.com",
+					"path":              "/test1.txt",
+					"check_interval":    uint(4000),
+					"expected_response": uint(200),
+					"http_version":      "1.1",
+					"initial":           uint(2),
+					"method":            "HEAD",
+					"threshold":         uint(3),
+					"timeout":           uint(5000),
+					"window":            uint(5),
+				},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		out := flattenHealthchecks(c.remote)
+		if !reflect.DeepEqual(out, c.local) {
+			t.Fatalf("Error matching:\nexpected: %#v\n got: %#v", c.local, out)
+		}
+	}
+
+}
+
 func TestAccFastlyServiceV1_healthcheck_basic(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))

--- a/fastly/resource_fastly_service_v1_healthcheck_test.go
+++ b/fastly/resource_fastly_service_v1_healthcheck_test.go
@@ -49,7 +49,7 @@ func TestResourceFastlyFlattenHealthChecks(t *testing.T) {
 			actual := flattenHealthchecks(tt.in)
 
 			if !reflect.DeepEqual(actual, tt.expected) {
-				t.Fatalf("Error matching:\nexpected: %#v\ngot: %#v", tt.expected, actual)
+				t.Errorf("Error matching:\nexpected: %#v\ngot: %#v", tt.expected, actual)
 			}
 		})
 	}

--- a/fastly/resource_fastly_service_v1_healthcheck_test.go
+++ b/fastly/resource_fastly_service_v1_healthcheck_test.go
@@ -11,54 +11,48 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestResourceFastlyFlattenHealthChecks(t *testing.T) {
-
-	cases := []struct {
-		remote []*gofastly.HealthCheck
-		local  []map[string]interface{}
-	}{
-		{
-			remote: []*gofastly.HealthCheck{
-				{
-					Version:          1,
-					Name:             "myhealthcheck",
-					Host:             "example1.com",
-					Path:             "/test1.txt",
-					CheckInterval:    4000,
-					ExpectedResponse: 200,
-					HTTPVersion:      "1.1",
-					Initial:          2,
-					Method:           "HEAD",
-					Threshold:        3,
-					Timeout:          5000,
-					Window:           5,
-				},
-			},
-			local: []map[string]interface{}{
-				{
-					"name":              "myhealthcheck",
-					"host":              "example1.com",
-					"path":              "/test1.txt",
-					"check_interval":    uint(4000),
-					"expected_response": uint(200),
-					"http_version":      "1.1",
-					"initial":           uint(2),
-					"method":            "HEAD",
-					"threshold":         uint(3),
-					"timeout":           uint(5000),
-					"window":            uint(5),
-				},
+var flattenHealthCheckTests = []struct {
+	name     string
+	in       []*gofastly.HealthCheck
+	expected []map[string]interface{}
+}{
+	{
+		name: "basic flatten",
+		in: []*gofastly.HealthCheck{
+			{
+				Version: 1, Name: "myhealthcheck",
+				Host: "example1.com", Path: "/test1.txt",
+				CheckInterval: 4000, ExpectedResponse: 200,
+				HTTPVersion: "1.1", Initial: 2,
+				Method: "HEAD", Threshold: 3,
+				Timeout: 5000, Window: 5,
 			},
 		},
-	}
+		expected: []map[string]interface{}{
+			{
+				"name": "myhealthcheck", "host": "example1.com",
+				"path": "/test1.txt", "check_interval": uint(4000),
+				"expected_response": uint(200), "http_version": "1.1",
+				"initial": uint(2), "method": "HEAD",
+				"threshold": uint(3), "timeout": uint(5000),
+				"window": uint(5),
+			},
+		},
+	},
+}
 
-	for _, c := range cases {
-		out := flattenHealthchecks(c.remote)
-		if !reflect.DeepEqual(out, c.local) {
-			t.Fatalf("Error matching:\nexpected: %#v\n got: %#v", c.local, out)
-		}
-	}
+func TestResourceFastlyFlattenHealthChecks(t *testing.T) {
 
+	for _, tt := range flattenHealthCheckTests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			actual := flattenHealthchecks(tt.in)
+
+			if !reflect.DeepEqual(actual, tt.expected) {
+				t.Fatalf("Error matching:\nexpected: %#v\ngot: %#v", tt.expected, actual)
+			}
+		})
+	}
 }
 
 func TestAccFastlyServiceV1_healthcheck_basic(t *testing.T) {

--- a/fastly/resource_fastly_service_v1_logentries_test.go
+++ b/fastly/resource_fastly_service_v1_logentries_test.go
@@ -46,7 +46,7 @@ func TestResourceFastlyFlattenLogentries(t *testing.T) {
 			actual := flattenLogentries(tt.in)
 
 			if !reflect.DeepEqual(actual, tt.expected) {
-				t.Fatalf("Error matching:\nexpected: %#v\ngot: %#v", tt.expected, actual)
+				t.Errorf("Error matching:\nexpected: %#v\ngot: %#v", tt.expected, actual)
 			}
 		})
 	}

--- a/fastly/resource_fastly_service_v1_logentries_test.go
+++ b/fastly/resource_fastly_service_v1_logentries_test.go
@@ -12,6 +12,47 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
+func TestResourceFastlyFlattenLogentries(t *testing.T) {
+
+	cases := []struct {
+		remote []*gofastly.Logentries
+		local  []map[string]interface{}
+	}{
+		{
+			remote: []*gofastly.Logentries{
+				{
+					Version:           1,
+					Name:              "somelogentriesname",
+					Port:              8080,
+					Token:             "mytoken",
+					Format:            "%h %l %u %t %r %>s",
+					FormatVersion:     1,
+					ResponseCondition: "response_condition_test",
+				},
+			},
+			local: []map[string]interface{}{
+				{
+					"name":               "somelogentriesname",
+					"port":               uint(8080),
+					"token":              "mytoken",
+					"format":             "%h %l %u %t %r %>s",
+					"format_version":     uint(1),
+					"response_condition": "response_condition_test",
+					"use_tls":            false,
+				},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		out := flattenLogentries(c.remote)
+		if !reflect.DeepEqual(out, c.local) {
+			t.Fatalf("Error matching:\nexpected: %#v\n got: %#v", c.local, out)
+		}
+	}
+
+}
+
 func TestAccFastlyServiceV1_logentries_basic(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))

--- a/fastly/resource_fastly_service_v1_logentries_test.go
+++ b/fastly/resource_fastly_service_v1_logentries_test.go
@@ -12,45 +12,44 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestResourceFastlyFlattenLogentries(t *testing.T) {
-
-	cases := []struct {
-		remote []*gofastly.Logentries
-		local  []map[string]interface{}
-	}{
-		{
-			remote: []*gofastly.Logentries{
-				{
-					Version:           1,
-					Name:              "somelogentriesname",
-					Port:              8080,
-					Token:             "mytoken",
-					Format:            "%h %l %u %t %r %>s",
-					FormatVersion:     1,
-					ResponseCondition: "response_condition_test",
-				},
-			},
-			local: []map[string]interface{}{
-				{
-					"name":               "somelogentriesname",
-					"port":               uint(8080),
-					"token":              "mytoken",
-					"format":             "%h %l %u %t %r %>s",
-					"format_version":     uint(1),
-					"response_condition": "response_condition_test",
-					"use_tls":            false,
-				},
+var flattenLogentriesTests = []struct {
+	name     string
+	in       []*gofastly.Logentries
+	expected []map[string]interface{}
+}{
+	{
+		name: "basic flatten",
+		in: []*gofastly.Logentries{
+			{
+				Version: 1, Name: "somelogentriesname",
+				Port: 8080, Token: "mytoken",
+				Format: "%h %l %u %t %r %>s", FormatVersion: 1,
+				ResponseCondition: "response_condition_test",
 			},
 		},
-	}
+		expected: []map[string]interface{}{
+			{
+				"name": "somelogentriesname", "port": uint(8080),
+				"token": "mytoken", "format": "%h %l %u %t %r %>s",
+				"format_version": uint(1), "response_condition": "response_condition_test",
+				"use_tls": false,
+			},
+		},
+	},
+}
 
-	for _, c := range cases {
-		out := flattenLogentries(c.remote)
-		if !reflect.DeepEqual(out, c.local) {
-			t.Fatalf("Error matching:\nexpected: %#v\n got: %#v", c.local, out)
-		}
-	}
+func TestResourceFastlyFlattenLogentries(t *testing.T) {
 
+	for _, tt := range flattenLogentriesTests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			actual := flattenLogentries(tt.in)
+
+			if !reflect.DeepEqual(actual, tt.expected) {
+				t.Fatalf("Error matching:\nexpected: %#v\ngot: %#v", tt.expected, actual)
+			}
+		})
+	}
 }
 
 func TestAccFastlyServiceV1_logentries_basic(t *testing.T) {

--- a/fastly/resource_fastly_service_v1_papertrail_test.go
+++ b/fastly/resource_fastly_service_v1_papertrail_test.go
@@ -43,7 +43,7 @@ func TestResourceFastlyFlattenPapertrail(t *testing.T) {
 			actual := flattenPapertrails(tt.in)
 
 			if !reflect.DeepEqual(actual, tt.expected) {
-				t.Fatalf("Error matching:\nexpected: %#v\ngot: %#v", tt.expected, actual)
+				t.Errorf("Error matching:\nexpected: %#v\ngot: %#v", tt.expected, actual)
 			}
 		})
 	}

--- a/fastly/resource_fastly_service_v1_papertrail_test.go
+++ b/fastly/resource_fastly_service_v1_papertrail_test.go
@@ -11,6 +11,44 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
+func TestResourceFastlyFlattenPapertrail(t *testing.T) {
+
+	cases := []struct {
+		remote []*gofastly.Papertrail
+		local  []map[string]interface{}
+	}{
+		{
+			remote: []*gofastly.Papertrail{
+				{
+					Version:           1,
+					Name:              "papertrailtesting",
+					Address:           "test1.papertrailapp.com",
+					Port:              3600,
+					Format:            "%h %l %u %t %r %>s",
+					ResponseCondition: "test_response_condition",
+				},
+			},
+			local: []map[string]interface{}{
+				{
+					"name":               "papertrailtesting",
+					"address":            "test1.papertrailapp.com",
+					"port":               uint(3600),
+					"format":             "%h %l %u %t %r %>s",
+					"response_condition": "test_response_condition",
+				},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		out := flattenPapertrails(c.remote)
+		if !reflect.DeepEqual(out, c.local) {
+			t.Fatalf("Error matching:\nexpected: %#v\n got: %#v", c.local, out)
+		}
+	}
+
+}
+
 func TestAccFastlyServiceV1_papertrail_basic(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))

--- a/fastly/resource_fastly_service_v1_papertrail_test.go
+++ b/fastly/resource_fastly_service_v1_papertrail_test.go
@@ -11,42 +11,42 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestResourceFastlyFlattenPapertrail(t *testing.T) {
-
-	cases := []struct {
-		remote []*gofastly.Papertrail
-		local  []map[string]interface{}
-	}{
-		{
-			remote: []*gofastly.Papertrail{
-				{
-					Version:           1,
-					Name:              "papertrailtesting",
-					Address:           "test1.papertrailapp.com",
-					Port:              3600,
-					Format:            "%h %l %u %t %r %>s",
-					ResponseCondition: "test_response_condition",
-				},
-			},
-			local: []map[string]interface{}{
-				{
-					"name":               "papertrailtesting",
-					"address":            "test1.papertrailapp.com",
-					"port":               uint(3600),
-					"format":             "%h %l %u %t %r %>s",
-					"response_condition": "test_response_condition",
-				},
+var flattenPapertrailTests = []struct {
+	name     string
+	in       []*gofastly.Papertrail
+	expected []map[string]interface{}
+}{
+	{
+		name: "basic flatten",
+		in: []*gofastly.Papertrail{
+			{
+				Version: 1, Name: "papertrailtesting",
+				Address: "test1.papertrailapp.com", Port: 3600,
+				Format: "%h %l %u %t %r %>s", ResponseCondition: "test_response_condition",
 			},
 		},
-	}
+		expected: []map[string]interface{}{
+			{
+				"name": "papertrailtesting", "address": "test1.papertrailapp.com",
+				"port": uint(3600), "format": "%h %l %u %t %r %>s",
+				"response_condition": "test_response_condition",
+			},
+		},
+	},
+}
 
-	for _, c := range cases {
-		out := flattenPapertrails(c.remote)
-		if !reflect.DeepEqual(out, c.local) {
-			t.Fatalf("Error matching:\nexpected: %#v\n got: %#v", c.local, out)
-		}
-	}
+func TestResourceFastlyFlattenPapertrail(t *testing.T) {
 
+	for _, tt := range flattenPapertrailTests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			actual := flattenPapertrails(tt.in)
+
+			if !reflect.DeepEqual(actual, tt.expected) {
+				t.Fatalf("Error matching:\nexpected: %#v\ngot: %#v", tt.expected, actual)
+			}
+		})
+	}
 }
 
 func TestAccFastlyServiceV1_papertrail_basic(t *testing.T) {

--- a/fastly/resource_fastly_service_v1_request_setting_test.go
+++ b/fastly/resource_fastly_service_v1_request_setting_test.go
@@ -47,7 +47,7 @@ func TestResourceFastlyFlattenRequestSettings(t *testing.T) {
 			actual := flattenRequestSettings(tt.in)
 
 			if !reflect.DeepEqual(actual, tt.expected) {
-				t.Fatalf("Error matching:\nexpected: %#v\ngot: %#v", tt.expected, actual)
+				t.Errorf("Error matching:\nexpected: %#v\ngot: %#v", tt.expected, actual)
 			}
 		})
 	}

--- a/fastly/resource_fastly_service_v1_request_setting_test.go
+++ b/fastly/resource_fastly_service_v1_request_setting_test.go
@@ -11,48 +11,46 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestResourceFastlyFlattenRequestSettings(t *testing.T) {
-
-	cases := []struct {
-		remote []*gofastly.RequestSetting
-		local  []map[string]interface{}
-	}{
-		{
-			remote: []*gofastly.RequestSetting{
-				{
-					Name:             "alt_backend",
-					RequestCondition: "serve_alt_backend",
-					DefaultHost:      "tftestingother.tftesting.net.s3-website-us-west-2.amazonaws.com",
-					XForwardedFor:    gofastly.RequestSettingXFFAppend,
-					MaxStaleAge:      90,
-					Action:           gofastly.RequestSettingActionPass,
-				},
-			},
-			local: []map[string]interface{}{
-				{
-					"name":              "alt_backend",
-					"request_condition": "serve_alt_backend",
-					"default_host":      "tftestingother.tftesting.net.s3-website-us-west-2.amazonaws.com",
-					"xff":               gofastly.RequestSettingXFFAppend,
-					"max_stale_age":     uint(90),
-					"action":            gofastly.RequestSettingActionPass,
-					"bypass_busy_wait":  false,
-					"force_miss":        false,
-					"force_ssl":         false,
-					"geo_headers":       false,
-					"timer_support":     false,
-				},
+var flattenRequestSettingTests = []struct {
+	name     string
+	in       []*gofastly.RequestSetting
+	expected []map[string]interface{}
+}{
+	{
+		name: "basic flatten",
+		in: []*gofastly.RequestSetting{
+			{
+				Name: "alt_backend", RequestCondition: "serve_alt_backend",
+				DefaultHost:   "tftestingother.tftesting.net.s3-website-us-west-2.amazonaws.com",
+				XForwardedFor: gofastly.RequestSettingXFFAppend, MaxStaleAge: 90,
+				Action: gofastly.RequestSettingActionPass,
 			},
 		},
-	}
+		expected: []map[string]interface{}{
+			{
+				"name": "alt_backend", "request_condition": "serve_alt_backend",
+				"default_host": "tftestingother.tftesting.net.s3-website-us-west-2.amazonaws.com",
+				"xff":          gofastly.RequestSettingXFFAppend, "max_stale_age": uint(90),
+				"action": gofastly.RequestSettingActionPass, "bypass_busy_wait": false,
+				"force_miss": false, "force_ssl": false,
+				"geo_headers": false, "timer_support": false,
+			},
+		},
+	},
+}
 
-	for _, c := range cases {
-		out := flattenRequestSettings(c.remote)
-		if !reflect.DeepEqual(out, c.local) {
-			t.Fatalf("Error matching:\nexpected: %#v\n got: %#v", c.local, out)
-		}
-	}
+func TestResourceFastlyFlattenRequestSettings(t *testing.T) {
 
+	for _, tt := range flattenRequestSettingTests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			actual := flattenRequestSettings(tt.in)
+
+			if !reflect.DeepEqual(actual, tt.expected) {
+				t.Fatalf("Error matching:\nexpected: %#v\ngot: %#v", tt.expected, actual)
+			}
+		})
+	}
 }
 
 func TestAccFastlyServiceV1RequestSetting_basic(t *testing.T) {

--- a/fastly/resource_fastly_service_v1_request_setting_test.go
+++ b/fastly/resource_fastly_service_v1_request_setting_test.go
@@ -11,6 +11,50 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
+func TestResourceFastlyFlattenRequestSettings(t *testing.T) {
+
+	cases := []struct {
+		remote []*gofastly.RequestSetting
+		local  []map[string]interface{}
+	}{
+		{
+			remote: []*gofastly.RequestSetting{
+				{
+					Name:             "alt_backend",
+					RequestCondition: "serve_alt_backend",
+					DefaultHost:      "tftestingother.tftesting.net.s3-website-us-west-2.amazonaws.com",
+					XForwardedFor:    gofastly.RequestSettingXFFAppend,
+					MaxStaleAge:      90,
+					Action:           gofastly.RequestSettingActionPass,
+				},
+			},
+			local: []map[string]interface{}{
+				{
+					"name":              "alt_backend",
+					"request_condition": "serve_alt_backend",
+					"default_host":      "tftestingother.tftesting.net.s3-website-us-west-2.amazonaws.com",
+					"xff":               gofastly.RequestSettingXFFAppend,
+					"max_stale_age":     uint(90),
+					"action":            gofastly.RequestSettingActionPass,
+					"bypass_busy_wait":  false,
+					"force_miss":        false,
+					"force_ssl":         false,
+					"geo_headers":       false,
+					"timer_support":     false,
+				},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		out := flattenRequestSettings(c.remote)
+		if !reflect.DeepEqual(out, c.local) {
+			t.Fatalf("Error matching:\nexpected: %#v\n got: %#v", c.local, out)
+		}
+	}
+
+}
+
 func TestAccFastlyServiceV1RequestSetting_basic(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))

--- a/fastly/resource_fastly_service_v1_response_object_test.go
+++ b/fastly/resource_fastly_service_v1_response_object_test.go
@@ -45,7 +45,7 @@ func TestResourceFastlyFlattenResponseObjects(t *testing.T) {
 			actual := flattenResponseObjects(tt.in)
 
 			if !reflect.DeepEqual(actual, tt.expected) {
-				t.Fatalf("Error matching:\nexpected: %#v\ngot: %#v", tt.expected, actual)
+				t.Errorf("Error matching:\nexpected: %#v\ngot: %#v", tt.expected, actual)
 			}
 		})
 	}

--- a/fastly/resource_fastly_service_v1_response_object_test.go
+++ b/fastly/resource_fastly_service_v1_response_object_test.go
@@ -11,46 +11,44 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestResourceFastlyFlattenResponseObjects(t *testing.T) {
-
-	cases := []struct {
-		remote []*gofastly.ResponseObject
-		local  []map[string]interface{}
-	}{
-		{
-			remote: []*gofastly.ResponseObject{
-				{
-					Version:          1,
-					Name:             "responseObjecttesting",
-					Status:           200,
-					Response:         "OK",
-					Content:          "test content",
-					ContentType:      "text/html",
-					RequestCondition: "test-request-condition",
-					CacheCondition:   "test-cache-condition",
-				},
-			},
-			local: []map[string]interface{}{
-				{
-					"name":              "responseObjecttesting",
-					"status":            uint(200),
-					"response":          "OK",
-					"content":           "test content",
-					"content_type":      "text/html",
-					"request_condition": "test-request-condition",
-					"cache_condition":   "test-cache-condition",
-				},
+var flattenResponseObjectTests = []struct {
+	name     string
+	in       []*gofastly.ResponseObject
+	expected []map[string]interface{}
+}{
+	{
+		name: "basic flatten",
+		in: []*gofastly.ResponseObject{
+			{
+				Version: 1, Name: "responseObjecttesting",
+				Status: 200, Response: "OK",
+				Content: "test content", ContentType: "text/html",
+				RequestCondition: "test-request-condition", CacheCondition: "test-cache-condition",
 			},
 		},
-	}
+		expected: []map[string]interface{}{
+			{
+				"name": "responseObjecttesting", "status": uint(200),
+				"response": "OK", "content": "test content",
+				"content_type": "text/html", "request_condition": "test-request-condition",
+				"cache_condition": "test-cache-condition",
+			},
+		},
+	},
+}
 
-	for _, c := range cases {
-		out := flattenResponseObjects(c.remote)
-		if !reflect.DeepEqual(out, c.local) {
-			t.Fatalf("Error matching:\nexpected: %#v\n got: %#v", c.local, out)
-		}
-	}
+func TestResourceFastlyFlattenResponseObjects(t *testing.T) {
 
+	for _, tt := range flattenResponseObjectTests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			actual := flattenResponseObjects(tt.in)
+
+			if !reflect.DeepEqual(actual, tt.expected) {
+				t.Fatalf("Error matching:\nexpected: %#v\ngot: %#v", tt.expected, actual)
+			}
+		})
+	}
 }
 
 func TestAccFastlyServiceV1_response_object_basic(t *testing.T) {

--- a/fastly/resource_fastly_service_v1_response_object_test.go
+++ b/fastly/resource_fastly_service_v1_response_object_test.go
@@ -11,6 +11,48 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
+func TestResourceFastlyFlattenResponseObjects(t *testing.T) {
+
+	cases := []struct {
+		remote []*gofastly.ResponseObject
+		local  []map[string]interface{}
+	}{
+		{
+			remote: []*gofastly.ResponseObject{
+				{
+					Version:          1,
+					Name:             "responseObjecttesting",
+					Status:           200,
+					Response:         "OK",
+					Content:          "test content",
+					ContentType:      "text/html",
+					RequestCondition: "test-request-condition",
+					CacheCondition:   "test-cache-condition",
+				},
+			},
+			local: []map[string]interface{}{
+				{
+					"name":              "responseObjecttesting",
+					"status":            uint(200),
+					"response":          "OK",
+					"content":           "test content",
+					"content_type":      "text/html",
+					"request_condition": "test-request-condition",
+					"cache_condition":   "test-cache-condition",
+				},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		out := flattenResponseObjects(c.remote)
+		if !reflect.DeepEqual(out, c.local) {
+			t.Fatalf("Error matching:\nexpected: %#v\n got: %#v", c.local, out)
+		}
+	}
+
+}
+
 func TestAccFastlyServiceV1_response_object_basic(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))

--- a/fastly/resource_fastly_service_v1_s3logging_test.go
+++ b/fastly/resource_fastly_service_v1_s3logging_test.go
@@ -54,7 +54,7 @@ func TestResourceFastlyFlattenS3logging(t *testing.T) {
 			actual := flattenS3s(tt.in)
 
 			if !reflect.DeepEqual(actual, tt.expected) {
-				t.Fatalf("Error matching:\nexpected: %#v\ngot: %#v", tt.expected, actual)
+				t.Errorf("Error matching:\nexpected: %#v\ngot: %#v", tt.expected, actual)
 			}
 		})
 	}

--- a/fastly/resource_fastly_service_v1_s3logging_test.go
+++ b/fastly/resource_fastly_service_v1_s3logging_test.go
@@ -12,6 +12,54 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
+var flattenS3loggingTests = []struct {
+	name     string
+	in       []*gofastly.S3
+	expected []map[string]interface{}
+}{
+	{
+		name: "basic flatten",
+		in: []*gofastly.S3{
+			{
+				Version: 1, Name: "somebucketlog",
+				BucketName: "fastlytestlogging", Domain: "s3-us-west-2.amazonaws.com",
+				AccessKey: "somekey", SecretKey: "somesecret",
+				Period: 3600, GzipLevel: 0,
+				Format: "%h %l %u %t %r %>s", FormatVersion: 1,
+				MessageType: "classic", TimestampFormat: "%Y-%m-%dT%H:%M:%S.000",
+				Redundancy:        gofastly.S3RedundancyStandard,
+				ResponseCondition: "response_condition_test",
+			},
+		},
+		expected: []map[string]interface{}{
+			{
+				"name":        "somebucketlog",
+				"bucket_name": "fastlytestlogging", "domain": "s3-us-west-2.amazonaws.com",
+				"s3_access_key": "somekey", "s3_secret_key": "somesecret",
+				"period": uint(3600), "gzip_level": uint(0),
+				"format": "%h %l %u %t %r %>s", "format_version": uint(1),
+				"message_type": "classic",
+				"redundancy":   gofastly.S3RedundancyStandard, "timestamp_format": "%Y-%m-%dT%H:%M:%S.000",
+				"response_condition": "response_condition_test",
+			},
+		},
+	},
+}
+
+func TestResourceFastlyFlattenS3logging(t *testing.T) {
+
+	for _, tt := range flattenS3loggingTests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			actual := flattenS3s(tt.in)
+
+			if !reflect.DeepEqual(actual, tt.expected) {
+				t.Fatalf("Error matching:\nexpected: %#v\ngot: %#v", tt.expected, actual)
+			}
+		})
+	}
+}
+
 func TestAccFastlyServiceV1_s3logging_basic(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))

--- a/fastly/resource_fastly_service_v1_s3logging_test.go
+++ b/fastly/resource_fastly_service_v1_s3logging_test.go
@@ -12,6 +12,12 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
+const testAwsPrimaryAccessKey = "KEYABCDEFGHIJKLMNOPQ"
+const testAwsPrimarySecretKey = "SECRET0123456789012345678901234567890123"
+
+const testAwsOtherAccessKey = "KEYQPONMLKJIHGFEDCBA"
+const testAwsOtherSecretKey = "SECRETOTHER01234567890123456789012345678"
+
 var flattenS3loggingTests = []struct {
 	name     string
 	in       []*gofastly.S3
@@ -23,7 +29,7 @@ var flattenS3loggingTests = []struct {
 			{
 				Version: 1, Name: "somebucketlog",
 				BucketName: "fastlytestlogging", Domain: "s3-us-west-2.amazonaws.com",
-				AccessKey: "somekey", SecretKey: "somesecret",
+				AccessKey: testAwsPrimaryAccessKey, SecretKey: testAwsPrimarySecretKey,
 				Period: 3600, GzipLevel: 0,
 				Format: "%h %l %u %t %r %>s", FormatVersion: 1,
 				MessageType: "classic", TimestampFormat: "%Y-%m-%dT%H:%M:%S.000",
@@ -35,7 +41,7 @@ var flattenS3loggingTests = []struct {
 			{
 				"name":        "somebucketlog",
 				"bucket_name": "fastlytestlogging", "domain": "s3-us-west-2.amazonaws.com",
-				"s3_access_key": "somekey", "s3_secret_key": "somesecret",
+				"s3_access_key": testAwsPrimaryAccessKey, "s3_secret_key": testAwsPrimarySecretKey,
 				"period": uint(3600), "gzip_level": uint(0),
 				"format": "%h %l %u %t %r %>s", "format_version": uint(1),
 				"message_type": "classic",
@@ -70,8 +76,8 @@ func TestAccFastlyServiceV1_s3logging_basic(t *testing.T) {
 		Name:              "somebucketlog",
 		BucketName:        "fastlytestlogging",
 		Domain:            "s3-us-west-2.amazonaws.com",
-		AccessKey:         "somekey",
-		SecretKey:         "somesecret",
+		AccessKey:         testAwsPrimaryAccessKey,
+		SecretKey:         testAwsPrimarySecretKey,
 		Period:            uint(3600),
 		GzipLevel:         uint(0),
 		Format:            "%h %l %u %t %r %>s",
@@ -86,8 +92,8 @@ func TestAccFastlyServiceV1_s3logging_basic(t *testing.T) {
 		Name:              "somebucketlog",
 		BucketName:        "fastlytestlogging",
 		Domain:            "s3-us-west-2.amazonaws.com",
-		AccessKey:         "somekey",
-		SecretKey:         "somesecret",
+		AccessKey:         testAwsPrimaryAccessKey,
+		SecretKey:         testAwsPrimarySecretKey,
 		Period:            uint(3600),
 		GzipLevel:         uint(0),
 		Format:            "%h %l %u %t %r %>s",
@@ -103,8 +109,8 @@ func TestAccFastlyServiceV1_s3logging_basic(t *testing.T) {
 		Name:            "someotherbucketlog",
 		BucketName:      "fastlytestlogging2",
 		Domain:          "s3-us-west-2.amazonaws.com",
-		AccessKey:       "someotherkey",
-		SecretKey:       "someothersecret",
+		AccessKey:       testAwsOtherAccessKey,
+		SecretKey:       testAwsOtherSecretKey,
 		GzipLevel:       uint(3),
 		Period:          uint(60),
 		Format:          "%h %l %u %t %r %>s",
@@ -119,7 +125,7 @@ func TestAccFastlyServiceV1_s3logging_basic(t *testing.T) {
 		CheckDestroy: testAccCheckServiceV1Destroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccServiceV1S3LoggingConfig(name, domainName1),
+				Config: testAccServiceV1S3LoggingConfig(name, domainName1, testAwsPrimaryAccessKey, testAwsPrimarySecretKey),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
 					testAccCheckFastlyServiceV1S3LoggingAttributes(&service, []*gofastly.S3{&log1}),
@@ -155,8 +161,8 @@ func TestAccFastlyServiceV1_s3logging_domain_default(t *testing.T) {
 		Name:              "somebucketlog",
 		BucketName:        "fastlytestlogging",
 		Domain:            "s3.amazonaws.com",
-		AccessKey:         "somekey",
-		SecretKey:         "somesecret",
+		AccessKey:         testAwsPrimaryAccessKey,
+		SecretKey:         testAwsPrimarySecretKey,
 		Period:            uint(3600),
 		GzipLevel:         uint(0),
 		Format:            "%h %l %u %t %r %>s",
@@ -193,7 +199,7 @@ func TestAccFastlyServiceV1_s3logging_s3_env(t *testing.T) {
 	domainName1 := fmt.Sprintf("fastly-test.tf-%s.com", acctest.RandString(10))
 
 	// set env Vars to something we expect
-	resetEnv := setEnv("someEnv", t)
+	resetEnv := setEnv(testAwsPrimaryAccessKey, testAwsPrimarySecretKey, t)
 	defer resetEnv()
 
 	log3 := gofastly.S3{
@@ -201,8 +207,8 @@ func TestAccFastlyServiceV1_s3logging_s3_env(t *testing.T) {
 		Name:            "somebucketlog",
 		BucketName:      "fastlytestlogging",
 		Domain:          "s3-us-west-2.amazonaws.com",
-		AccessKey:       "someEnv",
-		SecretKey:       "someEnv",
+		AccessKey:       testAwsPrimaryAccessKey,
+		SecretKey:       testAwsPrimarySecretKey,
 		Period:          uint(3600),
 		GzipLevel:       uint(0),
 		Format:          "%h %l %u %t %r %>s",
@@ -241,8 +247,8 @@ func TestAccFastlyServiceV1_s3logging_formatVersion(t *testing.T) {
 		Name:            "somebucketlog",
 		BucketName:      "fastlytestlogging",
 		Domain:          "s3-us-west-2.amazonaws.com",
-		AccessKey:       "somekey",
-		SecretKey:       "somesecret",
+		AccessKey:       testAwsPrimaryAccessKey,
+		SecretKey:       testAwsPrimarySecretKey,
 		Period:          uint(3600),
 		GzipLevel:       uint(0),
 		Format:          "%a %l %u %t %m %U%q %H %>s %b %T",
@@ -257,7 +263,7 @@ func TestAccFastlyServiceV1_s3logging_formatVersion(t *testing.T) {
 		CheckDestroy: testAccCheckServiceV1Destroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccServiceV1S3LoggingConfig_formatVersion(name, domainName1),
+				Config: testAccServiceV1S3LoggingConfig_formatVersion(name, domainName1, testAwsPrimaryAccessKey, testAwsPrimarySecretKey),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
 					testAccCheckFastlyServiceV1S3LoggingAttributes(&service, []*gofastly.S3{&log1}),
@@ -340,16 +346,16 @@ resource "fastly_service_v1" "foo" {
   s3logging {
     name               = "somebucketlog"
     bucket_name        = "fastlytestlogging"
-    s3_access_key      = "somekey"
-    s3_secret_key      = "somesecret"
+    s3_access_key      = "%s"
+    s3_secret_key      = "%s"
 		response_condition = "response_condition_test"
   }
 
   force_destroy = true
-}`, name, domain)
+}`, name, domain, testAwsPrimaryAccessKey, testAwsPrimarySecretKey)
 }
 
-func testAccServiceV1S3LoggingConfig(name, domain string) string {
+func testAccServiceV1S3LoggingConfig(name, domain, key, secret string) string {
 	return fmt.Sprintf(`
 resource "fastly_service_v1" "foo" {
   name = "%s"
@@ -375,13 +381,13 @@ resource "fastly_service_v1" "foo" {
     name               = "somebucketlog"
     bucket_name        = "fastlytestlogging"
     domain             = "s3-us-west-2.amazonaws.com"
-    s3_access_key      = "somekey"
-    s3_secret_key      = "somesecret"
+    s3_access_key      = "%s"
+    s3_secret_key      = "%s"
 		response_condition = "response_condition_test"
   }
 
   force_destroy = true
-}`, name, domain)
+}`, name, domain, key, secret)
 }
 
 func testAccServiceV1S3LoggingConfig_update(name, domain string) string {
@@ -410,8 +416,8 @@ resource "fastly_service_v1" "foo" {
     name               = "somebucketlog"
     bucket_name        = "fastlytestlogging"
     domain             = "s3-us-west-2.amazonaws.com"
-    s3_access_key      = "somekey"
-    s3_secret_key      = "somesecret"
+    s3_access_key      = "%s"
+    s3_secret_key      = "%s"
     response_condition = "response_condition_test"
     message_type       = "blank"
     redundancy         = "reduced_redundancy"
@@ -421,14 +427,14 @@ resource "fastly_service_v1" "foo" {
     name          = "someotherbucketlog"
     bucket_name   = "fastlytestlogging2"
     domain        = "s3-us-west-2.amazonaws.com"
-    s3_access_key = "someotherkey"
-    s3_secret_key = "someothersecret"
+    s3_access_key = "%s"
+    s3_secret_key = "%s"
     period        = 60
     gzip_level    = 3
   }
 
   force_destroy = true
-}`, name, domain)
+}`, name, domain, testAwsPrimaryAccessKey, testAwsPrimarySecretKey, testAwsOtherAccessKey, testAwsOtherSecretKey)
 }
 
 func testAccServiceV1S3LoggingConfig_env(name, domain string) string {
@@ -456,7 +462,7 @@ resource "fastly_service_v1" "foo" {
 }`, name, domain)
 }
 
-func testAccServiceV1S3LoggingConfig_formatVersion(name, domain string) string {
+func testAccServiceV1S3LoggingConfig_formatVersion(name, domain, key, secret string) string {
 	return fmt.Sprintf(`
 resource "fastly_service_v1" "foo" {
   name = "%s"
@@ -475,23 +481,23 @@ resource "fastly_service_v1" "foo" {
     name           = "somebucketlog"
     bucket_name    = "fastlytestlogging"
     domain         = "s3-us-west-2.amazonaws.com"
-    s3_access_key  = "somekey"
-    s3_secret_key  = "somesecret"
+    s3_access_key  = "%s"
+    s3_secret_key  = "%s"
     format         = "%%a %%l %%u %%t %%m %%U%%q %%H %%>s %%b %%T"
     format_version = 2
   }
 
   force_destroy = true
-}`, name, domain)
+}`, name, domain, key, secret)
 }
 
-func setEnv(s string, t *testing.T) func() {
+func setEnv(key, secret string, t *testing.T) func() {
 	e := getEnv()
 	// Set all the envs to a dummy value
-	if err := os.Setenv("FASTLY_S3_ACCESS_KEY", s); err != nil {
-		t.Fatalf("Error setting env var AWS_ACCESS_KEY_ID: %s", err)
+	if err := os.Setenv("FASTLY_S3_ACCESS_KEY", key); err != nil {
+		t.Fatalf("Error setting env var FASTLY_S3_ACCESS_KEY: %s", err)
 	}
-	if err := os.Setenv("FASTLY_S3_SECRET_KEY", s); err != nil {
+	if err := os.Setenv("FASTLY_S3_SECRET_KEY", secret); err != nil {
 		t.Fatalf("Error setting env var FASTLY_S3_SECRET_KEY: %s", err)
 	}
 

--- a/fastly/resource_fastly_service_v1_snippet_test.go
+++ b/fastly/resource_fastly_service_v1_snippet_test.go
@@ -11,6 +11,41 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
+func TestResourceFastlyFlattenSnippets(t *testing.T) {
+
+	cases := []struct {
+		remote []*gofastly.Snippet
+		local  []map[string]interface{}
+	}{
+		{
+			remote: []*gofastly.Snippet{
+				{
+					Name:     "recv_test",
+					Type:     gofastly.SnippetTypeRecv,
+					Priority: 110,
+					Content:  "if ( req.url ) {\n set req.http.my-snippet-test-header = \"true\";\n}",
+				},
+			},
+			local: []map[string]interface{}{
+				{
+					"name":     "recv_test",
+					"type":     gofastly.SnippetTypeRecv,
+					"priority": 110,
+					"content":  "if ( req.url ) {\n set req.http.my-snippet-test-header = \"true\";\n}",
+				},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		out := flattenSnippets(c.remote)
+		if !reflect.DeepEqual(out, c.local) {
+			t.Fatalf("Error matching:\nexpected: %#v\n got: %#v", c.local, out)
+		}
+	}
+
+}
+
 func TestAccFastlyServiceV1Snippet_basic(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))

--- a/fastly/resource_fastly_service_v1_snippet_test.go
+++ b/fastly/resource_fastly_service_v1_snippet_test.go
@@ -41,7 +41,7 @@ func TestResourceFastlyFlattenSnippets(t *testing.T) {
 			actual := flattenSnippets(tt.in)
 
 			if !reflect.DeepEqual(actual, tt.expected) {
-				t.Fatalf("Error matching:\nexpected: %#v\ngot: %#v", tt.expected, actual)
+				t.Errorf("Error matching:\nexpected: %#v\ngot: %#v", tt.expected, actual)
 			}
 		})
 	}

--- a/fastly/resource_fastly_service_v1_snippet_test.go
+++ b/fastly/resource_fastly_service_v1_snippet_test.go
@@ -11,39 +11,40 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestResourceFastlyFlattenSnippets(t *testing.T) {
-
-	cases := []struct {
-		remote []*gofastly.Snippet
-		local  []map[string]interface{}
-	}{
-		{
-			remote: []*gofastly.Snippet{
-				{
-					Name:     "recv_test",
-					Type:     gofastly.SnippetTypeRecv,
-					Priority: 110,
-					Content:  "if ( req.url ) {\n set req.http.my-snippet-test-header = \"true\";\n}",
-				},
-			},
-			local: []map[string]interface{}{
-				{
-					"name":     "recv_test",
-					"type":     gofastly.SnippetTypeRecv,
-					"priority": 110,
-					"content":  "if ( req.url ) {\n set req.http.my-snippet-test-header = \"true\";\n}",
-				},
+var flattenSnippetTests = []struct {
+	name     string
+	in       []*gofastly.Snippet
+	expected []map[string]interface{}
+}{
+	{
+		name: "basic flatten",
+		in: []*gofastly.Snippet{
+			{
+				Name: "recv_test", Type: gofastly.SnippetTypeRecv,
+				Priority: 110, Content: "if ( req.url ) {\n set req.http.my-snippet-test-header = \"true\";\n}",
 			},
 		},
-	}
+		expected: []map[string]interface{}{
+			{
+				"name": "recv_test", "type": gofastly.SnippetTypeRecv,
+				"priority": 110, "content": "if ( req.url ) {\n set req.http.my-snippet-test-header = \"true\";\n}",
+			},
+		},
+	},
+}
 
-	for _, c := range cases {
-		out := flattenSnippets(c.remote)
-		if !reflect.DeepEqual(out, c.local) {
-			t.Fatalf("Error matching:\nexpected: %#v\n got: %#v", c.local, out)
-		}
-	}
+func TestResourceFastlyFlattenSnippets(t *testing.T) {
 
+	for _, tt := range flattenSnippetTests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			actual := flattenSnippets(tt.in)
+
+			if !reflect.DeepEqual(actual, tt.expected) {
+				t.Fatalf("Error matching:\nexpected: %#v\ngot: %#v", tt.expected, actual)
+			}
+		})
+	}
 }
 
 func TestAccFastlyServiceV1Snippet_basic(t *testing.T) {

--- a/fastly/resource_fastly_service_v1_sumologic_test.go
+++ b/fastly/resource_fastly_service_v1_sumologic_test.go
@@ -43,7 +43,7 @@ func TestResourceFastlyFlattenSumologic(t *testing.T) {
 			actual := flattenSumologics(tt.in)
 
 			if !reflect.DeepEqual(actual, tt.expected) {
-				t.Fatalf("Error matching:\nexpected: %#v\ngot: %#v", tt.expected, actual)
+				t.Errorf("Error matching:\nexpected: %#v\ngot: %#v", tt.expected, actual)
 			}
 		})
 	}

--- a/fastly/resource_fastly_service_v1_sumologic_test.go
+++ b/fastly/resource_fastly_service_v1_sumologic_test.go
@@ -11,40 +11,41 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestResourceFastlyFlattenSumologic(t *testing.T) {
-	cases := []struct {
-		remote []*gofastly.Sumologic
-		local  []map[string]interface{}
-	}{
-		{
-			remote: []*gofastly.Sumologic{
-				{
-					Name:              "sumo collector",
-					URL:               "https://sumologic.com/collector/1",
-					Format:            "log format",
-					FormatVersion:     2,
-					MessageType:       "classic",
-					ResponseCondition: "condition 1",
-				},
-			},
-			local: []map[string]interface{}{
-				{
-					"name":               "sumo collector",
-					"url":                "https://sumologic.com/collector/1",
-					"format":             "log format",
-					"format_version":     2,
-					"message_type":       "classic",
-					"response_condition": "condition 1",
-				},
+var flattenSumologicTests = []struct {
+	name     string
+	in       []*gofastly.Sumologic
+	expected []map[string]interface{}
+}{
+	{
+		name: "basic flatten",
+		in: []*gofastly.Sumologic{
+			{
+				Name: "sumo collector", URL: "https://sumologic.com/collector/1",
+				Format: "log format", FormatVersion: 2,
+				MessageType: "classic", ResponseCondition: "condition 1",
 			},
 		},
-	}
+		expected: []map[string]interface{}{
+			{
+				"name": "sumo collector", "url": "https://sumologic.com/collector/1",
+				"format": "log format", "format_version": 2,
+				"message_type": "classic", "response_condition": "condition 1",
+			},
+		},
+	},
+}
 
-	for _, c := range cases {
-		out := flattenSumologics(c.remote)
-		if !reflect.DeepEqual(out, c.local) {
-			t.Fatalf("Error matching:\nexpected: %#v\ngot: %#v", c.local, out)
-		}
+func TestResourceFastlyFlattenSumologic(t *testing.T) {
+
+	for _, tt := range flattenSumologicTests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			actual := flattenSumologics(tt.in)
+
+			if !reflect.DeepEqual(actual, tt.expected) {
+				t.Fatalf("Error matching:\nexpected: %#v\ngot: %#v", tt.expected, actual)
+			}
+		})
 	}
 }
 

--- a/fastly/resource_fastly_service_v1_sumologic_test.go
+++ b/fastly/resource_fastly_service_v1_sumologic_test.go
@@ -57,14 +57,14 @@ func TestAccFastlyServiceV1_sumologic(t *testing.T) {
 
 	s := gofastly.Sumologic{
 		Name:          "sumologger",
-		URL:           "https://sumologic.com/collector/1",
+		URL:           "https://collectors.sumologic.com/receiver/1",
 		FormatVersion: 2,
 		Format:        "my format",
 	}
 
 	sn := gofastly.Sumologic{
 		Name:          "sumologger",
-		URL:           "https://sumologic.com/collector/1",
+		URL:           "https://collectors.sumologic.com/receiver/1",
 		FormatVersion: 2,
 		Format:        "my format new",
 	}

--- a/fastly/resource_fastly_service_v1_syslog_test.go
+++ b/fastly/resource_fastly_service_v1_syslog_test.go
@@ -47,7 +47,7 @@ func TestResourceFastlyFlattenSyslog(t *testing.T) {
 			actual := flattenSyslogs(tt.in)
 
 			if !reflect.DeepEqual(actual, tt.expected) {
-				t.Fatalf("Error matching:\nexpected: %#v\ngot: %#v", tt.expected, actual)
+				t.Errorf("Error matching:\nexpected: %#v\ngot: %#v", tt.expected, actual)
 			}
 		})
 	}

--- a/fastly/resource_fastly_service_v1_syslog_test.go
+++ b/fastly/resource_fastly_service_v1_syslog_test.go
@@ -12,48 +12,45 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestResourceFastlyFlattenSyslog(t *testing.T) {
-
-	cases := []struct {
-		remote []*gofastly.Syslog
-		local  []map[string]interface{}
-	}{
-		{
-			remote: []*gofastly.Syslog{
-				{
-					Version:           1,
-					Name:              "somesyslogname",
-					Address:           "127.0.0.1",
-					IPV4:              "127.0.0.1",
-					Port:              8080,
-					Format:            "%h %l %u %t \"%r\" %>s %b",
-					FormatVersion:     1,
-					ResponseCondition: "response_condition_test",
-					MessageType:       "classic",
-				},
-			},
-			local: []map[string]interface{}{
-				{
-					"name":               "somesyslogname",
-					"address":            "127.0.0.1",
-					"port":               uint(8080),
-					"format":             "%h %l %u %t \"%r\" %>s %b",
-					"format_version":     uint(1),
-					"response_condition": "response_condition_test",
-					"message_type":       "classic",
-					"use_tls":            false,
-				},
+var flattenSyslogTests = []struct {
+	name     string
+	in       []*gofastly.Syslog
+	expected []map[string]interface{}
+}{
+	{
+		name: "basic flatten",
+		in: []*gofastly.Syslog{
+			{
+				Version: 1, Name: "somesyslogname",
+				Address: "127.0.0.1", IPV4: "127.0.0.1",
+				Port: 8080, Format: "%h %l %u %t \"%r\" %>s %b",
+				FormatVersion: 1, ResponseCondition: "response_condition_test",
+				MessageType: "classic",
 			},
 		},
-	}
+		expected: []map[string]interface{}{
+			{
+				"name": "somesyslogname", "address": "127.0.0.1",
+				"port": uint(8080), "format": "%h %l %u %t \"%r\" %>s %b",
+				"format_version": uint(1), "response_condition": "response_condition_test",
+				"message_type": "classic", "use_tls": false,
+			},
+		},
+	},
+}
 
-	for _, c := range cases {
-		out := flattenSyslogs(c.remote)
-		if !reflect.DeepEqual(out, c.local) {
-			t.Fatalf("Error matching:\nexpected: %#v\n got: %#v", c.local, out)
-		}
-	}
+func TestResourceFastlyFlattenSyslog(t *testing.T) {
 
+	for _, tt := range flattenSyslogTests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			actual := flattenSyslogs(tt.in)
+
+			if !reflect.DeepEqual(actual, tt.expected) {
+				t.Fatalf("Error matching:\nexpected: %#v\ngot: %#v", tt.expected, actual)
+			}
+		})
+	}
 }
 
 func TestAccFastlyServiceV1_syslog_basic(t *testing.T) {

--- a/fastly/resource_fastly_service_v1_syslog_test.go
+++ b/fastly/resource_fastly_service_v1_syslog_test.go
@@ -12,6 +12,50 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
+func TestResourceFastlyFlattenSyslog(t *testing.T) {
+
+	cases := []struct {
+		remote []*gofastly.Syslog
+		local  []map[string]interface{}
+	}{
+		{
+			remote: []*gofastly.Syslog{
+				{
+					Version:           1,
+					Name:              "somesyslogname",
+					Address:           "127.0.0.1",
+					IPV4:              "127.0.0.1",
+					Port:              8080,
+					Format:            "%h %l %u %t \"%r\" %>s %b",
+					FormatVersion:     1,
+					ResponseCondition: "response_condition_test",
+					MessageType:       "classic",
+				},
+			},
+			local: []map[string]interface{}{
+				{
+					"name":               "somesyslogname",
+					"address":            "127.0.0.1",
+					"port":               uint(8080),
+					"format":             "%h %l %u %t \"%r\" %>s %b",
+					"format_version":     uint(1),
+					"response_condition": "response_condition_test",
+					"message_type":       "classic",
+					"use_tls":            false,
+				},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		out := flattenSyslogs(c.remote)
+		if !reflect.DeepEqual(out, c.local) {
+			t.Fatalf("Error matching:\nexpected: %#v\n got: %#v", c.local, out)
+		}
+	}
+
+}
+
 func TestAccFastlyServiceV1_syslog_basic(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))

--- a/fastly/resource_fastly_service_v1_test.go
+++ b/fastly/resource_fastly_service_v1_test.go
@@ -12,118 +12,106 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestResourceFastlyFlattenDomains(t *testing.T) {
-	cases := []struct {
-		remote []*gofastly.Domain
-		local  []map[string]interface{}
-	}{
-		{
-			remote: []*gofastly.Domain{
-				{
-					Name:    "test.notexample.com",
-					Comment: "not comment",
-				},
-			},
-			local: []map[string]interface{}{
-				{
-					"name":    "test.notexample.com",
-					"comment": "not comment",
-				},
+var flattenDomainTests = []struct {
+	name     string
+	in       []*gofastly.Domain
+	expected []map[string]interface{}
+}{
+	{
+		name: "basic flatten",
+		in: []*gofastly.Domain{
+			{
+				Name: "test.notexample.com",
 			},
 		},
-		{
-			remote: []*gofastly.Domain{
-				{
-					Name: "test.notexample.com",
-				},
-			},
-			local: []map[string]interface{}{
-				{
-					"name":    "test.notexample.com",
-					"comment": "",
-				},
+		expected: []map[string]interface{}{
+			{
+				"name": "test.notexample.com", "comment": "",
 			},
 		},
-	}
+	},
+	{
+		name: "flatten with comment",
+		in: []*gofastly.Domain{
+			{
+				Name: "test.notexample.com", Comment: "not comment",
+			},
+		},
+		expected: []map[string]interface{}{
+			{
+				"name": "test.notexample.com", "comment": "not comment",
+			},
+		},
+	},
+}
 
-	for _, c := range cases {
-		out := flattenDomains(c.remote)
-		if !reflect.DeepEqual(out, c.local) {
-			t.Fatalf("Error matching:\nexpected: %#v\ngot: %#v", c.local, out)
-		}
+func TestResourceFastlyFlattenDomains(t *testing.T) {
+
+	for _, tt := range flattenDomainTests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			actual := flattenDomains(tt.in)
+
+			if !reflect.DeepEqual(actual, tt.expected) {
+				t.Fatalf("Error matching:\nexpected: %#v\ngot: %#v", tt.expected, actual)
+			}
+		})
 	}
 }
 
-func TestResourceFastlyFlattenBackend(t *testing.T) {
-	cases := []struct {
-		remote []*gofastly.Backend
-		local  []map[string]interface{}
-	}{
-		{
-			remote: []*gofastly.Backend{
-				{
-					Name:                "test.notexample.com",
-					Address:             "www.notexample.com",
-					Port:                uint(80),
-					AutoLoadbalance:     true,
-					BetweenBytesTimeout: uint(10000),
-					ConnectTimeout:      uint(1000),
-					ErrorThreshold:      uint(0),
-					FirstByteTimeout:    uint(15000),
-					MaxConn:             uint(200),
-					RequestCondition:    "",
-					HealthCheck:         "",
-					UseSSL:              false,
-					SSLCheckCert:        true,
-					SSLHostname:         "",
-					SSLCACert:           "",
-					SSLCertHostname:     "",
-					SSLSNIHostname:      "",
-					SSLClientKey:        "",
-					SSLClientCert:       "",
-					MaxTLSVersion:       "",
-					MinTLSVersion:       "",
-					SSLCiphers:          []string{"foo", "bar", "baz"},
-					Shield:              "New York",
-					Weight:              uint(100),
-				},
-			},
-			local: []map[string]interface{}{
-				{
-					"name":                  "test.notexample.com",
-					"address":               "www.notexample.com",
-					"port":                  80,
-					"auto_loadbalance":      true,
-					"between_bytes_timeout": 10000,
-					"connect_timeout":       1000,
-					"error_threshold":       0,
-					"first_byte_timeout":    15000,
-					"max_conn":              200,
-					"request_condition":     "",
-					"healthcheck":           "",
-					"use_ssl":               false,
-					"ssl_check_cert":        true,
-					"ssl_hostname":          "",
-					"ssl_ca_cert":           "",
-					"ssl_cert_hostname":     "",
-					"ssl_sni_hostname":      "",
-					"ssl_client_key":        "",
-					"ssl_client_cert":       "",
-					"max_tls_version":       "",
-					"min_tls_version":       "",
-					"ssl_ciphers":           "foo,bar,baz",
-					"shield":                "New York",
-					"weight":                100,
-				},
+var flattenBackendTests = []struct {
+	name     string
+	in       []*gofastly.Backend
+	expected []map[string]interface{}
+}{
+	{
+		name: "basic flatten",
+		in: []*gofastly.Backend{
+			{
+				Name: "test.notexample.com", Address: "www.notexample.com",
+				Port: uint(80), AutoLoadbalance: true,
+				BetweenBytesTimeout: uint(10000), ConnectTimeout: uint(1000),
+				ErrorThreshold: uint(0), FirstByteTimeout: uint(15000),
+				MaxConn: uint(200), RequestCondition: "",
+				HealthCheck: "", UseSSL: false,
+				SSLCheckCert: true, SSLHostname: "",
+				SSLCACert: "", SSLCertHostname: "",
+				SSLSNIHostname: "", SSLClientKey: "",
+				SSLClientCert: "", MaxTLSVersion: "",
+				MinTLSVersion: "", SSLCiphers: []string{"foo", "bar", "baz"},
+				Shield: "New York", Weight: uint(100),
 			},
 		},
-	}
+		expected: []map[string]interface{}{
+			{
+				"name": "test.notexample.com", "address": "www.notexample.com",
+				"port": 80, "auto_loadbalance": true,
+				"between_bytes_timeout": 10000, "connect_timeout": 1000,
+				"error_threshold": 0, "first_byte_timeout": 15000,
+				"max_conn": 200, "request_condition": "",
+				"healthcheck": "", "use_ssl": false,
+				"ssl_check_cert": true, "ssl_hostname": "",
+				"ssl_ca_cert": "", "ssl_cert_hostname": "",
+				"ssl_sni_hostname": "", "ssl_client_key": "", "ssl_client_cert": "",
+				"max_tls_version": "", "min_tls_version": "",
+				"ssl_ciphers": "foo,bar,baz", "shield": "New York",
+				"weight": 100,
+			},
+		},
+	},
+}
 
-	for _, c := range cases {
-		out := flattenBackends(c.remote)
-		if !reflect.DeepEqual(out, c.local) {
-			t.Fatalf("Error matching:\nexpected: %#v\n     got: %#v", c.local, out)
-		}
+func TestResourceFastlyFlattenBackend(t *testing.T) {
+
+	for _, tt := range flattenBackendTests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			actual := flattenBackends(tt.in)
+
+			if !reflect.DeepEqual(actual, tt.expected) {
+				t.Fatalf("Error matching:\nexpected: %#v\ngot: %#v", tt.expected, actual)
+			}
+		})
 	}
 }
 

--- a/fastly/resource_fastly_service_v1_test.go
+++ b/fastly/resource_fastly_service_v1_test.go
@@ -53,7 +53,7 @@ func TestResourceFastlyFlattenDomains(t *testing.T) {
 			actual := flattenDomains(tt.in)
 
 			if !reflect.DeepEqual(actual, tt.expected) {
-				t.Fatalf("Error matching:\nexpected: %#v\ngot: %#v", tt.expected, actual)
+				t.Errorf("Error matching:\nexpected: %#v\ngot: %#v", tt.expected, actual)
 			}
 		})
 	}
@@ -109,7 +109,7 @@ func TestResourceFastlyFlattenBackend(t *testing.T) {
 			actual := flattenBackends(tt.in)
 
 			if !reflect.DeepEqual(actual, tt.expected) {
-				t.Fatalf("Error matching:\nexpected: %#v\ngot: %#v", tt.expected, actual)
+				t.Errorf("Error matching:\nexpected: %#v\ngot: %#v", tt.expected, actual)
 			}
 		})
 	}

--- a/fastly/resource_fastly_service_v1_vcl_test.go
+++ b/fastly/resource_fastly_service_v1_vcl_test.go
@@ -2,6 +2,7 @@ package fastly
 
 import (
 	"fmt"
+	"reflect"
 	"testing"
 
 	gofastly "github.com/fastly/go-fastly/fastly"
@@ -9,6 +10,39 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
+
+func TestResourceFastlyFlattenVCLs(t *testing.T) {
+
+	cases := []struct {
+		remote []*gofastly.VCL
+		local  []map[string]interface{}
+	}{
+		{
+			remote: []*gofastly.VCL{
+				{
+					Name:    "myVCL",
+					Content: "<<EOF somecontent EOF",
+					Main:    true,
+				},
+			},
+			local: []map[string]interface{}{
+				{
+					"name":    "myVCL",
+					"content": "<<EOF somecontent EOF",
+					"main":    true,
+				},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		out := flattenVCLs(c.remote)
+		if !reflect.DeepEqual(out, c.local) {
+			t.Fatalf("Error matching:\nexpected: %#v\n got: %#v", c.local, out)
+		}
+	}
+
+}
 
 func TestAccFastlyServiceV1_VCL_basic(t *testing.T) {
 	var service gofastly.ServiceDetail

--- a/fastly/resource_fastly_service_v1_vcl_test.go
+++ b/fastly/resource_fastly_service_v1_vcl_test.go
@@ -41,7 +41,7 @@ func TestResourceFastlyFlattenVCLs(t *testing.T) {
 			actual := flattenVCLs(tt.in)
 
 			if !reflect.DeepEqual(actual, tt.expected) {
-				t.Fatalf("Error matching:\nexpected: %#v\ngot: %#v", tt.expected, actual)
+				t.Errorf("Error matching:\nexpected: %#v\ngot: %#v", tt.expected, actual)
 			}
 		})
 	}

--- a/fastly/resource_fastly_service_v1_vcl_test.go
+++ b/fastly/resource_fastly_service_v1_vcl_test.go
@@ -11,37 +11,40 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestResourceFastlyFlattenVCLs(t *testing.T) {
-
-	cases := []struct {
-		remote []*gofastly.VCL
-		local  []map[string]interface{}
-	}{
-		{
-			remote: []*gofastly.VCL{
-				{
-					Name:    "myVCL",
-					Content: "<<EOF somecontent EOF",
-					Main:    true,
-				},
-			},
-			local: []map[string]interface{}{
-				{
-					"name":    "myVCL",
-					"content": "<<EOF somecontent EOF",
-					"main":    true,
-				},
+var flattenVCLTests = []struct {
+	name     string
+	in       []*gofastly.VCL
+	expected []map[string]interface{}
+}{
+	{
+		name: "basic flatten",
+		in: []*gofastly.VCL{
+			{
+				Name: "myVCL", Content: "<<EOF somecontent EOF",
+				Main: true,
 			},
 		},
-	}
+		expected: []map[string]interface{}{
+			{
+				"name": "myVCL", "content": "<<EOF somecontent EOF",
+				"main": true,
+			},
+		},
+	},
+}
 
-	for _, c := range cases {
-		out := flattenVCLs(c.remote)
-		if !reflect.DeepEqual(out, c.local) {
-			t.Fatalf("Error matching:\nexpected: %#v\n got: %#v", c.local, out)
-		}
-	}
+func TestResourceFastlyFlattenVCLs(t *testing.T) {
 
+	for _, tt := range flattenVCLTests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			actual := flattenVCLs(tt.in)
+
+			if !reflect.DeepEqual(actual, tt.expected) {
+				t.Fatalf("Error matching:\nexpected: %#v\ngot: %#v", tt.expected, actual)
+			}
+		})
+	}
 }
 
 func TestAccFastlyServiceV1_VCL_basic(t *testing.T) {


### PR DESCRIPTION
This PR introduces missing flatten function unit test for the following nested blocks within the service
cache_setting, conditionals, director, gzip, headers, healthcheck, logentries, papertrail, request_setting, response_object, snippet, syslog, vcl, S3logging.

The following make target and regx can be used to execute the unit tests.
```sh
make testacc TESTARGS="-run=TestResourceFastlyFlatten.*"
```

The test cases that featured inside the test function has been replaced with table tests.  This will allow the data to be increased without the function becoming too noisy.