### PR TITLE
Fix documentation sidebar navigation links and markdown rendering

### DIFF
--- a/website/docs/r/service_acl_entries_v1.html.markdown
+++ b/website/docs/r/service_acl_entries_v1.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "fastly"
 page_title: "Fastly: service_acl_entries_v1"
-sidebar_current: "docs-fastly-resource-service-v1"
+sidebar_current: "docs-fastly-resource-service-acl-entries-v1"
 description: |-
   Defines a set of Fastly ACL entries that can be used to populate a service ACL. 
 ---

--- a/website/docs/r/service_dictionary_items_v1.html.markdown
+++ b/website/docs/r/service_dictionary_items_v1.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "fastly"
 page_title: "Fastly: service_dictionary_items_v1"
-sidebar_current: "docs-fastly-resource-service-v1"
+sidebar_current: "docs-fastly-resource-service-dictionary-items-v1"
 description: |-
   Provides a grouping of Fastly dictionary items that can be applied to a service. 
 ---

--- a/website/docs/r/service_dynamic_snippet_content_v1.html.markdown
+++ b/website/docs/r/service_dynamic_snippet_content_v1.html.markdown
@@ -4,117 +4,116 @@ page_title: "Fastly: service_dynamic_snippet_content_v1"
 sidebar_current: "docs-fastly-resource-service-dynamic-snippet-content-v1"
 description: |-
   Provides a means to define blocks of VCL logic that is inserted into your service through Fastly dynamic snippets.
-   
 ---
 
- # fastly_service_dynamic_snippet_content_v1
+# fastly_service_dynamic_snippet_content_v1
 
- Defines content that represents blocks of VCL logic that is inserted into your service.  This resource will populate the content of a dynamic snippet and allow it to be manged without the creation of a new service verison. 
+Defines content that represents blocks of VCL logic that is inserted into your service.  This resource will populate the content of a dynamic snippet and allow it to be manged without the creation of a new service verison. 
  
- ~> **Warning:** Terraform will take precedence over any changes you make through the API. Such changes are likely to be reversed if you run Terraform again.  
+~> **Warning:** Terraform will take precedence over any changes you make through the API. Such changes are likely to be reversed if you run Terraform again.  
 
- If Terraform is being used to populate the initial content of a dynamic snippet which you intend to manage via the API, then the lifecycle `ignore_changes` field can be used with the resource.  An example of this configuration is provided below.    
+If Terraform is being used to populate the initial content of a dynamic snippet which you intend to manage via the API, then the lifecycle `ignore_changes` field can be used with the resource.  An example of this configuration is provided below.
 
 
- ## Example Usage
+## Example Usage
 
- Basic usage:
+Basic usage:
 
