### PR TITLE
Introduction of ACL and ACL Entries

### DIFF
--- a/fastly/provider.go
+++ b/fastly/provider.go
@@ -28,6 +28,7 @@ func Provider() terraform.ResourceProvider {
 		},
 		ResourcesMap: map[string]*schema.Resource{
 			"fastly_service_v1": resourceServiceV1(),
+			"fastly_service_acl_entries_v1": resourceServiceAclEntriesV1(),
 		},
 
 		ConfigureFunc: providerConfigure,

--- a/fastly/provider.go
+++ b/fastly/provider.go
@@ -27,7 +27,7 @@ func Provider() terraform.ResourceProvider {
 			"fastly_ip_ranges": dataSourceFastlyIPRanges(),
 		},
 		ResourcesMap: map[string]*schema.Resource{
-			"fastly_service_v1": resourceServiceV1(),
+			"fastly_service_v1":             resourceServiceV1(),
 			"fastly_service_acl_entries_v1": resourceServiceAclEntriesV1(),
 		},
 

--- a/fastly/provider.go
+++ b/fastly/provider.go
@@ -27,7 +27,8 @@ func Provider() terraform.ResourceProvider {
 			"fastly_ip_ranges": dataSourceFastlyIPRanges(),
 		},
 		ResourcesMap: map[string]*schema.Resource{
-			"fastly_service_v1": resourceServiceV1(),
+			"fastly_service_v1":                  resourceServiceV1(),
+			"fastly_service_dictionary_items_v1": resourceServiceDictionaryItemsV1(),
 		},
 
 		ConfigureFunc: providerConfigure,

--- a/fastly/resource_fastly_service_acl_entries_v1.go
+++ b/fastly/resource_fastly_service_acl_entries_v1.go
@@ -45,24 +45,24 @@ func resourceServiceAclEntriesV1() *schema.Resource {
 						},
 						"ip": {
 							Type:        schema.TypeString,
-							Description: "",
+							Description: "An IP address that is the focus for the ACL",
 							Required:    true,
 						},
 						"subnet": {
 							Type:        schema.TypeString,
 							Optional:    true,
-							Description: "",
+							Description: "An optional subnet mask applied to the IP address",
 						},
 						"negated": {
 							Type:        schema.TypeBool,
 							Optional:    true,
 							Default:     false,
-							Description: "",
+							Description: "A boolean that will negate the match if true",
 						},
 						"comment": {
 							Type:        schema.TypeString,
 							Optional:    true,
-							Description: "",
+							Description: "A personal freeform descriptive note",
 						},
 					},
 				},

--- a/fastly/resource_fastly_service_acl_entries_v1.go
+++ b/fastly/resource_fastly_service_acl_entries_v1.go
@@ -35,7 +35,7 @@ func resourceServiceAclEntriesV1() *schema.Resource {
 				Type:        schema.TypeSet,
 				Optional:    true,
 				Description: "ACL Entries",
-				ValidateFunc: validateACLEntries(),
+				MaxItems: 	 gofastly.MaximumACLSize,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"id": {

--- a/fastly/resource_fastly_service_acl_entries_v1.go
+++ b/fastly/resource_fastly_service_acl_entries_v1.go
@@ -35,7 +35,7 @@ func resourceServiceAclEntriesV1() *schema.Resource {
 				Type:        schema.TypeSet,
 				Optional:    true,
 				Description: "ACL Entries",
-				MaxItems: 	 gofastly.MaximumACLSize,
+				MaxItems:    gofastly.MaximumACLSize,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"id": {

--- a/fastly/resource_fastly_service_acl_entries_v1.go
+++ b/fastly/resource_fastly_service_acl_entries_v1.go
@@ -35,6 +35,7 @@ func resourceServiceAclEntriesV1() *schema.Resource {
 				Type:        schema.TypeSet,
 				Optional:    true,
 				Description: "ACL Entries",
+				ValidateFunc: validateACLEntries(),
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"id": {

--- a/fastly/resource_fastly_service_acl_entries_v1.go
+++ b/fastly/resource_fastly_service_acl_entries_v1.go
@@ -1,0 +1,130 @@
+package fastly
+
+import (
+"fmt"
+gofastly "github.com/fastly/go-fastly/fastly"
+"github.com/hashicorp/terraform/helper/schema"
+"strings"
+)
+
+func resourceServiceAclEntriesV1() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceServiceAclEntriesV1Create,
+		Read:   resourceServiceAclEntriesV1Read,
+		Update: resourceServiceAclEntriesV1Update,
+		Delete: resourceServiceAclEntriesV1Delete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"service_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "Service Id",
+			},
+
+			"acl_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "ACL Id",
+			},
+			"entry": {
+				Type: schema.TypeSet,
+				Optional: true,
+				Description: "ACL Entries",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"ip": {
+							Type:     schema.TypeString,
+							Description: "",
+							Required: true,
+						},
+						"subnet": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Description: "",
+						},
+						"negated": {
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Description: "",
+						},
+						"comment": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "",
+						},
+					},
+				},
+
+			},
+		},
+	}
+}
+
+func resourceServiceAclEntriesV1Create(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*FastlyClient).conn
+
+	serviceID := d.Get("service_id").(string)
+	aclId := d.Get("acl_id").(string)
+
+	entries := d.Get("entry")
+
+
+
+	// TODO review this
+	d.SetId(fmt.Sprintf("%s/%s", serviceID, aclId))
+	return resourceServiceAclEntriesV1Read(d, meta)
+}
+
+func resourceServiceAclEntriesV1Update(d *schema.ResourceData, meta interface{}) error {
+
+	conn := meta.(*FastlyClient).conn
+	comp := strings.Split(d.Id(), "/")
+
+	return resourceServiceAclEntriesV1Read(d, meta)
+}
+
+func resourceServiceAclEntriesV1Read(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*FastlyClient).conn
+	comp := strings.Split(d.Id(), "/")
+
+	return nil
+}
+
+func resourceServiceAclEntriesV1Delete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*FastlyClient).conn
+	comp := strings.Split(d.Id(), "/")
+
+
+
+	d.SetId("")
+	return nil
+}
+
+func flattenAclEntries(aclEntryList []*gofastly.ACLEntry) []map[string]interface{} {
+
+	var resultList []map[string]interface{}
+
+	for _, currentAclEntry := range aclEntryList {
+		aes := map[string]interface{}{
+			"ip": currentAclEntry.IP,
+			"subnet": currentAclEntry.Subnet,
+			"negated": currentAclEntry.Negated,
+			"comment": currentAclEntry.Comment,
+		}
+
+		for k, v := range aes {
+			if v == "" {
+				delete(aes, k)
+			}
+		}
+
+		resultList = append(resultList, aes)
+	}
+
+	return resultList
+}

--- a/fastly/resource_fastly_service_acl_entries_v1_test.go
+++ b/fastly/resource_fastly_service_acl_entries_v1_test.go
@@ -1,0 +1,37 @@
+package fastly
+
+import (
+	gofastly "github.com/fastly/go-fastly/fastly"
+	"reflect"
+	"testing"
+)
+
+func TestResourceFastlyFlattenDictionaryItems(t *testing.T) {
+	cases := []struct {
+		remote []*gofastly.ACLEntry
+		local  map[string]string
+	}{
+		{
+			remote: []*gofastly.ACLEntry{
+				{
+					ServiceID:    "service-id",
+					ACLID: "1234567890",
+				},
+				{
+					ServiceID:    "service-id",
+					ACLID: "1234567890",
+				},
+			},
+			local: map[string]string{
+
+			},
+		},
+	}
+
+	for _, c := range cases {
+		out := flattenAclEntries(c.remote)
+		if !reflect.DeepEqual(out, c.local) {
+			t.Fatalf("Error matching:\nexpected: %#v\ngot: %#v", c.local, out)
+		}
+	}
+}

--- a/fastly/resource_fastly_service_acl_entries_v1_test.go
+++ b/fastly/resource_fastly_service_acl_entries_v1_test.go
@@ -219,7 +219,6 @@ func TestAccFastlyServiceAclEntriesV1_import(t *testing.T) {
 	})
 }
 
-
 func TestAccFastlyServiceAclEntriesV1_process_1001_entries(t *testing.T) {
 
 	var service gofastly.ServiceDetail
@@ -264,11 +263,9 @@ func TestAccFastlyServiceAclEntriesV1_process_1001_entries(t *testing.T) {
 					resource.TestCheckResourceAttr("fastly_service_acl_entries_v1.entries", "entry.#", strconv.Itoa(expectedBatchSize)),
 				),
 			},
-
 		},
 	})
 }
