### PR TITLE
Fix setting default_ttl to 0 on create

### DIFF
--- a/fastly/resource_fastly_service_v1.go
+++ b/fastly/resource_fastly_service_v1.go
@@ -1621,6 +1621,11 @@ func resourceServiceV1Update(d *schema.ResourceData, meta interface{}) error {
 		}
 
 		// update general settings
+
+		// If the requested default_ttl is 0, and this is the first
+		// version being created, HasChange will return false, but we need
+		// to set it anyway, so ensure we update the settings in that
+		// case.
 		if d.HasChange("default_host") || d.HasChange("default_ttl") || (d.Get("default_ttl") == 0 && initialVersion) {
 			opts := gofastly.UpdateSettingsInput{
 				Service: d.Id(),

--- a/fastly/resource_fastly_service_v1.go
+++ b/fastly/resource_fastly_service_v1.go
@@ -1574,9 +1574,12 @@ func resourceServiceV1Update(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
+	initialVersion := false
+
 	if needsChange {
 		latestVersion := d.Get("active_version").(int)
 		if latestVersion == 0 {
+			initialVersion = true
 			// If the service was just created, there is an empty Version 1 available
 			// that is unlocked and can be updated
 			latestVersion = 1
@@ -1618,7 +1621,7 @@ func resourceServiceV1Update(d *schema.ResourceData, meta interface{}) error {
 		}
 
 		// update general settings
-		if d.HasChange("default_host") || d.HasChange("default_ttl") {
+		if d.HasChange("default_host") || d.HasChange("default_ttl") || (d.Get("default_ttl") == 0 && initialVersion) {
 			opts := gofastly.UpdateSettingsInput{
 				Service: d.Id(),
 				Version: latestVersion,

--- a/fastly/resource_fastly_service_v1_test.go
+++ b/fastly/resource_fastly_service_v1_test.go
@@ -458,6 +458,8 @@ func TestAccFastlyServiceV1_defaultTTL(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
 					testAccCheckFastlyServiceV1Attributes_backends(&service, name, []string{backendName}),
+					resource.TestCheckResourceAttr(
+						"fastly_service_v1.foo", "default_ttl", "3600"),
 				),
 			},
 
@@ -482,6 +484,30 @@ func TestAccFastlyServiceV1_defaultTTL(t *testing.T) {
 						"fastly_service_v1.foo", "default_ttl", "0"),
 					resource.TestCheckResourceAttr(
 						"fastly_service_v1.foo", "active_version", "3"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccFastlyServiceV1_createDefaultTTL(t *testing.T) {
+	var service gofastly.ServiceDetail
+	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	domain := fmt.Sprintf("terraform-acc-test-%s.com", acctest.RandString(10))
+	backendName := fmt.Sprintf("%s.aws.amazon.com", acctest.RandString(3))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckServiceV1Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServiceV1Config_backendTTL(name, domain, backendName, 3400),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
+					testAccCheckFastlyServiceV1Attributes_backends(&service, name, []string{backendName}),
+					resource.TestCheckResourceAttr(
+						"fastly_service_v1.foo", "default_ttl", "3400"),
 				),
 			},
 		},


### PR DESCRIPTION
This change allows a service to be created with a  `default_ttl` of `0`, fixing #204.

The problem was that, for integer values, the "old" value in the `ResourceData` is `0`, meaning that, if the "new" value is `0`, `HasChange(key)` returns `false`.

It didn't seem possible to override this behavior, either by modifying the "old" value in the `ResourceData` or by specifying a `CustomizeDiff` function (which appears to only be able to *remove* differences, not add ones that wouldn't, otherwise, be detected). Note: if there *is* a way to accomplish this, and that is the preferred method to fix these issues, let us know and we can update the PR.

Instead, we have added an explicit check for the `default_ttl` being set to `0` on service creation and we force the update call to be made, in that case.

We aren't very familiar with the tools available inside the Terraform Plugin SDK, so we may have missed a better solution. Please let us know if there's a better way to fix this issue.