- ```hcl 
- resource "fastly_service_v1" "myservice" {
-   name = "snippet_test"
- 
-   domain {
-     name    = "snippet.fastlytestdomain.com"
-     comment = "snippet test"
-   }
- 
-   backend {
-     address = "tftesting.tftesting.net.s3-website-us-west-2.amazonaws.com"
-     name    = "AWS S3 hosting"
-     port    = 80
-   }
- 
-   dynamicsnippet {
-     name     = "My Dynamic Snippet"
-     type     = "recv"
-     priority = 110
-   }
- 
-   default_host = "tftesting.tftesting.net.s3-website-us-west-2.amazonaws.com"
- 
-   force_destroy = true
+```hcl 
+resource "fastly_service_v1" "myservice" {
+ name = "snippet_test"
+
+ domain {
+   name    = "snippet.fastlytestdomain.com"
+   comment = "snippet test"
  }
- 
- resource "fastly_service_dynamic_snippet_content_v1" "my_dyn_content" {
- 
-   service_id = fastly_service_v1.myservice.id
-   snippet_id = { for s in fastly_service_v1.myservice.dynamicsnippet : s.name => s.snippet_id }["My Dynamic Snippet"]
- 
-   content = "if ( req.url ) {\n set req.http.my-snippet-test-header = \"true\";\n}"
- 
+
+ backend {
+   address = "tftesting.tftesting.net.s3-website-us-west-2.amazonaws.com"
+   name    = "AWS S3 hosting"
+   port    = 80
  }
- ```
+
+ dynamicsnippet {
+   name     = "My Dynamic Snippet"
+   type     = "recv"
+   priority = 110
+ }
+
+ default_host = "tftesting.tftesting.net.s3-website-us-west-2.amazonaws.com"
+
+ force_destroy = true
+}
+
+resource "fastly_service_dynamic_snippet_content_v1" "my_dyn_content" {
+
+ service_id = fastly_service_v1.myservice.id
+ snippet_id = { for s in fastly_service_v1.myservice.dynamicsnippet : s.name => s.snippet_id }["My Dynamic Snippet"]
+
+ content = "if ( req.url ) {\n set req.http.my-snippet-test-header = \"true\";\n}"
+
+}
+```
 
 Multiple dynamic snippets:
 
- ```hcl
- resource "fastly_service_v1" "myservice" {
-   name = "snippet_test"
- 
-   domain {
-     name    = "snippet.fastlytestdomain.com"
-     comment = "snippet test"
-   }
- 
-   backend {
-     address = "tftesting.tftesting.net.s3-website-us-west-2.amazonaws.com"
-     name    = "AWS S3 hosting"
-     port    = 80
-   }
- 
-   dynamicsnippet {
-     name     = "My Dynamic Snippet One"
-     type     = "recv"
-     priority = 110
-   }
-   
-   dynamicsnippet {
-        name     = "My Dynamic Snippet Two"
-        type     = "recv"
-        priority = 110
-      }
- 
-   default_host = "tftesting.tftesting.net.s3-website-us-west-2.amazonaws.com"
- 
-   force_destroy = true
- }
- 
- resource "fastly_service_dynamic_snippet_content_v1" "my_dyn_content_one" {
- 
-   service_id = fastly_service_v1.myservice.id
-   snippet_id = { for s in fastly_service_v1.myservice.dynamicsnippet : s.name => s.snippet_id }["My Dynamic Snippet One"]
- 
-   content = "if ( req.url ) {\n set req.http.my-snippet-test-header-one = \"true\";\n}"
- 
+```hcl
+resource "fastly_service_v1" "myservice" {
+ name = "snippet_test"
+
+ domain {
+   name    = "snippet.fastlytestdomain.com"
+   comment = "snippet test"
  }
 
- resource "fastly_service_dynamic_snippet_content_v1" "my_dyn_content_two" {
- 
-   service_id = fastly_service_v1.myservice.id
-   snippet_id = { for s in fastly_service_v1.myservice.dynamicsnippet : s.name => s.snippet_id }["My Dynamic Snippet Two"]
- 
-   content = "if ( req.url ) {\n set req.http.my-snippet-test-header-two = \"true\";\n}"
- 
+ backend {
+   address = "tftesting.tftesting.net.s3-website-us-west-2.amazonaws.com"
+   name    = "AWS S3 hosting"
+   port    = 80
  }
- ```
 
- ### Supporting API dynamic snippet updates with ignore_changes
+ dynamicsnippet {
+   name     = "My Dynamic Snippet One"
+   type     = "recv"
+   priority = 110
+ }
+ 
+ dynamicsnippet {
+      name     = "My Dynamic Snippet Two"
+      type     = "recv"
+      priority = 110
+    }
 
- The following example demonstrates how the lifecycle `ignore_changes` field can be used to suppress updates against the 
+ default_host = "tftesting.tftesting.net.s3-website-us-west-2.amazonaws.com"
+
+ force_destroy = true
+}
+
+resource "fastly_service_dynamic_snippet_content_v1" "my_dyn_content_one" {
+
+ service_id = fastly_service_v1.myservice.id
+ snippet_id = { for s in fastly_service_v1.myservice.dynamicsnippet : s.name => s.snippet_id }["My Dynamic Snippet One"]
+
+ content = "if ( req.url ) {\n set req.http.my-snippet-test-header-one = \"true\";\n}"
+
+}
+
+resource "fastly_service_dynamic_snippet_content_v1" "my_dyn_content_two" {
+
+ service_id = fastly_service_v1.myservice.id
+ snippet_id = { for s in fastly_service_v1.myservice.dynamicsnippet : s.name => s.snippet_id }["My Dynamic Snippet Two"]
+
+ content = "if ( req.url ) {\n set req.http.my-snippet-test-header-two = \"true\";\n}"
+
+}
+```
+
+### Supporting API dynamic snippet updates with ignore_changes
+
+The following example demonstrates how the lifecycle `ignore_changes` field can be used to suppress updates against the 
 content in a dynamic snippet.  If, after your first deploy, the Fastly API is to be used to manage items in a dynamic snippet, then this will stop Terraform realigning the remote state with the initial content defined in your HCL.
 
- ```hcl
+```hcl
 ...
 
 resource "fastly_service_dynamic_snippet_content_v1" "my_dyn_content" {
@@ -128,34 +127,34 @@ resource "fastly_service_dynamic_snippet_content_v1" "my_dyn_content" {
     ignore_changes = [content, ]
   }
 }
- ```
+```
 
 
- ## Argument Reference
+## Argument Reference
 
- The following arguments are supported:
+The following arguments are supported:
 
 * `service_id` - (Required) The ID of the service that the dynamic snippet belongs to
 * `snippet_id` - (Required) The ID of the dynamic snippet that the content belong to
 * `content` - (Required) The VCL code that specifies exactly what the snippet does.
 
- ## Attributes Reference
+## Attributes Reference
 
 * [fastly-vcl](https://docs.fastly.com/api/config#vcl)
 * [fastly-vcl-snippets](https://docs.fastly.com/api/config#snippet)
 
- ## Import
+## Import
 
 This is an example of the import command being applied to the resource named `fastly_service_dynamic_snippet_content_v1.content`
 The resource ID is a combined value of the `service_id` and `snippet_id` separated by a forward slash.
 
- ```
+```
 $ terraform import fastly_service_dynamic_snippet_content_v1.content xxxxxxxxxxxxxxxxxxxx/xxxxxxxxxxxxxxxxxxxx
 ```
 
-If Terraform is already managing remote content against a resource being imported then the user will be asked to remove it from the existing Terraform state.  
-The following is an example of the Terraform state command to remove the resource named fastly_service_dynamic_snippet_content_v1.content` from the Terraform state file.
+If Terraform is already managing remote content against a resource being imported then the user will be asked to remove it from the existing Terraform state.
+The following is an example of the Terraform state command to remove the resource named `fastly_service_dynamic_snippet_content_v1.content` from the Terraform state file.
 
- ```
+```
 $ terraform state rm fastly_service_dynamic_snippet_content_v1.content
 ```

--- a/website/docs/r/service_dynamic_snippet_content_v1.html.markdown
+++ b/website/docs/r/service_dynamic_snippet_content_v1.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "fastly"
 page_title: "Fastly: service_dynamic_snippet_content_v1"
-sidebar_current: "docs-fastly-resource-service-v1"
+sidebar_current: "docs-fastly-resource-service-dynamic-snippet-content-v1"
 description: |-
   Provides a means to define blocks of VCL logic that is inserted into your service through Fastly dynamic snippets.
    

--- a/website/fastly.erb
+++ b/website/fastly.erb
@@ -25,7 +25,15 @@
                     <ul class="nav nav-visible">
                         <li<%= sidebar_current("docs-fastly-resource-service-v1") %>>
                             <a href="/docs/providers/fastly/r/service_v1.html">fastly_service_v1</a>
+                        </li>
+                        <li<%= sidebar_current("docs-fastly-resource-service-dictionary-items-v1") %>>
                             <a href="/docs/providers/fastly/r/service_dictionary_items_v1.html">fastly_service_dictionary_items_v1</a>
+                        </li>
+                        <li<%= sidebar_current("docs-fastly-resource-service-acl-entries-v1") %>>
+                            <a href="/docs/providers/fastly/r/service_acl_entries_v1.html">fastly_service_acl_entries_v1</a>
+                        </li>
+                        <li<%= sidebar_current("docs-fastly-resource-service-dynamic-snippet-content-v1") %>>
+                            <a href="/docs/providers/fastly/r/service_dynamic_snippet_content_v1.html">fastly_service_dynamic_snippet_content_v1</a>
                         </li>
                     </ul>
 


### PR DESCRIPTION
### TL;DR
Fixes the sidebar navigation links for the documentation website and some rendering of the markdown.

### What:
- Update all new resource markdown to include correct `sidebar_current` metadata value
- Fix link for `fastly_service_v1` which was accidentally hidden in #184 
- Add links to new resources introduce in #184
- Fix rendering of `fastly_service_dynamic_snippet_content_v1` markdown