### PR TITLE
Revert "Revert "Accept PREFETCH condition type value""

### DIFF
--- a/fastly/validators.go
+++ b/fastly/validators.go
@@ -38,6 +38,7 @@ func validateConditionType() schema.SchemaValidateFunc {
 		"REQUEST",
 		"RESPONSE",
 		"CACHE",
+		"PREFETCH",
 	}, false)
 }
 

--- a/fastly/validators_test.go
+++ b/fastly/validators_test.go
@@ -136,9 +136,11 @@ func TestValidateConditionType(t *testing.T) {
 		{"REQUEST", 0, 0},
 		{"RESPONSE", 0, 0},
 		{"CACHE", 0, 0},
+		{"PREFETCH", 0, 0},
 		{"request", 0, 1},
 		{"response", 0, 1},
 		{"cache", 0, 1},
+		{"prefetch", 0, 1},
 	} {
 		t.Run(testcase.value, func(t *testing.T) {
 			actualWarns, actualErrors := validateConditionType()(testcase.value, "type")


### PR DESCRIPTION
Reverts terraform-providers/terraform-provider-fastly#174 and closes [#171](https://github.com/terraform-providers/terraform-provider-fastly/issues/171).

The `PREFETCH` value has also been added to the Fastly API [docs](https://docs.fastly.com/api/config#api-section-condition).