### PR TITLE
add support for write-only dictionaries

### DIFF
--- a/fastly/resource_fastly_service_v1.go
+++ b/fastly/resource_fastly_service_v1.go
@@ -1452,6 +1452,13 @@ func resourceServiceV1() *schema.Resource {
 							Computed:    true,
 							Description: "Generated dictionary ID",
 						},
+						"write_only": {
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Default:     false,
+							ForceNew:    true,
+							Description: "Determines if items in the dictionary are readable or not",
+						},
 					},
 				},
 			},
@@ -4563,7 +4570,8 @@ func flattenDynamicSnippets(dynamicSnippetList []*gofastly.Snippet) []map[string
 func buildDictionary(dictMap interface{}) (*gofastly.CreateDictionaryInput, error) {
 	df := dictMap.(map[string]interface{})
 	opts := gofastly.CreateDictionaryInput{
-		Name: df["name"].(string),
+		Name:      df["name"].(string),
+		WriteOnly: gofastly.CBool(df["write_only"].(bool)),
 	}
 
 	return &opts, nil
@@ -4576,6 +4584,7 @@ func flattenDictionaries(dictList []*gofastly.Dictionary) []map[string]interface
 		dictMapString := map[string]interface{}{
 			"dictionary_id": currentDict.ID,
 			"name":          currentDict.Name,
+			"write_only":    currentDict.WriteOnly,
 		}
 
 		// prune any empty values that come from the default string value in structs

--- a/fastly/resource_fastly_service_v1.go
+++ b/fastly/resource_fastly_service_v1.go
@@ -1456,7 +1456,6 @@ func resourceServiceV1() *schema.Resource {
 							Type:        schema.TypeBool,
 							Optional:    true,
 							Default:     false,
-							ForceNew:    true,
 							Description: "Determines if items in the dictionary are readable or not",
 						},
 					},

--- a/fastly/resource_fastly_service_v1_dictionary_test.go
+++ b/fastly/resource_fastly_service_v1_dictionary_test.go
@@ -19,14 +19,16 @@ func TestResourceFastlyFlattenDictionary(t *testing.T) {
 		{
 			remote: []*gofastly.Dictionary{
 				{
-					ID:   "1234567890",
-					Name: "dictionary-example",
+					ID:        "1234567890",
+					Name:      "dictionary-example",
+					WriteOnly: false,
 				},
 			},
 			local: []map[string]interface{}{
 				{
 					"dictionary_id": "1234567890",
 					"name":          "dictionary-example",
+					"write_only":    false,
 				},
 			},
 		},
@@ -54,7 +56,28 @@ func TestAccFastlyServiceV1_dictionary(t *testing.T) {
 				Config: testAccServiceV1Config_dictionary(name, dictName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
-					testAccCheckFastlyServiceV1Attributes_dictionary(&service, name, dictName),
+					testAccCheckFastlyServiceV1Attributes_dictionary(&service, name, dictName, false),
+				),
+			},
+		},
+	})
+}
+
+func TestAccFastlyServiceV1_dictionary_write_only(t *testing.T) {
+	var service gofastly.ServiceDetail
+	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	dictName := fmt.Sprintf("dict %s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckServiceV1Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServiceV1Config_dictionary_write_only(name, dictName, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
+					testAccCheckFastlyServiceV1Attributes_dictionary(&service, name, dictName, true),
 				),
 			},
 		},
@@ -77,21 +100,21 @@ func TestAccFastlyServiceV1_dictionary_update_name(t *testing.T) {
 				Config: testAccServiceV1Config_dictionary(name, dictName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
-					testAccCheckFastlyServiceV1Attributes_dictionary(&service, name, dictName),
+					testAccCheckFastlyServiceV1Attributes_dictionary(&service, name, dictName, false),
 				),
 			},
 			{
 				Config: testAccServiceV1Config_dictionary(name, updatedDictName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
-					testAccCheckFastlyServiceV1Attributes_dictionary(&service, name, updatedDictName),
+					testAccCheckFastlyServiceV1Attributes_dictionary(&service, name, updatedDictName, false),
 				),
 			},
 		},
 	})
 }
 
