### PR TITLE
Update director backends if changed

### DIFF
--- a/fastly/resource_fastly_service_v1.go
+++ b/fastly/resource_fastly_service_v1.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
-var fastlyNoServiceFoundErr = errors.New("No matching Fastly Service found")
+var errFastlyNoServiceFound = errors.New("No matching Fastly Service found")
 
 func resourceServiceV1() *schema.Resource {
 	return &schema.Resource{
@@ -3195,7 +3195,7 @@ func resourceServiceV1Read(d *schema.ResourceData, meta interface{}) error {
 	_, err := findService(d.Id(), meta)
 	if err != nil {
 		switch err {
-		case fastlyNoServiceFoundErr:
+		case errFastlyNoServiceFound:
 			log.Printf("[WARN] %s for ID (%s)", err, d.Id())
 			d.SetId("")
 			return nil
@@ -3686,7 +3686,7 @@ func resourceServiceV1Delete(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		switch err {
 		// we expect no records to be found here
-		case fastlyNoServiceFoundErr:
+		case errFastlyNoServiceFound:
 			d.SetId("")
 			return nil
 		default:
@@ -3710,7 +3710,7 @@ func resourceServiceV1Delete(d *schema.ResourceData, meta interface{}) error {
 // in question. This endpoint only returns active or "alive" services. If the
 // Service is not included, then it's "gone"
 //
-// Returns a fastlyNoServiceFoundErr error if the Service is not found in the
+// Returns a errFastlyNoServiceFound error if the Service is not found in the
 // ListServices response.
 func findService(id string, meta interface{}) (*gofastly.Service, error) {
 	conn := meta.(*FastlyClient).conn
@@ -3727,7 +3727,7 @@ func findService(id string, meta interface{}) (*gofastly.Service, error) {
 		}
 	}
 
-	return nil, fastlyNoServiceFoundErr
+	return nil, errFastlyNoServiceFound
 }
 
 func flattenDomains(list []*gofastly.Domain) []map[string]interface{} {


### PR DESCRIPTION
### TL;DR
This attempts to address #143 by ensuring we re-create the backend to director relationship when a backend changes. However the solution is non-ideal, see below for further information.

## Why?
As the provider uses a `schema.TypeSet` set as the type for the `backend` field, we cannot cleanly determine whether a backend has been updated versus being added. Therefore, it simply deletes any backends in the change set and adds them again. See lines. (Note: this seems to be the convention for most collection based fields on the service resource.)

When the backend is deleted, this also propagates the delete through the models relationships and thus deletes the backend from the director. 

Therefore, we have multiple options to solve this problem:\

1) Refactor the provider to use `schema.List` as the `backend` field type, which will allow us to safely detect updates and use the appropriate `gofastly.UpdateBackend` API client call. This will ensure the backend isn't dereferenced from the director. However, this is a breaking change and should be considered as a wider refactor to update other fields to also use `TypeList`.
2) Attempt to determine the updates in the change set using the `backend.name` property. However this is brittle as doesn't account for changes to the backend name itself.
3) If there are backend changes, iterate over the directors on the service version and re-create the relationship if the backend name matches a backend in the change set.

This PR has implemented *option 3* above, however I don't feel comfortable with the change and therefore would like to open discussion here for wider consensus.