-
 
 func testAccCheckFastlyServiceAclEntriesV1RemoteState(service *gofastly.ServiceDetail, serviceName, aclName string, expectedEntries []map[string]interface{}) resource.TestCheckFunc {
 

--- a/fastly/resource_fastly_service_acl_entries_v1_test.go
+++ b/fastly/resource_fastly_service_acl_entries_v1_test.go
@@ -80,7 +80,7 @@ func TestAccFastlyServiceAclEntriesV1_create(t *testing.T) {
 		CheckDestroy: testAccCheckServiceV1Destroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccServiceAclEntriesV1Config_create(serviceName, aclName),
+				Config: testAccServiceDictionaryItemsV1Config_one_acl_with_entries(serviceName, aclName, expectedRemoteEntries),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
 					testAccCheckFastlyServiceAclEntriesV1RemoteState(&service, serviceName, aclName, expectedRemoteEntries),
@@ -122,7 +122,7 @@ func TestAccFastlyServiceAclEntriesV1_update(t *testing.T) {
 		CheckDestroy: testAccCheckServiceV1Destroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccServiceAclEntriesV1Config_create(serviceName, aclName),
+				Config: testAccServiceDictionaryItemsV1Config_one_acl_with_entries(serviceName, aclName, expectedRemoteEntries),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
 					testAccCheckFastlyServiceAclEntriesV1RemoteState(&service, serviceName, aclName, expectedRemoteEntries),
@@ -130,7 +130,7 @@ func TestAccFastlyServiceAclEntriesV1_update(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccServiceAclEntriesV1Config_update(serviceName, aclName),
+				Config: testAccServiceDictionaryItemsV1Config_one_acl_with_entries(serviceName, aclName, expectedRemoteEntriesAfterUpdate),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
 					testAccCheckFastlyServiceAclEntriesV1RemoteState(&service, serviceName, aclName, expectedRemoteEntriesAfterUpdate),
@@ -162,7 +162,7 @@ func TestAccFastlyServiceAclEntriesV1_delete(t *testing.T) {
 		CheckDestroy: testAccCheckServiceV1Destroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccServiceAclEntriesV1Config_create(serviceName, aclName),
+				Config: testAccServiceDictionaryItemsV1Config_one_acl_with_entries(serviceName, aclName, expectedRemoteEntries),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
 					testAccCheckFastlyServiceAclEntriesV1RemoteState(&service, serviceName, aclName, expectedRemoteEntries),
@@ -170,7 +170,7 @@ func TestAccFastlyServiceAclEntriesV1_delete(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccServiceAclEntriesV1Config_delete(serviceName, aclName),
+				Config: testAccServiceDictionaryItemsV1Config_one_acl_no_entries(serviceName, aclName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
 					resource.TestCheckNoResourceAttr("fastly_service_v1.foo", "entry"),
@@ -259,98 +259,27 @@ func testAccCheckFastlyServiceAclEntriesV1RemoteState(service *gofastly.ServiceD
 	}
 }
 
-func testAccServiceAclEntriesV1Config_create(serviceName, aclName string) string {
-	backendName := fmt.Sprintf("%s.aws.amazon.com", acctest.RandString(3))
-	domainName := fmt.Sprintf("fastly-test.tf-%s.com", acctest.RandString(10))
+func testAccServiceDictionaryItemsV1Config_one_acl_no_entries(serviceName, aclName string) string {
 
-	return fmt.Sprintf(`
-variable "myacl_name" {
-	type = string
-	default = "%s"
-}
-
-resource "fastly_service_v1" "foo" {
-	name = "%s"
-	domain {
-		name    = "%s"
-		comment = "tf-testing-domain"
-	}
-	backend {
-		address = "%s"
-		name    = "tf-testing-backend"
-	}
-	acl {
-		name       = var.myacl_name
-	}
-	force_destroy = true
-}
- resource "fastly_service_acl_entries_v1" "entries" {
-	service_id = fastly_service_v1.foo.id
-	acl_id = {for s in fastly_service_v1.foo.acl : s.name => s.acl_id}[var.myacl_name]
-	entry {
-		ip = "127.0.0.1"
-		subnet = "24"
-		negated = false
-		comment = "ALC Entry 1"
-	}
-}`, aclName, serviceName, domainName, backendName)
-}
-
-func testAccServiceAclEntriesV1Config_update(serviceName, aclName string) string {
-	backendName := fmt.Sprintf("%s.aws.amazon.com", acctest.RandString(3))
-	domainName := fmt.Sprintf("fastly-test.tf-%s.com", acctest.RandString(10))
-
-	return fmt.Sprintf(`
-variable "myacl_name" {
-	type = string
-	default = "%s"
-}
-
-resource "fastly_service_v1" "foo" {
-	name = "%s"
-	domain {
-		name    = "%s"
-		comment = "tf-testing-domain"
-	}
-	backend {
-		address = "%s"
-		name    = "tf-testing-backend"
-	}
-	acl {
-		name       = var.myacl_name
-	}
-	force_destroy = true
-}
- resource "fastly_service_acl_entries_v1" "entries" {
-	service_id = fastly_service_v1.foo.id
-	acl_id = {for s in fastly_service_v1.foo.acl : s.name => s.acl_id}[var.myacl_name]
-	entry {
-		ip = "127.0.0.2"
-		subnet = "24"
-		negated = false
-		comment = "ALC Entry 1"
-	}
-}`, aclName, serviceName, domainName, backendName)
-}
-
-func testAccServiceAclEntriesV1Config_delete(serviceName, aclName string) string {
 	backendName := fmt.Sprintf("%s.aws.amazon.com", acctest.RandString(3))
 	domainName := fmt.Sprintf("fastly-test.tf-%s.com", acctest.RandString(10))
 
 	return fmt.Sprintf(`
 resource "fastly_service_v1" "foo" {
-	name = "%s"
-	domain {
-		name    = "%s"
-		comment = "tf-testing-domain"
+  name = "%s"
+  domain {
+    name    = "%s"
+    comment = "tf-testing-domain"
 	}
-	backend {
-		address = "%s"
-		name    = "tf-testing-backend"
-	}
-
-	force_destroy = true
-}`, serviceName, domainName, backendName)
+  backend {
+    address = "%s"
+    name    = "tf -test backend"
+  }
+  acl {
+	name       = "%s"
+  }
+  force_destroy = true
+}`, serviceName, domainName, backendName, aclName)
 }
 
 func testAccServiceDictionaryItemsV1Config_one_acl_with_entries(serviceName, aclName string, aclEntriesList []map[string]interface{}) string {

--- a/fastly/resource_fastly_service_acl_entries_v1_test.go
+++ b/fastly/resource_fastly_service_acl_entries_v1_test.go
@@ -64,6 +64,23 @@ func TestAccFastlyServiceAclEntriesV1_create(t *testing.T) {
 	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	aclName := fmt.Sprintf("ACL %s", acctest.RandString(10))
 
+	expectedEntries := []map[string]interface{}{
+		{
+			"id":      "",
+			"ip":      "127.0.0.1",
+			"subnet":  "24",
+			"negated": false,
+			"comment": "ALC Entry 1",
+		},
+		{
+			"id":      "",
+			"ip":      "192.168.0.1",
+			"subnet":  "16",
+			"negated": false,
+			"comment": "ALC Entry 2",
+		},
+	}
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -73,7 +90,7 @@ func TestAccFastlyServiceAclEntriesV1_create(t *testing.T) {
 				Config: testAccServiceAclEntriesV1Config_create(serviceName, aclName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
-					testAccCheckFastlyServiceDictionaryItemsV1RemoteState(&service, serviceName, aclName),
+					testAccCheckFastlyServiceAclEntriesV1RemoteState(&service, serviceName, aclName, expectedEntries),
 					resource.TestCheckResourceAttr("fastly_service_acl_entries_v1.entries", "entry.#", "2"),
 				),
 			},
@@ -81,11 +98,44 @@ func TestAccFastlyServiceAclEntriesV1_create(t *testing.T) {
 	})
 }
 
-func testAccCheckFastlyServiceDictionaryItemsV1RemoteState(service *gofastly.ServiceDetail, serviceName, aclName string) resource.TestCheckFunc {
+func testAccCheckFastlyServiceAclEntriesV1RemoteState(service *gofastly.ServiceDetail, serviceName, aclName string, expectedEntries []map[string]interface{}) resource.TestCheckFunc {
 
 	return func(s *terraform.State) error {
 
-		// TODO check against remote state through api.
+		if service.Name != serviceName {
+			return fmt.Errorf("[ERR] Bad name, expected (%s), got (%s)", serviceName, service.Name)
+		}
+
+		conn := testAccProvider.Meta().(*FastlyClient).conn
+		acl, err := conn.GetACL(&gofastly.GetACLInput{
+			Service: service.ID,
+			Version: service.ActiveVersion.Number,
+			Name:    aclName,
+		})
+
+		if err != nil {
+			return fmt.Errorf("[ERR] Error looking up ACL records for (%s), version (%v): %s", service.Name, service.ActiveVersion.Number, err)
+		}
+
+		aclEntries, err := conn.ListACLEntries(&gofastly.ListACLEntriesInput{
+			Service: service.ID,
+			ACL:     acl.ID,
+		})
+
+		if err != nil {
+			return fmt.Errorf("[ERR] Error looking up ACL entry records for (%s), ACL (%s): %s", service.Name, acl.ID, err)
+		}
+
+		flatAclEntries := flattenAclEntries(aclEntries)
+		// Clear out the id values to allow a deep equal of the other attributes set in terraform.
+		for _, val := range flatAclEntries {
+			val["id"] = ""
+		}
+
+		if !reflect.DeepEqual(flatAclEntries, expectedEntries) {
+			return fmt.Errorf("[ERR] Error matching:\nexpected: %#v\ngot: %#v", expectedEntries, flatAclEntries)
+		}
+
 		return nil
 	}
 }
@@ -127,7 +177,7 @@ resource "fastly_service_v1" "foo" {
 
 	entry {
 		ip = "192.168.0.1"
-		subnet = "24"
+		subnet = "16"
 		negated = false
 		comment = "ALC Entry 2"
 	}

--- a/fastly/resource_fastly_service_acl_entries_v1_test.go
+++ b/fastly/resource_fastly_service_acl_entries_v1_test.go
@@ -1,29 +1,52 @@
 package fastly
 
 import (
+	"fmt"
 	gofastly "github.com/fastly/go-fastly/fastly"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
 	"reflect"
 	"testing"
 )
 
-func TestResourceFastlyFlattenDictionaryItems(t *testing.T) {
+func TestResourceFastlyFlattenAclEntries(t *testing.T) {
 	cases := []struct {
 		remote []*gofastly.ACLEntry
-		local  map[string]string
+		local  []map[string]interface{}
 	}{
 		{
 			remote: []*gofastly.ACLEntry{
 				{
-					ServiceID:    "service-id",
-					ACLID: "1234567890",
+					ServiceID: "service-id",
+					ACLID:     "1234567890",
+					IP:        "127.0.0.1",
+					Subnet:    "24",
+					Negated:   false,
+					Comment:   "ALC Entry 1",
 				},
 				{
-					ServiceID:    "service-id",
-					ACLID: "1234567890",
+					ServiceID: "service-id",
+					ACLID:     "0987654321",
+					IP:        "192.168.0.1",
+					Subnet:    "16",
+					Negated:   true,
+					Comment:   "ALC Entry 2",
 				},
 			},
-			local: map[string]string{
-
+			local: []map[string]interface{}{
+				{
+					"ip":      "127.0.0.1",
+					"subnet":  "24",
+					"negated": false,
+					"comment": "ALC Entry 1",
+				},
+				{
+					"ip":      "192.168.0.1",
+					"subnet":  "16",
+					"negated": true,
+					"comment": "ALC Entry 2",
+				},
 			},
 		},
 	}
@@ -34,4 +57,79 @@ func TestResourceFastlyFlattenDictionaryItems(t *testing.T) {
 			t.Fatalf("Error matching:\nexpected: %#v\ngot: %#v", c.local, out)
 		}
 	}
+}
+
+func TestAccFastlyServiceAclEntriesV1_create(t *testing.T) {
+	var service gofastly.ServiceDetail
+	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	aclName := fmt.Sprintf("ACL %s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckServiceV1Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServiceAclEntriesV1Config_create(serviceName, aclName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
+					testAccCheckFastlyServiceDictionaryItemsV1RemoteState(&service, serviceName, aclName),
+					resource.TestCheckResourceAttr("fastly_service_acl_entries_v1.entries", "entry.#", "2"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckFastlyServiceDictionaryItemsV1RemoteState(service *gofastly.ServiceDetail, serviceName, aclName string) resource.TestCheckFunc {
+
+	return func(s *terraform.State) error {
+
+		// TODO check against remote state through api.
+		return nil
+	}
+}
+
+func testAccServiceAclEntriesV1Config_create(serviceName, aclName string) string {
+	backendName := fmt.Sprintf("%s.aws.amazon.com", acctest.RandString(3))
+	domainName := fmt.Sprintf("fastly-test.tf-%s.com", acctest.RandString(10))
+
+	return fmt.Sprintf(`
+variable "myacl_name" {
+	type = string
+	default = "%s"
+}
+
+resource "fastly_service_v1" "foo" {
+	name = "%s"
+	domain {
+		name    = "%s"
+		comment = "tf-testing-domain"
+	}
+	backend {
+		address = "%s"
+		name    = "tf-testing-backend"
+	}
+	acl {
+		name       = var.myacl_name
+	}
+	force_destroy = true
+}
+ resource "fastly_service_acl_entries_v1" "entries" {
+	service_id = "${fastly_service_v1.foo.id}"
+	acl_id = "${{for s in fastly_service_v1.foo.acl : s.name => s.acl_id}[var.myacl_name]}"
+	entry {
+		ip = "127.0.0.1"
+		subnet = "24"
+		negated = false
+		comment = "ALC Entry 1"
+	}
+
+	entry {
+		ip = "192.168.0.1"
+		subnet = "24"
+		negated = false
+		comment = "ALC Entry 2"
+	}
+}`, aclName, serviceName, domainName, backendName)
 }

--- a/fastly/resource_fastly_service_dictionary_items_v1.go
+++ b/fastly/resource_fastly_service_dictionary_items_v1.go
@@ -1,0 +1,239 @@
+package fastly
+
+import (
+	"fmt"
+	gofastly "github.com/fastly/go-fastly/fastly"
+	"github.com/hashicorp/terraform/helper/schema"
+	"strings"
+)
+
+func resourceServiceDictionaryItemsV1() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceServiceDictionaryItemsV1Create,
+		Read:   resourceServiceDictionaryItemsV1Read,
+		Update: resourceServiceDictionaryItemsV1Update,
+		Delete: resourceServiceDictionaryItemsV1Delete,
+		Importer: &schema.ResourceImporter{
+			State: resourceServiceDictionaryItemsV1Import,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"service_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The service the dictionary belongs to",
+			},
+
+			"dictionary_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The dictionary the items belong to",
+			},
+
+			"items": {
+				Type:         schema.TypeMap,
+				Optional:     true,
+				Description:  "Map of key/value pairs that make up an item in the dictionary",
+				ValidateFunc: validateDictionaryItems(),
+			},
+		},
+	}
+}
+
+func resourceServiceDictionaryItemsV1Create(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*FastlyClient).conn
+
+	serviceID := d.Get("service_id").(string)
+	dictionaryID := d.Get("dictionary_id").(string)
+	items := d.Get("items").(map[string]interface{})
+
+	var batchDictionaryItems = []*gofastly.BatchDictionaryItem{}
+
+	for key, val := range items {
+
+		batchDictionaryItems = append(batchDictionaryItems, &gofastly.BatchDictionaryItem{
+			Operation: gofastly.CreateBatchOperation,
+			ItemKey:   key,
+			ItemValue: val.(string),
+		})
+	}
+
+	// Process the batch operations
+	err := executeBatchDictionaryOperations(conn, serviceID, dictionaryID, batchDictionaryItems)
+	if err != nil {
+		return fmt.Errorf("Error creating dictionary items: service %s, dictionary %s, %s", serviceID, dictionaryID, err)
+	}
+
+	d.SetId(fmt.Sprintf("%s/%s", serviceID, dictionaryID))
+	return resourceServiceDictionaryItemsV1Read(d, meta)
+}
+
+func resourceServiceDictionaryItemsV1Update(d *schema.ResourceData, meta interface{}) error {
+
+	conn := meta.(*FastlyClient).conn
+
+	serviceID := d.Get("service_id").(string)
+	dictionaryID := d.Get("dictionary_id").(string)
+
+	d.Partial(true)
+
+	if d.HasChange("items") {
+
+		var batchDictionaryItems = []*gofastly.BatchDictionaryItem{}
+
+		o, n := d.GetChange("items")
+
+		os := o.(map[string]interface{})
+		ns := n.(map[string]interface{})
+
+		// Handle Removal
+		for key := range os {
+			if _, ok := ns[key]; !ok {
+
+				batchDictionaryItems = append(batchDictionaryItems, &gofastly.BatchDictionaryItem{
+					Operation: gofastly.DeleteBatchOperation,
+					ItemKey:   key,
+				})
+			}
+		}
+
+		for key, val := range ns {
+			// Handle replaces
+			if _, ok := os[key]; ok {
+
+				batchDictionaryItems = append(batchDictionaryItems, &gofastly.BatchDictionaryItem{
+					Operation: gofastly.UpdateBatchOperation,
+					ItemKey:   key,
+					ItemValue: val.(string),
+				})
+			}
+
+			// Handle additions
+			if _, ok := os[key]; !ok {
+
+				batchDictionaryItems = append(batchDictionaryItems, &gofastly.BatchDictionaryItem{
+					Operation: gofastly.CreateBatchOperation,
+					ItemKey:   key,
+					ItemValue: val.(string),
+				})
+
+			}
+		}
+
+		// Process the batch operations
+		err := executeBatchDictionaryOperations(conn, serviceID, dictionaryID, batchDictionaryItems)
+		if err != nil {
+			return fmt.Errorf("Error updating dictionary items: service %s, dictionary %s, %s", serviceID, dictionaryID, err)
+		}
+
+		d.SetPartial("items")
+	}
+
+	d.Partial(false)
+
+	return resourceServiceDictionaryItemsV1Read(d, meta)
+}
+
+func resourceServiceDictionaryItemsV1Read(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*FastlyClient).conn
+
+	serviceID := d.Get("service_id").(string)
+	dictionaryID := d.Get("dictionary_id").(string)
+
+	dictList, err := conn.ListDictionaryItems(&gofastly.ListDictionaryItemsInput{
+		Service:    serviceID,
+		Dictionary: dictionaryID,
+	})
+	if err != nil {
+		return err
+	}
+
+	d.Set("items", flattenDictionaryItems(dictList))
+	return nil
+}
+
+func resourceServiceDictionaryItemsV1Delete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*FastlyClient).conn
+
+	serviceID := d.Get("service_id").(string)
+	dictionaryID := d.Get("dictionary_id").(string)
+	items := d.Get("items").(map[string]interface{})
+
+	var batchDictionaryItems = []*gofastly.BatchDictionaryItem{}
+
+	for key, _ := range items {
+
+		batchDictionaryItems = append(batchDictionaryItems, &gofastly.BatchDictionaryItem{
+			Operation: gofastly.DeleteBatchOperation,
+			ItemKey:   key,
+		})
+	}
+
+	// Process the batch operations
+	err := executeBatchDictionaryOperations(conn, serviceID, dictionaryID, batchDictionaryItems)
+	if err != nil {
+		return fmt.Errorf("Error creating dictionary items: service %s, dictionary %s, %s", serviceID, dictionaryID, err)
+	}
+
+	d.SetId("")
+	return nil
+}
+
+func resourceServiceDictionaryItemsV1Import(d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+	split := strings.Split(d.Id(), "/")
+
+	if len(split) != 2 {
+		return nil, fmt.Errorf("Invalid id: %s. The ID should be in the format [service_id]/[dictionary_id]", d.Id())
+	}
+
+	serviceID := split[0]
+	dictionaryID := split[1]
+
+	err := d.Set("service_id", serviceID)
+	if err != nil {
+		return nil, fmt.Errorf("Error importing dictionary items: service %s, dictionary %s, %s", serviceID, dictionaryID, err)
+	}
+
+	err = d.Set("dictionary_id", dictionaryID)
+	if err != nil {
+		return nil, fmt.Errorf("Error importing dictionary items: service %s, dictionary %s, %s", serviceID, dictionaryID, err)
+	}
+
+	return []*schema.ResourceData{d}, nil
+}
+
+func flattenDictionaryItems(dictItemList []*gofastly.DictionaryItem) map[string]string {
+	resultList := make(map[string]string)
+	for _, currentDictItem := range dictItemList {
+		resultList[currentDictItem.ItemKey] = currentDictItem.ItemValue
+	}
+
+	return resultList
+}
+
+func executeBatchDictionaryOperations(conn *gofastly.Client, serviceID, dictionaryID string, batchDictionaryItems []*gofastly.BatchDictionaryItem) error {
+
+	batchSize := gofastly.BatchModifyMaximumOperations
+
+	for i := 0; i < len(batchDictionaryItems); i += batchSize {
+		j := i + batchSize
+		if j > len(batchDictionaryItems) {
+			j = len(batchDictionaryItems)
+		}
+
+		err := conn.BatchModifyDictionaryItems(&gofastly.BatchModifyDictionaryItemsInput{
+			Service:    serviceID,
+			Dictionary: dictionaryID,
+			Items:      batchDictionaryItems[i:j],
+		})
+
+		if err != nil {
+			return err
+		}
+
+	}
+
+	return nil
+}

--- a/fastly/resource_fastly_service_dictionary_items_v1_test.go
+++ b/fastly/resource_fastly_service_dictionary_items_v1_test.go
@@ -1,0 +1,489 @@
+package fastly
+
+import (
+	"fmt"
+	"reflect"
+	"strconv"
+	"testing"
+
+	gofastly "github.com/fastly/go-fastly/fastly"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestResourceFastlyFlattenDictionaryItems(t *testing.T) {
+	cases := []struct {
+		remote []*gofastly.DictionaryItem
+		local  map[string]string
+	}{
+		{
+			remote: []*gofastly.DictionaryItem{
+				{
+					ServiceID:    "service-id",
+					DictionaryID: "1234567890",
+					ItemKey:      "key-1",
+					ItemValue:    "value-1",
+				},
+				{
+					ServiceID:    "service-id",
+					DictionaryID: "1234567890",
+					ItemKey:      "key-2",
+					ItemValue:    "value-2",
+				},
+			},
+			local: map[string]string{
+				"key-1": "value-1",
+				"key-2": "value-2",
+			},
+		},
+	}
+
+	for _, c := range cases {
+		out := flattenDictionaryItems(c.remote)
+		if !reflect.DeepEqual(out, c.local) {
+			t.Fatalf("Error matching:\nexpected: %#v\ngot: %#v", c.local, out)
+		}
+	}
+}
+
+func TestAccFastlyServiceDictionaryItemV1_create(t *testing.T) {
+	var service gofastly.ServiceDetail
+	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	dictName := fmt.Sprintf("dict %s", acctest.RandString(10))
+
+	expectedRemoteItems := map[string]string{
+		"key1": "value1",
+		"key2": "value2",
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckServiceV1Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServiceDictionaryItemsV1Config_one_dictionary_with_items(name, dictName, expectedRemoteItems),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
+					testAccCheckFastlyServiceDictionaryItemsV1RemoteState(&service, name, dictName, expectedRemoteItems),
+					resource.TestCheckResourceAttr("fastly_service_dictionary_items_v1.items", "items.%", "2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccFastlyServiceDictionaryItemV1_create_dynamic(t *testing.T) {
+	var service gofastly.ServiceDetail
+	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	dictName := fmt.Sprintf("dict %s", acctest.RandString(10))
+
+	expectedRemoteItems := map[string]string{
+		"alpha": "alpha.demo.notexample.com",
+		"beta":  "beta.demo.notexample.com",
+		"gamma": "gamma.demo.notexample.com",
+		"delta": "delta.demo.notexample.com",
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckServiceV1Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServiceDictionaryItemsV1Config_create_dynamic(name, dictName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceV1Exists("fastly_service_v1.myservice", &service),
+					testAccCheckFastlyServiceDictionaryItemsV1RemoteState(&service, name, dictName, expectedRemoteItems),
+					resource.TestCheckResourceAttr("fastly_service_dictionary_items_v1.common", "items.%", "4"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccFastlyServiceDictionaryItemV1_update(t *testing.T) {
+	var service gofastly.ServiceDetail
+	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	dictName := fmt.Sprintf("dict %s", acctest.RandString(10))
+
+	expectedRemoteItems := map[string]string{
+		"key1": "value1",
+		"key2": "value2",
+	}
+
+	expectedRemoteItemsAfterUpdate := map[string]string{
+		"key1": "valueOne",
+		"key2": "value2",
+		"key3": "value3",
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckServiceV1Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServiceDictionaryItemsV1Config_one_dictionary_with_items(name, dictName, expectedRemoteItems),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
+					testAccCheckFastlyServiceDictionaryItemsV1RemoteState(&service, name, dictName, expectedRemoteItems),
+					resource.TestCheckResourceAttr("fastly_service_dictionary_items_v1.items", "items.%", "2"),
+				),
+			},
+			{
+				Config: testAccServiceDictionaryItemsV1Config_one_dictionary_with_items(name, dictName, expectedRemoteItemsAfterUpdate),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
+					testAccCheckFastlyServiceDictionaryItemsV1RemoteState(&service, name, dictName, expectedRemoteItemsAfterUpdate),
+					resource.TestCheckResourceAttr("fastly_service_dictionary_items_v1.items", "items.%", "3"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccFastlyServiceDictionaryItemV1_external_item_is_removed(t *testing.T) {
+
+	var service gofastly.ServiceDetail
+
+	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	dictName := fmt.Sprintf("dict %s", acctest.RandString(10))
+
+	expectedRemoteItems := map[string]string{
+		"key1": "value1",
+		"key2": "value2",
+	}
+
+	config := testAccServiceDictionaryItemsV1Config_one_dictionary_with_items(name, dictName, expectedRemoteItems)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckServiceV1Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
+					testAccCheckFastlyServiceDictionaryItemsV1RemoteState(&service, name, dictName, expectedRemoteItems),
+					resource.TestCheckResourceAttr("fastly_service_dictionary_items_v1.items", "items.%", "2"),
+				),
+			},
+			{
+				PreConfig: func() { createDictionaryItemThroughApi(t, &service, dictName, "key3", "value3") },
+				Config:    config,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
+					testAccCheckFastlyServiceDictionaryItemsV1RemoteState(&service, name, dictName, expectedRemoteItems),
+					resource.TestCheckResourceAttr("fastly_service_dictionary_items_v1.items", "items.%", "2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccFastlyServiceDictionaryItemV1_external_item_deleted(t *testing.T) {
+
+	var service gofastly.ServiceDetail
+
+	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	dictName := fmt.Sprintf("dict %s", acctest.RandString(10))
+
+	expectedRemoteItems := map[string]string{
+		"key1": "value1",
+		"key2": "value2",
+	}
+
+	expectedRemoteItemsAfterUpdate := map[string]string{}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckServiceV1Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServiceDictionaryItemsV1Config_one_dictionary_with_items(name, dictName, expectedRemoteItems),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
+					testAccCheckFastlyServiceDictionaryItemsV1RemoteState(&service, name, dictName, expectedRemoteItems),
+					resource.TestCheckResourceAttr("fastly_service_dictionary_items_v1.items", "items.%", "2"),
+				),
+			},
+			{
+				PreConfig: func() { createDictionaryItemThroughApi(t, &service, dictName, "key3", "value3") },
+				Config:    testAccServiceDictionaryItemsV1Config_one_dictionary_no_items(name, dictName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
+					testAccCheckFastlyServiceDictionaryItemsV1RemoteState(&service, name, dictName, expectedRemoteItemsAfterUpdate),
+					testAccCheckFastlyServiceDictionaryItemsV1DoesNotExists("fastly_service_dictionary_items_v1.items"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccFastlyServiceDictionaryItemV1_batch_1001_items(t *testing.T) {
+
+	var service gofastly.ServiceDetail
+
+	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	dictName := fmt.Sprintf("dict %s", acctest.RandString(10))
+
+	var expectedRemoteItems = make(map[string]string)
+	expectedBatchSize := gofastly.BatchModifyMaximumOperations + 1
+
+	for i := 0; i < expectedBatchSize; i++ {
+		expectedRemoteItems[fmt.Sprintf("key%d", i)] = fmt.Sprintf("value%d", i)
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckServiceV1Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServiceDictionaryItemsV1Config_one_dictionary_with_items(name, dictName, expectedRemoteItems),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
+					testAccCheckFastlyServiceDictionaryItemsV1RemoteState(&service, name, dictName, expectedRemoteItems),
+					resource.TestCheckResourceAttr("fastly_service_dictionary_items_v1.items", "items.%", strconv.Itoa(expectedBatchSize)),
+				),
+			},
+		},
+	})
+}
+
+func TestAccFastlyServiceDictionaryItemV1_import(t *testing.T) {
+
+	var service gofastly.ServiceDetail
+
+	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	dictName := fmt.Sprintf("dict %s", acctest.RandString(10))
+
+	expectedRemoteItems := map[string]string{
+		"key1": "value1",
+		"key2": "value2",
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckServiceV1Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServiceDictionaryItemsV1Config_one_dictionary_with_items(name, dictName, expectedRemoteItems),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
+				),
+			},
+			{
+				ResourceName:      "fastly_service_dictionary_items_v1.items",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckFastlyServiceDictionaryItemsV1DoesNotExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		_, ok := s.RootModule().Resources[n]
+		if ok {
+			return fmt.Errorf("Found: %s", n)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckFastlyServiceDictionaryItemsV1RemoteState(service *gofastly.ServiceDetail, name, dictName string, expectedItems map[string]string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+
+		if service.Name != name {
+			return fmt.Errorf("Bad name, expected (%s), got (%s)", name, service.Name)
+		}
+
+		conn := testAccProvider.Meta().(*FastlyClient).conn
+		dict, err := conn.GetDictionary(&gofastly.GetDictionaryInput{
+			Service: service.ID,
+			Version: service.ActiveVersion.Number,
+			Name:    dictName,
+		})
+
+		if err != nil {
+			return fmt.Errorf("[ERR] Error looking up Dictionary records for (%s), version (%v): %s", service.Name, service.ActiveVersion.Number, err)
+		}
+
+		dictItems, err := conn.ListDictionaryItems(&gofastly.ListDictionaryItemsInput{
+			Service:    service.ID,
+			Dictionary: dict.ID,
+		})
+
+		if err != nil {
+			return fmt.Errorf("[ERR] Error looking up Dictionary Items records for (%s), dictionary (%s): %s", service.Name, dict.ID, err)
+		}
+
+		dictItemsMap := flattenDictionaryItems(dictItems)
+
+		if !reflect.DeepEqual(dictItemsMap, expectedItems) {
+			return fmt.Errorf("[ERR] Error matching:\nexpected: %#v\ngot: %#v", expectedItems, dictItemsMap)
+		}
+
+		return nil
+	}
+}
+
+func createDictionaryItemThroughApi(t *testing.T, service *gofastly.ServiceDetail, dictName, expectedKey, expectedValue string) {
+
+	conn := testAccProvider.Meta().(*FastlyClient).conn
+
+	dict, err := getDictionaryByName(service, dictName)
+
+	if err != nil {
+		t.Fatalf("[ERR] Error looking up Dictionary records for (%s), version (%v): %s", service.Name, service.ActiveVersion.Number, err)
+	}
+
+	_, err = conn.CreateDictionaryItem(&gofastly.CreateDictionaryItemInput{
+		Service:    service.ID,
+		Dictionary: dict.ID,
+
+		ItemKey:   expectedKey,
+		ItemValue: expectedValue,
+	})
+
+	if err != nil {
+		t.Fatalf("[ERR] Error Createing Dictionary item for (%s), dictionary (%s): %s", service.Name, dict.Name, err)
+	}
+
+}
+
+func getDictionaryByName(service *gofastly.ServiceDetail, dictName string) (*gofastly.Dictionary, error) {
+	conn := testAccProvider.Meta().(*FastlyClient).conn
+
+	dict, err := conn.GetDictionary(&gofastly.GetDictionaryInput{
+		Service: service.ID,
+		Version: service.ActiveVersion.Number,
+		Name:    dictName,
+	})
+	return dict, err
+}
+
+func testAccServiceDictionaryItemsV1Config_one_dictionary_with_items(serviceName, dictName string, dictItemsList map[string]string) string {
+	backendName := fmt.Sprintf("%s.aws.amazon.com", acctest.RandString(3))
+	domainName := fmt.Sprintf("fastly-test.tf-%s.com", acctest.RandString(10))
+
+	var dictItems = "{\n"
+
+	for key, value := range dictItemsList {
+		dictItems += fmt.Sprintf("%s: \"%s\"\n", key, value)
+	}
+
+	dictItems += "}\n"
+
+	return fmt.Sprintf(`
+variable "mydict" {
+	type = object({ name=string, items=map(string) })
+	default = {
+		name = "%s" 
+		items = %s
+	}
+}
+
+resource "fastly_service_v1" "foo" {
+  name = "%s"
+
+  domain {
+    name    = "%s"
+    comment = "tf-testing-domain"
+	}
+
+  backend {
+    address = "%s"
+    name    = "tf -test backend"
+  }
+
+  dictionary {
+	name       = var.mydict.name
+  }
+
+  force_destroy = true
+}
+
+resource "fastly_service_dictionary_items_v1" "items" {
+    service_id = fastly_service_v1.foo.id
+    dictionary_id = {for s in fastly_service_v1.foo.dictionary : s.name => s.dictionary_id}[var.mydict.name]
+    items = var.mydict.items
+}`, dictName, dictItems, serviceName, domainName, backendName)
+}
+
+func testAccServiceDictionaryItemsV1Config_one_dictionary_no_items(serviceName, dictName string) string {
+
+	backendName := fmt.Sprintf("%s.aws.amazon.com", acctest.RandString(3))
+	domainName := fmt.Sprintf("fastly-test.tf-%s.com", acctest.RandString(10))
+
+	return fmt.Sprintf(`
+resource "fastly_service_v1" "foo" {
+  name = "%s"
+
+  domain {
+    name    = "%s"
+    comment = "tf-testing-domain"
+	}
+
+  backend {
+    address = "%s"
+    name    = "tf -test backend"
+  }
+
+  dictionary {
+	name       = "%s"
+  }
+
+  force_destroy = true
+}`, serviceName, domainName, backendName, dictName)
+}
+
+func testAccServiceDictionaryItemsV1Config_create_dynamic(serviceName, dictName string) string {
+
+	backendName := fmt.Sprintf("%s.aws.amazon.com", acctest.RandString(3))
+	domainName := fmt.Sprintf("fastly-test.tf-%s.com", acctest.RandString(10))
+
+	return fmt.Sprintf(`
+locals {
+  dictionary_name = "%s"
+  host_base = "demo.notexample.com"
+  host_divisions = ["alpha", "beta", "gamma", "delta"]
+}
+
+resource "fastly_service_v1" "myservice" {
+  name = "%s"
+
+  domain {
+    name    = "%s"
+    comment = "tf-testing-domain"
+	}
+
+  backend {
+    address = "%s"
+    name    = "tf -test backend"
+  }
+
+  dictionary {
+    name       = local.dictionary_name
+  }
+
+  force_destroy = true
+}
+
+resource "fastly_service_dictionary_items_v1" "common" {
+  service_id = fastly_service_v1.myservice.id
+  dictionary_id = {for d in fastly_service_v1.myservice.dictionary : d.name => d.dictionary_id}[local.dictionary_name]
+  items = {
+    for division in local.host_divisions:
+      division => format("%%s.%%s", division, local.host_base)
+  }
+
+}`, dictName, serviceName, domainName, backendName)
+}

--- a/fastly/resource_fastly_service_v1.go
+++ b/fastly/resource_fastly_service_v1.go
@@ -1385,6 +1385,26 @@ func resourceServiceV1() *schema.Resource {
 					},
 				},
 			},
+			"acl": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						// Required fields
+						"name": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "Unique name to refer to this ACL",
+						},
+						// Optional fields
+						"acl_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Generated acl id",
+						},
+					},
+				},
+			},
 		},
 	}
 }
@@ -1456,6 +1476,7 @@ func resourceServiceV1Update(d *schema.ResourceData, meta interface{}) error {
 		"cache_setting",
 		"snippet",
 		"vcl",
+		"acl",
 	} {
 		if d.HasChange(v) {
 			needsChange = true
@@ -2889,6 +2910,60 @@ func resourceServiceV1Update(d *schema.ResourceData, meta interface{}) error {
 			}
 		}
 
+		// Find differences in ACLs
+		if d.HasChange("acl") {
+
+			oldACLVal, newACLVal := d.GetChange("acl")
+			if oldACLVal == nil {
+				oldACLVal = new(schema.Set)
+			}
+			if newACLVal == nil {
+				newACLVal = new(schema.Set)
+			}
+
+			oldACLSet := oldACLVal.(*schema.Set)
+			newACLSet := newACLVal.(*schema.Set)
+
+			remove := oldACLSet.Difference(newACLSet).List()
+			add := newACLSet.Difference(oldACLSet).List()
+
+			// Delete removed ACL configurations
+			for _, vRaw := range remove {
+				val := vRaw.(map[string]interface{})
+				opts := gofastly.DeleteACLInput{
+					Service: d.Id(),
+					Version: latestVersion,
+					Name:    val["name"].(string),
+				}
+
+				log.Printf("[DEBUG] Fastly ACL removal opts: %#v", opts)
+				err := conn.DeleteACL(&opts)
+				if errRes, ok := err.(*gofastly.HTTPError); ok {
+					if errRes.StatusCode != 404 {
+						return err
+					}
+				} else if err != nil {
+					return err
+				}
+			}
+			// POST new ACL configurations
+			for _, vRaw := range add {
+				val := vRaw.(map[string]interface{})
+				opts := gofastly.CreateACLInput{
+					Service: d.Id(),
+					Version: latestVersion,
+					Name:    val["name"].(string),
+				}
+
+				log.Printf("[DEBUG] Fastly ACL creation opts: %#v", opts)
+				_, err := conn.CreateACL(&opts)
+				if err != nil {
+					return err
+				}
+
+			}
+		}
+
 		// validate version
 		log.Printf("[DEBUG] Validating Fastly Service (%s), Version (%v)", d.Id(), latestVersion)
 		valid, msg, err := conn.ValidateVersion(&gofastly.ValidateVersionInput{
@@ -3311,6 +3386,22 @@ func resourceServiceV1Read(d *schema.ResourceData, meta interface{}) error {
 
 		if err := d.Set("vcl", vl); err != nil {
 			log.Printf("[WARN] Error setting VCLs for (%s): %s", d.Id(), err)
+		}
+
+		// refresh ACLs
+		log.Printf("[DEBUG] Refreshing ACLs for (%s)", d.Id())
+		aclList, err := conn.ListACLs(&gofastly.ListACLsInput{
+			Service: d.Id(),
+			Version: s.ActiveVersion.Number,
+		})
+		if err != nil {
+			return fmt.Errorf("[ERR] Error looking up ACLs for (%s), version (%v): %s", d.Id(), s.ActiveVersion.Number, err)
+		}
+
+		al := flattenACLs(aclList)
+
+		if err := d.Set("acl", al); err != nil {
+			log.Printf("[WARN] Error setting ACLs for (%s): %s", d.Id(), err)
 		}
 
 		// refresh VCL Snippets
@@ -4130,6 +4221,28 @@ func flattenVCLs(vclList []*gofastly.VCL) []map[string]interface{} {
 	}
 
 	return vl
+}
+
+func flattenACLs(aclList []*gofastly.ACL) []map[string]interface{} {
+	var al []map[string]interface{}
+	for _, acl := range aclList {
+		// Convert VCLs to a map for saving to state.
+		vclMap := map[string]interface{}{
+			"acl_id": acl.ID,
+			"name":   acl.Name,
+		}
+
+		// prune any empty values that come from the default string value in structs
+		for k, v := range vclMap {
+			if v == "" {
+				delete(vclMap, k)
+			}
+		}
+
+		al = append(al, vclMap)
+	}
+
+	return al
 }
 
 func buildSnippet(snippetMap interface{}) (*gofastly.CreateSnippetInput, error) {

--- a/fastly/resource_fastly_service_v1.go
+++ b/fastly/resource_fastly_service_v1.go
@@ -1385,6 +1385,26 @@ func resourceServiceV1() *schema.Resource {
 					},
 				},
 			},
+			"dictionary": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						// Required fields
+						"name": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "Unique name to refer to this Dictionary",
+						},
+						// Optional fields
+						"dictionary_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Generated dictionary ID",
+						},
+					},
+				},
+			},
 		},
 	}
 }
@@ -1456,6 +1476,7 @@ func resourceServiceV1Update(d *schema.ResourceData, meta interface{}) error {
 		"cache_setting",
 		"snippet",
 		"vcl",
+		"dictionary",
 	} {
 		if d.HasChange(v) {
 			needsChange = true
@@ -2889,6 +2910,62 @@ func resourceServiceV1Update(d *schema.ResourceData, meta interface{}) error {
 			}
 		}
 
+		// Find differences in dictionary
+		if d.HasChange("dictionary") {
+
+			oldDictVal, newDictVal := d.GetChange("dictionary")
+
+			if oldDictVal == nil {
+				oldDictVal = new(schema.Set)
+			}
+			if newDictVal == nil {
+				newDictVal = new(schema.Set)
+			}
+
+			oldDictSet := oldDictVal.(*schema.Set)
+			newDictSet := newDictVal.(*schema.Set)
+
+			remove := oldDictSet.Difference(newDictSet).List()
+			add := newDictSet.Difference(oldDictSet).List()
+
+			// Delete removed dictionary configurations
+			for _, dRaw := range remove {
+				df := dRaw.(map[string]interface{})
+				opts := gofastly.DeleteDictionaryInput{
+					Service: d.Id(),
+					Version: latestVersion,
+					Name:    df["name"].(string),
+				}
+
+				log.Printf("[DEBUG] Fastly Dictionary Removal opts: %#v", opts)
+				err := conn.DeleteDictionary(&opts)
+				if errRes, ok := err.(*gofastly.HTTPError); ok {
+					if errRes.StatusCode != 404 {
+						return err
+					}
+				} else if err != nil {
+					return err
+				}
+			}
+
+			// POST new dictionary configurations
+			for _, dRaw := range add {
+				opts, err := buildDictionary(dRaw.(map[string]interface{}))
+				if err != nil {
+					log.Printf("[DEBUG] Error building Dicitionary: %s", err)
+					return err
+				}
+				opts.Service = d.Id()
+				opts.Version = latestVersion
+
+				log.Printf("[DEBUG] Fastly Dictionary Addition opts: %#v", opts)
+				_, err = conn.CreateDictionary(opts)
+				if err != nil {
+					return err
+				}
+			}
+		}
+
 		// validate version
 		log.Printf("[DEBUG] Validating Fastly Service (%s), Version (%v)", d.Id(), latestVersion)
 		valid, msg, err := conn.ValidateVersion(&gofastly.ValidateVersionInput{
@@ -3343,6 +3420,22 @@ func resourceServiceV1Read(d *schema.ResourceData, meta interface{}) error {
 
 		if err := d.Set("cache_setting", csl); err != nil {
 			log.Printf("[WARN] Error setting Cache Settings for (%s): %s", d.Id(), err)
+		}
+
+		// refresh Dictionaries
+		log.Printf("[DEBUG] Refreshing Dictionaries for (%s)", d.Id())
+		dictList, err := conn.ListDictionaries(&gofastly.ListDictionariesInput{
+			Service: d.Id(),
+			Version: s.ActiveVersion.Number,
+		})
+		if err != nil {
+			return fmt.Errorf("[ERR] Error looking up Dictionaries for (%s), version (%v): %s", d.Id(), s.ActiveVersion.Number, err)
+		}
+
+		dict := flattenDictionaries(dictList)
+
+		if err := d.Set("dictionary", dict); err != nil {
+			log.Printf("[WARN] Error setting Dictionary for (%s): %s", d.Id(), err)
 		}
 
 	} else {
@@ -4194,6 +4287,37 @@ func flattenSnippets(snippetList []*gofastly.Snippet) []map[string]interface{} {
 	}
 
 	return sl
+}
+
+func buildDictionary(dictMap interface{}) (*gofastly.CreateDictionaryInput, error) {
+	df := dictMap.(map[string]interface{})
+	opts := gofastly.CreateDictionaryInput{
+		Name: df["name"].(string),
+	}
+
+	return &opts, nil
+}
+
+func flattenDictionaries(dictList []*gofastly.Dictionary) []map[string]interface{} {
+	var dl []map[string]interface{}
+	for _, currentDict := range dictList {
+
+		dictMapString := map[string]interface{}{
+			"dictionary_id": currentDict.ID,
+			"name":          currentDict.Name,
+		}
+
+		// prune any empty values that come from the default string value in structs
+		for k, v := range dictMapString {
+			if v == "" {
+				delete(dictMapString, k)
+			}
+		}
+
+		dl = append(dl, dictMapString)
+	}
+
+	return dl
 }
 
 func validateVCLs(d *schema.ResourceData) error {

--- a/fastly/resource_fastly_service_v1_acl_test.go
+++ b/fastly/resource_fastly_service_v1_acl_test.go
@@ -19,14 +19,14 @@ func TestResourceFastlyFlattenAcl(t *testing.T) {
 		{
 			remote: []*gofastly.ACL{
 				{
-					ID:        "1234567890",
-					Name:      "acl-example",
+					ID:   "1234567890",
+					Name: "acl-example",
 				},
 			},
 			local: []map[string]interface{}{
 				{
 					"acl_id": "1234567890",
-					"name":    "acl-example",
+					"name":   "acl-example",
 				},
 			},
 		},

--- a/fastly/resource_fastly_service_v1_acl_test.go
+++ b/fastly/resource_fastly_service_v1_acl_test.go
@@ -1,0 +1,114 @@
+package fastly
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	gofastly "github.com/fastly/go-fastly/fastly"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestResourceFastlyFlattenAcl(t *testing.T) {
+	cases := []struct {
+		remote []*gofastly.ACL
+		local  []map[string]interface{}
+	}{
+		{
+			remote: []*gofastly.ACL{
+				{
+					ID:        "1234567890",
+					Name:      "acl-example",
+				},
+			},
+			local: []map[string]interface{}{
+				{
+					"acl_id": "1234567890",
+					"name":    "acl-example",
+				},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		out := flattenACLs(c.remote)
+		if !reflect.DeepEqual(out, c.local) {
+			t.Fatalf("Error matching:\nexpected: %#v\ngot: %#v", c.local, out)
+		}
+	}
+}
+
+func TestAccFastlyServiceV1_acl(t *testing.T) {
+	var service gofastly.ServiceDetail
+	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	aclName := fmt.Sprintf("acl %s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckServiceV1Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServiceV1Config_acl(name, aclName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
+					testAccCheckFastlyServiceV1Attributes_acl(&service, name, aclName),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckFastlyServiceV1Attributes_acl(service *gofastly.ServiceDetail, name, aclName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+
+		if service.Name != name {
+			return fmt.Errorf("Bad name, expected (%s), got (%s)", name, service.Name)
+		}
+
+		conn := testAccProvider.Meta().(*FastlyClient).conn
+		acl, err := conn.GetACL(&gofastly.GetACLInput{
+			Service: service.ID,
+			Version: service.ActiveVersion.Number,
+			Name:    aclName,
+		})
+
+		if err != nil {
+			return fmt.Errorf("[ERR] Error looking up ACL records for (%s), version (%v): %s", service.Name, service.ActiveVersion.Number, err)
+		}
+
+		if acl.Name != aclName {
+			return fmt.Errorf("ACL logging endpoint name mismatch, expected: %s, got: %#v", aclName, acl.Name)
+		}
+
+		return nil
+	}
+}
+
+func testAccServiceV1Config_acl(name, aclName string) string {
+	backendName := fmt.Sprintf("%s.aws.amazon.com", acctest.RandString(3))
+	domainName := fmt.Sprintf("fastly-test.tf-%s.com", acctest.RandString(10))
+
+	return fmt.Sprintf(`
+resource "fastly_service_v1" "foo" {
+  name = "%s"
+
+  domain {
+    name    = "%s"
+    comment = "tf-testing-domain"
+	}
+
+  backend {
+    address = "%s"
+    name    = "tf -test backend"
+  }
+
+  acl {
+	name       = "%s"
+  }
+
+  force_destroy = true
+}`, name, domainName, backendName, aclName)
+}

--- a/fastly/resource_fastly_service_v1_dictionary_test.go
+++ b/fastly/resource_fastly_service_v1_dictionary_test.go
@@ -1,0 +1,144 @@
+package fastly
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	gofastly "github.com/fastly/go-fastly/fastly"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestResourceFastlyFlattenDictionary(t *testing.T) {
+	cases := []struct {
+		remote []*gofastly.Dictionary
+		local  []map[string]interface{}
+	}{
+		{
+			remote: []*gofastly.Dictionary{
+				{
+					ID:   "1234567890",
+					Name: "dictionary-example",
+				},
+			},
+			local: []map[string]interface{}{
+				{
+					"dictionary_id": "1234567890",
+					"name":          "dictionary-example",
+				},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		out := flattenDictionaries(c.remote)
+		if !reflect.DeepEqual(out, c.local) {
+			t.Fatalf("Error matching:\nexpected: %#v\ngot: %#v", c.local, out)
+		}
+	}
+}
+
+func TestAccFastlyServiceV1_dictionary(t *testing.T) {
+	var service gofastly.ServiceDetail
+	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	dictName := fmt.Sprintf("dict %s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckServiceV1Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServiceV1Config_dictionary(name, dictName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
+					testAccCheckFastlyServiceV1Attributes_dictionary(&service, name, dictName),
+				),
+			},
+		},
+	})
+}
+
+func TestAccFastlyServiceV1_dictionary_update_name(t *testing.T) {
+	var service gofastly.ServiceDetail
+	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	dictName := fmt.Sprintf("dict %s", acctest.RandString(10))
+
+	updatedDictName := fmt.Sprintf("new dict %s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckServiceV1Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServiceV1Config_dictionary(name, dictName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
+					testAccCheckFastlyServiceV1Attributes_dictionary(&service, name, dictName),
+				),
+			},
+			{
+				Config: testAccServiceV1Config_dictionary(name, updatedDictName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
+					testAccCheckFastlyServiceV1Attributes_dictionary(&service, name, updatedDictName),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckFastlyServiceV1Attributes_dictionary(service *gofastly.ServiceDetail, name, dictName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+
+		if service.Name != name {
+			return fmt.Errorf("Bad name, expected (%s), got (%s)", name, service.Name)
+		}
+
+		conn := testAccProvider.Meta().(*FastlyClient).conn
+		dict, err := conn.GetDictionary(&gofastly.GetDictionaryInput{
+			Service: service.ID,
+			Version: service.ActiveVersion.Number,
+			Name:    dictName,
+		})
+
+		if err != nil {
+			return fmt.Errorf("[ERR] Error looking up Dictionary records for (%s), version (%v): %s", service.Name, service.ActiveVersion.Number, err)
+		}
+
+		if dict.Name != dictName {
+			return fmt.Errorf("Dictionary logging endpoint name mismatch, expected: %s, got: %#v", dictName, dict.Name)
+		}
+
+		return nil
+	}
+}
+
+func testAccServiceV1Config_dictionary(name, dictName string) string {
+	backendName := fmt.Sprintf("%s.aws.amazon.com", acctest.RandString(3))
+	domainName := fmt.Sprintf("fastly-test.tf-%s.com", acctest.RandString(10))
+
+	return fmt.Sprintf(`
+resource "fastly_service_v1" "foo" {
+  name = "%s"
+
+  domain {
+    name    = "%s"
+    comment = "tf-testing-domain"
+	}
+
+  backend {
+    address = "%s"
+    name    = "tf -test backend"
+  }
+
+  dictionary {
+	name       = "%s"
+  }
+
+  force_destroy = true
+}`, name, domainName, backendName, dictName)
+}

--- a/fastly/validators.go
+++ b/fastly/validators.go
@@ -1,8 +1,10 @@
 package fastly
 
 import (
+	"fmt"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
+	gofastly "github.com/fastly/go-fastly/fastly"
 )
 
 func validateLoggingFormatVersion() schema.SchemaValidateFunc {
@@ -73,4 +75,26 @@ func validateSnippetType() schema.SchemaValidateFunc {
 		"log",
 		"none",
 	}, false)
+}
+
+func validateACLEntries() schema.SchemaValidateFunc {
+
+	max := gofastly.MaximumACLSize
+
+	return func(i interface{}, k string) (s []string, es []error) {
+
+		v, ok := i.(*schema.Set)
+		if !ok {
+			es = append(es, fmt.Errorf("expected type of %s to be a schema.Set", k))
+			return
+		}
+
+		if len(v.List()) > max {
+			es = append(es, fmt.Errorf("expected %s to be at most (%d), got %d", k, max, len(v.List())))
+			return
+		}
+
+		return
+	}
+
 }

--- a/fastly/validators.go
+++ b/fastly/validators.go
@@ -1,6 +1,8 @@
 package fastly
 
 import (
+	"fmt"
+	gofastly "github.com/fastly/go-fastly/fastly"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
 )
@@ -74,4 +76,26 @@ func validateSnippetType() schema.SchemaValidateFunc {
 		"log",
 		"none",
 	}, false)
+}
+
+func validateDictionaryItems() schema.SchemaValidateFunc {
+
+	max := gofastly.MaximumDictionarySize
+
+	return func(i interface{}, k string) (s []string, es []error) {
+
+		v, ok := i.(map[string]interface{})
+		if !ok {
+			es = append(es, fmt.Errorf("expected type of %s to be a map[string]interface", k))
+			return
+		}
+
+		if len(v) > max {
+			es = append(es, fmt.Errorf("expected %s to be at most (%d), got %d", k, max, len(v)))
+			return
+		}
+
+		return
+	}
+
 }

--- a/fastly/validators.go
+++ b/fastly/validators.go
@@ -1,10 +1,8 @@
 package fastly
 
 import (
-	"fmt"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
-	gofastly "github.com/fastly/go-fastly/fastly"
 )
 
 func validateLoggingFormatVersion() schema.SchemaValidateFunc {
@@ -75,26 +73,4 @@ func validateSnippetType() schema.SchemaValidateFunc {
 		"log",
 		"none",
 	}, false)
-}
-
-func validateACLEntries() schema.SchemaValidateFunc {
-
-	max := gofastly.MaximumACLSize
-
-	return func(i interface{}, k string) (s []string, es []error) {
-
-		v, ok := i.(*schema.Set)
-		if !ok {
-			es = append(es, fmt.Errorf("expected type of %s to be a schema.Set", k))
-			return
-		}
-
-		if len(v.List()) > max {
-			es = append(es, fmt.Errorf("expected %s to be at most (%d), got %d", k, max, len(v.List())))
-			return
-		}
-
-		return
-	}
-
 }

--- a/fastly/validators_test.go
+++ b/fastly/validators_test.go
@@ -1,9 +1,6 @@
 package fastly
 
 import (
-	"fmt"
-	gofastly "github.com/fastly/go-fastly/fastly"
-	"github.com/hashicorp/terraform/helper/schema"
 	"testing"
 )
 
@@ -250,40 +247,4 @@ func TestValidateSnippetType(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestValidateACLEntriesMaxSize(t *testing.T) {
-
-	for name, testcase := range map[string]struct {
-		value          *schema.Set
-		expectedWarns  int
-		expectedErrors int
-	}{
-		"Ten hundred ACL entries":          {createTestACLEntries(10), 0, 0},
-		"Ten thousand ACL entries":         {createTestACLEntries(gofastly.MaximumACLSize), 0, 0},
-		"Ten thousand and one ACL entries": {createTestACLEntries(gofastly.MaximumACLSize + 1), 0, 1},
-	} {
-		t.Run(name, func(t *testing.T) {
-			actualWarns, actualErrors := validateACLEntries()(testcase.value, "acl_entries")
-			if len(actualWarns) != testcase.expectedWarns {
-				t.Errorf("expected %d warnings, actual %d ", testcase.expectedWarns, len(actualWarns))
-			}
-			if len(actualErrors) != testcase.expectedErrors {
-				t.Errorf("expected %d errors, actual %d ", testcase.expectedErrors, len(actualErrors))
-			}
-		})
-	}
-}
-
-func createTestACLEntries(size int) *schema.Set {
-
-	set := &schema.Set{
-		F:schema.HashString,
-	}
-
-	for i := 0; i < size; i++ {
-		set.Add(fmt.Sprintf("127.0.0.%d", i))
-	}
-
-	return set
 }

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/terraform-providers/terraform-provider-fastly
 require (
 	github.com/ajg/form v0.0.0-20160822230020-523a5da1a92f // indirect
 	github.com/dnaeon/go-vcr v1.0.1 // indirect
-	github.com/fastly/go-fastly v1.0.0
+	github.com/fastly/go-fastly v1.2.1
 	github.com/google/jsonapi v0.0.0-20180313013858-2dcc18f43696 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.0
 	github.com/hashicorp/terraform v0.12.3

--- a/go.sum
+++ b/go.sum
@@ -87,6 +87,8 @@ github.com/dylanmei/winrmtest v0.0.0-20170819153634-c2fbb09e6c08/go.mod h1:VBVDF
 github.com/dylanmei/winrmtest v0.0.0-20190225150635-99b7fe2fddf1/go.mod h1:lcy9/2gH1jn/VCLouHA6tOEwLoNVd4GW6zhuKLmHC2Y=
 github.com/fastly/go-fastly v1.0.0 h1:56wmg3LX3Q9BkFikg4qZf+xFJTrIuHYmxIjCVKo9wNg=
 github.com/fastly/go-fastly v1.0.0/go.mod h1:ACxsUdqChasXcraa3/IigjE01rVn3A1F4vaI18Gmm0g=
+github.com/fastly/go-fastly v1.2.1 h1:7aZI3PL9vHDuHcBgLwj3uv+yCd80tpKTr10B3Q3A1Vk=
+github.com/fastly/go-fastly v1.2.1/go.mod h1:ACxsUdqChasXcraa3/IigjE01rVn3A1F4vaI18Gmm0g=
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=

--- a/go.sum
+++ b/go.sum
@@ -87,6 +87,16 @@ github.com/dylanmei/winrmtest v0.0.0-20170819153634-c2fbb09e6c08/go.mod h1:VBVDF
 github.com/dylanmei/winrmtest v0.0.0-20190225150635-99b7fe2fddf1/go.mod h1:lcy9/2gH1jn/VCLouHA6tOEwLoNVd4GW6zhuKLmHC2Y=
 github.com/fastly/go-fastly v1.0.0 h1:56wmg3LX3Q9BkFikg4qZf+xFJTrIuHYmxIjCVKo9wNg=
 github.com/fastly/go-fastly v1.0.0/go.mod h1:ACxsUdqChasXcraa3/IigjE01rVn3A1F4vaI18Gmm0g=
+github.com/fastly/go-fastly v1.0.1-0.20190716135524-b59d50e7bbfb h1:Dy7Zo2WJYMNOxAVlYk37/qZKsWnJ91c56xzOwXY7FvU=
+github.com/fastly/go-fastly v1.0.1-0.20190716135524-b59d50e7bbfb/go.mod h1:ACxsUdqChasXcraa3/IigjE01rVn3A1F4vaI18Gmm0g=
+github.com/fastly/go-fastly v1.0.1-0.20190722130720-c77fe029a012 h1:mwefdo3Vv1XDocrmU6pGcaPeAsOdYqZasUZx48dhNEs=
+github.com/fastly/go-fastly v1.0.1-0.20190722130720-c77fe029a012/go.mod h1:ACxsUdqChasXcraa3/IigjE01rVn3A1F4vaI18Gmm0g=
+github.com/fastly/go-fastly v1.1.0 h1:6XaWf7vnetohY1PVkS5fPtmwgItU0WUP9CspL3+2Ld8=
+github.com/fastly/go-fastly v1.1.0/go.mod h1:ACxsUdqChasXcraa3/IigjE01rVn3A1F4vaI18Gmm0g=
+github.com/fastly/go-fastly v1.2.0 h1:6msl05/o4fpsJFJm35EX5t0ltsYxNo5wc9CypGH5U94=
+github.com/fastly/go-fastly v1.2.0/go.mod h1:ACxsUdqChasXcraa3/IigjE01rVn3A1F4vaI18Gmm0g=
+github.com/fastly/go-fastly v1.2.1 h1:7aZI3PL9vHDuHcBgLwj3uv+yCd80tpKTr10B3Q3A1Vk=
+github.com/fastly/go-fastly v1.2.1/go.mod h1:ACxsUdqChasXcraa3/IigjE01rVn3A1F4vaI18Gmm0g=
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=

--- a/vendor/github.com/fastly/go-fastly/fastly/client.go
+++ b/vendor/github.com/fastly/go-fastly/fastly/client.go
@@ -35,7 +35,7 @@ const RealtimeStatsEndpoint = "https://rt.fastly.com"
 var ProjectURL = "github.com/fastly/go-fastly"
 
 // ProjectVersion is the version of this library.
-var ProjectVersion = "1.0.0"
+var ProjectVersion = "1.2.1"
 
 // UserAgent is the user agent for this particular client.
 var UserAgent = fmt.Sprintf("FastlyGo/%s (+%s; %s)",

--- a/vendor/github.com/fastly/go-fastly/fastly/dictionary_item.go
+++ b/vendor/github.com/fastly/go-fastly/fastly/dictionary_item.go
@@ -189,6 +189,49 @@ func (c *Client) UpdateDictionaryItem(i *UpdateDictionaryItemInput) (*Dictionary
 	return b, nil
 }
 
+type BatchModifyDictionaryItemsInput struct {
+	Service    string `json:"-,"`
+	Dictionary string `json:"-,"`
+
+	Items []*BatchDictionaryItem `json:"items"`
+}
+
+type BatchDictionaryItem struct {
+
+
+	Operation BatchOperation `json:"op"`
+	ItemKey   string         `json:"item_key"`
+	ItemValue string         `json:"item_value"`
+}
+
+func (c *Client) BatchModifyDictionaryItems(i *BatchModifyDictionaryItemsInput) error {
+
+	if i.Service == "" {
+		return ErrMissingService
+	}
+
+	if i.Dictionary == "" {
+		return ErrMissingDictionary
+	}
+
+	if len(i.Items) > BatchModifyMaximumOperations {
+		return ErrBatchUpdateMaximumOperationsExceeded
+	}
+
+	path := fmt.Sprintf("/service/%s/dictionary/%s/items", i.Service, i.Dictionary)
+	resp, err := c.PatchJSON(path, i, nil)
+	if err != nil {
+		return err
+	}
+
+	var batchModifyResult map[string]string
+	if err := decodeJSON(&batchModifyResult, resp.Body); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // DeleteDictionaryItemInput is the input parameter to DeleteDictionaryItem.
 type DeleteDictionaryItemInput struct {
 	// Service is the ID of the service. Dictionary is the ID of the dictionary.

--- a/vendor/github.com/fastly/go-fastly/fastly/errors.go
+++ b/vendor/github.com/fastly/go-fastly/fastly/errors.go
@@ -113,6 +113,10 @@ var ErrMissingConfigSetID = errors.New("Missing required field 'ConfigSetID'")
 // requires a list of WAF id's, but it is empty
 var ErrMissingWAFList = errors.New("WAF slice is empty")
 
+// ErrBatchUpdateMaximumItemsExceeded is an error that indicates that too many batch operations are being executed.
+// The Fastly API specifies an maximum limit.
+var ErrBatchUpdateMaximumOperationsExceeded = errors.New("batch modify maximum operations exceeded")
+
 // Ensure HTTPError is, in fact, an error.
 var _ error = (*HTTPError)(nil)
 

--- a/vendor/github.com/fastly/go-fastly/fastly/fastly.go
+++ b/vendor/github.com/fastly/go-fastly/fastly/fastly.go
@@ -5,6 +5,25 @@ import (
 	"encoding"
 )
 
+type BatchOperation string
+
+const (
+	CreateBatchOperation BatchOperation = "create"
+	UpdateBatchOperation BatchOperation = "update"
+	UpsertBatchOperation BatchOperation = "upsert"
+	DeleteBatchOperation BatchOperation = "delete"
+
+	// Represents the maximum number of operations that can be sent within a single batch request.
+	// This is currently not documented in the API.
+	BatchModifyMaximumOperations = 1000
+
+	// Represents the maximum number of items that can be placed within an Edge Dictionary.
+	MaximumDictionarySize = 10000
+
+	// Represents the maximum number of entries that can be placed within an ACL.
+	MaximumACLSize = 10000
+)
+
 type statusResp struct {
 	Status string
 	Msg    string

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -60,7 +60,7 @@ github.com/bgentry/speakeasy
 github.com/blang/semver
 # github.com/davecgh/go-spew v1.1.1
 github.com/davecgh/go-spew/spew
-# github.com/fastly/go-fastly v1.0.0
+# github.com/fastly/go-fastly v1.2.1
 github.com/fastly/go-fastly/fastly
 # github.com/fatih/color v1.7.0
 github.com/fatih/color

--- a/website/docs/r/service_acl_entries_v1.html.markdown
+++ b/website/docs/r/service_acl_entries_v1.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Defines a set of Fastly ACL entries that can be used to populate a service ACL.  This resource will populate an ACL with the entries and will track their state.
 
-~> **Warning:** Terraform will take precedence over any changes you make in the UI or API. Such changes are likely to be reversed if you run terraform again.  
+~> **Warning:** Terraform will take precedence over any changes you make in the UI or API. Such changes are likely to be reversed if you run Terraform again.  
 
 If Terraform is being used to populate the initial content of an ACL which you intend to manage via API or UI, then the lifecycle `ignore_changes` field can be used with the resource.  An example of this configuration is provided below.    
 
@@ -123,7 +123,7 @@ resource "fastly_service_acl_entries_v1" "entries" {
 
 ### Supporting API and UI ACL updates with ignore_changes
 
-The following example demonstrates how the lifecycle ignore_change field can be used to suppress updates against the 
+The following example demonstrates how the lifecycle `ignore_changes` field can be used to suppress updates against the 
 entries in an ACL.  If, after your first deploy, the Fastly API or UI is to be used to manage entries in an ACL, then this will stop Terraform realigning the remote state with the initial set of ACL entries defined in your HCL.
 
 ```hcl

--- a/website/docs/r/service_acl_entries_v1.html.markdown
+++ b/website/docs/r/service_acl_entries_v1.html.markdown
@@ -1,0 +1,78 @@
+---
+layout: "fastly"
+page_title: "Fastly: service_acl_entries_v1"
+sidebar_current: "docs-fastly-resource-service-v1"
+description: |-
+  Provides a grouping of fastly acl entries that can be applied to a service. 
+---
+
+# fastly_service_acl_entries_v1
+
+Provides a grouping of fastly acl entries that can be applied to a service.
+
+## Example Usage
+
+Basic usage:
+
+```hcl
+
+variable "myacl_name" {
+	type = string
+	default = "My ACL"
+}
+
+resource "fastly_service_v1" "myservice" {
+  name = "demofastly"
+
+  domain {
+      name = "demo.notexample.com"
+      comment = "demo"
+  }
+
+  backend {
+      address = "demo.notexample.com.s3-website-us-west-2.amazonaws.com"
+      name = "AWS S3 hosting"
+      port = 80
+    }
+
+  acl {
+	name = var.myacl_name
+  }
+
+  force_destroy = true
+}
+
+resource "fastly_service_acl_entries_v1" "entries" {
+  service_id = fastly_service_v1.myservice.id
+  acl_id = {for d in fastly_service_v1.myservice.acl : d.name => d.acl_id}[var.myacl_name]
+  entry {
+    ip = "127.0.0.1"
+    subnet = "24"
+    negated = false
+    comment = "ALC Entry 1"
+  }
+}
+```
+
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `service_id` - (Required) The ID of the Service that the acl belongs to
+* `acl_id` - (Required) The ID of the acl that the items belong to
+* `entry` - (Optional) A Set ACL entries that are applied to the service. Defined below
+
+The `entry` block supports:
+
+* `ip` - (Required, string) An IP address that is the focus for the ACL
+* `subnet` - (Optional, string) An optional subnet mask applied to the IP address
+* `negated` - (Optional, boolean) A boolean that will negate the match if true
+* `comment` - (Optional, string) A personal freeform descriptive note
+
+
+
+## Attributes Reference
+
+[fastly-acl]: https://docs.fastly.com/api/config#acl
+[fastly-acl_entry]: https://docs.fastly.com/api/config#acl_entry

--- a/website/docs/r/service_acl_entries_v1.html.markdown
+++ b/website/docs/r/service_acl_entries_v1.html.markdown
@@ -20,7 +20,6 @@ If Terraform is being used to populate the initial content of an ACL which you i
 Basic usage:
 
 ```hcl
-
 variable "myacl_name" {
 	type = string
 	default = "My ACL"
@@ -59,7 +58,7 @@ resource "fastly_service_acl_entries_v1" "entries" {
 }
 ```
 
-###Supporting API and UI ACL updates with ignore_changes
+### Supporting API and UI ACL updates with ignore_changes
 
 The following example demonstrates how the lifecycle ignore_change field can be used to suppress updates against the 
 entries in an ACL.  If, after your first deploy, the Fastly API or UI is to be used to manage entries in an ACL, then this will stop Terraform realigning the remote state with the initial set of ACL entries defined in your HCL.
@@ -82,7 +81,6 @@ resource "fastly_service_acl_entries_v1" "entries" {
   }
   
 }
-
 ```
 
 

--- a/website/docs/r/service_dictionary_items_v1.html.markdown
+++ b/website/docs/r/service_dictionary_items_v1.html.markdown
@@ -1,0 +1,196 @@
+---
+layout: "fastly"
+page_title: "Fastly: service_dictionary_items_v1"
+sidebar_current: "docs-fastly-resource-service-v1"
+description: |-
+  Provides a grouping of Fastly dictionary items that can be applied to a service. 
+---
+
+# fastly_service_dictionary_items_v1
+
+Defines a map of Fastly dictionary items that can be used to populate a service dictionary.  This resource will populate a dictionary with the items and will track their state.
+
+
+~> **Warning:** Terraform will take precedence over any changes you make in the UI or API. Such changes are likely to be reversed if you run Terraform again.  
+
+If Terraform is being used to populate the initial content of a dictionary which you intend to manage via API or UI, then the lifecycle `ignore_changes` field can be used with the resource.  An example of this configuration is provided below.    
+
+
+## Example Usage
+
+Basic usage:
+
+```hcl
+variable "mydict_name" {
+	type = string
+	default = "My Dictionary"
+}
+
+resource "fastly_service_v1" "myservice" {
+  name = "demofastly"
+
+  domain {
+      name    = "demo.notexample.com"
+      comment = "demo"
+  }
+
+  backend {
+      address = "demo.notexample.com.s3-website-us-west-2.amazonaws.com"
+      name    = "AWS S3 hosting"
+      port    = 80
+    }
+
+  dictionary {
+	name       = var.mydict_name
+  }
+
+  force_destroy = true
+}
+
+resource "fastly_service_dictionary_items_v1" "items" {
+    service_id = "${fastly_service_v1.myservice.id}"
+    dictionary_id = "${{for s in fastly_service_v1.myservice.dictionary : s.name => s.dictionary_id}[var.mydict_name]}"
+    items = {
+        key1: "value1"
+        key2: "value2"
+    }
+}
+```
+
+Complex object usage:
+
+```hcl
+variable "mydict" {
+  type = object({ name=string, items=map(string) })
+  default = {
+    name = "My Dictionary"
+    items = {
+      key1: "value1x"
+      key2: "value2x"
+    }
+  }
+}
+
+resource "fastly_service_v1" "myservice" {
+  name = "demofastly"
+
+  domain {
+    name    = "demo.notexample.com"
+    comment = "demo"
+  }
+
+  backend {
+    address = "demo.notexample.com.s3-website-us-west-2.amazonaws.com"
+    name    = "AWS S3 hosting"
+    port    = 80
+  }
+
+  dictionary {
+    name = var.mydict.name
+  }
+
+  force_destroy = true
+  }
+
+resource "fastly_service_dictionary_items_v1" "items" {
+  service_id = fastly_service_v1.myservice.id
+  dictionary_id = {for d in fastly_service_v1.myservice.dictionary : d.name => d.dictionary_id}[var.mydict.name]
+  items = var.mydict.items
+}
+```
+
+Expression and functions usage:
+
+```hcl
+// Local variables used when formating values for the "My Project Dictionary" example
+locals {
+  dictionary_name = "My Project Dictionary"
+  host_base = "demo.ocnotexample.com"
+  host_divisions = ["alpha", "beta", "gamma", "delta"]
+}
+
+// Define the standard service that will be used to manage the dictionaries.
+resource "fastly_service_v1" "myservice" {
+  name = "demofastly"
+
+  domain {
+    name = "demo.ocnotexample.com"
+    comment = "demo"
+  }
+
+  backend {
+    address = "demo.ocnotexample.com.s3-website-us-west-2.amazonaws.com"
+    name = "AWS S3 hosting"
+    port = 80
+  }
+
+  dictionary {
+    name = local.dictionary_name
+  }
+
+  force_destroy = true
+}
+
+// This resource is dynamically creating the items from the local variables through for expressions and functions.
+resource "fastly_service_dictionary_items_v1" "project" {
+  service_id = fastly_service_v1.myservice.id
+  dictionary_id = {for d in fastly_service_v1.myservice.dictionary : d.name => d.dictionary_id}[local.dictionary_name]
+  items = {
+    for division in local.host_divisions:
+      division => format("%s.%s", division, local.host_base)
+  }
+}
+```
+
+### Supporting API and UI dictionary updates with ignore_changes
+
+The following example demonstrates how the lifecycle `ignore_changes` field can be used to suppress updates against the 
+items in a dictionary.  If, after your first deploy, the Fastly API or UI is to be used to manage items in a dictionary, then this will stop Terraform realigning the remote state with the initial set of dictionary items defined in your HCL.
+
+```hcl
+...
+
+resource "fastly_service_dictionary_items_v1" "items" {
+    service_id = "${fastly_service_v1.myservice.id}"
+    dictionary_id = "${{for s in fastly_service_v1.myservice.dictionary : s.name => s.dictionary_id}[var.mydict_name]}"
+    items = {
+        key1: "value1"
+        key2: "value2"
+    }
+    
+    lifecycle {
+      ignore_changes = [items,]
+    }
+}
+```
+
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `service_id` - (Required) The ID of the service that the dictionary belongs to
+* `dictionary_id` - (Required) The ID of the dictionary that the items belong to
+* `items` - (Optional) A map representing an entry in the dictionary, (key/value)
+
+
+## Attributes Reference
+
+* [fastly-dictionary](https://docs.fastly.com/api/config#dictionary)
+* [fastly-dictionary_item](https://docs.fastly.com/api/config#dictionary_item)
+
+## Import
+
+This is an example of the import command being applied to the resource named `fastly_service_dictionary_items_v1.items`
+The resource ID is a combined value of the `service_id` and `dictionary_id` separated by a forward slash.
+
+```
+$ terraform import fastly_service_dictionary_items_v1.items xxxxxxxxxxxxxxxxxxxx/xxxxxxxxxxxxxxxxxxxx
+```
+
+If Terraform is already managing remote dictionary items against a resource being imported then the user will be asked to remove it from the existing Terraform state.  
+The following is an example of the Terraform state command to remove the resource named `fastly_service_dictionary_items_v1.items` from the Terraform state file.
+
+```
+$ terraform state rm fastly_service_dictionary_items_v1.items
+``` 

--- a/website/docs/r/service_v1.html.markdown
+++ b/website/docs/r/service_v1.html.markdown
@@ -528,7 +528,7 @@ In addition to the arguments listed above, the following attributes are exported
 
 The `acl` block exports:
 
-* `acl_id` - The ID of the ACL 
+* `acl_id` - The ID of the ACL.
 
 [fastly-s3]: https://docs.fastly.com/guides/integrations/amazon-s3
 [fastly-cname]: https://docs.fastly.com/guides/basic-setup/adding-cname-records

--- a/website/docs/r/service_v1.html.markdown
+++ b/website/docs/r/service_v1.html.markdown
@@ -210,6 +210,7 @@ Defined below.
 * `vcl` - (Optional) A set of custom VCL configuration blocks. The
 ability to upload custom VCL code is not enabled by default for new Fastly
 accounts (see the [Fastly documentation](https://docs.fastly.com/guides/vcl/uploading-custom-vcl) for details).
+* `acl` - (Optional) A set of ACL configuration blocks.  Defined below.
 
 The `domain` block supports:
 
@@ -513,12 +514,21 @@ The `vcl` block supports:
 `false`, use this block as an includable library. Only a single VCL block can be
 marked as the main block. Default is `false`.
 
+The `acl` block supports:
+
+* `name` - (Required) A unique name to identify this ACL.
+
+
 ## Attributes Reference
 
 In addition to the arguments listed above, the following attributes are exported:
 
 * `id` – The ID of the Service.
 * `active_version` – The currently active version of your Fastly Service.
+
+The `acl` block attributes:
+
+* `acl_id` - The ID of the ACL 
 
 [fastly-s3]: https://docs.fastly.com/guides/integrations/amazon-s3
 [fastly-cname]: https://docs.fastly.com/guides/basic-setup/adding-cname-records

--- a/website/docs/r/service_v1.html.markdown
+++ b/website/docs/r/service_v1.html.markdown
@@ -526,7 +526,7 @@ In addition to the arguments listed above, the following attributes are exported
 * `id` – The ID of the Service.
 * `active_version` – The currently active version of your Fastly Service.
 
-The `acl` block attributes:
+The `acl` block exports:
 
 * `acl_id` - The ID of the ACL 
 

--- a/website/docs/r/service_v1.html.markdown
+++ b/website/docs/r/service_v1.html.markdown
@@ -180,7 +180,7 @@ when an item is not to be cached based on an above `condition`. Defined below
 content. Defined below.
 * `header` - (Optional) A set of Headers to manipulate for each request. Defined
 below.
-* `healthcheck` - (Optional) Automated healthchecks on the cache that can change how fastly interacts with the cache based on its health.
+* `healthcheck` - (Optional) Automated healthchecks on the cache that can change how Fastly interacts with the cache based on its health.
 * `default_host` - (Optional) The default hostname.
 * `default_ttl` - (Optional) The default Time-to-live (TTL) for
 requests.
@@ -210,6 +210,8 @@ Defined below.
 * `vcl` - (Optional) A set of custom VCL configuration blocks. The
 ability to upload custom VCL code is not enabled by default for new Fastly
 accounts (see the [Fastly documentation](https://docs.fastly.com/guides/vcl/uploading-custom-vcl) for details).
+* `dictionary` - (Optional) A set of dictionaries that allow the storing of key values pair for use within VCL functions. Defined below.
+
 
 The `domain` block supports:
 
@@ -513,6 +515,10 @@ The `vcl` block supports:
 `false`, use this block as an includable library. Only a single VCL block can be
 marked as the main block. Default is `false`.
 
+The `dictionary` block supports:
+
+* `name` - (Required) A unique name to identify this dictionary.
+
 ## Attributes Reference
 
 In addition to the arguments listed above, the following attributes are exported:
@@ -520,11 +526,15 @@ In addition to the arguments listed above, the following attributes are exported
 * `id` – The ID of the Service.
 * `active_version` – The currently active version of your Fastly Service.
 
-[fastly-s3]: https://docs.fastly.com/guides/integrations/amazon-s3
-[fastly-cname]: https://docs.fastly.com/guides/basic-setup/adding-cname-records
-[fastly-conditionals]: https://docs.fastly.com/guides/conditions/using-conditions
-[fastly-sumologic]: https://docs.fastly.com/api/logging#logging_sumologic
-[fastly-gcs]: https://docs.fastly.com/api/logging#logging_gcs
+The `dictionary` block exports:
+
+ * `dictionary_id` - The ID of the dictionary.
+
+* [fastly-s3](https://docs.fastly.com/guides/integrations/amazon-s3)
+* [fastly-cname](https://docs.fastly.com/guides/basic-setup/adding-cname-records)
+* [fastly-conditionals](https://docs.fastly.com/guides/conditions/using-conditions)
+* [fastly-sumologic](https://docs.fastly.com/api/logging#logging_sumologic)
+* [fastly-gcs](https://docs.fastly.com/api/logging#logging_gcs)
 
 ## Import
 

--- a/website/fastly.erb
+++ b/website/fastly.erb
@@ -25,6 +25,7 @@
                     <ul class="nav nav-visible">
                         <li<%= sidebar_current("docs-fastly-resource-service-v1") %>>
                             <a href="/docs/providers/fastly/r/service_v1.html">fastly_service_v1</a>
+                            <a href="/docs/providers/fastly/r/service_dictionary_items_v1.html">fastly_service_dictionary_items_v1</a>
                         </li>
                     </ul>
 


### PR DESCRIPTION
This PR represents an implementation of the Fastly ACL resource.

The resource has two parts to it.

Association with the service itself. One or more ACLs can be created as nested blocks and are linked to a service version. The configuration is activated in the same way as other service fields.
Versionless entries that can be entered in to a ACL. These entries are represented as a separate resource that references the ACL from the service. Within this resource a set representing the entry is supplied.  Each entry is a map matching the fields from the API.

The resource that represents the items is called fastly_service_acl_entries_v1 and there will be one for every ACL that requires entries to be associated with it.

The resource will keep track of the entries that it has created in the remote state. If there is a need to update terraform created items, then the resource can be configured with the lifecycle ignore_change configuration and this will instruct updates to these items to be ignored.

lifecycle {
  ignore_changes = [entries,]
}

Entries are represented as a set of nest blocks.  This will help to reduce the duplication.