### PR TITLE
Add support for version comment field

### DIFF
--- a/fastly/resource_fastly_service_v1.go
+++ b/fastly/resource_fastly_service_v1.go
@@ -40,6 +40,12 @@ func resourceServiceV1() *schema.Resource {
 				Description: "A personal freeform descriptive note",
 			},
 
+			"version_comment": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "A personal freeform descriptive note",
+			},
+
 			// Active Version represents the currently activated version in Fastly. In
 			// Terraform, we abstract this number away from the users and manage
 			// creating and activating. It's used internally, but also exported for
@@ -1416,6 +1422,28 @@ func resourceServiceV1Update(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
+	// Update the active version's comment. No new version is required for this
+	if d.HasChange("version_comment") && !needsChange {
+		latestVersion := d.Get("active_version").(int)
+		if latestVersion == 0 {
+			// If the service was just created, there is an empty Version 1 available
+			// that is unlocked and can be updated
+			latestVersion = 1
+		}
+
+		opts := gofastly.UpdateVersionInput{
+			Service: d.Id(),
+			Version: latestVersion,
+			Comment: d.Get("version_comment").(string),
+		}
+
+		log.Printf("[DEBUG] Update Version opts: %#v", opts)
+		_, err := conn.UpdateVersion(&opts)
+		if err != nil {
+			return err
+		}
+	}
+
 	if needsChange {
 		latestVersion := d.Get("active_version").(int)
 		if latestVersion == 0 {
@@ -1441,6 +1469,21 @@ func resourceServiceV1Update(d *schema.ResourceData, meta interface{}) error {
 			// itself. Typically, 7 seconds is enough
 			log.Print("[DEBUG] Sleeping 7 seconds to allow Fastly Version to be available")
 			time.Sleep(7 * time.Second)
+
+			// Update the cloned version's comment
+			if d.Get("version_comment").(string) != "" {
+				opts := gofastly.UpdateVersionInput{
+					Service: d.Id(),
+					Version: latestVersion,
+					Comment: d.Get("version_comment").(string),
+				}
+
+				log.Printf("[DEBUG] Update Version opts: %#v", opts)
+				_, err := conn.UpdateVersion(&opts)
+				if err != nil {
+					return err
+				}
+			}
 		}
 
 		// update general settings
@@ -2807,6 +2850,7 @@ func resourceServiceV1Read(d *schema.ResourceData, meta interface{}) error {
 
 	d.Set("name", s.Name)
 	d.Set("comment", s.Comment)
+	d.Set("version_comment", s.Version.Comment)
 	d.Set("active_version", s.ActiveVersion.Number)
 
 	// If CreateService succeeds, but initial updates to the Service fail, we'll

--- a/fastly/resource_fastly_service_v1_test.go
+++ b/fastly/resource_fastly_service_v1_test.go
@@ -248,6 +248,7 @@ func TestAccFastlyServiceV1_basic(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	comment := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	versionComment := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	domainName1 := fmt.Sprintf("tf-acc-test-%s.com", acctest.RandString(10))
 	domainName2 := fmt.Sprintf("tf-acc-test-%s.com", acctest.RandString(10))
 
@@ -265,6 +266,8 @@ func TestAccFastlyServiceV1_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"fastly_service_v1.foo", "comment", "Managed by Terraform"),
 					resource.TestCheckResourceAttr(
+						"fastly_service_v1.foo", "version_comment", ""),
+					resource.TestCheckResourceAttr(
 						"fastly_service_v1.foo", "active_version", "1"),
 					resource.TestCheckResourceAttr(
 						"fastly_service_v1.foo", "domain.#", "1"),
@@ -274,13 +277,15 @@ func TestAccFastlyServiceV1_basic(t *testing.T) {
 			},
 
 			{
-				Config: testAccServiceV1Config_basicUpdate(name, comment, domainName2),
+				Config: testAccServiceV1Config_basicUpdate(name, comment, versionComment, domainName2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
 					resource.TestCheckResourceAttr(
 						"fastly_service_v1.foo", "name", name),
 					resource.TestCheckResourceAttr(
 						"fastly_service_v1.foo", "comment", comment),
+					resource.TestCheckResourceAttr(
+						"fastly_service_v1.foo", "version_comment", versionComment),
 					resource.TestCheckResourceAttr(
 						"fastly_service_v1.foo", "active_version", "2"),
 					resource.TestCheckResourceAttr(
@@ -524,11 +529,12 @@ resource "fastly_service_v1" "foo" {
 }`, name, domain)
 }
 
-func testAccServiceV1Config_basicUpdate(name, comment, domain string) string {
+func testAccServiceV1Config_basicUpdate(name, comment, versionComment, domain string) string {
 	return fmt.Sprintf(`
 resource "fastly_service_v1" "foo" {
   name    = "%s"
   comment = "%s"
+  version_comment = "%s"
 
   domain {
     name    = "%s"
@@ -541,7 +547,7 @@ resource "fastly_service_v1" "foo" {
   }
 
   force_destroy = true
-}`, name, comment, domain)
+}`, name, comment, versionComment, domain)
 }
 
 func testAccServiceV1Config_domainUpdate(name, domain1, domain2 string) string {

--- a/website/docs/r/service_v1.html.markdown
+++ b/website/docs/r/service_v1.html.markdown
@@ -165,6 +165,7 @@ The following arguments are supported:
 * `activate` - (Optional) Conditionally prevents the Service from being activated. The apply step will continue to create a new draft version but will not activate it if this is set to false. Default true.
 * `name` - (Required) The unique name for the Service to create.
 * `comment` - (Optional) Description field for the service. Default `Managed by Terraform`.
+* `version_comment` - (Optional) Description field for the version.
 * `domain` - (Required) A set of Domain names to serve as entry points for your
 Service. Defined below.
 * `backend` - (Optional) A set of Backends to service requests from your Domains.


### PR DESCRIPTION
This solves #126.

Acceptance tests:

```
=== RUN   TestAccFastlyServiceV1_updateDomain
--- PASS: TestAccFastlyServiceV1_updateDomain (87.91s)
=== RUN   TestAccFastlyServiceV1_updateBackend
--- PASS: TestAccFastlyServiceV1_updateBackend (89.50s)
=== RUN   TestAccFastlyServiceV1_updateInvalidBackend
--- PASS: TestAccFastlyServiceV1_updateInvalidBackend (45.57s)
=== RUN   TestAccFastlyServiceV1_basic
--- PASS: TestAccFastlyServiceV1_basic (89.08s)
=== RUN   TestAccFastlyServiceV1_disappears
--- PASS: TestAccFastlyServiceV1_disappears (18.04s)
=== RUN   TestAccFastlyServiceV1_defaultTTL
--- PASS: TestAccFastlyServiceV1_defaultTTL (132.99s)
```