### PR TITLE
Add computed output field to get the latest cloned version by the provider

### DIFF
--- a/fastly/resource_fastly_service_v1.go
+++ b/fastly/resource_fastly_service_v1.go
@@ -52,6 +52,17 @@ func resourceServiceV1() *schema.Resource {
 				Computed: true,
 			},
 
+			// Cloned Version represents the latest cloned version by the provider. It
+			// gets set whenever Terraform detects changes and clones the currently
+			// activated version in order to modify it. Active Version and Cloned
+			// Version can be different if the Activate field is set to false in order
+			// to prevent the service from being activated. It is not used internally,
+			// but it is exported for users to see after running `terraform apply`.
+			"cloned_version": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+
 			"activate": {
 				Type:        schema.TypeBool,
 				Description: "Conditionally prevents the Service from being activated",
@@ -1576,6 +1587,7 @@ func resourceServiceV1Update(d *schema.ResourceData, meta interface{}) error {
 
 			// The new version number is named "Number", but it's actually a string
 			latestVersion = newVersion.Number
+			d.Set("cloned_version", latestVersion)
 
 			// New versions are not immediately found in the API, or are not
 			// immediately mutable, so we need to sleep a few and let Fastly ready

--- a/website/docs/r/service_v1.html.markdown
+++ b/website/docs/r/service_v1.html.markdown
@@ -536,6 +536,7 @@ In addition to the arguments listed above, the following attributes are exported
 
 * `id` – The ID of the Service.
 * `active_version` – The currently active version of your Fastly Service.
+* `cloned_version` - The latest cloned version by the provider. The value gets only set after running `terraform apply`.
 
 The `dynamicsnippet` block exports:
 


### PR DESCRIPTION
This allows users of the provider to get the latest cloned version by the provider. If the `activate` field is set to `false` and the plan output shows changes then the values of `active_version` and `cloned_version` are actually different after applying them otherwise, the values are the same. The value of `cloned_version` is only available after running the `terraform apply` command. Here are some examples after applying:

1. Brand new service:

```
fastly_service_v1.demo: Creating...
fastly_service_v1.demo: Creation complete after 18s [id=5wzq2Rcc7rEg2H6s1AJGdU]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

Outputs:

active_version = 1
```

2. Updating existing service (activate = true)

```
fastly_service_v1.demo: Modifying... [id=5wzq2Rcc7rEg2H6s1AJGdU]
fastly_service_v1.demo: Modifications complete after 24s [id=5wzq2Rcc7rEg2H6s1AJGdU]

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.

Outputs:

active_version = 2
cloned_version = 2
```

3. Updating existing service (activate = false)

```
fastly_service_v1.demo: Modifying... [id=5wzq2Rcc7rEg2H6s1AJGdU]
fastly_service_v1.demo: Modifications complete after 25s [id=5wzq2Rcc7rEg2H6s1AJGdU]

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.

Outputs:

active_version = 2
cloned_version = 3
```