### PR TITLE
[WIP] Adding dynamic server support

### DIFF
--- a/fastly/provider.go
+++ b/fastly/provider.go
@@ -31,6 +31,7 @@ func Provider() terraform.ResourceProvider {
 			"fastly_service_acl_entries_v1":             resourceServiceAclEntriesV1(),
 			"fastly_service_dictionary_items_v1":        resourceServiceDictionaryItemsV1(),
 			"fastly_service_dynamic_snippet_content_v1": resourceServiceDynamicSnippetContentV1(),
+			"fastly_service_pool_servers_v1":            resourceServicePoolServersV1(),
 		},
 	}
 

--- a/fastly/resource_fastly_service_pool_servers_v1.go
+++ b/fastly/resource_fastly_service_pool_servers_v1.go
@@ -1,0 +1,271 @@
+package fastly
+
+import (
+	"fmt"
+	gofastly "github.com/fastly/go-fastly/fastly"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"strings"
+)
+
+func resourceServicePoolServersV1() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceServicePoolServersV1Create,
+		Read:   resourceServicePoolServersV1Read,
+		Update: resourceServicePoolServersV1Update,
+		Delete: resourceServicePoolServersV1Delete,
+		Importer: &schema.ResourceImporter{
+			State: resourceServicePoolServersV1Import,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"service_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "Service Id",
+			},
+
+			"pool_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "Pool Id",
+			},
+			"server": {
+				Type:        schema.TypeSet,
+				Optional:    true,
+				Description: "Server Entries",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Description: "",
+							Computed:    true,
+						},
+						"weight": {
+							Type:        schema.TypeInt,
+							Description: "Weight (1-100) used to load balance this server against others. Optional. Defaults to '100' if not set.",
+							Optional:    true,
+						},
+						"max_conn": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Description: "Maximum number of connections. If the value is '0', it inherits the value from pool's max_conn_default. Optional. Defaults to '0' if not set.",
+						},
+						"port": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Description: "Port number. Setting port 443 does not force TLS. Set use_tls in pool to force TLS. Optional. Defaults to '80' if not set.",
+						},
+						"address": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "A hostname, IPv4, or IPv6 address for the server. Required.",
+						},
+						"comment": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "A personal freeform descriptive note",
+						},
+						"disabled": {
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Default:     false,
+							Description: "Allows servers to be enabled and disabled in a pool.",
+						},
+						"override_host": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "The hostname to override the Host header. Optional. Defaults to null meaning no override of the Host header if not set.",
+						},
+					},
+				},
+			},
+		},
+	}
+
+}
+
+func resourceServicePoolServersV1Create(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*FastlyClient).conn
+
+	serviceID := d.Get("service_id").(string)
+	poolID := d.Get("pool_id").(string)
+	servers := d.Get("server").(*schema.Set)
+
+	for _, vRaw := range servers.List() {
+		val := vRaw.(map[string]interface{})
+
+		_, err := conn.CreateServer(&gofastly.CreateServerInput{
+			Service:      serviceID,
+			Pool:         poolID,
+			Weight:       val["weight"].(*uint),
+			MaxConn:      val["max_conn"].(*uint),
+			Port:         val["port"].(*uint),
+			Address:      val["address"].(string),
+			Comment:      val["comment"].(*string),
+			Disabled:     val["disabled"].(*bool),
+			OverrideHost: val["override_host"].(*string),
+		})
+		if err != nil {
+			return fmt.Errorf("Error creating Pool servers: service %s, Pool %s, %s", serviceID, poolID, err)
+		}
+	}
+
+	d.SetId(fmt.Sprintf("%s/%s", serviceID, poolID))
+	return resourceServicePoolServersV1Read(d, meta)
+}
+
+func resourceServicePoolServersV1Read(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*FastlyClient).conn
+
+	serviceID := d.Get("service_id").(string)
+	poolID := d.Get("pool_id").(string)
+
+	poolServers, err := conn.ListServers(&gofastly.ListServersInput{
+		Service: serviceID,
+		Pool:    poolID,
+	})
+
+	if err != nil {
+		return err
+	}
+
+	d.Set("server", flattenPoolServers(poolServers))
+	return nil
+}
+
+func resourceServicePoolServersV1Update(d *schema.ResourceData, meta interface{}) error {
+
+	conn := meta.(*FastlyClient).conn
+
+	serviceID := d.Get("service_id").(string)
+	poolID := d.Get("pool_id").(string)
+
+	if d.HasChange("server") {
+
+		oe, ne := d.GetChange("server")
+		if oe == nil {
+			oe = new(schema.Set)
+		}
+		if ne == nil {
+			ne = new(schema.Set)
+		}
+
+		oes := oe.(*schema.Set)
+		nes := ne.(*schema.Set)
+
+		removeServers := oes.Difference(nes).List()
+		addServers := nes.Difference(oes).List()
+
+		// DELETE old Server entries
+		for _, vRaw := range removeServers {
+			val := vRaw.(map[string]interface{})
+			err := conn.DeleteServer(&gofastly.DeleteServerInput{
+				Service: serviceID,
+				Pool:    poolID,
+				Server:  val["id"].(string),
+			})
+			if err != nil {
+				return fmt.Errorf("Error deleting Pool Server: service %s, Pool %s, %s", serviceID, poolID, err)
+			}
+		}
+
+		// POST new Server entry
+		for _, vRaw := range addServers {
+			val := vRaw.(map[string]interface{})
+
+			_, err := conn.CreateServer(&gofastly.CreateServerInput{
+				Service:      serviceID,
+				Pool:         poolID,
+				Weight:       val["weight"].(*uint),
+				MaxConn:      val["max_conn"].(*uint),
+				Port:         val["port"].(*uint),
+				Address:      val["address"].(string),
+				Comment:      val["comment"].(*string),
+				Disabled:     val["disabled"].(*bool),
+				OverrideHost: val["override_host"].(*string),
+			})
+			if err != nil {
+				return fmt.Errorf("Error creating Pool servers: service %s, Pool %s, %s", serviceID, poolID, err)
+			}
+		}
+	}
+
+	return resourceServicePoolServersV1Read(d, meta)
+}
+
+func resourceServicePoolServersV1Delete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*FastlyClient).conn
+
+	serviceID := d.Get("service_id").(string)
+	poolID := d.Get("pool_id").(string)
+	servers := d.Get("server").(*schema.Set)
+
+	for _, vRaw := range servers.List() {
+		val := vRaw.(map[string]interface{})
+
+		err := conn.DeleteServer(&gofastly.DeleteServerInput{
+			Service: serviceID,
+			Pool:    poolID,
+			Server:  val["id"].(string),
+		})
+		if err != nil {
+			return fmt.Errorf("Error deleting Pool Server: service %s, Pool %s, %s", serviceID, poolID, err)
+		}
+	}
+
+	d.SetId("")
+	return nil
+}
+
+func flattenPoolServers(poolServersList []*gofastly.Server) []map[string]interface{} {
+
+	var resultList []map[string]interface{}
+
+	for _, currentPoolServer := range poolServersList {
+		ps := map[string]interface{}{
+			"id":            currentPoolServer.ID,
+			"weight":        currentPoolServer.Weight,
+			"max_conn":      currentPoolServer.MaxConn,
+			"port":          currentPoolServer.Port,
+			"address":       currentPoolServer.Address,
+			"comment":       currentPoolServer.Comment,
+			"disabled":      currentPoolServer.Disabled,
+			"override_host": currentPoolServer.OverrideHost,
+		}
+
+		for k, v := range ps {
+			if v == "" {
+				delete(ps, k)
+			}
+		}
+
+		resultList = append(resultList, ps)
+	}
+
+	return resultList
+}
+
+func resourceServicePoolServersV1Import(d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+	split := strings.Split(d.Id(), "/")
+
+	if len(split) != 2 {
+		return nil, fmt.Errorf("Invalid id: %s. The ID should be in the format [service_id]/[pool_id]", d.Id())
+	}
+
+	serviceID := split[0]
+	poolID := split[1]
+
+	err := d.Set("service_id", serviceID)
+	if err != nil {
+		return nil, fmt.Errorf("Error importing Pool Servers: service %s, Pool %s, %s", serviceID, poolID, err)
+	}
+
+	err = d.Set("pool_id", poolID)
+	if err != nil {
+		return nil, fmt.Errorf("Error importing Pool Servers: service %s, Pool %s, %s", serviceID, poolID, err)
+	}
+
+	return []*schema.ResourceData{d}, nil
+}

