### PR TITLE
Introduction of Edge Dictionaries

### DIFF
--- a/fastly/provider.go
+++ b/fastly/provider.go
@@ -27,7 +27,8 @@ func Provider() terraform.ResourceProvider {
 			"fastly_ip_ranges": dataSourceFastlyIPRanges(),
 		},
 		ResourcesMap: map[string]*schema.Resource{
-			"fastly_service_v1": resourceServiceV1(),
+			"fastly_service_v1":                  resourceServiceV1(),
+			"fastly_service_dictionary_items_v1": resourceServiceDictionaryItemsV1(),
 		},
 
 		ConfigureFunc: providerConfigure,

--- a/fastly/resource_fastly_service_dictionary_items_v1.go
+++ b/fastly/resource_fastly_service_dictionary_items_v1.go
@@ -73,6 +73,72 @@ func resourceServiceDictionaryItemsV1Create(d *schema.ResourceData, meta interfa
 
 func resourceServiceDictionaryItemsV1Update(d *schema.ResourceData, meta interface{}) error {
 
+	conn := meta.(*FastlyClient).conn
+
+	serviceID := d.Get("service_id").(string)
+	dictionaryID := d.Get("dictionary_id").(string)
+
+	d.Partial(true)
+
+	if d.HasChange("items") {
+
+		o, n := d.GetChange("items")
+
+		os := o.(map[string]interface{})
+		ns := n.(map[string]interface{})
+
+		// Handle Removal
+		for k := range os {
+			if _, ok := ns[k]; !ok {
+				err := conn.DeleteDictionaryItem(&gofastly.DeleteDictionaryItemInput{
+					serviceID,
+					dictionaryID,
+					k,
+				})
+
+				if err != nil {
+					return fmt.Errorf("Error updating, (removal) dictionary items: service %s, dictionary %s, %#v", serviceID, dictionaryID, err)
+				}
+			}
+		}
+
+		for k, v := range ns {
+			// Handle replaces
+			if _, ok := os[k]; ok {
+
+				_, err := conn.UpdateDictionaryItem(&gofastly.UpdateDictionaryItemInput{
+					serviceID,
+					dictionaryID,
+					k,
+					v.(string),
+				})
+
+				if err != nil {
+					return fmt.Errorf("Error updating, (update) dictionary items: service %s, dictionary %s, %#v", serviceID, dictionaryID, err)
+				}
+			}
+
+			// Handle additions
+			if _, ok := os[k]; !ok {
+
+				_, err := conn.CreateDictionaryItem(&gofastly.CreateDictionaryItemInput{
+					serviceID,
+					dictionaryID,
+					k,
+					v.(string),
+				})
+
+				if err != nil {
+					return fmt.Errorf("Error updating, (create) dictionary items: service %s, dictionary %s, %#v", serviceID, dictionaryID, err)
+				}
+			}
+		}
+
+		d.SetPartial("items")
+	}
+
+	d.Partial(false)
+
 	return resourceServiceDictionaryItemsV1Read(d, meta)
 }
 
@@ -95,6 +161,29 @@ func resourceServiceDictionaryItemsV1Read(d *schema.ResourceData, meta interface
 }
 
 func resourceServiceDictionaryItemsV1Delete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*FastlyClient).conn
+
+	serviceID := d.Get("service_id").(string)
+	dictionaryID := d.Get("dictionary_id").(string)
+	items := d.Get("items").(map[string]interface{})
+
+	for k, _ := range items {
+		err := conn.DeleteDictionaryItem(&gofastly.DeleteDictionaryItemInput{
+			Service:    serviceID,
+			Dictionary: dictionaryID,
+			ItemKey:    k,
+		})
+
+		if errRes, ok := err.(*gofastly.HTTPError); ok {
+			if errRes.StatusCode != 409 {
+				return err
+			}
+		} else if err != nil {
+			return err
+		}
+	}
+
+	d.SetId("")
 	return nil
 }
 

--- a/fastly/resource_fastly_service_dictionary_items_v1.go
+++ b/fastly/resource_fastly_service_dictionary_items_v1.go
@@ -32,9 +32,9 @@ func resourceServiceDictionaryItemsV1() *schema.Resource {
 			},
 
 			"items": {
-				Type:        schema.TypeMap,
-				Optional:    true,
-				Description: "Key/value pairs that make up an item in the dictionary",
+				Type:         schema.TypeMap,
+				Optional:     true,
+				Description:  "Key/value pairs that make up an item in the dictionary",
 				ValidateFunc: validateDictionaryItems(),
 			},
 		},

--- a/fastly/resource_fastly_service_dictionary_items_v1.go
+++ b/fastly/resource_fastly_service_dictionary_items_v1.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	gofastly "github.com/fastly/go-fastly/fastly"
 	"github.com/hashicorp/terraform/helper/schema"
-	"strings"
 )
 
 func resourceServiceDictionaryItemsV1() *schema.Resource {
@@ -144,11 +143,13 @@ func resourceServiceDictionaryItemsV1Update(d *schema.ResourceData, meta interfa
 func resourceServiceDictionaryItemsV1Read(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*FastlyClient).conn
 
-	comp := strings.Split(d.Id(), "/")
+	serviceID := d.Get("service_id").(string)
+	dictionaryID := d.Get("dictionary_id").(string)
+
 	// TODO Size check
 	dictList, err := conn.ListDictionaryItems(&gofastly.ListDictionaryItemsInput{
-		Service:    comp[0],
-		Dictionary: comp[1],
+		Service:    serviceID,
+		Dictionary: dictionaryID,
 	})
 	if err != nil {
 		return err

--- a/fastly/resource_fastly_service_dictionary_items_v1.go
+++ b/fastly/resource_fastly_service_dictionary_items_v1.go
@@ -64,7 +64,6 @@ func resourceServiceDictionaryItemsV1Create(d *schema.ResourceData, meta interfa
 		}
 	}
 
-	// TODO review this
 	d.SetId(fmt.Sprintf("%s/%s", serviceID, dictionaryID))
 	return resourceServiceDictionaryItemsV1Read(d, meta)
 }

--- a/fastly/resource_fastly_service_dictionary_items_v1.go
+++ b/fastly/resource_fastly_service_dictionary_items_v1.go
@@ -33,9 +33,10 @@ func resourceServiceDictionaryItemsV1() *schema.Resource {
 			},
 
 			"items": {
-				Type:        schema.TypeMap,
-				Optional:    true,
-				Description: "Key/value pairs that make up an item in the dictionary",
+				Type:         schema.TypeMap,
+				Optional:     true,
+				Description:  "Key/value pairs that make up an item in the dictionary",
+				ValidateFunc: validateDictionaryItems(),
 			},
 		},
 	}

--- a/fastly/resource_fastly_service_dictionary_items_v1.go
+++ b/fastly/resource_fastly_service_dictionary_items_v1.go
@@ -35,7 +35,7 @@ func resourceServiceDictionaryItemsV1() *schema.Resource {
 			"items": {
 				Type:         schema.TypeMap,
 				Optional:     true,
-				Description:  "Key/value pairs that make up an item in the dictionary",
+				Description:  "Map of key/value pairs that make up an item in the dictionary",
 				ValidateFunc: validateDictionaryItems(),
 			},
 		},

--- a/fastly/resource_fastly_service_dictionary_items_v1.go
+++ b/fastly/resource_fastly_service_dictionary_items_v1.go
@@ -1,0 +1,108 @@
+package fastly
+
+import (
+	"fmt"
+	"strings"
+
+	gofastly "github.com/fastly/go-fastly/fastly"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceServiceDictionaryItemsV1() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceServiceDictionaryItemsV1Create,
+		Read:   resourceServiceDictionaryItemsV1Read,
+		Update: resourceServiceDictionaryItemsV1Update,
+		Delete: resourceServiceDictionaryItemsV1Delete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"service_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "Service Id",
+			},
+
+			"dictionary_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "Dictionary Id",
+			},
+
+			"items": {
+				Type:        schema.TypeMap,
+				Description: "Dictionary Items",
+				Optional:    true,
+			},
+		},
+	}
+}
+
+func resourceServiceDictionaryItemsV1Create(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*FastlyClient).conn
+
+	serviceID := d.Get("service_id").(string)
+	dictionaryID := d.Get("dictionary_id").(string)
+	items := d.Get("items").(map[string]interface{})
+
+	for k, v := range items {
+		_, err := conn.CreateDictionaryItem(&gofastly.CreateDictionaryItemInput{
+			Service:    serviceID,
+			Dictionary: dictionaryID,
+			ItemKey:    k,
+			ItemValue:  v.(string),
+		})
+
+		if errRes, ok := err.(*gofastly.HTTPError); ok {
+			if errRes.StatusCode != 409 {
+				return err
+			}
+		} else if err != nil {
+			return err
+		}
+	}
+
+	// TODO review this
+	d.SetId(fmt.Sprintf("%s/%s", serviceID, dictionaryID))
+	return resourceServiceDictionaryItemsV1Read(d, meta)
+}
+
+func resourceServiceDictionaryItemsV1Update(d *schema.ResourceData, meta interface{}) error {
+
+	return resourceServiceDictionaryItemsV1Read(d, meta)
+}
+
+func resourceServiceDictionaryItemsV1Read(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*FastlyClient).conn
+
+	comp := strings.Split(d.Id(), "/")
+	// TODO Size check
+	dictList, err := conn.ListDictionaryItems(&gofastly.ListDictionaryItemsInput{
+		Service:    comp[0],
+		Dictionary: comp[1],
+	})
+	if err != nil {
+		return err
+	}
+
+	d.Set("items", flattenDictionaryItems(dictList))
+
+	return nil
+}
+
+func resourceServiceDictionaryItemsV1Delete(d *schema.ResourceData, meta interface{}) error {
+	return nil
+}
+
+func flattenDictionaryItems(dictItemList []*gofastly.DictionaryItem) map[string]string {
+	resultList := make(map[string]string)
+	for _, currentDictItem := range dictItemList {
+		resultList[currentDictItem.ItemKey] = currentDictItem.ItemValue
+	}
+
+	return resultList
+}

--- a/fastly/resource_fastly_service_dictionary_items_v1_test.go
+++ b/fastly/resource_fastly_service_dictionary_items_v1_test.go
@@ -51,23 +51,66 @@ func TestAccFastlyServiceDictionaryItemV1(t *testing.T) {
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	dictName := fmt.Sprintf("dict %s", acctest.RandString(10))
 
+	expectedItems := map[string]string{
+		"key1": "value1",
+		"key2": "value2",
+	}
+
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
-		//CheckDestroy: testAccCheckServiceV1Destroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckServiceV1Destroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccServiceDictionaryItemsV1Config(name, dictName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
-					testAccCheckFastlyServiceDictionaryItemsV1Attributes(&service, name, dictName),
+					testAccCheckFastlyServiceDictionaryItemsV1Attributes(&service, name, dictName, expectedItems),
 				),
 			},
 		},
 	})
 }
 
