### PR TITLE
Add validation for backend weight attribute

### DIFF
--- a/fastly/resource_fastly_service_v1.go
+++ b/fastly/resource_fastly_service_v1.go
@@ -349,10 +349,11 @@ func resourceServiceV1() *schema.Resource {
 						},
 
 						"weight": {
-							Type:        schema.TypeInt,
-							Optional:    true,
-							Default:     100,
-							Description: "The portion of traffic to send to a specific origins. Each origin receives weight/total of the traffic.",
+							Type:         schema.TypeInt,
+							Optional:     true,
+							Default:      100,
+							Description:  "The percentage of the total traffic used to load balance this backend against others.",
+							ValidateFunc: validateBackendWeight(),
 						},
 					},
 				},

--- a/fastly/validators.go
+++ b/fastly/validators.go
@@ -74,3 +74,7 @@ func validateSnippetType() schema.SchemaValidateFunc {
 		"none",
 	}, false)
 }
+
+func validateBackendWeight() schema.SchemaValidateFunc {
+	return validation.IntBetween(1, 100)
+}

--- a/fastly/validators_test.go
+++ b/fastly/validators_test.go
@@ -246,3 +246,28 @@ func TestValidateSnippetType(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateBackendWeight(t *testing.T) {
+	for name, testcase := range map[string]struct {
+		value          int
+		expectedWarns  int
+		expectedErrors int
+	}{
+		"1":   {1, 0, 0},
+		"55":  {55, 0, 0},
+		"100": {100, 0, 0},
+		"0":   {0, 0, 1},
+		"101": {101, 0, 1},
+		"150": {150, 0, 1},
+	} {
+		t.Run(name, func(t *testing.T) {
+			actualWarns, actualErrors := validateBackendWeight()(testcase.value, "weight")
+			if len(actualWarns) != testcase.expectedWarns {
+				t.Errorf("expected %d warnings, actual %d ", testcase.expectedWarns, len(actualWarns))
+			}
+			if len(actualErrors) != testcase.expectedErrors {
+				t.Errorf("expected %d errors, actual %d ", testcase.expectedErrors, len(actualErrors))
+			}
+		})
+	}
+}

--- a/website/docs/r/service_v1.html.markdown
+++ b/website/docs/r/service_v1.html.markdown
@@ -245,7 +245,7 @@ Default `200`.
 * `ssl_cert_hostname` - (Optional) Overrides ssl_hostname, but only for cert verification. Does not affect SNI at all.
 * `ssl_sni_hostname` - (Optional) Overrides ssl_hostname, but only for SNI in the handshake. Does not affect cert validation at all.
 * `shield` - (Optional) The POP of the shield designated to reduce inbound load.
-* `weight` - (Optional) The [portion of traffic](https://docs.fastly.com/guides/performance-tuning/load-balancing-configuration.html#how-weight-affects-load-balancing) to send to this Backend. Each Backend receives `weight / total` of the traffic. Default `100`.
+* `weight` - (Optional) The percentage (`1-100`) of the total traffic used to [load balance](https://docs.fastly.com/guides/performance-tuning/load-balancing-configuration.html#how-weight-affects-load-balancing) this backend against others. Default `100`.
 * `healthcheck` - (Optional) Name of a defined `healthcheck` to assign to this backend.
 
 The `condition` block supports allows you to add logic to any basic configuration


### PR DESCRIPTION
The Fastly API does not validate the weight attribute. Useful values for this attribute are integers
from 1 to 100.

Closes #109.