--- a/fastly/resource_fastly_service_pool_servers_v1.go
+++ b/fastly/resource_fastly_service_pool_servers_v1.go
@@ -93,20 +93,32 @@ func resourceServicePoolServersV1Create(d *schema.ResourceData, meta interface{}
 	poolID := d.Get("pool_id").(string)
 	servers := d.Get("server").(*schema.Set)
 
+	fmt.Printf("server===> %v", servers)
+
 	for _, vRaw := range servers.List() {
 		val := vRaw.(map[string]interface{})
 
-		_, err := conn.CreateServer(&gofastly.CreateServerInput{
+		weight := uint(val["weight"].(int))
+		fmt.Printf("%v", weight)
+		max_conn := uint(val["max_conn"].(int))
+		port := uint(val["port"].(int))
+		comment := val["comment"].(string)
+		disabled := val["disabled"].(bool)
+		override_host := val["override_host"].(string)
+
+		opts := gofastly.CreateServerInput{
 			Service:      serviceID,
 			Pool:         poolID,
-			Weight:       val["weight"].(*uint),
-			MaxConn:      val["max_conn"].(*uint),
-			Port:         val["port"].(*uint),
+			Weight:       &weight,
+			MaxConn:      &max_conn,
+			Port:         &port,
 			Address:      val["address"].(string),
-			Comment:      val["comment"].(*string),
-			Disabled:     val["disabled"].(*bool),
-			OverrideHost: val["override_host"].(*string),
-		})
+			Comment:      &comment,
+			Disabled:     &disabled,
+			OverrideHost: &override_host,
+		}
+
+		_, err := conn.CreateServer(&opts)
 		if err != nil {
 			return fmt.Errorf("Error creating Pool servers: service %s, Pool %s, %s", serviceID, poolID, err)
 		}
@@ -175,17 +187,26 @@ func resourceServicePoolServersV1Update(d *schema.ResourceData, meta interface{}
 		for _, vRaw := range addServers {
 			val := vRaw.(map[string]interface{})
 
-			_, err := conn.CreateServer(&gofastly.CreateServerInput{
+			weight := uint(val["weight"].(int))
+			max_conn := uint(val["max_conn"].(int))
+			port := uint(val["port"].(int))
+			comment := val["comment"].(string)
+			disabled := val["disabled"].(bool)
+			override_host := val["override_host"].(string)
+
+			opts := gofastly.CreateServerInput{
 				Service:      serviceID,
 				Pool:         poolID,
-				Weight:       val["weight"].(*uint),
-				MaxConn:      val["max_conn"].(*uint),
-				Port:         val["port"].(*uint),
+				Weight:       &weight,
+				MaxConn:      &max_conn,
+				Port:         &port,
 				Address:      val["address"].(string),
-				Comment:      val["comment"].(*string),
-				Disabled:     val["disabled"].(*bool),
-				OverrideHost: val["override_host"].(*string),
-			})
+				Comment:      &comment,
+				Disabled:     &disabled,
+				OverrideHost: &override_host,
+			}
+
+			_, err := conn.CreateServer(&opts)
 			if err != nil {
 				return fmt.Errorf("Error creating Pool servers: service %s, Pool %s, %s", serviceID, poolID, err)
 			}

--- a/fastly/resource_fastly_service_pool_servers_v1_test.go
+++ b/fastly/resource_fastly_service_pool_servers_v1_test.go
@@ -1,0 +1,451 @@
+package fastly
+
+import (
+	"fmt"
+	"reflect"
+	"sort"
+	"testing"
+
+	gofastly "github.com/fastly/go-fastly/fastly"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestResourceFastlyFlattenPoolServers(t *testing.T) {
+	cases := []struct {
+		remote []*gofastly.Server
+		local  []map[string]interface{}
+	}{
+		{
+			remote: []*gofastly.Server{
+				{
+					ServiceID: "service-id",
+					PoolID:    "1234567890",
+					Address:   "127.0.0.1",
+					Weight:    uint(100),
+					MaxConn:   uint(200),
+					Port:      uint(80),
+					Disabled:  false,
+					Comment:   "Server 1",
+				},
+				{
+					ServiceID:    "service-id",
+					PoolID:       "0987654321",
+					Address:      "192.168.0.1",
+					Weight:       uint(50),
+					MaxConn:      uint(400),
+					Port:         uint(88),
+					OverrideHost: "origin.notexample.fastly",
+					Disabled:     true,
+					Comment:      "Server 2",
+				},
+			},
+			local: []map[string]interface{}{
+				{
+					"address":  "127.0.0.1",
+					"weight":   uint(100),
+					"max_conn": uint(200),
+					"port":     uint(80),
+					"disabled": false,
+					"comment":  "Server 1",
+				},
+				{
+					"address":       "192.168.0.1",
+					"weight":        uint(50),
+					"max_conn":      uint(400),
+					"port":          uint(88),
+					"override_host": "origin.notexample.fastly",
+					"disabled":      true,
+					"comment":       "Server 2",
+				},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		out := flattenPoolServers(c.remote)
+		if !reflect.DeepEqual(out, c.local) {
+			t.Fatalf("Error matching:\nexpected: %#v\ngot: %#v", c.local, out)
+		}
+	}
+}
+
+func TestAccFastlyServicePoolServersV1_create(t *testing.T) {
+	var service gofastly.ServiceDetail
+	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	poolName := fmt.Sprintf("pool_%s", acctest.RandString(10))
+
+	expectedRemoteEntries := []map[string]interface{}{
+		{
+			"id":            "",
+			"address":       "127.0.0.1",
+			"weight":        uint(100),
+			"max_conn":      uint(200),
+			"port":          uint(80),
+			"override_host": "",
+			"disabled":      false,
+			"comment":       "Server 1",
+		},
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckServiceV1Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServicePoolServersV1Config_one_pool_with_server(serviceName, poolName, expectedRemoteEntries),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
+					testAccCheckFastlyServicePoolServersV1RemoteState(&service, serviceName, poolName, expectedRemoteEntries),
+					resource.TestCheckResourceAttr("fastly_service_pool_servers_v1.server", "server.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccFastlyServicePoolServersV1_update(t *testing.T) {
+	var service gofastly.ServiceDetail
+	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	poolName := fmt.Sprintf("Pool %s", acctest.RandString(10))
+
+	expectedRemoteEntries := []map[string]interface{}{
+		{
+			"id":            "",
+			"address":       "127.0.0.1",
+			"weight":        100,
+			"max_conn":      200,
+			"port":          80,
+			"override_host": "",
+			"disabled":      false,
+			"comment":       "Server 1",
+		},
+	}
+
+	expectedRemoteEntriesAfterUpdate := []map[string]interface{}{
+		{
+			"id":            "",
+			"address":       "127.0.0.1",
+			"weight":        100,
+			"max_conn":      200,
+			"port":          80,
+			"override_host": "",
+			"disabled":      false,
+			"comment":       "Server 1",
+		},
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckServiceV1Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServicePoolServersV1Config_one_pool_with_server(serviceName, poolName, expectedRemoteEntries),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
+					testAccCheckFastlyServicePoolServersV1RemoteState(&service, serviceName, poolName, expectedRemoteEntries),
+					resource.TestCheckResourceAttr("fastly_service_pool_servers_v1.server", "server.#", "1"),
+				),
+			},
+			{
+				Config: testAccServicePoolServersV1Config_one_pool_with_server(serviceName, poolName, expectedRemoteEntriesAfterUpdate),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
+					testAccCheckFastlyServicePoolServersV1RemoteState(&service, serviceName, poolName, expectedRemoteEntriesAfterUpdate),
+					resource.TestCheckResourceAttr("fastly_service_pool_servers_v1.server", "server.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccFastlyServicePoolServersV1_update_additional_fields(t *testing.T) {
+	var service gofastly.ServiceDetail
+	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	poolName := "Server Test Update Disabled Field"
+
+	expectedRemoteEntries := []map[string]interface{}{
+		{
+			"id":            "",
+			"address":       "127.0.0.1",
+			"weight":        100,
+			"max_conn":      200,
+			"port":          80,
+			"override_host": "",
+			"disabled":      false,
+			"comment":       "Server 1",
+		},
+	}
+
+	expectedRemoteEntriesAfterUpdate := []map[string]interface{}{
+		{
+			"id":            "",
+			"address":       "127.0.0.1",
+			"weight":        100,
+			"max_conn":      200,
+			"port":          80,
+			"override_host": "",
+			"disabled":      true,
+			"comment":       "Server 1 Updated",
+		},
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckServiceV1Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServicePoolServersV1Config_one_pool_with_server(serviceName, poolName, expectedRemoteEntries),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
+					testAccCheckFastlyServicePoolServersV1RemoteState(&service, serviceName, poolName, expectedRemoteEntries),
+					resource.TestCheckResourceAttr("fastly_service_pool_servers_v1.servers", "server.#", "1"),
+					resource.TestCheckResourceAttr("fastly_service_pool_servers_v1.servers", "server.2838444859.address", "127.0.0.1"),
+					resource.TestCheckResourceAttr("fastly_service_pool_servers_v1.servers", "server.2838444859.weight", "100"),
+					resource.TestCheckResourceAttr("fastly_service_pool_servers_v1.servers", "server.2838444859.max_conn", "200"),
+					resource.TestCheckResourceAttr("fastly_service_pool_servers_v1.servers", "server.2838444859.port", "80"),
+					resource.TestCheckResourceAttr("fastly_service_pool_servers_v1.servers", "server.2838444859.override_host", ""),
+					resource.TestCheckResourceAttr("fastly_service_pool_servers_v1.servers", "server.2838444859.disabled", "false"),
+					resource.TestCheckResourceAttr("fastly_service_pool_servers_v1.servers", "server.2838444859.comment", "Server 1"),
+				),
+			},
+			{
+				Config: testAccServicePoolServersV1Config_one_pool_with_server(serviceName, poolName, expectedRemoteEntriesAfterUpdate),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
+					testAccCheckFastlyServicePoolServersV1RemoteState(&service, serviceName, poolName, expectedRemoteEntriesAfterUpdate),
+					resource.TestCheckResourceAttr("fastly_service_pool_servers_v1.servers", "server.#", "1"),
+					resource.TestCheckResourceAttr("fastly_service_pool_servers_v1.servers", "server.1817859044.address", "127.0.0.1"),
+					resource.TestCheckResourceAttr("fastly_service_pool_servers_v1.servers", "server.1817859044.weight", "100"),
+					resource.TestCheckResourceAttr("fastly_service_pool_servers_v1.servers", "server.1817859044.max_conn", "200"),
+					resource.TestCheckResourceAttr("fastly_service_pool_servers_v1.servers", "server.1817859044.port", "80"),
+					resource.TestCheckResourceAttr("fastly_service_pool_servers_v1.servers", "server.1817859044.override_host", ""),
+					resource.TestCheckResourceAttr("fastly_service_pool_servers_v1.servers", "server.1817859044.disabled", "true"),
+					resource.TestCheckResourceAttr("fastly_service_pool_servers_v1.servers", "server.1817859044.comment", "Server 1 Updated"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccFastlyServicePoolServersV1_delete(t *testing.T) {
+	var service gofastly.ServiceDetail
+	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	poolName := fmt.Sprintf("pool_%s", acctest.RandString(10))
+
+	expectedRemoteEntries := []map[string]interface{}{
+		{
+			"id":            "",
+			"address":       "127.0.0.1",
+			"weight":        100,
+			"max_conn":      200,
+			"port":          80,
+			"override_host": "",
+			"disabled":      false,
+			"comment":       "Server 1",
+		},
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckServiceV1Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServicePoolServersV1Config_one_pool_with_server(serviceName, poolName, expectedRemoteEntries),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
+					testAccCheckFastlyServicePoolServersV1RemoteState(&service, serviceName, poolName, expectedRemoteEntries),
+					resource.TestCheckResourceAttr("fastly_service_acl_entries_v1.servers", "server.#", "1"),
+				),
+			},
+			{
+				Config: testAccServiceDictionaryItemsV1Config_one_pool_no_entries(serviceName, poolName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
+					resource.TestCheckNoResourceAttr("fastly_service_v1.foo", "servers"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccFastlyServicePoolServersV1_import(t *testing.T) {
+
+	var service gofastly.ServiceDetail
+
+	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	poolName := fmt.Sprintf("pool %s", acctest.RandString(10))
+
+	expectedRemoteEntries := []map[string]interface{}{
+		{
+			"id":            "",
+			"address":       "127.0.0.1",
+			"weight":        100,
+			"max_conn":      200,
+			"port":          80,
+			"override_host": "",
+			"disabled":      false,
+			"comment":       "Server 1",
+		},
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckServiceV1Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServicePoolServersV1Config_one_pool_with_server(name, poolName, expectedRemoteEntries),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
+				),
+			},
+			{
+				ResourceName:      "fastly_service_pool_servers_v1.server",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckFastlyServicePoolServersV1RemoteState(service *gofastly.ServiceDetail, serviceName, poolName string, expectedEntries []map[string]interface{}) resource.TestCheckFunc {
+
+	return func(s *terraform.State) error {
+
+		if service.Name != serviceName {
+			return fmt.Errorf("[ERR] Bad name, expected (%s), got (%s)", serviceName, service.Name)
+		}
+
+		conn := testAccProvider.Meta().(*FastlyClient).conn
+		var pool *gofastly.Pool
+		pool, err := conn.GetPool(&gofastly.GetPoolInput{
+			Service: service.ID,
+			Version: service.ActiveVersion.Number,
+			Name:    poolName,
+		})
+
+		if err != nil {
+			return fmt.Errorf("[ERR] Error looking up Pool records for (%s), version (%v): %s", service.Name, service.ActiveVersion.Number, err)
+		}
+
+		fmt.Errorf("[ERR] Something Pool name, expected (%s), got (%s)", poolName, pool.Name)
+
+		server, err := conn.GetServer(&gofastly.GetServerInput{
+			Service: service.ID,
+			Pool:    pool.ID,
+			Server:  "server-id-string-here",
+		})
+
+		if err != nil {
+			return fmt.Errorf("[ERR] Error looking up Server records for (%s - %s), version (%v): %s", service.Name, pool.Name, service.ActiveVersion.Number, err)
+		}
+
+		serverEntries, err := conn.ListServers(&gofastly.ListServersInput{
+			Service: service.ID,
+			Pool:    pool.ID,
+		})
+
+		if err != nil {
+			return fmt.Errorf("[ERR] Error looking up Pool servers for (%s), Pool (%s - %s): %s", service.Name, pool.ID, server.ID, err)
+		}
+
+		flatPoolServers := flattenPoolServers(serverEntries)
+		// Clear out the id values to allow a deep equal of the other attributes set in terraform.
+		for _, val := range flatPoolServers {
+			val["id"] = ""
+		}
+
+		sort.Slice(flatPoolServers, func(i, j int) bool {
+			return flatPoolServers[i]["address"].(string) < flatPoolServers[j]["address"].(string)
+		})
+
+		sort.Slice(expectedEntries, func(i, j int) bool {
+			return expectedEntries[i]["address"].(string) < expectedEntries[j]["address"].(string)
+		})
+
+		if !reflect.DeepEqual(flatPoolServers, expectedEntries) {
+			return fmt.Errorf("[ERR] Error matching:\nexpected: %#v\ngot: %#v", expectedEntries, flatPoolServers)
+		}
+
+		return nil
+	}
+}
+
+func testAccServiceDictionaryItemsV1Config_one_pool_no_entries(serviceName, poolName string) string {
+
+	backendName := fmt.Sprintf("%s.aws.amazon.com", acctest.RandString(3))
+	domainName := fmt.Sprintf("fastly-test.tf-%s.com", acctest.RandString(10))
+
+	return fmt.Sprintf(`
+resource "fastly_service_v1" "foo" {
+  name = "%s"
+  domain {
+    name    = "%s"
+    comment = "tf-testing-domain"
+	}
+  backend {
+    address = "%s"
+    name    = "tf -test backend"
+  }
+  pool {
+	name       = "%s"
+	type       = "hash"
+  }
+  force_destroy = true
+}`, serviceName, domainName, backendName, poolName)
+}
+
+func testAccServicePoolServersV1Config_one_pool_with_server(serviceName, poolName string, serverList []map[string]interface{}) string {
+	backendName := fmt.Sprintf("%s.aws.amazon.com", acctest.RandString(3))
+	domainName := fmt.Sprintf("fastly-test.tf-%s.com", acctest.RandString(10))
+
+	serverEntries := ""
+
+	for _, val := range serverList {
+		serverEntries += "server {\n"
+		serverEntries += fmt.Sprintf("address = \"%s\"\n", val["address"])
+		serverEntries += fmt.Sprintf("weight = %d\n", val["weight"])
+		serverEntries += fmt.Sprintf("max_conn = %d\n", val["max_conn"])
+		serverEntries += fmt.Sprintf("port = %d\n", val["port"])
+		serverEntries += fmt.Sprintf("override_host = \"%s\"\n", val["override_host"])
+		serverEntries += fmt.Sprintf("disabled = %t\n", val["disabled"])
+		serverEntries += fmt.Sprintf("comment = \"%s\"\n", val["comment"])
+		serverEntries += "}\n"
+	}
+
+	return fmt.Sprintf(`
+variable "pool_name" {
+	type = string
+	default = "%s"
+}
+
+resource "fastly_service_v1" "foo" {
+	name = "%s"
+	domain {
+		name    = "%s"
+		comment = "tf-testing-domain"
+	}
+	backend {
+		address = "%s"
+		name    = "tf-testing-backend"
+	}
+	pool {
+		name       = var.pool_name
+	}
+	force_destroy = true
+}
+
+resource "fastly_service_pool_servers_v1" "servers" {
+	service_id = fastly_service_v1.foo.id
+	# pool_id = {for s in fastly_service_v1.foo.pool : s.name => s.id}[var.pool_name]
+         pool_id    = {for p in fastly_service_v1.foo.pool : p.name => p.pool_id}[var.pool_name]
+	%s
+
+}`, poolName, serviceName, domainName, backendName, serverEntries)
+}

--- a/fastly/resource_fastly_service_v1.go
+++ b/fastly/resource_fastly_service_v1.go
@@ -218,6 +218,11 @@ func resourceServiceV1() *schema.Resource {
 							Required:    true,
 							Description: "A name for this Pool",
 						},
+						"id": {
+							Type:        schema.TypeString,
+							Description: "",
+							Computed:    true,
+						},
 						// Optional fields, defaults where they exist
 						"shield": {
 							Type:        schema.TypeString,

--- a/fastly/validators.go
+++ b/fastly/validators.go
@@ -99,3 +99,7 @@ func validateDictionaryItems() schema.SchemaValidateFunc {
 	}
 
 }
+
+func validatePoolQuorum() schema.SchemaValidateFunc {
+	return validation.IntBetween(0, 100)
+}

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/terraform-providers/terraform-provider-fastly
 
 require (
 	github.com/ajg/form v0.0.0-20160822230020-523a5da1a92f // indirect
-	github.com/fastly/go-fastly v1.4.0
+	github.com/fastly/go-fastly v1.5.0
 	github.com/google/jsonapi v0.0.0-20180313013858-2dcc18f43696 // indirect
 	github.com/hashicorp/terraform-plugin-sdk v1.1.0
 )

--- a/go.sum
+++ b/go.sum
@@ -48,6 +48,8 @@ github.com/fastly/go-fastly v1.2.1 h1:7aZI3PL9vHDuHcBgLwj3uv+yCd80tpKTr10B3Q3A1V
 github.com/fastly/go-fastly v1.2.1/go.mod h1:ACxsUdqChasXcraa3/IigjE01rVn3A1F4vaI18Gmm0g=
 github.com/fastly/go-fastly v1.4.0 h1:HAEsfIT97X6Tv5QXBxW4BfDoeecBe+F3yJdRvaQRVhs=
 github.com/fastly/go-fastly v1.4.0/go.mod h1:cBtWXhszIFx9xpzgm9L/3PW3Ixszo153xJBEHJghGUk=
+github.com/fastly/go-fastly v1.5.0 h1:yNzc7CRrNYV3voxgYs420UplsR+YVJPMwYMyh5lzeL4=
+github.com/fastly/go-fastly v1.5.0/go.mod h1:cBtWXhszIFx9xpzgm9L/3PW3Ixszo153xJBEHJghGUk=
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=


### PR DESCRIPTION
Hello,

A Work In Progress to add dynamic server support (pool and server go-fastly 1.5.0.)

My next steps are to go through the following tasks :  
- Write tests for pool and server support
- Documentation to update (?)
- Vendor folder update to include go-fastly 1.5.0. (currently go.mod and go.sum have been updated)  Let me know if you want me to include the 1.5.0 update as part of this PR.

Thanks
Ed


Terraform point of view the Pool and Server resources can be defined as follows:
```
resource "fastly_service_v1" "fastly_service" {
     pool {
         name = "${var.pool_name}"
          …
    }
}

resource "fastly_service_pool_servers_v1" "server" {
  service_id = "${fastly_service_v1.fastly_service.id}"
  pool_id      = "${fastly_service_v1.fastly_service.pool.pool_id}"
  server {
    address   = "127.0.0.1"
    comment = "Server 1"
  }
}

resource "fastly_service_pool_servers_v1" "server2" {
  service_id = "${fastly_service_v1.fastly_service.id}"
  pool_id      = "${fastly_service_v1.fastly_service.pool.pool_id}"
  server {
    address   = "127.0.0.2"
    comment = "Server 2"
  }
}
```
