### PR TITLE
Introduces and refactors flatten function unit tests.

### DIFF
--- a/fastly/resource_fastly_service_v1_cache_setting_test.go
+++ b/fastly/resource_fastly_service_v1_cache_setting_test.go
@@ -11,6 +11,43 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
+func TestResourceFastlyFlattenCacheSettings(t *testing.T) {
+
+	cases := []struct {
+		remote []*gofastly.CacheSetting
+		local  []map[string]interface{}
+	}{
+		{
+			remote: []*gofastly.CacheSetting{
+				{
+					Name:           "alt_backend",
+					Action:         gofastly.CacheSettingActionPass,
+					StaleTTL:       3600,
+					CacheCondition: "serve_alt_backend",
+					TTL:            300,
+				},
+			},
+			local: []map[string]interface{}{
+				{
+					"name":            "alt_backend",
+					"action":          gofastly.CacheSettingActionPass,
+					"cache_condition": "serve_alt_backend",
+					"stale_ttl":       uint(3600),
+					"ttl":             uint(300),
+				},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		out := flattenCacheSettings(c.remote)
+		if !reflect.DeepEqual(out, c.local) {
+			t.Fatalf("Error matching:\nexpected: %#v\n got: %#v", c.local, out)
+		}
+	}
+
+}
+
 func TestAccFastlyServiceV1CacheSetting_basic(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))

--- a/fastly/resource_fastly_service_v1_conditionals_test.go
+++ b/fastly/resource_fastly_service_v1_conditionals_test.go
@@ -11,6 +11,41 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
+func TestResourceFastlyFlattenConditions(t *testing.T) {
+
+	cases := []struct {
+		remote []*gofastly.Condition
+		local  []map[string]interface{}
+	}{
+		{
+			remote: []*gofastly.Condition{
+				{
+					Name:      "some amz condition",
+					Priority:  10,
+					Type:      "REQUEST",
+					Statement: `req.url ~ "^/yolo/"`,
+				},
+			},
+			local: []map[string]interface{}{
+				{
+					"name":      "some amz condition",
+					"priority":  10,
+					"type":      "REQUEST",
+					"statement": "req.url ~ \"^/yolo/\"",
+				},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		out := flattenConditions(c.remote)
+		if !reflect.DeepEqual(out, c.local) {
+			t.Fatalf("Error matching:\nexpected: %#v\n got: %#v", c.local, out)
+		}
+	}
+
+}
+
 func TestAccFastlyServiceV1_conditional_basic(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))

--- a/fastly/resource_fastly_service_v1_director_test.go
+++ b/fastly/resource_fastly_service_v1_director_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestFastlyServiceV1_FlattenDirectors(t *testing.T) {
+func TestResourceFastlyFlattenDirectors(t *testing.T) {
 	cases := []struct {
 		remote_director        []*gofastly.Director
 		remote_directorbackend []*gofastly.DirectorBackend

--- a/fastly/resource_fastly_service_v1_gzip_test.go
+++ b/fastly/resource_fastly_service_v1_gzip_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestFastlyServiceV1_FlattenGzips(t *testing.T) {
+func TestResourceFastlyFlattenGzips(t *testing.T) {
 	cases := []struct {
 		remote []*gofastly.Gzip
 		local  []map[string]interface{}

--- a/fastly/resource_fastly_service_v1_headers_test.go
+++ b/fastly/resource_fastly_service_v1_headers_test.go
@@ -11,6 +11,51 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
+func TestResourceFastlyFlattenHeaders(t *testing.T) {
+
+	cases := []struct {
+		remote []*gofastly.Header
+		local  []map[string]interface{}
+	}{
+		{
+			remote: []*gofastly.Header{
+				{
+					Name:              "myheader",
+					Action:            "delete",
+					IgnoreIfSet:       true,
+					Type:              "cache",
+					Destination:       "http.aws-id",
+					Source:            "",
+					Regex:             "",
+					Substitution:      "",
+					Priority:          100,
+					RequestCondition:  "",
+					CacheCondition:    "",
+					ResponseCondition: "",
+				},
+			},
+			local: []map[string]interface{}{
+				{
+					"name":          "myheader",
+					"action":        gofastly.HeaderActionDelete,
+					"ignore_if_set": true,
+					"type":          gofastly.HeaderTypeCache,
+					"destination":   "http.aws-id",
+					"priority":      int(100),
+				},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		out := flattenHeaders(c.remote)
+		if !reflect.DeepEqual(out, c.local) {
+			t.Fatalf("Error matching:\nexpected: %#v\n got: %#v", c.local, out)
+		}
+	}
+
+}
+
 func TestFastlyServiceV1_BuildHeaders(t *testing.T) {
 	cases := []struct {
 		remote *gofastly.CreateHeaderInput

--- a/fastly/resource_fastly_service_v1_healthcheck_test.go
+++ b/fastly/resource_fastly_service_v1_healthcheck_test.go
@@ -11,6 +11,56 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
+func TestResourceFastlyFlattenHealthChecks(t *testing.T) {
+
+	cases := []struct {
+		remote []*gofastly.HealthCheck
+		local  []map[string]interface{}
+	}{
+		{
+			remote: []*gofastly.HealthCheck{
+				{
+					Version:          1,
+					Name:             "myhealthcheck",
+					Host:             "example1.com",
+					Path:             "/test1.txt",
+					CheckInterval:    4000,
+					ExpectedResponse: 200,
+					HTTPVersion:      "1.1",
+					Initial:          2,
+					Method:           "HEAD",
+					Threshold:        3,
+					Timeout:          5000,
+					Window:           5,
+				},
+			},
+			local: []map[string]interface{}{
+				{
+					"name":              "myhealthcheck",
+					"host":              "example1.com",
+					"path":              "/test1.txt",
+					"check_interval":    uint(4000),
+					"expected_response": uint(200),
+					"http_version":      "1.1",
+					"initial":           uint(2),
+					"method":            "HEAD",
+					"threshold":         uint(3),
+					"timeout":           uint(5000),
+					"window":            uint(5),
+				},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		out := flattenHealthchecks(c.remote)
+		if !reflect.DeepEqual(out, c.local) {
+			t.Fatalf("Error matching:\nexpected: %#v\n got: %#v", c.local, out)
+		}
+	}
+
+}
+
 func TestAccFastlyServiceV1_healthcheck_basic(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))

--- a/fastly/resource_fastly_service_v1_logentries_test.go
+++ b/fastly/resource_fastly_service_v1_logentries_test.go
@@ -12,6 +12,47 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
+func TestResourceFastlyFlattenLogentries(t *testing.T) {
+
+	cases := []struct {
+		remote []*gofastly.Logentries
+		local  []map[string]interface{}
+	}{
+		{
+			remote: []*gofastly.Logentries{
+				{
+					Version:           1,
+					Name:              "somelogentriesname",
+					Port:              8080,
+					Token:             "mytoken",
+					Format:            "%h %l %u %t %r %>s",
+					FormatVersion:     1,
+					ResponseCondition: "response_condition_test",
+				},
+			},
+			local: []map[string]interface{}{
+				{
+					"name":               "somelogentriesname",
+					"port":               uint(8080),
+					"token":              "mytoken",
+					"format":             "%h %l %u %t %r %>s",
+					"format_version":     uint(1),
+					"response_condition": "response_condition_test",
+					"use_tls":            false,
+				},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		out := flattenLogentries(c.remote)
+		if !reflect.DeepEqual(out, c.local) {
+			t.Fatalf("Error matching:\nexpected: %#v\n got: %#v", c.local, out)
+		}
+	}
+
+}
+
 func TestAccFastlyServiceV1_logentries_basic(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))

--- a/fastly/resource_fastly_service_v1_papertrail_test.go
+++ b/fastly/resource_fastly_service_v1_papertrail_test.go
@@ -11,6 +11,44 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
+func TestResourceFastlyFlattenPapertrail(t *testing.T) {
+
+	cases := []struct {
+		remote []*gofastly.Papertrail
+		local  []map[string]interface{}
+	}{
+		{
+			remote: []*gofastly.Papertrail{
+				{
+					Version:           1,
+					Name:              "papertrailtesting",
+					Address:           "test1.papertrailapp.com",
+					Port:              3600,
+					Format:            "%h %l %u %t %r %>s",
+					ResponseCondition: "test_response_condition",
+				},
+			},
+			local: []map[string]interface{}{
+				{
+					"name":               "papertrailtesting",
+					"address":            "test1.papertrailapp.com",
+					"port":               uint(3600),
+					"format":             "%h %l %u %t %r %>s",
+					"response_condition": "test_response_condition",
+				},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		out := flattenPapertrails(c.remote)
+		if !reflect.DeepEqual(out, c.local) {
+			t.Fatalf("Error matching:\nexpected: %#v\n got: %#v", c.local, out)
+		}
+	}
+
+}
+
 func TestAccFastlyServiceV1_papertrail_basic(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))

--- a/fastly/resource_fastly_service_v1_request_setting_test.go
+++ b/fastly/resource_fastly_service_v1_request_setting_test.go
@@ -11,6 +11,50 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
+func TestResourceFastlyFlattenRequestSettings(t *testing.T) {
+
+	cases := []struct {
+		remote []*gofastly.RequestSetting
+		local  []map[string]interface{}
+	}{
+		{
+			remote: []*gofastly.RequestSetting{
+				{
+					Name:             "alt_backend",
+					RequestCondition: "serve_alt_backend",
+					DefaultHost:      "tftestingother.tftesting.net.s3-website-us-west-2.amazonaws.com",
+					XForwardedFor:    gofastly.RequestSettingXFFAppend,
+					MaxStaleAge:      90,
+					Action:           gofastly.RequestSettingActionPass,
+				},
+			},
+			local: []map[string]interface{}{
+				{
+					"name":              "alt_backend",
+					"request_condition": "serve_alt_backend",
+					"default_host":      "tftestingother.tftesting.net.s3-website-us-west-2.amazonaws.com",
+					"xff":               gofastly.RequestSettingXFFAppend,
+					"max_stale_age":     uint(90),
+					"action":            gofastly.RequestSettingActionPass,
+					"bypass_busy_wait":  false,
+					"force_miss":        false,
+					"force_ssl":         false,
+					"geo_headers":       false,
+					"timer_support":     false,
+				},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		out := flattenRequestSettings(c.remote)
+		if !reflect.DeepEqual(out, c.local) {
+			t.Fatalf("Error matching:\nexpected: %#v\n got: %#v", c.local, out)
+		}
+	}
+
+}
+
 func TestAccFastlyServiceV1RequestSetting_basic(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))

--- a/fastly/resource_fastly_service_v1_response_object_test.go
+++ b/fastly/resource_fastly_service_v1_response_object_test.go
@@ -11,6 +11,48 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
+func TestResourceFastlyFlattenResponseObjects(t *testing.T) {
+
+	cases := []struct {
+		remote []*gofastly.ResponseObject
+		local  []map[string]interface{}
+	}{
+		{
+			remote: []*gofastly.ResponseObject{
+				{
+					Version:          1,
+					Name:             "responseObjecttesting",
+					Status:           200,
+					Response:         "OK",
+					Content:          "test content",
+					ContentType:      "text/html",
+					RequestCondition: "test-request-condition",
+					CacheCondition:   "test-cache-condition",
+				},
+			},
+			local: []map[string]interface{}{
+				{
+					"name":              "responseObjecttesting",
+					"status":            uint(200),
+					"response":          "OK",
+					"content":           "test content",
+					"content_type":      "text/html",
+					"request_condition": "test-request-condition",
+					"cache_condition":   "test-cache-condition",
+				},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		out := flattenResponseObjects(c.remote)
+		if !reflect.DeepEqual(out, c.local) {
+			t.Fatalf("Error matching:\nexpected: %#v\n got: %#v", c.local, out)
+		}
+	}
+
+}
+
 func TestAccFastlyServiceV1_response_object_basic(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))

--- a/fastly/resource_fastly_service_v1_snippet_test.go
+++ b/fastly/resource_fastly_service_v1_snippet_test.go
@@ -11,6 +11,41 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
+func TestResourceFastlyFlattenSnippets(t *testing.T) {
+
+	cases := []struct {
+		remote []*gofastly.Snippet
+		local  []map[string]interface{}
+	}{
+		{
+			remote: []*gofastly.Snippet{
+				{
+					Name:     "recv_test",
+					Type:     gofastly.SnippetTypeRecv,
+					Priority: 110,
+					Content:  "if ( req.url ) {\n set req.http.my-snippet-test-header = \"true\";\n}",
+				},
+			},
+			local: []map[string]interface{}{
+				{
+					"name":     "recv_test",
+					"type":     gofastly.SnippetTypeRecv,
+					"priority": 110,
+					"content":  "if ( req.url ) {\n set req.http.my-snippet-test-header = \"true\";\n}",
+				},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		out := flattenSnippets(c.remote)
+		if !reflect.DeepEqual(out, c.local) {
+			t.Fatalf("Error matching:\nexpected: %#v\n got: %#v", c.local, out)
+		}
+	}
+
+}
+
 func TestAccFastlyServiceV1Snippet_basic(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))

--- a/fastly/resource_fastly_service_v1_syslog_test.go
+++ b/fastly/resource_fastly_service_v1_syslog_test.go
@@ -12,6 +12,50 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
+func TestResourceFastlyFlattenSyslog(t *testing.T) {
+
+	cases := []struct {
+		remote []*gofastly.Syslog
+		local  []map[string]interface{}
+	}{
+		{
+			remote: []*gofastly.Syslog{
+				{
+					Version:           1,
+					Name:              "somesyslogname",
+					Address:           "127.0.0.1",
+					IPV4:              "127.0.0.1",
+					Port:              8080,
+					Format:            "%h %l %u %t \"%r\" %>s %b",
+					FormatVersion:     1,
+					ResponseCondition: "response_condition_test",
+					MessageType:       "classic",
+				},
+			},
+			local: []map[string]interface{}{
+				{
+					"name":               "somesyslogname",
+					"address":            "127.0.0.1",
+					"port":               uint(8080),
+					"format":             "%h %l %u %t \"%r\" %>s %b",
+					"format_version":     uint(1),
+					"response_condition": "response_condition_test",
+					"message_type":       "classic",
+					"use_tls":            false,
+				},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		out := flattenSyslogs(c.remote)
+		if !reflect.DeepEqual(out, c.local) {
+			t.Fatalf("Error matching:\nexpected: %#v\n got: %#v", c.local, out)
+		}
+	}
+
+}
+
 func TestAccFastlyServiceV1_syslog_basic(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))

--- a/fastly/resource_fastly_service_v1_vcl_test.go
+++ b/fastly/resource_fastly_service_v1_vcl_test.go
@@ -2,6 +2,7 @@ package fastly
 
 import (
 	"fmt"
+	"reflect"
 	"testing"
 
 	gofastly "github.com/fastly/go-fastly/fastly"
@@ -9,6 +10,39 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
+
+func TestResourceFastlyFlattenVCLs(t *testing.T) {
+
+	cases := []struct {
+		remote []*gofastly.VCL
+		local  []map[string]interface{}
+	}{
+		{
+			remote: []*gofastly.VCL{
+				{
+					Name:    "myVCL",
+					Content: "<<EOF somecontent EOF",
+					Main:    true,
+				},
+			},
+			local: []map[string]interface{}{
+				{
+					"name":    "myVCL",
+					"content": "<<EOF somecontent EOF",
+					"main":    true,
+				},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		out := flattenVCLs(c.remote)
+		if !reflect.DeepEqual(out, c.local) {
+			t.Fatalf("Error matching:\nexpected: %#v\n got: %#v", c.local, out)
+		}
+	}
+
+}
 
 func TestAccFastlyServiceV1_VCL_basic(t *testing.T) {
 	var service gofastly.ServiceDetail


### PR DESCRIPTION
This branch introduces new flatten unit tests covering the service nest blocks.  The base repository has moved on and this PR is focused on introducing the new tests and not refactoring the cases test data.