### PR TITLE
Adjust tests due to go-fastly v1.0.0 update

### DIFF
--- a/fastly/resource_fastly_service_v1_cache_setting_test.go
+++ b/fastly/resource_fastly_service_v1_cache_setting_test.go
@@ -126,6 +126,10 @@ func testAccCheckFastlyServiceV1CacheSettingsAttributes(service *gofastly.Servic
 					// we don't know these things ahead of time, so populate them now
 					c.ServiceID = service.ID
 					c.Version = service.ActiveVersion.Number
+					// We don't track these, so clear them out because we also wont know
+					// these ahead of time
+					lc.CreatedAt = nil
+					lc.UpdatedAt = nil
 					if !reflect.DeepEqual(c, lc) {
 						return fmt.Errorf("Bad match Cache Setting match, expected (%#v), got (%#v)", c, lc)
 					}

--- a/fastly/resource_fastly_service_v1_conditionals_test.go
+++ b/fastly/resource_fastly_service_v1_conditionals_test.go
@@ -106,6 +106,10 @@ func testAccCheckFastlyServiceV1ConditionalAttributes(service *gofastly.ServiceD
 					// we don't know these things ahead of time, so populate them now
 					c.ServiceID = service.ID
 					c.Version = service.ActiveVersion.Number
+					// We don't track these, so clear them out because we also wont know
+					// these ahead of time
+					lc.CreatedAt = nil
+					lc.UpdatedAt = nil
 					if !reflect.DeepEqual(c, lc) {
 						return fmt.Errorf("Bad match Conditions match, expected (%#v), got (%#v)", c, lc)
 					}

--- a/fastly/resource_fastly_service_v1_gzip_test.go
+++ b/fastly/resource_fastly_service_v1_gzip_test.go
@@ -183,6 +183,10 @@ func testAccCheckFastlyServiceV1GzipsAttributes(service *gofastly.ServiceDetail,
 					// we don't know these things ahead of time, so populate them now
 					g.ServiceID = service.ID
 					g.Version = service.ActiveVersion.Number
+					// We don't track these, so clear them out because we also wont know
+					// these ahead of time
+					lg.CreatedAt = nil
+					lg.UpdatedAt = nil
 					if !reflect.DeepEqual(g, lg) {
 						return fmt.Errorf("Bad match Gzip match, expected (%#v), got (%#v)", g, lg)
 					}

--- a/fastly/resource_fastly_service_v1_headers_test.go
+++ b/fastly/resource_fastly_service_v1_headers_test.go
@@ -222,6 +222,10 @@ func testAccCheckFastlyServiceV1HeaderAttributes(service *gofastly.ServiceDetail
 					// we don't know these things ahead of time, so populate them now
 					h.ServiceID = service.ID
 					h.Version = service.ActiveVersion.Number
+					// We don't track these, so clear them out because we also wont know
+					// these ahead of time
+					lh.CreatedAt = nil
+					lh.UpdatedAt = nil
 					if !reflect.DeepEqual(h, lh) {
 						return fmt.Errorf("Bad match Header match, expected (%#v), got (%#v)", h, lh)
 					}

--- a/fastly/resource_fastly_service_v1_healthcheck_test.go
+++ b/fastly/resource_fastly_service_v1_healthcheck_test.go
@@ -152,6 +152,10 @@ func testAccCheckFastlyServiceV1HealthCheckAttributes(service *gofastly.ServiceD
 					// we don't know these things ahead of time, so populate them now
 					h.ServiceID = service.ID
 					h.Version = service.ActiveVersion.Number
+					// We don't track these, so clear them out because we also wont know
+					// these ahead of time
+					lh.CreatedAt = nil
+					lh.UpdatedAt = nil
 					if !reflect.DeepEqual(h, lh) {
 						return fmt.Errorf("Bad match Healthcheck match, expected (%#v), got (%#v)", h, lh)
 					}

--- a/fastly/resource_fastly_service_v1_papertrail_test.go
+++ b/fastly/resource_fastly_service_v1_papertrail_test.go
@@ -127,6 +127,8 @@ func testAccCheckFastlyServiceV1PapertrailAttributes(service *gofastly.ServiceDe
 					// we don't know these things ahead of time, so populate them now
 					p.ServiceID = service.ID
 					p.Version = service.ActiveVersion.Number
+					// we don't support the format_version field, so set it to the zero value
+					lp.FormatVersion = 0
 					// We don't track these, so clear them out because we also wont know
 					// these ahead of time
 					lp.CreatedAt = nil

--- a/fastly/resource_fastly_service_v1_request_setting_test.go
+++ b/fastly/resource_fastly_service_v1_request_setting_test.go
@@ -114,6 +114,10 @@ func testAccCheckFastlyServiceV1RequestSettingsAttributes(service *gofastly.Serv
 					// we don't know these things ahead of time, so populate them now
 					r.ServiceID = service.ID
 					r.Version = service.ActiveVersion.Number
+					// We don't track these, so clear them out because we also wont know
+					// these ahead of time
+					lr.CreatedAt = nil
+					lr.UpdatedAt = nil
 					if !reflect.DeepEqual(r, lr) {
 						return fmt.Errorf("Bad match Request Setting match, expected (%#v), got (%#v)", r, lr)
 					}

--- a/fastly/resource_fastly_service_v1_response_object_test.go
+++ b/fastly/resource_fastly_service_v1_response_object_test.go
@@ -136,6 +136,10 @@ func testAccCheckFastlyServiceV1ResponseObjectAttributes(service *gofastly.Servi
 					// we don't know these things ahead of time, so populate them now
 					p.ServiceID = service.ID
 					p.Version = service.ActiveVersion.Number
+					// We don't track these, so clear them out because we also wont know
+					// these ahead of time
+					lp.CreatedAt = nil
+					lp.UpdatedAt = nil
 					if !reflect.DeepEqual(p, lp) {
 						return fmt.Errorf("Bad match Response Object match, expected (%#v), got (%#v)", p, lp)
 					}


### PR DESCRIPTION
Due to the latest update of the `go-fastly` client v1.0.0, the following tests are failing:

```
=== RUN   TestAccFastlyServiceV1CacheSetting_basic
--- FAIL: TestAccFastlyServiceV1CacheSetting_basic (35.09s)
    testing.go:538: Step 0 error: Check failed: Check 2/5 error: Bad match Cache Setting match, expected (&fastly.CacheSetting{ServiceID:"20dMVuUuYwI2477xauYDNC", Version:1, Name:"alt_backend", Action:"pass", TTL:0x0, StaleTTL:0xe10, CacheCondition:"serve_alt_backend", CreatedAt:(*time.Time)(nil), UpdatedAt:(*time.Time)(nil), DeletedAt:(*time.Time)(nil)}), got (&fastly.CacheSetting{ServiceID:"20dMVuUuYwI2477xauYDNC", Version:1, Name:"alt_backend", Action:"pass", TTL:0x0, StaleTTL:0xe10, CacheCondition:"serve_alt_backend", CreatedAt:(*time.Time)(0xc0001e0da0), UpdatedAt:(*time.Time)(0xc0001e0ca0), DeletedAt:(*time.Time)(nil)})
```

```
=== RUN   TestAccFastlyServiceV1_conditional_basic
--- FAIL: TestAccFastlyServiceV1_conditional_basic (34.03s)
    testing.go:538: Step 0 error: Check failed: Check 2/4 error: Bad match Conditions match, expected (&fastly.Condition{ServiceID:"0DdgXxYqYtcwzBiU6Zhvxh", Version:1, Name:"some amz condition", Comment:"", Statement:"req.url ~ \"^/yolo/\"", Type:"REQUEST", Priority:10, CreatedAt:(*time.Time)(nil), UpdatedAt:(*time.Time)(nil), DeletedAt:(*time.Time)(nil)}), got (&fastly.Condition{ServiceID:"0DdgXxYqYtcwzBiU6Zhvxh", Version:1, Name:"some amz condition", Comment:"", Statement:"req.url ~ \"^/yolo/\"", Type:"REQUEST", Priority:10, CreatedAt:(*time.Time)(0xc00024ea80), UpdatedAt:(*time.Time)(0xc00024eae0), DeletedAt:(*time.Time)(nil)})
```

```
=== RUN   TestAccFastlyServiceV1_gzips_basic
--- FAIL: TestAccFastlyServiceV1_gzips_basic (33.76s)
    testing.go:538: Step 0 error: Check failed: Check 2/4 error: Bad match Gzip match, expected (&fastly.Gzip{ServiceID:"4OPJ7YQ9nOITXoo7iN2p5M", Version:1, Name:"gzip file types", ContentTypes:"", Extensions:"js css", CacheCondition:"testing_condition", CreatedAt:(*time.Time)(nil), UpdatedAt:(*time.Time)(nil), DeletedAt:(*time.Time)(nil)}), got (&fastly.Gzip{ServiceID:"4OPJ7YQ9nOITXoo7iN2p5M", Version:1, Name:"gzip file types", ContentTypes:"", Extensions:"js css", CacheCondition:"testing_condition", CreatedAt:(*time.Time)(0xc00025d2c0), UpdatedAt:(*time.Time)(0xc00025d240), DeletedAt:(*time.Time)(nil)})
```

```
=== RUN   TestAccFastlyServiceV1_headers_basic
--- FAIL: TestAccFastlyServiceV1_headers_basic (37.44s)
    testing.go:538: Step 0 error: Check failed: Check 2/4 error: Bad match Header match, expected (&fastly.Header{ServiceID:"1V1TI9mQKchscfbJFjBKzF", Version:1, Name:"remove x-amz-request-id", Action:"delete", IgnoreIfSet:false, Type:"cache", Destination:"http.x-amz-request-id", Source:"", Regex:"", Substitution:"", Priority:0x64, RequestCondition:"", CacheCondition:"", ResponseCondition:"", CreatedAt:(*time.Time)(nil), UpdatedAt:(*time.Time)(nil), DeletedAt:(*time.Time)(nil)}), got (&fastly.Header{ServiceID:"1V1TI9mQKchscfbJFjBKzF", Version:1, Name:"remove x-amz-request-id", Action:"delete", IgnoreIfSet:false, Type:"cache", Destination:"http.x-amz-request-id", Source:"", Regex:"", Substitution:"", Priority:0x64, RequestCondition:"", CacheCondition:"", ResponseCondition:"", CreatedAt:(*time.Time)(0xc0003565e0), UpdatedAt:(*time.Time)(0xc000356680), DeletedAt:(*time.Time)(nil)})
```

```
=== RUN   TestAccFastlyServiceV1_healthcheck_basic
--- FAIL: TestAccFastlyServiceV1_healthcheck_basic (36.70s)
    testing.go:538: Step 0 error: Check failed: Check 2/4 error: Bad match Healthcheck match, expected (&fastly.HealthCheck{ServiceID:"3eWsApPyoD1ZfhdCZXwURv", Version:1, Name:"example-healthcheck1", Comment:"", Method:"HEAD", Host:"example1.com", Path:"/test1.txt", HTTPVersion:"1.1", Timeout:0x1388, CheckInterval:0xfa0, ExpectedResponse:0xc8, Window:0x5, Threshold:0x3, Initial:0x2, CreatedAt:(*time.Time)(nil), UpdatedAt:(*time.Time)(nil), DeletedAt:(*time.Time)(nil)}), got (&fastly.HealthCheck{ServiceID:"3eWsApPyoD1ZfhdCZXwURv", Version:1, Name:"example-healthcheck1", Comment:"", Method:"HEAD", Host:"example1.com", Path:"/test1.txt", HTTPVersion:"1.1", Timeout:0x1388, CheckInterval:0xfa0, ExpectedResponse:0xc8, Window:0x5, Threshold:0x3, Initial:0x2, CreatedAt:(*time.Time)(0xc000396c00), UpdatedAt:(*time.Time)(0xc000396ae0), DeletedAt:(*time.Time)(nil)})
```

```
=== RUN   TestAccFastlyServiceV1_papertrail_basic
--- FAIL: TestAccFastlyServiceV1_papertrail_basic (35.48s)
    testing.go:538: Step 0 error: Check failed: Check 2/4 error: Bad match Papertrail match, expected (&fastly.Papertrail{ServiceID:"4yIvpMiPtq9fKFDmUU03mf", Version:1, Name:"papertrailtesting", Address:"test1.papertrailapp.com", Port:0xe10, Format:"%h %l %u %t %r %>s", FormatVersion:0x0, ResponseCondition:"test_response_condition", CreatedAt:(*time.Time)(nil), UpdatedAt:(*time.Time)(nil), DeletedAt:(*time.Time)(nil), Placement:""}), got (&fastly.Papertrail{ServiceID:"4yIvpMiPtq9fKFDmUU03mf", Version:1, Name:"papertrailtesting", Address:"test1.papertrailapp.com", Port:0xe10, Format:"%h %l %u %t %r %>s", FormatVersion:0x2, ResponseCondition:"test_response_condition", CreatedAt:(*time.Time)(nil), UpdatedAt:(*time.Time)(nil), DeletedAt:(*time.Time)(nil), Placement:""})
```

```
=== RUN   TestAccFastlyServiceV1RequestSetting_basic
--- FAIL: TestAccFastlyServiceV1RequestSetting_basic (36.88s)
    testing.go:538: Step 0 error: Check failed: Check 2/5 error: Bad match Request Setting match, expected (&fastly.RequestSetting{ServiceID:"3L4ObLO6OEChLt5bETa9nd", Version:1, Name:"alt_backend", ForceMiss:false, ForceSSL:false, Action:"", BypassBusyWait:false, MaxStaleAge:0x5a, HashKeys:"", XForwardedFor:"append", TimerSupport:false, GeoHeaders:false, DefaultHost:"tftestingother.tftesting.net.s3-website-us-west-2.amazonaws.com", RequestCondition:"serve_alt_backend", CreatedAt:(*time.Time)(nil), UpdatedAt:(*time.Time)(nil), DeletedAt:(*time.Time)(nil)}), got (&fastly.RequestSetting{ServiceID:"3L4ObLO6OEChLt5bETa9nd", Version:1, Name:"alt_backend", ForceMiss:false, ForceSSL:false, Action:"", BypassBusyWait:false, MaxStaleAge:0x5a, HashKeys:"", XForwardedFor:"append", TimerSupport:false, GeoHeaders:false, DefaultHost:"tftestingother.tftesting.net.s3-website-us-west-2.amazonaws.com", RequestCondition:"serve_alt_backend", CreatedAt:(*time.Time)(0xc00024f060), UpdatedAt:(*time.Time)(0xc00024efa0), DeletedAt:(*time.Time)(nil)})
```

```
=== RUN   TestAccFastlyServiceV1_response_object_basic
--- FAIL: TestAccFastlyServiceV1_response_object_basic (36.59s)
    testing.go:538: Step 0 error: Check failed: Check 2/4 error: Bad match Response Object match, expected (&fastly.ResponseObject{ServiceID:"1lVjoTaksUE0RogyRafb34", Version:1, Name:"responseObjecttesting", Status:0xc8, Response:"OK", Content:"test content", ContentType:"text/html", RequestCondition:"test-request-condition", CacheCondition:"test-cache-condition", CreatedAt:(*time.Time)(nil), UpdatedAt:(*time.Time)(nil), DeletedAt:(*time.Time)(nil)}), got (&fastly.ResponseObject{ServiceID:"1lVjoTaksUE0RogyRafb34", Version:1, Name:"responseObjecttesting", Status:0xc8, Response:"OK", Content:"test content", ContentType:"text/html", RequestCondition:"test-request-condition", CacheCondition:"test-cache-condition", CreatedAt:(*time.Time)(0xc000396280), UpdatedAt:(*time.Time)(0xc0003961e0), DeletedAt:(*time.Time)(nil)})
```