-func testAccCheckFastlyServiceDictionaryItemsV1Attributes(service *gofastly.ServiceDetail, name, dictName string) resource.TestCheckFunc {
+func TestAccFastlyServiceDictionaryItemV1_update_items(t *testing.T) {
+	var service gofastly.ServiceDetail
+	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	dictName := fmt.Sprintf("dict %s", acctest.RandString(10))
+
+	expectedItems := map[string]string{
+		"key1": "value1",
+		"key2": "value2",
+	}
+
+	expectedItemsAfterUpdate := map[string]string{
+		"key2": "valuetwo",
+		"key3": "value3",
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckServiceV1Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServiceDictionaryItemsV1Config(name, dictName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
+					testAccCheckFastlyServiceDictionaryItemsV1Attributes(&service, name, dictName, expectedItems),
+				),
+			},
+			{
+				Config: testAccServiceDictionaryItemsV1ConfigUpdateItems(name, dictName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
+					testAccCheckFastlyServiceDictionaryItemsV1Attributes(&service, name, dictName, expectedItemsAfterUpdate),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckFastlyServiceDictionaryItemsV1Attributes(service *gofastly.ServiceDetail, name, dictName string, expectedItems map[string]string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 
 		if service.Name != name {
@@ -96,11 +139,6 @@ func testAccCheckFastlyServiceDictionaryItemsV1Attributes(service *gofastly.Serv
 
 		dictItemsMap := flattenDictionaryItems(dictItems)
 
-		expectedItems := map[string]string{
-			"key1": "value1",
-			"key2": "value2",
-		}
-
 		if !reflect.DeepEqual(dictItemsMap, expectedItems) {
 			return fmt.Errorf("[ERR] Error matching:\nexpected: %#v\ngot: %#v", expectedItems, dictItemsMap)
 		}
@@ -108,6 +146,7 @@ func testAccCheckFastlyServiceDictionaryItemsV1Attributes(service *gofastly.Serv
 		return nil
 	}
 }
+
 
 func testAccServiceDictionaryItemsV1Config(serviceName, dictName string) string {
 	backendName := fmt.Sprintf("%s.aws.amazon.com", acctest.RandString(3))
@@ -121,6 +160,50 @@ variable "mydict" {
 		items = {
 			key1: "value1"
 			key2: "value2"
+		}
+	}
+}
+
+resource "fastly_service_v1" "foo" {
+  name = "%s"
+
+  domain {
+    name    = "%s"
+    comment = "tf-testing-domain"
+	}
+
+  backend {
+    address = "%s"
+    name    = "tf -test backend"
+  }
+
+  dictionary {
+	name       = var.mydict.name
+	write_only = false
+  }
+
+  force_destroy = true
+}
+
+resource "fastly_service_dictionary_items_v1" "items" {
+    service_id = "${fastly_service_v1.foo.id}"
+    dictionary_id = "${{for s in fastly_service_v1.foo.dictionary : s.name => s.dictionary_id}[var.mydict.name]}"
+    items = var.mydict.items
+}`, dictName, serviceName, domainName, backendName)
+}
+
+func testAccServiceDictionaryItemsV1ConfigUpdateItems(serviceName, dictName string) string {
+	backendName := fmt.Sprintf("%s.aws.amazon.com", acctest.RandString(3))
+	domainName := fmt.Sprintf("fastly-test.tf-%s.com", acctest.RandString(10))
+
+	return fmt.Sprintf(`
+variable "mydict" {
+	type = object({ name=string, items=map(string) })
+	default = {
+		name = "%s" 
+		items = {
+			key2: "valuetwo"
+			key3: "value3"
 		}
 	}
 }

--- a/fastly/resource_fastly_service_dictionary_items_v1_test.go
+++ b/fastly/resource_fastly_service_dictionary_items_v1_test.go
@@ -1,0 +1,146 @@
+package fastly
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	gofastly "github.com/fastly/go-fastly/fastly"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestResourceFastlyFlattenDictionaryItems(t *testing.T) {
+	cases := []struct {
+		remote []*gofastly.DictionaryItem
+		local  map[string]string
+	}{
+		{
+			remote: []*gofastly.DictionaryItem{
+				{
+					ServiceID:    "service-id",
+					DictionaryID: "1234567890",
+					ItemKey:      "key-1",
+					ItemValue:    "value-1",
+				},
+				{
+					ServiceID:    "service-id",
+					DictionaryID: "1234567890",
+					ItemKey:      "key-2",
+					ItemValue:    "value-2",
+				},
+			},
+			local: map[string]string{
+				"key-1": "value-1",
+				"key-2": "value-2",
+			},
+		},
+	}
+
+	for _, c := range cases {
+		out := flattenDictionaryItems(c.remote)
+		if !reflect.DeepEqual(out, c.local) {
+			t.Fatalf("Error matching:\nexpected: %#v\ngot: %#v", c.local, out)
+		}
+	}
+}
+
+func TestAccFastlyServiceDictionaryItemV1(t *testing.T) {
+	var service gofastly.ServiceDetail
+	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	dictName := fmt.Sprintf("dict %s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckServiceV1Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServiceDictionaryItemsV1Config(name, dictName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
+					testAccCheckFastlyServiceDictionaryItemsV1Attributes(&service, name, dictName),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckFastlyServiceDictionaryItemsV1Attributes(service *gofastly.ServiceDetail, name, dictName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+
+		if service.Name != name {
+			return fmt.Errorf("Bad name, expected (%s), got (%s)", name, service.Name)
+		}
+
+		conn := testAccProvider.Meta().(*FastlyClient).conn
+		dict, err := conn.GetDictionary(&gofastly.GetDictionaryInput{
+			Service: service.ID,
+			Version: service.ActiveVersion.Number,
+			Name:    dictName,
+		})
+
+		if err != nil {
+			return fmt.Errorf("[ERR] Error looking up Dictionary records for (%s), version (%v): %s", service.Name, service.ActiveVersion.Number, err)
+		}
+
+		dictItems, err := conn.ListDictionaryItems(&gofastly.ListDictionaryItemsInput{
+			Service:    service.ID,
+			Dictionary: dict.ID,
+		})
+
+		if err != nil {
+			return fmt.Errorf("[ERR] Error looking up Dictionary Items records for (%s), dictionary (%s): %s", service.Name, dict.ID, err)
+		}
+
+		dictItemsMap := flattenDictionaryItems(dictItems)
+
+		expectedItems := map[string]string{
+			"key1": "value1",
+			"key2": "value2",
+		}
+
+		if !reflect.DeepEqual(dictItemsMap, expectedItems) {
+			return fmt.Errorf("[ERR] Error matching:\nexpected: %#v\ngot: %#v", expectedItems, dictItemsMap)
+		}
+
+		return nil
+	}
+}
+
+func testAccServiceDictionaryItemsV1Config(name, dictName string) string {
+	backendName := fmt.Sprintf("%s.aws.amazon.com", acctest.RandString(3))
+	domainName := fmt.Sprintf("fastly-test.tf-%s.com", acctest.RandString(10))
+
+	return fmt.Sprintf(`
+resource "fastly_service_v1" "foo" {
+  name = "%s"
+
+  domain {
+    name    = "%s"
+    comment = "tf-testing-domain"
+	}
+
+  backend {
+    address = "%s"
+    name    = "tf -test backend"
+  }
+
+  dictionary {
+	name       = "%s"
+	write_only = false
+  }
+
+  force_destroy = true
+}
+
+resource "fastly_service_dictionary_items_v1" "items" {
+    service_id = "${fastly_service_v1.foo.id}"
+    dictionary_id = "${{for s in fastly_service_v1.foo.dictionary : s.name => s if s["name"] == "%s"}["%s"]["dictionary_id"]}"
+    items = {
+        key1 = "value1"
+        key2 = "value2"
+	}
+}`, name, domainName, backendName, dictName, dictName, dictName)
+}

--- a/fastly/resource_fastly_service_dictionary_items_v1_test.go
+++ b/fastly/resource_fastly_service_dictionary_items_v1_test.go
@@ -184,7 +184,7 @@ func TestAccFastlyServiceDictionaryItemV1_external_item_is_removed(t *testing.T)
 	})
 }
 
-func TestAccFastlyServiceDictionaryItemV1_external_item_remains(t *testing.T) {
+func TestAccFastlyServiceDictionaryItemV1_external_item_deleted(t *testing.T) {
 
 	var service gofastly.ServiceDetail
 
@@ -196,9 +196,7 @@ func TestAccFastlyServiceDictionaryItemV1_external_item_remains(t *testing.T) {
 		"key2": "value2",
 	}
 
-	expectedRemoteItemsAfterUpdate := map[string]string{
-		"key3": "value3",
-	}
+	expectedRemoteItemsAfterUpdate := map[string]string{}
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/fastly/resource_fastly_service_dictionary_items_v1_test.go
+++ b/fastly/resource_fastly_service_dictionary_items_v1_test.go
@@ -63,7 +63,7 @@ func TestAccFastlyServiceDictionaryItemV1_create(t *testing.T) {
 		CheckDestroy: testAccCheckServiceV1Destroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccServiceDictionaryItemsV1Config_create(name, dictName),
+				Config: testAccServiceDictionaryItemsV1Config_one_dictionary_with_items(name, dictName, expectedRemoteItems),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
 					testAccCheckFastlyServiceDictionaryItemsV1RemoteState(&service, name, dictName, expectedRemoteItems),
@@ -125,7 +125,7 @@ func TestAccFastlyServiceDictionaryItemV1_update(t *testing.T) {
 		CheckDestroy: testAccCheckServiceV1Destroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccServiceDictionaryItemsV1Config_create(name, dictName),
+				Config: testAccServiceDictionaryItemsV1Config_one_dictionary_with_items(name, dictName, expectedRemoteItems),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
 					testAccCheckFastlyServiceDictionaryItemsV1RemoteState(&service, name, dictName, expectedRemoteItems),
@@ -133,7 +133,7 @@ func TestAccFastlyServiceDictionaryItemV1_update(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccServiceDictionaryItemsV1Config_update(name, dictName),
+				Config: testAccServiceDictionaryItemsV1Config_one_dictionary_with_items(name, dictName, expectedRemoteItemsAfterUpdate),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
 					testAccCheckFastlyServiceDictionaryItemsV1RemoteState(&service, name, dictName, expectedRemoteItemsAfterUpdate),
@@ -144,24 +144,19 @@ func TestAccFastlyServiceDictionaryItemV1_update(t *testing.T) {
 	})
 }
 
-func TestAccFastlyServiceDictionaryItemV1_external_item_is_ignored(t *testing.T) {
+func TestAccFastlyServiceDictionaryItemV1_external_item_is_removed(t *testing.T) {
 
 	var service gofastly.ServiceDetail
 
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	dictName := fmt.Sprintf("dict %s", acctest.RandString(10))
-	config := testAccServiceDictionaryItemsV1Config_create(name, dictName)
 
 	expectedRemoteItems := map[string]string{
 		"key1": "value1",
 		"key2": "value2",
 	}
 
-	expectedRemoteItemsAfterUpdate := map[string]string{
-		"key1": "value1",
-		"key2": "value2",
-		"key3": "value3",
-	}
+	config := testAccServiceDictionaryItemsV1Config_one_dictionary_with_items(name, dictName, expectedRemoteItems)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -181,7 +176,7 @@ func TestAccFastlyServiceDictionaryItemV1_external_item_is_ignored(t *testing.T)
 				Config:    config,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
-					testAccCheckFastlyServiceDictionaryItemsV1RemoteState(&service, name, dictName, expectedRemoteItemsAfterUpdate),
+					testAccCheckFastlyServiceDictionaryItemsV1RemoteState(&service, name, dictName, expectedRemoteItems),
 					resource.TestCheckResourceAttr("fastly_service_dictionary_items_v1.items", "items.%", "2"),
 				),
 			},
@@ -211,7 +206,7 @@ func TestAccFastlyServiceDictionaryItemV1_external_item_remains(t *testing.T) {
 		CheckDestroy: testAccCheckServiceV1Destroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccServiceDictionaryItemsV1Config_create(name, dictName),
+				Config: testAccServiceDictionaryItemsV1Config_one_dictionary_with_items(name, dictName, expectedRemoteItems),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
 					testAccCheckFastlyServiceDictionaryItemsV1RemoteState(&service, name, dictName, expectedRemoteItems),
@@ -220,7 +215,7 @@ func TestAccFastlyServiceDictionaryItemV1_external_item_remains(t *testing.T) {
 			},
 			{
 				PreConfig: func() { createDictionaryItemThroughApi(t, &service, dictName, "key3", "value3") },
-				Config:    testAccServiceDictionaryItemsV1Config_remove(name, dictName),
+				Config:    testAccServiceDictionaryItemsV1Config_one_dictionary_no_items(name, dictName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
 					testAccCheckFastlyServiceDictionaryItemsV1RemoteState(&service, name, dictName, expectedRemoteItemsAfterUpdate),
@@ -251,12 +246,44 @@ func TestAccFastlyServiceDictionaryItemV1_batch_1001_items(t *testing.T) {
 		CheckDestroy: testAccCheckServiceV1Destroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccServiceDictionaryItemsV1Config_batch(name, dictName, expectedBatchSize),
+				Config: testAccServiceDictionaryItemsV1Config_one_dictionary_with_items(name, dictName, expectedRemoteItems),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
 					testAccCheckFastlyServiceDictionaryItemsV1RemoteState(&service, name, dictName, expectedRemoteItems),
 					resource.TestCheckResourceAttr("fastly_service_dictionary_items_v1.items", "items.%", strconv.Itoa(expectedBatchSize)),
 				),
+			},
+		},
+	})
+}
+
+func TestAccFastlyServiceDictionaryItemV1_import(t *testing.T) {
+
+	var service gofastly.ServiceDetail
+
+	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	dictName := fmt.Sprintf("dict %s", acctest.RandString(10))
+
+	expectedRemoteItems := map[string]string{
+		"key1": "value1",
+		"key2": "value2",
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckServiceV1Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServiceDictionaryItemsV1Config_one_dictionary_with_items(name, dictName, expectedRemoteItems),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
+				),
+			},
+			{
+				ResourceName:      "fastly_service_dictionary_items_v1.items",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -310,28 +337,11 @@ func testAccCheckFastlyServiceDictionaryItemsV1RemoteState(service *gofastly.Ser
 	}
 }
 
-func testAccServiceDictionaryItemsV1Config_batch(serviceName, dictName string, batchSize int) string {
-
-	var dictItems = "{\n"
-
-	for i := 0; i < batchSize; i++ {
-		dictItems += fmt.Sprintf("key%d: \"value%d\"\n", i, i)
-	}
-
-	dictItems += "}\n"
-
-	return testAccServiceDictionaryItemsV1Config(serviceName, dictName, dictItems)
-}
-
 func createDictionaryItemThroughApi(t *testing.T, service *gofastly.ServiceDetail, dictName, expectedKey, expectedValue string) {
 
 	conn := testAccProvider.Meta().(*FastlyClient).conn
 
-	dict, err := conn.GetDictionary(&gofastly.GetDictionaryInput{
-		Service: service.ID,
-		Version: service.ActiveVersion.Number,
-		Name:    dictName,
-	})
+	dict, err := getDictionaryByName(service, dictName)
 
 	if err != nil {
 		t.Fatalf("[ERR] Error looking up Dictionary records for (%s), version (%v): %s", service.Name, service.ActiveVersion.Number, err)
@@ -351,30 +361,28 @@ func createDictionaryItemThroughApi(t *testing.T, service *gofastly.ServiceDetai
 
 }
 
-func testAccServiceDictionaryItemsV1Config_create(serviceName, dictName string) string {
+func getDictionaryByName(service *gofastly.ServiceDetail, dictName string) (*gofastly.Dictionary, error) {
+	conn := testAccProvider.Meta().(*FastlyClient).conn
 
-	dictItems := `{
-	key1: "value1"
-	key2: "value2"
-}`
-
-	return testAccServiceDictionaryItemsV1Config(serviceName, dictName, dictItems)
+	dict, err := conn.GetDictionary(&gofastly.GetDictionaryInput{
+		Service: service.ID,
+		Version: service.ActiveVersion.Number,
+		Name:    dictName,
+	})
+	return dict, err
 }
 
-func testAccServiceDictionaryItemsV1Config_update(serviceName, dictName string) string {
-
-	dictItems := `{
-	key1: "valueOne"
-	key2: "value2"
-	key3: "value3"
-}`
-
-	return testAccServiceDictionaryItemsV1Config(serviceName, dictName, dictItems)
-}
-
-func testAccServiceDictionaryItemsV1Config(serviceName, dictName, dictItems string) string {
+func testAccServiceDictionaryItemsV1Config_one_dictionary_with_items(serviceName, dictName string, dictItemsList map[string]string) string {
 	backendName := fmt.Sprintf("%s.aws.amazon.com", acctest.RandString(3))
 	domainName := fmt.Sprintf("fastly-test.tf-%s.com", acctest.RandString(10))
+
+	var dictItems = "{\n"
+
+	for key, value := range dictItemsList {
+		dictItems += fmt.Sprintf("%s: \"%s\"\n", key, value)
+	}
+
+	dictItems += "}\n"
 
 	return fmt.Sprintf(`
 variable "mydict" {
@@ -412,7 +420,7 @@ resource "fastly_service_dictionary_items_v1" "items" {
 }`, dictName, dictItems, serviceName, domainName, backendName)
 }
 
-func testAccServiceDictionaryItemsV1Config_remove(serviceName, dictName string) string {
+func testAccServiceDictionaryItemsV1Config_one_dictionary_no_items(serviceName, dictName string) string {
 
 	backendName := fmt.Sprintf("%s.aws.amazon.com", acctest.RandString(3))
 	domainName := fmt.Sprintf("fastly-test.tf-%s.com", acctest.RandString(10))

--- a/fastly/resource_fastly_service_dictionary_items_v1_test.go
+++ b/fastly/resource_fastly_service_dictionary_items_v1_test.go
@@ -326,15 +326,14 @@ resource "fastly_service_v1" "foo" {
 
   dictionary {
 	name       = var.mydict.name
-	write_only = false
   }
 
   force_destroy = true
 }
 
 resource "fastly_service_dictionary_items_v1" "items" {
-    service_id = "${fastly_service_v1.foo.id}"
-    dictionary_id = "${{for s in fastly_service_v1.foo.dictionary : s.name => s.dictionary_id}[var.mydict.name]}"
+    service_id = fastly_service_v1.foo.id
+    dictionary_id = {for s in fastly_service_v1.foo.dictionary : s.name => s.dictionary_id}[var.mydict.name]
     items = var.mydict.items
 }`, dictName, dictItems, serviceName, domainName, backendName)
 }
@@ -360,7 +359,6 @@ resource "fastly_service_v1" "foo" {
 
   dictionary {
 	name       = "%s"
-	write_only = false
   }
 
   force_destroy = true

--- a/fastly/resource_fastly_service_v1.go
+++ b/fastly/resource_fastly_service_v1.go
@@ -1400,7 +1400,7 @@ func resourceServiceV1() *schema.Resource {
 						"dictionary_id": {
 							Type:        schema.TypeString,
 							Computed:    true,
-							Description: "Generated dictionary id",
+							Description: "Generated dictionary ID",
 						},
 					},
 				},

--- a/fastly/resource_fastly_service_v1.go
+++ b/fastly/resource_fastly_service_v1.go
@@ -1385,6 +1385,32 @@ func resourceServiceV1() *schema.Resource {
 					},
 				},
 			},
+			"dictionary": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						// Required fields
+						"name": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "Unique name to refer to this Dictionary",
+						},
+						// Optional fields
+						"write_only": {
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Default:     false,
+							Description: "Determines if items in the dictionary are readable or not.",
+						},
+						"dictionary_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Generated dictionary id",
+						},
+					},
+				},
+			},
 		},
 	}
 }
@@ -1456,6 +1482,7 @@ func resourceServiceV1Update(d *schema.ResourceData, meta interface{}) error {
 		"cache_setting",
 		"snippet",
 		"vcl",
+		"dictionary",
 	} {
 		if d.HasChange(v) {
 			needsChange = true
@@ -2889,6 +2916,62 @@ func resourceServiceV1Update(d *schema.ResourceData, meta interface{}) error {
 			}
 		}
 
+		// Find differences in dictionary
+		if d.HasChange("dictionary") {
+
+			oldDictVal, newDictVal := d.GetChange("dictionary")
+
+			if oldDictVal == nil {
+				oldDictVal = new(schema.Set)
+			}
+			if newDictVal == nil {
+				newDictVal = new(schema.Set)
+			}
+
+			oldDictSet := oldDictVal.(*schema.Set)
+			newDictSet := newDictVal.(*schema.Set)
+
+			remove := oldDictSet.Difference(newDictSet).List()
+			add := newDictSet.Difference(oldDictSet).List()
+
+			// Delete removed dictionary configurations
+			for _, dRaw := range remove {
+				df := dRaw.(map[string]interface{})
+				opts := gofastly.DeleteDictionaryInput{
+					Service: d.Id(),
+					Version: latestVersion,
+					Name:    df["name"].(string),
+				}
+
+				log.Printf("[DEBUG] Fastly Dictionary Removal opts: %#v", opts)
+				err := conn.DeleteDictionary(&opts)
+				if errRes, ok := err.(*gofastly.HTTPError); ok {
+					if errRes.StatusCode != 404 {
+						return err
+					}
+				} else if err != nil {
+					return err
+				}
+			}
+
+			// POST new dictionary configurations
+			for _, dRaw := range add {
+				opts, err := buildDictionary(dRaw.(map[string]interface{}))
+				if err != nil {
+					log.Printf("[DEBUG] Error building Dicitionary: %s", err)
+					return err
+				}
+				opts.Service = d.Id()
+				opts.Version = latestVersion
+
+				log.Printf("[DEBUG] Fastly Dictionary Addition opts: %#v", opts)
+				_, err = conn.CreateDictionary(opts)
+				if err != nil {
+					return err
+				}
+			}
+		}
+
 		// validate version
 		log.Printf("[DEBUG] Validating Fastly Service (%s), Version (%v)", d.Id(), latestVersion)
 		valid, msg, err := conn.ValidateVersion(&gofastly.ValidateVersionInput{
@@ -3343,6 +3426,22 @@ func resourceServiceV1Read(d *schema.ResourceData, meta interface{}) error {
 
 		if err := d.Set("cache_setting", csl); err != nil {
 			log.Printf("[WARN] Error setting Cache Settings for (%s): %s", d.Id(), err)
+		}
+
+		// refresh Dictionaries
+		log.Printf("[DEBUG] Refreshing Dictionaries for (%s)", d.Id())
+		dictList, err := conn.ListDictionaries(&gofastly.ListDictionariesInput{
+			Service: d.Id(),
+			Version: s.ActiveVersion.Number,
+		})
+		if err != nil {
+			return fmt.Errorf("[ERR] Error looking up Dictionaries for (%s), version (%v): %s", d.Id(), s.ActiveVersion.Number, err)
+		}
+
+		dict := flattenDictionaries(dictList)
+
+		if err := d.Set("dictionary", dict); err != nil {
+			log.Printf("[WARN] Error setting Dictionary for (%s): %s", d.Id(), err)
 		}
 
 	} else {
@@ -4194,6 +4293,39 @@ func flattenSnippets(snippetList []*gofastly.Snippet) []map[string]interface{} {
 	}
 
 	return sl
+}
+
+func buildDictionary(dictMap interface{}) (*gofastly.CreateDictionaryInput, error) {
+	df := dictMap.(map[string]interface{})
+	opts := gofastly.CreateDictionaryInput{
+		Name:      df["name"].(string),
+		WriteOnly: gofastly.CBool(df["write_only"].(bool)),
+	}
+
+	return &opts, nil
+}
+
+func flattenDictionaries(dictList []*gofastly.Dictionary) []map[string]interface{} {
+	var dl []map[string]interface{}
+	for _, currentDict := range dictList {
+
+		dictMapString := map[string]interface{}{
+			"dictionary_id": currentDict.ID,
+			"name":          currentDict.Name,
+			"write_only":    currentDict.WriteOnly,
+		}
+
+		// prune any empty values that come from the default string value in structs
+		for k, v := range dictMapString {
+			if v == "" {
+				delete(dictMapString, k)
+			}
+		}
+
+		dl = append(dl, dictMapString)
+	}
+
+	return dl
 }
 
 func validateVCLs(d *schema.ResourceData) error {

--- a/fastly/resource_fastly_service_v1.go
+++ b/fastly/resource_fastly_service_v1.go
@@ -1397,12 +1397,6 @@ func resourceServiceV1() *schema.Resource {
 							Description: "Unique name to refer to this Dictionary",
 						},
 						// Optional fields
-						"write_only": {
-							Type:        schema.TypeBool,
-							Optional:    true,
-							Default:     false,
-							Description: "Determines if items in the dictionary are readable or not.",
-						},
 						"dictionary_id": {
 							Type:        schema.TypeString,
 							Computed:    true,
@@ -4298,8 +4292,7 @@ func flattenSnippets(snippetList []*gofastly.Snippet) []map[string]interface{} {
 func buildDictionary(dictMap interface{}) (*gofastly.CreateDictionaryInput, error) {
 	df := dictMap.(map[string]interface{})
 	opts := gofastly.CreateDictionaryInput{
-		Name:      df["name"].(string),
-		WriteOnly: gofastly.CBool(df["write_only"].(bool)),
+		Name: df["name"].(string),
 	}
 
 	return &opts, nil
@@ -4312,7 +4305,6 @@ func flattenDictionaries(dictList []*gofastly.Dictionary) []map[string]interface
 		dictMapString := map[string]interface{}{
 			"dictionary_id": currentDict.ID,
 			"name":          currentDict.Name,
-			"write_only":    currentDict.WriteOnly,
 		}
 
 		// prune any empty values that come from the default string value in structs

--- a/fastly/resource_fastly_service_v1_dictionary_test.go
+++ b/fastly/resource_fastly_service_v1_dictionary_test.go
@@ -1,0 +1,117 @@
+package fastly
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	gofastly "github.com/fastly/go-fastly/fastly"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestResourceFastlyFlattenDictionary(t *testing.T) {
+	cases := []struct {
+		remote []*gofastly.Dictionary
+		local  []map[string]interface{}
+	}{
+		{
+			remote: []*gofastly.Dictionary{
+				{
+					ID:        "1234567890",
+					Name:      "dictionary-example",
+					WriteOnly: true,
+				},
+			},
+			local: []map[string]interface{}{
+				{
+					"dictionary_id": "1234567890",
+					"name":          "dictionary-example",
+					"write_only":    true,
+				},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		out := flattenDictionaries(c.remote)
+		if !reflect.DeepEqual(out, c.local) {
+			t.Fatalf("Error matching:\nexpected: %#v\ngot: %#v", c.local, out)
+		}
+	}
+}
+
+func TestAccFastlyServiceV1_dictionary(t *testing.T) {
+	var service gofastly.ServiceDetail
+	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	dictName := fmt.Sprintf("dict %s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckServiceV1Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServiceV1Config_dictionary(name, dictName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
+					testAccCheckFastlyServiceV1Attributes_dictionary(&service, name, dictName),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckFastlyServiceV1Attributes_dictionary(service *gofastly.ServiceDetail, name, dictName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+
+		if service.Name != name {
+			return fmt.Errorf("Bad name, expected (%s), got (%s)", name, service.Name)
+		}
+
+		conn := testAccProvider.Meta().(*FastlyClient).conn
+		dict, err := conn.GetDictionary(&gofastly.GetDictionaryInput{
+			Service: service.ID,
+			Version: service.ActiveVersion.Number,
+			Name:    dictName,
+		})
+
+		if err != nil {
+			return fmt.Errorf("[ERR] Error looking up Dictionary records for (%s), version (%v): %s", service.Name, service.ActiveVersion.Number, err)
+		}
+
+		if dict.Name != dictName {
+			return fmt.Errorf("Dictionary logging endpoint name mismatch, expected: %s, got: %#v", dictName, dict.Name)
+		}
+
+		return nil
+	}
+}
+
+func testAccServiceV1Config_dictionary(name, dictName string) string {
+	backendName := fmt.Sprintf("%s.aws.amazon.com", acctest.RandString(3))
+	domainName := fmt.Sprintf("fastly-test.tf-%s.com", acctest.RandString(10))
+
+	return fmt.Sprintf(`
+resource "fastly_service_v1" "foo" {
+  name = "%s"
+
+  domain {
+    name    = "%s"
+    comment = "tf-testing-domain"
+	}
+
+  backend {
+    address = "%s"
+    name    = "tf -test backend"
+  }
+
+  dictionary {
+	name       = "%s"
+	write_only = false
+  }
+
+  force_destroy = true
+}`, name, domainName, backendName, dictName)
+}

--- a/fastly/resource_fastly_service_v1_dictionary_test.go
+++ b/fastly/resource_fastly_service_v1_dictionary_test.go
@@ -63,6 +63,36 @@ func TestAccFastlyServiceV1_dictionary(t *testing.T) {
 	})
 }
 
+func TestAccFastlyServiceV1_update_dictionary_name(t *testing.T) {
+	var service gofastly.ServiceDetail
+	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	dictName := fmt.Sprintf("dict %s", acctest.RandString(10))
+
+	updatedDictName := fmt.Sprintf("new dict %s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckServiceV1Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServiceV1Config_dictionary(name, dictName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
+					testAccCheckFastlyServiceV1Attributes_dictionary(&service, name, dictName),
+				),
+			},
+			{
+				Config: testAccServiceV1Config_dictionary(name, updatedDictName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
+					testAccCheckFastlyServiceV1Attributes_dictionary(&service, name, updatedDictName),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckFastlyServiceV1Attributes_dictionary(service *gofastly.ServiceDetail, name, dictName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 

--- a/fastly/resource_fastly_service_v1_dictionary_test.go
+++ b/fastly/resource_fastly_service_v1_dictionary_test.go
@@ -19,16 +19,14 @@ func TestResourceFastlyFlattenDictionary(t *testing.T) {
 		{
 			remote: []*gofastly.Dictionary{
 				{
-					ID:        "1234567890",
-					Name:      "dictionary-example",
-					WriteOnly: true,
+					ID:   "1234567890",
+					Name: "dictionary-example",
 				},
 			},
 			local: []map[string]interface{}{
 				{
 					"dictionary_id": "1234567890",
 					"name":          "dictionary-example",
-					"write_only":    true,
 				},
 			},
 		},
@@ -63,7 +61,7 @@ func TestAccFastlyServiceV1_dictionary(t *testing.T) {
 	})
 }
 
-func TestAccFastlyServiceV1_update_dictionary_name(t *testing.T) {
+func TestAccFastlyServiceV1_dictionary_update_name(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	dictName := fmt.Sprintf("dict %s", acctest.RandString(10))
@@ -139,7 +137,6 @@ resource "fastly_service_v1" "foo" {
 
   dictionary {
 	name       = "%s"
-	write_only = false
   }
 
   force_destroy = true

--- a/fastly/validators.go
+++ b/fastly/validators.go
@@ -1,6 +1,7 @@
 package fastly
 
 import (
+	"fmt"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
 )
@@ -76,5 +77,22 @@ func validateSnippetType() schema.SchemaValidateFunc {
 }
 
 func validateDictionaryItems() schema.SchemaValidateFunc {
-	return validation.IntAtMost(10000)
+	max := 10000
+
+	return func(i interface{}, k string) (s []string, es []error) {
+
+		v, ok := i.(map[string]interface{})
+		if !ok {
+			es = append(es, fmt.Errorf("expected type of %s to be a map[string]interface", k))
+			return
+		}
+
+		if len(v) > max {
+			es = append(es, fmt.Errorf("expected %s to be at most (%d), got %d", k, max, len(v)))
+			return
+		}
+
+		return
+	}
+
 }

--- a/fastly/validators.go
+++ b/fastly/validators.go
@@ -74,3 +74,7 @@ func validateSnippetType() schema.SchemaValidateFunc {
 		"none",
 	}, false)
 }
+
+func validateDictionaryItems() schema.SchemaValidateFunc {
+	return validation.IntAtMost(10000)
+}

--- a/fastly/validators.go
+++ b/fastly/validators.go
@@ -2,6 +2,7 @@ package fastly
 
 import (
 	"fmt"
+	gofastly "github.com/fastly/go-fastly/fastly"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
 )
@@ -77,7 +78,8 @@ func validateSnippetType() schema.SchemaValidateFunc {
 }
 
 func validateDictionaryItems() schema.SchemaValidateFunc {
-	max := 10000
+
+	max := gofastly.MaximumDictionarySize
 
 	return func(i interface{}, k string) (s []string, es []error) {
 

--- a/fastly/validators_test.go
+++ b/fastly/validators_test.go
@@ -2,6 +2,7 @@ package fastly
 
 import (
 	"fmt"
+	gofastly "github.com/fastly/go-fastly/fastly"
 	"testing"
 )
 
@@ -258,8 +259,8 @@ func TestValidateDictionaryItemMaxSize(t *testing.T) {
 		expectedErrors int
 	}{
 		"Ten hundred dictionary items":          {createTestDictionaryItems(10), 0, 0},
-		"Ten thousand dictionary items":         {createTestDictionaryItems(10000), 0, 0},
-		"Ten thousand and one dictionary items": {createTestDictionaryItems(10001), 0, 1},
+		"Ten thousand dictionary items":         {createTestDictionaryItems(gofastly.MaximumDictionarySize), 0, 0},
+		"Ten thousand and one dictionary items": {createTestDictionaryItems(gofastly.MaximumDictionarySize + 1), 0, 1},
 	} {
 		t.Run(name, func(t *testing.T) {
 			actualWarns, actualErrors := validateDictionaryItems()(testcase.value, "dictionary_items")

--- a/fastly/validators_test.go
+++ b/fastly/validators_test.go
@@ -246,3 +246,27 @@ func TestValidateSnippetType(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateDictionaryItemMaxSize(t *testing.T) {
+	for name, testcase := range map[string]struct {
+		value          int
+		expectedWarns  int
+		expectedErrors int
+	}{
+		"Ten dictionary items": {10, 0, 0},
+		"One Hundres dictionary items": {100, 0, 0},
+		"One Thousand dictionary items": {1000, 0, 0},
+		"Ten thousand dictionary items": {10000, 0, 0},
+		"Ten thousand and one dictionary items": {10001, 0, 1},
+	} {
+		t.Run(name, func(t *testing.T) {
+			actualWarns, actualErrors := validateDictionaryItems()(testcase.value, "dictionary_items")
+			if len(actualWarns) != testcase.expectedWarns {
+				t.Errorf("expected %d warnings, actual %d ", testcase.expectedWarns, len(actualWarns))
+			}
+			if len(actualErrors) != testcase.expectedErrors {
+				t.Errorf("expected %d errors, actual %d ", testcase.expectedErrors, len(actualErrors))
+			}
+		})
+	}
+}

--- a/fastly/validators_test.go
+++ b/fastly/validators_test.go
@@ -1,6 +1,9 @@
 package fastly
 
-import "testing"
+import (
+	"fmt"
+	"testing"
+)
 
 func TestValidateLoggingFormatVersion(t *testing.T) {
 	for name, testcase := range map[string]struct {
@@ -248,16 +251,15 @@ func TestValidateSnippetType(t *testing.T) {
 }
 
 func TestValidateDictionaryItemMaxSize(t *testing.T) {
+
 	for name, testcase := range map[string]struct {
-		value          int
+		value          map[string]interface{}
 		expectedWarns  int
 		expectedErrors int
 	}{
-		"Ten dictionary items":                  {10, 0, 0},
-		"One Hundres dictionary items":          {100, 0, 0},
-		"One Thousand dictionary items":         {1000, 0, 0},
-		"Ten thousand dictionary items":         {10000, 0, 0},
-		"Ten thousand and one dictionary items": {10001, 0, 1},
+		"Ten hundred dictionary items":          {createTestDictionaryItems(10), 0, 0},
+		"Ten thousand dictionary items":         {createTestDictionaryItems(10000), 0, 0},
+		"Ten thousand and one dictionary items": {createTestDictionaryItems(10001), 0, 1},
 	} {
 		t.Run(name, func(t *testing.T) {
 			actualWarns, actualErrors := validateDictionaryItems()(testcase.value, "dictionary_items")
@@ -269,4 +271,15 @@ func TestValidateDictionaryItemMaxSize(t *testing.T) {
 			}
 		})
 	}
+}
+
+func createTestDictionaryItems(size int) map[string]interface{} {
+
+	dictionaryItems := make(map[string]interface{})
+
+	for i := 0; i < size; i++ {
+		dictionaryItems[fmt.Sprintf("key%d", i)] = fmt.Sprintf("value%d", i)
+	}
+
+	return dictionaryItems
 }

--- a/fastly/validators_test.go
+++ b/fastly/validators_test.go
@@ -253,10 +253,10 @@ func TestValidateDictionaryItemMaxSize(t *testing.T) {
 		expectedWarns  int
 		expectedErrors int
 	}{
-		"Ten dictionary items": {10, 0, 0},
-		"One Hundres dictionary items": {100, 0, 0},
-		"One Thousand dictionary items": {1000, 0, 0},
-		"Ten thousand dictionary items": {10000, 0, 0},
+		"Ten dictionary items":                  {10, 0, 0},
+		"One Hundres dictionary items":          {100, 0, 0},
+		"One Thousand dictionary items":         {1000, 0, 0},
+		"Ten thousand dictionary items":         {10000, 0, 0},
 		"Ten thousand and one dictionary items": {10001, 0, 1},
 	} {
 		t.Run(name, func(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/terraform-providers/terraform-provider-fastly
 require (
 	github.com/ajg/form v0.0.0-20160822230020-523a5da1a92f // indirect
 	github.com/dnaeon/go-vcr v1.0.1 // indirect
-	github.com/fastly/go-fastly v1.1.0
+	github.com/fastly/go-fastly v1.2.0
 	github.com/google/jsonapi v0.0.0-20180313013858-2dcc18f43696 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.0
 	github.com/hashicorp/terraform v0.12.3

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/terraform-providers/terraform-provider-fastly
 require (
 	github.com/ajg/form v0.0.0-20160822230020-523a5da1a92f // indirect
 	github.com/dnaeon/go-vcr v1.0.1 // indirect
-	github.com/fastly/go-fastly v1.0.1-0.20190722130720-c77fe029a012
+	github.com/fastly/go-fastly v1.1.0
 	github.com/google/jsonapi v0.0.0-20180313013858-2dcc18f43696 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.0
 	github.com/hashicorp/terraform v0.12.3

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/terraform-providers/terraform-provider-fastly
 require (
 	github.com/ajg/form v0.0.0-20160822230020-523a5da1a92f // indirect
 	github.com/dnaeon/go-vcr v1.0.1 // indirect
-	github.com/fastly/go-fastly v1.0.0
+	github.com/fastly/go-fastly v1.0.1-0.20190716135524-b59d50e7bbfb
 	github.com/google/jsonapi v0.0.0-20180313013858-2dcc18f43696 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.0
 	github.com/hashicorp/terraform v0.12.3

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/terraform-providers/terraform-provider-fastly
 require (
 	github.com/ajg/form v0.0.0-20160822230020-523a5da1a92f // indirect
 	github.com/dnaeon/go-vcr v1.0.1 // indirect
-	github.com/fastly/go-fastly v1.2.0
+	github.com/fastly/go-fastly v1.2.1
 	github.com/google/jsonapi v0.0.0-20180313013858-2dcc18f43696 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.0
 	github.com/hashicorp/terraform v0.12.3

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/terraform-providers/terraform-provider-fastly
 require (
 	github.com/ajg/form v0.0.0-20160822230020-523a5da1a92f // indirect
 	github.com/dnaeon/go-vcr v1.0.1 // indirect
-	github.com/fastly/go-fastly v1.0.1-0.20190716135524-b59d50e7bbfb
+	github.com/fastly/go-fastly v1.0.1-0.20190722130720-c77fe029a012
 	github.com/google/jsonapi v0.0.0-20180313013858-2dcc18f43696 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.0
 	github.com/hashicorp/terraform v0.12.3

--- a/go.sum
+++ b/go.sum
@@ -95,6 +95,8 @@ github.com/fastly/go-fastly v1.1.0 h1:6XaWf7vnetohY1PVkS5fPtmwgItU0WUP9CspL3+2Ld
 github.com/fastly/go-fastly v1.1.0/go.mod h1:ACxsUdqChasXcraa3/IigjE01rVn3A1F4vaI18Gmm0g=
 github.com/fastly/go-fastly v1.2.0 h1:6msl05/o4fpsJFJm35EX5t0ltsYxNo5wc9CypGH5U94=
 github.com/fastly/go-fastly v1.2.0/go.mod h1:ACxsUdqChasXcraa3/IigjE01rVn3A1F4vaI18Gmm0g=
+github.com/fastly/go-fastly v1.2.1 h1:7aZI3PL9vHDuHcBgLwj3uv+yCd80tpKTr10B3Q3A1Vk=
+github.com/fastly/go-fastly v1.2.1/go.mod h1:ACxsUdqChasXcraa3/IigjE01rVn3A1F4vaI18Gmm0g=
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=

--- a/go.sum
+++ b/go.sum
@@ -89,6 +89,8 @@ github.com/fastly/go-fastly v1.0.0 h1:56wmg3LX3Q9BkFikg4qZf+xFJTrIuHYmxIjCVKo9wN
 github.com/fastly/go-fastly v1.0.0/go.mod h1:ACxsUdqChasXcraa3/IigjE01rVn3A1F4vaI18Gmm0g=
 github.com/fastly/go-fastly v1.0.1-0.20190716135524-b59d50e7bbfb h1:Dy7Zo2WJYMNOxAVlYk37/qZKsWnJ91c56xzOwXY7FvU=
 github.com/fastly/go-fastly v1.0.1-0.20190716135524-b59d50e7bbfb/go.mod h1:ACxsUdqChasXcraa3/IigjE01rVn3A1F4vaI18Gmm0g=
+github.com/fastly/go-fastly v1.0.1-0.20190722130720-c77fe029a012 h1:mwefdo3Vv1XDocrmU6pGcaPeAsOdYqZasUZx48dhNEs=
+github.com/fastly/go-fastly v1.0.1-0.20190722130720-c77fe029a012/go.mod h1:ACxsUdqChasXcraa3/IigjE01rVn3A1F4vaI18Gmm0g=
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=

--- a/go.sum
+++ b/go.sum
@@ -93,6 +93,8 @@ github.com/fastly/go-fastly v1.0.1-0.20190722130720-c77fe029a012 h1:mwefdo3Vv1XD
 github.com/fastly/go-fastly v1.0.1-0.20190722130720-c77fe029a012/go.mod h1:ACxsUdqChasXcraa3/IigjE01rVn3A1F4vaI18Gmm0g=
 github.com/fastly/go-fastly v1.1.0 h1:6XaWf7vnetohY1PVkS5fPtmwgItU0WUP9CspL3+2Ld8=
 github.com/fastly/go-fastly v1.1.0/go.mod h1:ACxsUdqChasXcraa3/IigjE01rVn3A1F4vaI18Gmm0g=
+github.com/fastly/go-fastly v1.2.0 h1:6msl05/o4fpsJFJm35EX5t0ltsYxNo5wc9CypGH5U94=
+github.com/fastly/go-fastly v1.2.0/go.mod h1:ACxsUdqChasXcraa3/IigjE01rVn3A1F4vaI18Gmm0g=
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=

--- a/go.sum
+++ b/go.sum
@@ -91,6 +91,8 @@ github.com/fastly/go-fastly v1.0.1-0.20190716135524-b59d50e7bbfb h1:Dy7Zo2WJYMNO
 github.com/fastly/go-fastly v1.0.1-0.20190716135524-b59d50e7bbfb/go.mod h1:ACxsUdqChasXcraa3/IigjE01rVn3A1F4vaI18Gmm0g=
 github.com/fastly/go-fastly v1.0.1-0.20190722130720-c77fe029a012 h1:mwefdo3Vv1XDocrmU6pGcaPeAsOdYqZasUZx48dhNEs=
 github.com/fastly/go-fastly v1.0.1-0.20190722130720-c77fe029a012/go.mod h1:ACxsUdqChasXcraa3/IigjE01rVn3A1F4vaI18Gmm0g=
+github.com/fastly/go-fastly v1.1.0 h1:6XaWf7vnetohY1PVkS5fPtmwgItU0WUP9CspL3+2Ld8=
+github.com/fastly/go-fastly v1.1.0/go.mod h1:ACxsUdqChasXcraa3/IigjE01rVn3A1F4vaI18Gmm0g=
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=

--- a/go.sum
+++ b/go.sum
@@ -87,6 +87,8 @@ github.com/dylanmei/winrmtest v0.0.0-20170819153634-c2fbb09e6c08/go.mod h1:VBVDF
 github.com/dylanmei/winrmtest v0.0.0-20190225150635-99b7fe2fddf1/go.mod h1:lcy9/2gH1jn/VCLouHA6tOEwLoNVd4GW6zhuKLmHC2Y=
 github.com/fastly/go-fastly v1.0.0 h1:56wmg3LX3Q9BkFikg4qZf+xFJTrIuHYmxIjCVKo9wNg=
 github.com/fastly/go-fastly v1.0.0/go.mod h1:ACxsUdqChasXcraa3/IigjE01rVn3A1F4vaI18Gmm0g=
+github.com/fastly/go-fastly v1.0.1-0.20190716135524-b59d50e7bbfb h1:Dy7Zo2WJYMNOxAVlYk37/qZKsWnJ91c56xzOwXY7FvU=
+github.com/fastly/go-fastly v1.0.1-0.20190716135524-b59d50e7bbfb/go.mod h1:ACxsUdqChasXcraa3/IigjE01rVn3A1F4vaI18Gmm0g=
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=

--- a/vendor/github.com/fastly/go-fastly/fastly/client.go
+++ b/vendor/github.com/fastly/go-fastly/fastly/client.go
@@ -35,7 +35,7 @@ const RealtimeStatsEndpoint = "https://rt.fastly.com"
 var ProjectURL = "github.com/fastly/go-fastly"
 
 // ProjectVersion is the version of this library.
-var ProjectVersion = "1.0.0"
+var ProjectVersion = "1.1.0"
 
 // UserAgent is the user agent for this particular client.
 var UserAgent = fmt.Sprintf("FastlyGo/%s (+%s; %s)",

--- a/vendor/github.com/fastly/go-fastly/fastly/client.go
+++ b/vendor/github.com/fastly/go-fastly/fastly/client.go
@@ -35,7 +35,7 @@ const RealtimeStatsEndpoint = "https://rt.fastly.com"
 var ProjectURL = "github.com/fastly/go-fastly"
 
 // ProjectVersion is the version of this library.
-var ProjectVersion = "1.1.0"
+var ProjectVersion = "1.2.0"
 
 // UserAgent is the user agent for this particular client.
 var UserAgent = fmt.Sprintf("FastlyGo/%s (+%s; %s)",

--- a/vendor/github.com/fastly/go-fastly/fastly/client.go
+++ b/vendor/github.com/fastly/go-fastly/fastly/client.go
@@ -35,7 +35,7 @@ const RealtimeStatsEndpoint = "https://rt.fastly.com"
 var ProjectURL = "github.com/fastly/go-fastly"
 
 // ProjectVersion is the version of this library.
-var ProjectVersion = "1.2.0"
+var ProjectVersion = "1.2.1"
 
 // UserAgent is the user agent for this particular client.
 var UserAgent = fmt.Sprintf("FastlyGo/%s (+%s; %s)",

--- a/vendor/github.com/fastly/go-fastly/fastly/dictionary_item.go
+++ b/vendor/github.com/fastly/go-fastly/fastly/dictionary_item.go
@@ -215,7 +215,7 @@ func (c *Client) BatchModifyDictionaryItems(i *BatchModifyDictionaryItemsInput) 
 	}
 
 	if len(i.Items) > BatchModifyMaximumOperations {
-		return ErrBatchUpdateMaximumItemsExceeded
+		return ErrBatchUpdateMaximumOperationsExceeded
 	}
 
 	path := fmt.Sprintf("/service/%s/dictionary/%s/items", i.Service, i.Dictionary)

--- a/vendor/github.com/fastly/go-fastly/fastly/dictionary_item.go
+++ b/vendor/github.com/fastly/go-fastly/fastly/dictionary_item.go
@@ -193,7 +193,7 @@ type BatchModifyDictionaryItemsInput struct {
 	Service    string `json:"-,"`
 	Dictionary string `json:"-,"`
 
-	Items []BatchDictionaryItem `json:"items"`
+	Items []*BatchDictionaryItem `json:"items"`
 }
 
 type BatchDictionaryItem struct {
@@ -214,7 +214,7 @@ func (c *Client) BatchModifyDictionaryItems(i *BatchModifyDictionaryItemsInput) 
 		return ErrMissingDictionary
 	}
 
-	if len(i.Items) > BatchModifyMaximumItems {
+	if len(i.Items) > BatchModifyMaximumOperations {
 		return ErrBatchUpdateMaximumItemsExceeded
 	}
 

--- a/vendor/github.com/fastly/go-fastly/fastly/dictionary_item.go
+++ b/vendor/github.com/fastly/go-fastly/fastly/dictionary_item.go
@@ -189,6 +189,49 @@ func (c *Client) UpdateDictionaryItem(i *UpdateDictionaryItemInput) (*Dictionary
 	return b, nil
 }
 
+type BatchModifyDictionaryItemsInput struct {
+	Service    string `json:"-,"`
+	Dictionary string `json:"-,"`
+
+	Items []BatchDictionaryItem `json:"items"`
+}
+
+type BatchDictionaryItem struct {
+
+
+	Operation BatchOperation `json:"op"`
+	ItemKey   string         `json:"item_key"`
+	ItemValue string         `json:"item_value"`
+}
+
+func (c *Client) BatchModifyDictionaryItems(i *BatchModifyDictionaryItemsInput) error {
+
+	if i.Service == "" {
+		return ErrMissingService
+	}
+
+	if i.Dictionary == "" {
+		return ErrMissingDictionary
+	}
+
+	if len(i.Items) > BatchModifyMaximumItems {
+		return ErrBatchUpdateMaximumItemsExceeded
+	}
+
+	path := fmt.Sprintf("/service/%s/dictionary/%s/items", i.Service, i.Dictionary)
+	resp, err := c.PatchJSON(path, i, nil)
+	if err != nil {
+		return err
+	}
+
+	var batchModifyResult map[string]string
+	if err := decodeJSON(&batchModifyResult, resp.Body); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // DeleteDictionaryItemInput is the input parameter to DeleteDictionaryItem.
 type DeleteDictionaryItemInput struct {
 	// Service is the ID of the service. Dictionary is the ID of the dictionary.

--- a/vendor/github.com/fastly/go-fastly/fastly/errors.go
+++ b/vendor/github.com/fastly/go-fastly/fastly/errors.go
@@ -113,6 +113,10 @@ var ErrMissingConfigSetID = errors.New("Missing required field 'ConfigSetID'")
 // requires a list of WAF id's, but it is empty
 var ErrMissingWAFList = errors.New("WAF slice is empty")
 
+// ErrBatchUpdateMaximumItemsExceeded is an error that indicates that too many batch operations are being executed.
+// The Fastly API specifies an maximum limit.
+var ErrBatchUpdateMaximumItemsExceeded = errors.New("batch modify maximum items exceeded")
+
 // Ensure HTTPError is, in fact, an error.
 var _ error = (*HTTPError)(nil)
 

--- a/vendor/github.com/fastly/go-fastly/fastly/errors.go
+++ b/vendor/github.com/fastly/go-fastly/fastly/errors.go
@@ -115,7 +115,7 @@ var ErrMissingWAFList = errors.New("WAF slice is empty")
 
 // ErrBatchUpdateMaximumItemsExceeded is an error that indicates that too many batch operations are being executed.
 // The Fastly API specifies an maximum limit.
-var ErrBatchUpdateMaximumItemsExceeded = errors.New("batch modify maximum items exceeded")
+var ErrBatchUpdateMaximumOperationsExceeded = errors.New("batch modify maximum operations exceeded")
 
 // Ensure HTTPError is, in fact, an error.
 var _ error = (*HTTPError)(nil)

--- a/vendor/github.com/fastly/go-fastly/fastly/fastly.go
+++ b/vendor/github.com/fastly/go-fastly/fastly/fastly.go
@@ -8,12 +8,14 @@ import (
 type BatchOperation string
 
 const (
-	Create BatchOperation = "create"
-	Update BatchOperation = "update"
-	Upsert BatchOperation = "upsert"
-	Delete BatchOperation = "delete"
+	CreateBatchOperation BatchOperation = "create"
+	UpdateBatchOperation BatchOperation = "update"
+	UpsertBatchOperation BatchOperation = "upsert"
+	DeleteBatchOperation BatchOperation = "delete"
 
-	BatchModifyMaximumItems = 1000
+	// Represents the maximum number of operations that can be sent within a single batch request.
+	// This is currently not documented in the API.
+	BatchModifyMaximumOperations = 1000
 )
 
 type statusResp struct {

--- a/vendor/github.com/fastly/go-fastly/fastly/fastly.go
+++ b/vendor/github.com/fastly/go-fastly/fastly/fastly.go
@@ -16,6 +16,12 @@ const (
 	// Represents the maximum number of operations that can be sent within a single batch request.
 	// This is currently not documented in the API.
 	BatchModifyMaximumOperations = 1000
+
+	// Represents the maximum number of items that can be placed within an Edge Dictionary.
+	MaximumDictionarySize = 10000
+
+	// Represents the maximum number of entries that can be placed within an ACL.
+	MaximumACLSize = 10000
 )
 
 type statusResp struct {

--- a/vendor/github.com/fastly/go-fastly/fastly/fastly.go
+++ b/vendor/github.com/fastly/go-fastly/fastly/fastly.go
@@ -5,6 +5,17 @@ import (
 	"encoding"
 )
 
+type BatchOperation string
+
+const (
+	Create BatchOperation = "create"
+	Update BatchOperation = "update"
+	Upsert BatchOperation = "upsert"
+	Delete BatchOperation = "delete"
+
+	BatchModifyMaximumItems = 1000
+)
+
 type statusResp struct {
 	Status string
 	Msg    string

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -60,7 +60,7 @@ github.com/bgentry/speakeasy
 github.com/blang/semver
 # github.com/davecgh/go-spew v1.1.1
 github.com/davecgh/go-spew/spew
-# github.com/fastly/go-fastly v1.1.0
+# github.com/fastly/go-fastly v1.2.0
 github.com/fastly/go-fastly/fastly
 # github.com/fatih/color v1.7.0
 github.com/fatih/color

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -60,7 +60,7 @@ github.com/bgentry/speakeasy
 github.com/blang/semver
 # github.com/davecgh/go-spew v1.1.1
 github.com/davecgh/go-spew/spew
-# github.com/fastly/go-fastly v1.2.0
+# github.com/fastly/go-fastly v1.2.1
 github.com/fastly/go-fastly/fastly
 # github.com/fatih/color v1.7.0
 github.com/fatih/color

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -60,7 +60,7 @@ github.com/bgentry/speakeasy
 github.com/blang/semver
 # github.com/davecgh/go-spew v1.1.1
 github.com/davecgh/go-spew/spew
-# github.com/fastly/go-fastly v1.0.1-0.20190722130720-c77fe029a012
+# github.com/fastly/go-fastly v1.1.0
 github.com/fastly/go-fastly/fastly
 # github.com/fatih/color v1.7.0
 github.com/fatih/color

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -60,7 +60,7 @@ github.com/bgentry/speakeasy
 github.com/blang/semver
 # github.com/davecgh/go-spew v1.1.1
 github.com/davecgh/go-spew/spew
-# github.com/fastly/go-fastly v1.0.0
+# github.com/fastly/go-fastly v1.0.1-0.20190716135524-b59d50e7bbfb
 github.com/fastly/go-fastly/fastly
 # github.com/fatih/color v1.7.0
 github.com/fatih/color

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -60,7 +60,7 @@ github.com/bgentry/speakeasy
 github.com/blang/semver
 # github.com/davecgh/go-spew v1.1.1
 github.com/davecgh/go-spew/spew
-# github.com/fastly/go-fastly v1.0.1-0.20190716135524-b59d50e7bbfb
+# github.com/fastly/go-fastly v1.0.1-0.20190722130720-c77fe029a012
 github.com/fastly/go-fastly/fastly
 # github.com/fatih/color v1.7.0
 github.com/fatih/color

--- a/website/docs/r/service_dictionary_items_v1.html.markdown
+++ b/website/docs/r/service_dictionary_items_v1.html.markdown
@@ -183,15 +183,16 @@ The following arguments are supported:
 
 ## Attributes Reference
 
-[fastly-dictionary]: https://docs.fastly.com/api/config#dictionary
-[fastly-dictionary_item]: https://docs.fastly.com/api/config#dictionary_item
+* [fastly-dictionary](https://docs.fastly.com/api/config#dictionary)
+* [fastly-dictionary_item](https://docs.fastly.com/api/config#dictionary_item)
 
 ## Import
 
 This is an example of the import command being applied to the resource named `fastly_service_dictionary_items_v1.items`
+The resource ID is a combined value of the `service_id` and `dictionary_id` separated by a forward slash.
 
 ```
-$ terraform import fastly_service_dictionary_items_v1.items 7fMJYRRNW9BhKxJhoDRcIc/4OeVlYFuaCO3VjE49MWaU2
+$ terraform import fastly_service_dictionary_items_v1.items xxxxxxxxxxxxxxxxxxxx/xxxxxxxxxxxxxxxxxxxx
 ```
 
 If Terraform is already managing remote dictionary items against a resource being imported then the user will be asked to remove it from the existing Terraform state.  

--- a/website/docs/r/service_dictionary_items_v1.html.markdown
+++ b/website/docs/r/service_dictionary_items_v1.html.markdown
@@ -83,20 +83,63 @@ resource "fastly_service_v1" "myservice" {
   }
 
   dictionary {
-    name       = var.mydict.name
+    name = var.mydict.name
   }
 
   force_destroy = true
   }
 
 resource "fastly_service_dictionary_items_v1" "items" {
-  service_id = "${fastly_service_v1.myservice.id}"
-  dictionary_id = "${{for s in fastly_service_v1.myservice.dictionary : s.name => s.dictionary_id}[var.mydict.name]}"
+  service_id = fastly_service_v1.myservice.id
+  dictionary_id = {for d in fastly_service_v1.myservice.dictionary : d.name => d.dictionary_id}[var.mydict.name]
   items = var.mydict.items
 }
 
 ```
 
+Expression and functions usage:
+
+```hcl
+// Local variables used when formating values for the "My Project Dictionary" example
+locals {
+  dictionary_name = "My Project Dictionary"
+  host_base = "demo.ocnotexample.com"
+  host_divisions = ["alpha", "beta", "gamma", "delta"]
+}
+
+// Define the standard service that will be used to manage the dictionaries.
+resource "fastly_service_v1" "myservice" {
+  name = "demofastly"
+
+  domain {
+    name = "demo.ocnotexample.com"
+    comment = "demo"
+  }
+
+  backend {
+    address = "demo.ocnotexample.com.s3-website-us-west-2.amazonaws.com"
+    name = "AWS S3 hosting"
+    port = 80
+  }
+
+  dictionary {
+    name = local.dictionary_name
+  }
+
+  force_destroy = true
+}
+
+// This resource is dynamically creating the items from the local variables through for expressions and functions.
+resource "fastly_service_dictionary_items_v1" "project" {
+  service_id = fastly_service_v1.myservice.id
+  dictionary_id = {for d in fastly_service_v1.myservice.dictionary : d.name => d.dictionary_id}[local.dictionary_name]
+  items = {
+    for division in local.host_divisions:
+      division => format("%s.%s", division, local.host_base)
+  }
+
+}
+```
 
 ## Argument Reference
 

--- a/website/docs/r/service_dictionary_items_v1.html.markdown
+++ b/website/docs/r/service_dictionary_items_v1.html.markdown
@@ -10,11 +10,14 @@ description: |-
 
 Provides a grouping of fastly dictionary items that can be applied to a service.
  
-This resource will populate a dictionary with the items configured in the items map and it will track their state going forward.
-Additional dictionary items can be added through the Fastly API/console.  These externally created items will be ignored by the resource.
+This resource will populate a dictionary with the items and it will track their state going forward.
+Additional dictionary items can be added through the Fastly API/console, but will be removed from fastly if terraform detects a difference in the remote state.
 
 The Fastly API/console can also be used to modify the items that are managed through Terraform.  In this case the default behaviour of the 
-resource will be to align the local and remoted states.  This would adjust the values in the items or delete them accordingly.  If Terraform is being used to only create items then the lifecyle ignore_changes field can be used with the resource.  An example of this configuraiton is provided below.    
+resource will be to realign the remoted state.  The items in the remote fastly dictionary will be updated or deleted according to the terraform plan.  
+
+If Terraform is being used to only create initial items in a dictionary, then the lifecyle ignore_changes field can be used with the resource.  An example of this configuraiton is provided below.    
+
 
 ## Example Usage
 
@@ -148,6 +151,9 @@ resource "fastly_service_dictionary_items_v1" "project" {
 ```
 
 Lifecyle ignore_changes usage:
+
+The following example demonstrates how the lifecycle ignore_change field can be used to suppress updates against the 
+items in a dictionary.  If an external means, (for example via the Fastly API) is used to manage items in a dictionary, then this will stop terraform realigning the remote state.
 
 ```hcl
 ...

--- a/website/docs/r/service_dictionary_items_v1.html.markdown
+++ b/website/docs/r/service_dictionary_items_v1.html.markdown
@@ -9,6 +9,12 @@ description: |-
 # fastly_service_dictionary_items_v1
 
 Provides a grouping of fastly dictionary items that can be applied to a service.
+ 
+This resource will populate a dictionary with the items configured in the items map and it will track their state going forward.
+Additional dictionary items can be added through the Fastly API/console.  These externally created items will be ignored by the resource.
+
+The Fastly API/console can also be used to modify the items that are managed through Terraform.  In this case the default behaviour of the 
+resource will be to align the local and remoted states.  This would adjust the values in the items or delete them accordingly.  If Terraform is being used to only create items then the lifecyle ignore_changes field can be used with the resource.  An example of this configuraiton is provided below.    
 
 ## Example Usage
 
@@ -140,6 +146,28 @@ resource "fastly_service_dictionary_items_v1" "project" {
 
 }
 ```
+
+Lifecyle ignore_changes usage:
+
+```hcl
+...
+
+resource "fastly_service_dictionary_items_v1" "items" {
+    service_id = "${fastly_service_v1.myservice.id}"
+    dictionary_id = "${{for s in fastly_service_v1.myservice.dictionary : s.name => s.dictionary_id}[var.mydict_name]}"
+    items = {
+        key1: "value1"
+        key2: "value2"
+    }
+    
+    lifecycle {
+      ignore_changes = [items,]
+    }
+}
+
+
+```
+
 
 ## Argument Reference
 

--- a/website/docs/r/service_dictionary_items_v1.html.markdown
+++ b/website/docs/r/service_dictionary_items_v1.html.markdown
@@ -153,7 +153,7 @@ resource "fastly_service_dictionary_items_v1" "project" {
 ###Supporting API and UI dictionary updates with ignore_changes
 
 The following example demonstrates how the lifecycle ignore_change field can be used to suppress updates against the 
-items in a dictionary.  If an external means, (for example via the Fastly API or UI) is used to manage items in a dictionary, then this will stop Terraform realigning the remote state.
+items in a dictionary.  If, after your first deploy, the Fastly API or UI is to be used to manage items in a dictionary, then this will stop Terraform realigning the remote state with the initial set of dictionary items defined in your HCL.
 
 ```hcl
 ...

--- a/website/docs/r/service_dictionary_items_v1.html.markdown
+++ b/website/docs/r/service_dictionary_items_v1.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Provides a map of Fastly dictionary items that can be applied to a service.
  
-This resource will populate a dictionary with the items and it will track their state going forward.
+This resource will populate a dictionary with the items and will track their state.
 Additional dictionary items can be added through the Fastly API or UI, but will be removed from Fastly if Terraform detects a difference in the remote state.
 
 The Fastly API or UI can also be used to modify the items that are managed through Terraform.  In this case the default behaviour of the 

--- a/website/docs/r/service_dictionary_items_v1.html.markdown
+++ b/website/docs/r/service_dictionary_items_v1.html.markdown
@@ -10,7 +10,8 @@ description: |-
 
 Defines a map of Fastly dictionary items that can be used to populate a service dictionary.  This resource will populate a dictionary with the items and will track their state.
 
-**Warning:** Terraform will take precedence over any changes you make in the UI or API. Such changes are likely to be reversed if you run terraform again.  
+
+~> **Warning:** Terraform will take precedence over any changes you make in the UI or API. Such changes are likely to be reversed if you run terraform again.  
 
 If Terraform is being used to populate the initial content of a dictionary which you intend to manage via API or UI, then the lifecycle `ignore_changes` field can be used with the resource.  An example of this configuration is provided below.    
 

--- a/website/docs/r/service_dictionary_items_v1.html.markdown
+++ b/website/docs/r/service_dictionary_items_v1.html.markdown
@@ -16,7 +16,7 @@ Dictionary items can also be added through the Fastly API or UI, but will be rem
 The Fastly API or UI can also be used to modify the items that are managed through Terraform.  In this case the default behaviour of the 
 resource will be to realign the remoted state.  The items in the remote Fastly dictionary will be updated or deleted according to the Terraform plan.  
 
-If Terraform is being used to only create initial items in a dictionary, then the lifecyle `ignore_changes` field can be used with the resource.  An example of this configuraiton is provided below.    
+If Terraform is being used to populate the initial content of a dictionary which you intend to manage via API or UI, then the lifecycle `ignore_changes` field can be used with the resource.  An example of this configuration is provided below.    
 
 
 ## Example Usage

--- a/website/docs/r/service_dictionary_items_v1.html.markdown
+++ b/website/docs/r/service_dictionary_items_v1.html.markdown
@@ -3,20 +3,20 @@ layout: "fastly"
 page_title: "Fastly: service_dictionary_items_v1"
 sidebar_current: "docs-fastly-resource-service-v1"
 description: |-
-  Provides a grouping of fastly dictionary items that can be applied to a service. 
+  Provides a grouping of Fastly dictionary items that can be applied to a service. 
 ---
 
 # fastly_service_dictionary_items_v1
 
-Provides a grouping of fastly dictionary items that can be applied to a service.
+Provides a map of Fastly dictionary items that can be applied to a service.
  
 This resource will populate a dictionary with the items and it will track their state going forward.
-Additional dictionary items can be added through the Fastly API/console, but will be removed from fastly if terraform detects a difference in the remote state.
+Additional dictionary items can be added through the Fastly API or UI, but will be removed from Fastly if Terraform detects a difference in the remote state.
 
-The Fastly API/console can also be used to modify the items that are managed through Terraform.  In this case the default behaviour of the 
-resource will be to realign the remoted state.  The items in the remote fastly dictionary will be updated or deleted according to the terraform plan.  
+The Fastly API or UI can also be used to modify the items that are managed through Terraform.  In this case the default behaviour of the 
+resource will be to realign the remoted state.  The items in the remote Fastly dictionary will be updated or deleted according to the Terraform plan.  
 
-If Terraform is being used to only create initial items in a dictionary, then the lifecyle ignore_changes field can be used with the resource.  An example of this configuraiton is provided below.    
+If Terraform is being used to only create initial items in a dictionary, then the lifecyle `ignore_changes` field can be used with the resource.  An example of this configuraiton is provided below.    
 
 
 ## Example Usage
@@ -153,7 +153,7 @@ resource "fastly_service_dictionary_items_v1" "project" {
 Lifecyle ignore_changes usage:
 
 The following example demonstrates how the lifecycle ignore_change field can be used to suppress updates against the 
-items in a dictionary.  If an external means, (for example via the Fastly API) is used to manage items in a dictionary, then this will stop terraform realigning the remote state.
+items in a dictionary.  If an external means, (for example via the Fastly API or UI) is used to manage items in a dictionary, then this will stop Terraform realigning the remote state.
 
 ```hcl
 ...
@@ -191,8 +191,8 @@ The following arguments are supported:
 
 ## Import
 
-Dictionary items can be populated through the Fastly API and/or the console.  These items can then be managed by terraform through the use of the import command.
-Resources are imported into the terraform state through the use of an ID, and the fastly_service_dictionary_items_v1 resouce has an ID that is made up of the following format.
+Dictionary items can be populated through the Fastly API or UI.  These items can then be managed by Terraform through the use of the import command.
+Resources are imported into the Terraform state through the use of an ID, and the fastly_service_dictionary_items_v1 resouce has an ID that is made up of the following format.
 
 ```
 <serviceID>/<dictionaryID>
@@ -204,8 +204,8 @@ This is an example of the import command being applied to the resource named `fa
 $ terraform import fastly_service_dictionary_items_v1.items <serviceID>/<dictionaryID>
 ```
 
-If terraform is already managing remote dictionary items against a resource being imported then the user will be asked to remove it from the existing terraform state.  
-The following is an example of the terraform state command to remove the resource named `fastly_service_dictionary_items_v1.items` from the terraform state file.
+If Terraform is already managing remote dictionary items against a resource being imported then the user will be asked to remove it from the existing Terraform state.  
+The following is an example of the Terraform state command to remove the resource named `fastly_service_dictionary_items_v1.items` from the Terraform state file.
 
 ```
 $ terraform state rm fastly_service_dictionary_items_v1.items

--- a/website/docs/r/service_dictionary_items_v1.html.markdown
+++ b/website/docs/r/service_dictionary_items_v1.html.markdown
@@ -16,10 +16,87 @@ Basic usage:
 
 ```hcl
 
-TODO Provide an example defining a basic dictionary items.
+variable "mydict_name" {
+	type = string
+	default = "My Dictionary"
+}
 
+resource "fastly_service_v1" "myservice" {
+  name = "demofastly"
+
+  domain {
+      name    = "demo.notexample.com"
+      comment = "demo"
+  }
+
+  backend {
+      address = "demo.notexample.com.s3-website-us-west-2.amazonaws.com"
+      name    = "AWS S3 hosting"
+      port    = 80
+    }
+
+  dictionary {
+	name       = var.mydict_name
+  }
+
+  force_destroy = true
+}
+
+resource "fastly_service_dictionary_items_v1" "items" {
+    service_id = "${fastly_service_v1.myservice.id}"
+    dictionary_id = "${{for s in fastly_service_v1.myservice.dictionary : s.name => s.dictionary_id}[var.mydict_name]}"
+    items = {
+        key1: "value1"
+        key2: "value2"
+    }
+}
 
 ```
+
+Complex object usage:
+
+```hcl
+
+variable "mydict" {
+  type = object({ name=string, items=map(string) })
+  default = {
+    name = "My Dictionary"
+    items = {
+      key1: "value1x"
+      key2: "value2x"
+    }
+  }
+}
+
+resource "fastly_service_v1" "myservice" {
+  name = "demofastly"
+
+  domain {
+    name    = "demo.notexample.com"
+    comment = "demo"
+  }
+
+  backend {
+    address = "demo.notexample.com.s3-website-us-west-2.amazonaws.com"
+    name    = "AWS S3 hosting"
+    port    = 80
+  }
+
+  dictionary {
+    name       = var.mydict.name
+  }
+
+  force_destroy = true
+  }
+
+resource "fastly_service_dictionary_items_v1" "items" {
+  service_id = "${fastly_service_v1.myservice.id}"
+  dictionary_id = "${{for s in fastly_service_v1.myservice.dictionary : s.name => s.dictionary_id}[var.mydict.name]}"
+  items = var.mydict.items
+}
+
+```
+
 
 ## Argument Reference
 

--- a/website/docs/r/service_dictionary_items_v1.html.markdown
+++ b/website/docs/r/service_dictionary_items_v1.html.markdown
@@ -188,3 +188,25 @@ The following arguments are supported:
 
 [fastly-dictionary]: https://docs.fastly.com/api/config#dictionary
 [fastly-dictionary_item]: https://docs.fastly.com/api/config#dictionary_item
+
+## Import
+
+Dictionary items can be populated through the Fastly API and/or the console.  These items can then be managed by terraform through the use of the import command.
+Resources are imported into the terraform state through the use of an ID, and the fastly_service_dictionary_items_v1 resouce has an ID that is made up of the following format.
+
+```
+<serviceID>/<dictionaryID>
+```
+
+This is an example of the import command being applied to the resource named `fastly_service_dictionary_items_v1.items`
+
+```
+$ terraform import fastly_service_dictionary_items_v1.items <serviceID>/<dictionaryID>
+```
+
+If terraform is already managing remote dictionary items against a resource being imported then the user will be asked to remove it from the existing terraform state.  
+The following is an example of the terraform state command to remove the resource named `fastly_service_dictionary_items_v1.items` from the terraform state file.
+
+```
+$ terraform state rm fastly_service_dictionary_items_v1.items
+``` 

--- a/website/docs/r/service_dictionary_items_v1.html.markdown
+++ b/website/docs/r/service_dictionary_items_v1.html.markdown
@@ -1,0 +1,36 @@
+---
+layout: "fastly"
+page_title: "Fastly: service_dictionary_items_v1"
+sidebar_current: "docs-fastly-resource-service-v1"
+description: |-
+  Provides a grouping of fastly dictionary items that can be applied to a service. 
+---
+
+# fastly_service_dictionary_items_v1
+
+Provides a grouping of fastly dictionary items that can be applied to a service.
+
+## Example Usage
+
+Basic usage:
+
+```hcl
+
+TODO Provide an example defining a basic dictionary items.
+
+
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `service_id` - (Required) The ID of the Service that the dictionary belongs to
+* `dictionary_id` - (Required) The ID of the dictionary that the items belong to
+* `items` - (Optional) A Map representing an entry in the dictionary, (key/value)
+
+
+## Attributes Reference
+
+[fastly-dictionary]: https://docs.fastly.com/api/config#dictionary
+[fastly-dictionary_item]: https://docs.fastly.com/api/config#dictionary_item

--- a/website/docs/r/service_dictionary_items_v1.html.markdown
+++ b/website/docs/r/service_dictionary_items_v1.html.markdown
@@ -179,9 +179,9 @@ resource "fastly_service_dictionary_items_v1" "items" {
 
 The following arguments are supported:
 
-* `service_id` - (Required) The ID of the Service that the dictionary belongs to
+* `service_id` - (Required) The ID of the service that the dictionary belongs to
 * `dictionary_id` - (Required) The ID of the dictionary that the items belong to
-* `items` - (Optional) A Map representing an entry in the dictionary, (key/value)
+* `items` - (Optional) A map representing an entry in the dictionary, (key/value)
 
 
 ## Attributes Reference

--- a/website/docs/r/service_dictionary_items_v1.html.markdown
+++ b/website/docs/r/service_dictionary_items_v1.html.markdown
@@ -21,7 +21,6 @@ If Terraform is being used to populate the initial content of a dictionary which
 Basic usage:
 
 ```hcl
-
 variable "mydict_name" {
 	type = string
 	default = "My Dictionary"
@@ -56,13 +55,11 @@ resource "fastly_service_dictionary_items_v1" "items" {
         key2: "value2"
     }
 }
-
 ```
 
 Complex object usage:
 
 ```hcl
-
 variable "mydict" {
   type = object({ name=string, items=map(string) })
   default = {
@@ -100,7 +97,6 @@ resource "fastly_service_dictionary_items_v1" "items" {
   dictionary_id = {for d in fastly_service_v1.myservice.dictionary : d.name => d.dictionary_id}[var.mydict.name]
   items = var.mydict.items
 }
-
 ```
 
 Expression and functions usage:
@@ -143,11 +139,10 @@ resource "fastly_service_dictionary_items_v1" "project" {
     for division in local.host_divisions:
       division => format("%s.%s", division, local.host_base)
   }
-
 }
 ```
 
-###Supporting API and UI dictionary updates with ignore_changes
+### Supporting API and UI dictionary updates with ignore_changes
 
 The following example demonstrates how the lifecycle ignore_change field can be used to suppress updates against the 
 items in a dictionary.  If, after your first deploy, the Fastly API or UI is to be used to manage items in a dictionary, then this will stop Terraform realigning the remote state with the initial set of dictionary items defined in your HCL.
@@ -167,8 +162,6 @@ resource "fastly_service_dictionary_items_v1" "items" {
       ignore_changes = [items,]
     }
 }
-
-
 ```
 
 

--- a/website/docs/r/service_dictionary_items_v1.html.markdown
+++ b/website/docs/r/service_dictionary_items_v1.html.markdown
@@ -11,7 +11,7 @@ description: |-
 Defines a map of Fastly dictionary items that can be used to populate a service dictionary.  This resource will populate a dictionary with the items and will track their state.
 
 
-~> **Warning:** Terraform will take precedence over any changes you make in the UI or API. Such changes are likely to be reversed if you run terraform again.  
+~> **Warning:** Terraform will take precedence over any changes you make in the UI or API. Such changes are likely to be reversed if you run Terraform again.  
 
 If Terraform is being used to populate the initial content of a dictionary which you intend to manage via API or UI, then the lifecycle `ignore_changes` field can be used with the resource.  An example of this configuration is provided below.    
 
@@ -144,7 +144,7 @@ resource "fastly_service_dictionary_items_v1" "project" {
 
 ### Supporting API and UI dictionary updates with ignore_changes
 
-The following example demonstrates how the lifecycle ignore_change field can be used to suppress updates against the 
+The following example demonstrates how the lifecycle `ignore_changes` field can be used to suppress updates against the 
 items in a dictionary.  If, after your first deploy, the Fastly API or UI is to be used to manage items in a dictionary, then this will stop Terraform realigning the remote state with the initial set of dictionary items defined in your HCL.
 
 ```hcl

--- a/website/docs/r/service_dictionary_items_v1.html.markdown
+++ b/website/docs/r/service_dictionary_items_v1.html.markdown
@@ -8,10 +8,9 @@ description: |-
 
 # fastly_service_dictionary_items_v1
 
-Defines a map of Fastly dictionary items that can be used to populate a service dictionary.
- 
-This resource will populate a dictionary with the items and will track their state.
-Terraform will take precedence over any changes you make in the UI or API. Such changes are likely to be reversed if you run terraform again.  
+Defines a map of Fastly dictionary items that can be used to populate a service dictionary.  This resource will populate a dictionary with the items and will track their state.
+
+**Warning:** Terraform will take precedence over any changes you make in the UI or API. Such changes are likely to be reversed if you run terraform again.  
 
 If Terraform is being used to populate the initial content of a dictionary which you intend to manage via API or UI, then the lifecycle `ignore_changes` field can be used with the resource.  An example of this configuration is provided below.    
 

--- a/website/docs/r/service_dictionary_items_v1.html.markdown
+++ b/website/docs/r/service_dictionary_items_v1.html.markdown
@@ -191,7 +191,7 @@ The following arguments are supported:
 
 ## Import
 
-Dictionary items can be populated through the Fastly API or UI.  These items can then be managed by Terraform through the use of the import command.
+Dictionary items in your HCL can be populated by pulling the current remote state of an existing Fastly service, using the `import` command.
 Resources are imported into the Terraform state through the use of an ID, and the fastly_service_dictionary_items_v1 resouce has an ID that is made up of the following format.
 
 ```

--- a/website/docs/r/service_dictionary_items_v1.html.markdown
+++ b/website/docs/r/service_dictionary_items_v1.html.markdown
@@ -11,7 +11,7 @@ description: |-
 Provides a map of Fastly dictionary items that can be applied to a service.
  
 This resource will populate a dictionary with the items and will track their state.
-Additional dictionary items can be added through the Fastly API or UI, but will be removed from Fastly if Terraform detects a difference in the remote state.
+Dictionary items can also be added through the Fastly API or UI, but will be removed from Fastly if Terraform detects a difference in the remote state.
 
 The Fastly API or UI can also be used to modify the items that are managed through Terraform.  In this case the default behaviour of the 
 resource will be to realign the remoted state.  The items in the remote Fastly dictionary will be updated or deleted according to the Terraform plan.  

--- a/website/docs/r/service_dictionary_items_v1.html.markdown
+++ b/website/docs/r/service_dictionary_items_v1.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # fastly_service_dictionary_items_v1
 
-Provides a map of Fastly dictionary items that can be applied to a service.
+Defines a map of Fastly dictionary items that can be used to populate a service dictionary.
  
 This resource will populate a dictionary with the items and will track their state.
 Dictionary items can also be added through the Fastly API or UI, but will be removed from Fastly if Terraform detects a difference in the remote state.
@@ -150,7 +150,7 @@ resource "fastly_service_dictionary_items_v1" "project" {
 }
 ```
 
-Lifecyle ignore_changes usage:
+###Supporting API and UI dictionary updates with ignore_changes
 
 The following example demonstrates how the lifecycle ignore_change field can be used to suppress updates against the 
 items in a dictionary.  If an external means, (for example via the Fastly API or UI) is used to manage items in a dictionary, then this will stop Terraform realigning the remote state.
@@ -191,17 +191,10 @@ The following arguments are supported:
 
 ## Import
 
-Dictionary items in your HCL can be populated by pulling the current remote state of an existing Fastly service, using the `import` command.
-Resources are imported into the Terraform state through the use of an ID, and the fastly_service_dictionary_items_v1 resouce has an ID that is made up of the following format.
-
-```
-<serviceID>/<dictionaryID>
-```
-
 This is an example of the import command being applied to the resource named `fastly_service_dictionary_items_v1.items`
 
 ```
-$ terraform import fastly_service_dictionary_items_v1.items <serviceID>/<dictionaryID>
+$ terraform import fastly_service_dictionary_items_v1.items 7fMJYRRNW9BhKxJhoDRcIc/4OeVlYFuaCO3VjE49MWaU2
 ```
 
 If Terraform is already managing remote dictionary items against a resource being imported then the user will be asked to remove it from the existing Terraform state.  

--- a/website/docs/r/service_dictionary_items_v1.html.markdown
+++ b/website/docs/r/service_dictionary_items_v1.html.markdown
@@ -11,10 +11,7 @@ description: |-
 Defines a map of Fastly dictionary items that can be used to populate a service dictionary.
  
 This resource will populate a dictionary with the items and will track their state.
-Dictionary items can also be added through the Fastly API or UI, but will be removed from Fastly if Terraform detects a difference in the remote state.
-
-The Fastly API or UI can also be used to modify the items that are managed through Terraform.  In this case the default behaviour of the 
-resource will be to realign the remoted state.  The items in the remote Fastly dictionary will be updated or deleted according to the Terraform plan.  
+Terraform will take precedence over any changes you make in the UI or API. Such changes are likely to be reversed if you run terraform again.  
 
 If Terraform is being used to populate the initial content of a dictionary which you intend to manage via API or UI, then the lifecycle `ignore_changes` field can be used with the resource.  An example of this configuration is provided below.    
 

--- a/website/docs/r/service_v1.html.markdown
+++ b/website/docs/r/service_v1.html.markdown
@@ -210,6 +210,8 @@ Defined below.
 * `vcl` - (Optional) A set of custom VCL configuration blocks. The
 ability to upload custom VCL code is not enabled by default for new Fastly
 accounts (see the [Fastly documentation](https://docs.fastly.com/guides/vcl/uploading-custom-vcl) for details).
+* `dictionary` - (Optional) A set of dictionaries that allow the storing of key values pair for use within VCL functions.
+
 
 The `domain` block supports:
 
@@ -512,6 +514,11 @@ The `vcl` block supports:
 * `main` - (Optional) If `true`, use this block as the main configuration. If
 `false`, use this block as an includable library. Only a single VCL block can be
 marked as the main block. Default is `false`.
+
+The `dictionary` block supports:
+
+* `name` - (Required) A unique name to identify this dictionary.
+* `write_only` - (Optional) Determines if items in the dictionary are readable or not.  Default `false`
 
 ## Attributes Reference
 

--- a/website/docs/r/service_v1.html.markdown
+++ b/website/docs/r/service_v1.html.markdown
@@ -180,7 +180,7 @@ when an item is not to be cached based on an above `condition`. Defined below
 content. Defined below.
 * `header` - (Optional) A set of Headers to manipulate for each request. Defined
 below.
-* `healthcheck` - (Optional) Automated healthchecks on the cache that can change how fastly interacts with the cache based on its health.
+* `healthcheck` - (Optional) Automated healthchecks on the cache that can change how Fastly interacts with the cache based on its health.
 * `default_host` - (Optional) The default hostname.
 * `default_ttl` - (Optional) The default Time-to-live (TTL) for
 requests.

--- a/website/docs/r/service_v1.html.markdown
+++ b/website/docs/r/service_v1.html.markdown
@@ -526,6 +526,10 @@ In addition to the arguments listed above, the following attributes are exported
 * `id` – The ID of the Service.
 * `active_version` – The currently active version of your Fastly Service.
 
+The `dictionary` block exports:
+
+ * `dictionary_id` - The ID of the dictionary
+
 * [fastly-s3](https://docs.fastly.com/guides/integrations/amazon-s3)
 * [fastly-cname](https://docs.fastly.com/guides/basic-setup/adding-cname-records)
 * [fastly-conditionals](https://docs.fastly.com/guides/conditions/using-conditions)

--- a/website/docs/r/service_v1.html.markdown
+++ b/website/docs/r/service_v1.html.markdown
@@ -526,11 +526,11 @@ In addition to the arguments listed above, the following attributes are exported
 * `id` – The ID of the Service.
 * `active_version` – The currently active version of your Fastly Service.
 
-[fastly-s3]: https://docs.fastly.com/guides/integrations/amazon-s3
-[fastly-cname]: https://docs.fastly.com/guides/basic-setup/adding-cname-records
-[fastly-conditionals]: https://docs.fastly.com/guides/conditions/using-conditions
-[fastly-sumologic]: https://docs.fastly.com/api/logging#logging_sumologic
-[fastly-gcs]: https://docs.fastly.com/api/logging#logging_gcs
+* [fastly-s3](https://docs.fastly.com/guides/integrations/amazon-s3)
+* [fastly-cname](https://docs.fastly.com/guides/basic-setup/adding-cname-records)
+* [fastly-conditionals](https://docs.fastly.com/guides/conditions/using-conditions)
+* [fastly-sumologic](https://docs.fastly.com/api/logging#logging_sumologic)
+* [fastly-gcs](https://docs.fastly.com/api/logging#logging_gcs)
 
 ## Import
 

--- a/website/docs/r/service_v1.html.markdown
+++ b/website/docs/r/service_v1.html.markdown
@@ -210,7 +210,7 @@ Defined below.
 * `vcl` - (Optional) A set of custom VCL configuration blocks. The
 ability to upload custom VCL code is not enabled by default for new Fastly
 accounts (see the [Fastly documentation](https://docs.fastly.com/guides/vcl/uploading-custom-vcl) for details).
-* `dictionary` - (Optional) A set of dictionaries that allow the storing of key values pair for use within VCL functions.
+* `dictionary` - (Optional) A set of dictionaries that allow the storing of key values pair for use within VCL functions. Defined below.
 
 
 The `domain` block supports:

--- a/website/docs/r/service_v1.html.markdown
+++ b/website/docs/r/service_v1.html.markdown
@@ -528,7 +528,7 @@ In addition to the arguments listed above, the following attributes are exported
 
 The `dictionary` block exports:
 
- * `dictionary_id` - The ID of the dictionary
+ * `dictionary_id` - The ID of the dictionary.
 
 * [fastly-s3](https://docs.fastly.com/guides/integrations/amazon-s3)
 * [fastly-cname](https://docs.fastly.com/guides/basic-setup/adding-cname-records)

--- a/website/docs/r/service_v1.html.markdown
+++ b/website/docs/r/service_v1.html.markdown
@@ -518,7 +518,6 @@ marked as the main block. Default is `false`.
 The `dictionary` block supports:
 
 * `name` - (Required) A unique name to identify this dictionary.
-* `write_only` - (Optional) Determines if items in the dictionary are readable or not.  Default `false`
 
 ## Attributes Reference
 

--- a/website/fastly.erb
+++ b/website/fastly.erb
@@ -25,6 +25,7 @@
                     <ul class="nav nav-visible">
                         <li<%= sidebar_current("docs-fastly-resource-service-v1") %>>
                             <a href="/docs/providers/fastly/r/service_v1.html">fastly_service_v1</a>
+                            <a href="/docs/providers/fastly/r/service_dictionary_items_v1.html">fastly_service_dictionary_items_v1</a>
                         </li>
                     </ul>
 


### PR DESCRIPTION
This PR represents an implementation of the Fastly Edge Dictionaries resource.  

The resource has two parts to it.  
- Association with the service itself.  One or more Edge Dictionaries can be created as nested blocks and are linked to a service version.  The configuration is activated in the same way as other service fields.  
- Versionless items that can be entered in to a dictionary.  These items are represented as a separate resource that references the dictionary from the service.  Within this resource a map representing the item values is supplied.

The resource that represents the items is called ```fastly_service_dictionary_items_v1``` and there will be one for every dictionary that requires items to be associated with it.  

The resource will only keep track of the items that it has created in the remote state.  The aim is to allow additional items to be added via external means, (e.g. api or console) and to not be removed by terraform.  If there is a need to update terraform created items, then the resource can be configured with the lifecycle ignore_change configuration and this will instruct updates to these items to be ignored.
```
lifecycle {
  ignore_changes = [items,]
}
```
The main design decision made is to represent the items as a single map within a resource instead of one resource per item.  The main positive is a reduction in repeated fields and that all related items are managed as a single grouping within Terraform.