-func testAccCheckFastlyServiceV1Attributes_dictionary(service *gofastly.ServiceDetail, name, dictName string) resource.TestCheckFunc {
+func testAccCheckFastlyServiceV1Attributes_dictionary(service *gofastly.ServiceDetail, name, dictName string, writeOnly bool) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 
 		if service.Name != name {
@@ -110,7 +133,11 @@ func testAccCheckFastlyServiceV1Attributes_dictionary(service *gofastly.ServiceD
 		}
 
 		if dict.Name != dictName {
-			return fmt.Errorf("Dictionary logging endpoint name mismatch, expected: %s, got: %#v", dictName, dict.Name)
+			return fmt.Errorf("Dictionary name mismatch, expected: %s, got: %#v", dictName, dict.Name)
+		}
+
+		if dict.WriteOnly != writeOnly {
+			return fmt.Errorf("Dictionary write_only attribute mismatch, expected: %#v, got: %#v", writeOnly, dict.WriteOnly)
 		}
 
 		return nil
@@ -128,7 +155,7 @@ resource "fastly_service_v1" "foo" {
   domain {
     name    = "%s"
     comment = "tf-testing-domain"
-	}
+  }
 
   backend {
     address = "%s"
@@ -136,9 +163,36 @@ resource "fastly_service_v1" "foo" {
   }
 
   dictionary {
-	name       = "%s"
+    name = "%s"
   }
 
   force_destroy = true
 }`, name, domainName, backendName, dictName)
+}
+
+func testAccServiceV1Config_dictionary_write_only(name, dictName string, writeOnly bool) string {
+	backendName := fmt.Sprintf("%s.aws.amazon.com", acctest.RandString(3))
+	domainName := fmt.Sprintf("fastly-test.tf-%s.com", acctest.RandString(10))
+
+	return fmt.Sprintf(`
+resource "fastly_service_v1" "foo" {
+  name = "%s"
+
+  domain {
+    name    = "%s"
+    comment = "tf-testing-domain"
+  }
+
+  backend {
+    address = "%s"
+    name    = "tf -test backend"
+  }
+
+  dictionary {
+    name       = "%s"
+    write_only = %v
+  }
+
+  force_destroy = true
+}`, name, domainName, backendName, dictName, writeOnly)
 }

--- a/fastly/resource_fastly_service_v1_dictionary_test.go
+++ b/fastly/resource_fastly_service_v1_dictionary_test.go
@@ -114,6 +114,34 @@ func TestAccFastlyServiceV1_dictionary_update_name(t *testing.T) {
 	})
 }
 
+func TestAccFastlyServiceV1_dictionary_update_write_only(t *testing.T) {
+	var service gofastly.ServiceDetail
+	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	dictName := fmt.Sprintf("dict %s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckServiceV1Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServiceV1Config_dictionary(name, dictName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
+					testAccCheckFastlyServiceV1Attributes_dictionary(&service, name, dictName, false),
+				),
+			},
+			{
+				Config: testAccServiceV1Config_dictionary_write_only(name, dictName, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
+					testAccCheckFastlyServiceV1Attributes_dictionary(&service, name, dictName, true),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckFastlyServiceV1Attributes_dictionary(service *gofastly.ServiceDetail, name, dictName string, writeOnly bool) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 

--- a/website/docs/r/service_v1.html.markdown
+++ b/website/docs/r/service_v1.html.markdown
@@ -529,6 +529,10 @@ The `acl` block supports:
 The `dictionary` block supports:
 
 * `name` - (Required) A unique name to identify this dictionary.
+* `write_only` - (Optional) If `true`, the dictionary is a private dictionary, and items are not readable in the UI or
+via API. Default is `false`. It is important to note that changing this attribute will delete and recreate the
+dictionary, discard the current items in the dictionary. Using a write-only/private dictionary should only be done if
+the items are managed outside of Terraform.
 
 ## Attributes Reference
 


### PR DESCRIPTION
This PR updates the service resource so that private (write-only) dictionaries are supported.
(see https://docs.fastly.com/en/guides/private-dictionaries)

By default dictionaries are not write-only (ie. `write_only` == `false`).

Changing the write-only attribute is not supported, so the provider will recreate the dictionary if the value of the write_only attribute is changed.

#### acceptance tests
```
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccFastlyServiceV1_dictionary.* -timeout 120m -ldflags="-X=github.com/terraform-providers/terraform-provider-fastly/version.ProviderVersion=acc"
?   	github.com/terraform-providers/terraform-provider-fastly	[no test files]
=== RUN   TestAccFastlyServiceV1_dictionary
--- PASS: TestAccFastlyServiceV1_dictionary (41.78s)
=== RUN   TestAccFastlyServiceV1_dictionary_write_only
--- PASS: TestAccFastlyServiceV1_dictionary_write_only (44.44s)
=== RUN   TestAccFastlyServiceV1_dictionary_update_name
--- PASS: TestAccFastlyServiceV1_dictionary_update_name (75.85s)
PASS
ok  	github.com/terraform-providers/terraform-provider-fastly/fastly	162.097s
?   	github.com/terraform-providers/terraform-provider-fastly/version	[no test files]
```