### PR TITLE
Use the same domain for all acceptance tests

### DIFF
--- a/fastly/resource_fastly_service_v1_syslog_test.go
+++ b/fastly/resource_fastly_service_v1_syslog_test.go
@@ -75,7 +75,7 @@ func TestResourceFastlyFlattenSyslog(t *testing.T) {
 func TestAccFastlyServiceV1_syslog_basic(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
-	domainName1 := fmt.Sprintf("%s.notadomain1.com", acctest.RandString(10))
+	domainName1 := fmt.Sprintf("fastly-test.tf-%s.com", acctest.RandString(10))
 
 	log1 := gofastly.Syslog{
 		Version:           1,
@@ -147,7 +147,7 @@ func TestAccFastlyServiceV1_syslog_basic(t *testing.T) {
 func TestAccFastlyServiceV1_syslog_formatVersion(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
-	domainName1 := fmt.Sprintf("%s.notadomain1.com", acctest.RandString(10))
+	domainName1 := fmt.Sprintf("fastly-test.tf-%s.com", acctest.RandString(10))
 
 	log1 := gofastly.Syslog{
 		Version:       1,
@@ -187,7 +187,7 @@ func TestAccFastlyServiceV1_syslog_useTls(t *testing.T) {
 	}
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
-	domainName1 := fmt.Sprintf("%s.notadomain1.com", acctest.RandString(10))
+	domainName1 := fmt.Sprintf("fastly-test.tf-%s.com", acctest.RandString(10))
 
 	// set env Vars to something we expect
 	resetEnv := setSyslogEnv(key, cert, t)

--- a/fastly/resource_fastly_service_v1_test.go
+++ b/fastly/resource_fastly_service_v1_test.go
@@ -175,7 +175,7 @@ func TestAccFastlyServiceV1_updateDomain(t *testing.T) {
 func TestAccFastlyServiceV1_updateBackend(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
-	domain := fmt.Sprintf("tf-acc-test-%s.com", acctest.RandString(10))
+	domain := fmt.Sprintf("fastly-test.tf-%s.com", acctest.RandString(10))
 	backendName := fmt.Sprintf("%s.aws.amazon.com", acctest.RandString(3))
 	backendName2 := fmt.Sprintf("%s.aws.amazon.com", acctest.RandString(3))
 
@@ -210,7 +210,7 @@ func TestAccFastlyServiceV1_updateBackend(t *testing.T) {
 func TestAccFastlyServiceV1_updateInvalidBackend(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
-	domain := fmt.Sprintf("tf-acc-test-%s.com", acctest.RandString(10))
+	domain := fmt.Sprintf("fastly-test.tf-%s.com", acctest.RandString(10))
 	badBackendName := fmt.Sprintf("%s.aws.amazon.com.", acctest.RandString(3))
 	backendName := fmt.Sprintf("%s.aws.amazon.com", acctest.RandString(3))
 	backendName2 := fmt.Sprintf("%s.aws.amazon.com", acctest.RandString(3))
@@ -249,8 +249,8 @@ func TestAccFastlyServiceV1_basic(t *testing.T) {
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	comment := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	versionComment := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
-	domainName1 := fmt.Sprintf("tf-acc-test-%s.com", acctest.RandString(10))
-	domainName2 := fmt.Sprintf("tf-acc-test-%s.com", acctest.RandString(10))
+	domainName1 := fmt.Sprintf("fastly-test.tf-%s.com", acctest.RandString(10))
+	domainName2 := fmt.Sprintf("fastly-test.tf-%s.com", acctest.RandString(10))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -304,7 +304,7 @@ func TestAccFastlyServiceV1_basic(t *testing.T) {
 func TestAccFastlyServiceV1_disappears(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
-	domainName := fmt.Sprintf("tf-acc-test-%s.com", acctest.RandString(10))
+	domainName := fmt.Sprintf("fastly-test.tf-%s.com", acctest.RandString(10))
 
 	testDestroy := func(*terraform.State) error {
 		// reach out and DELETE the service
@@ -444,7 +444,7 @@ func testAccCheckFastlyServiceV1Attributes_backends(service *gofastly.ServiceDet
 func TestAccFastlyServiceV1_defaultTTL(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
-	domain := fmt.Sprintf("terraform-acc-test-%s.com", acctest.RandString(10))
+	domain := fmt.Sprintf("fastly-test.tf-%s.com", acctest.RandString(10))
 	backendName := fmt.Sprintf("%s.aws.amazon.com", acctest.RandString(3))
 	backendName2 := fmt.Sprintf("%s.aws.amazon.com", acctest.RandString(3))
 
@@ -493,7 +493,7 @@ func TestAccFastlyServiceV1_defaultTTL(t *testing.T) {
 func TestAccFastlyServiceV1_createDefaultTTL(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
-	domain := fmt.Sprintf("terraform-acc-test-%s.com", acctest.RandString(10))
+	domain := fmt.Sprintf("fastly-test.tf-%s.com", acctest.RandString(10))
 	backendName := fmt.Sprintf("%s.aws.amazon.com", acctest.RandString(3))
 
 	resource.Test(t, resource.TestCase{
@@ -517,7 +517,7 @@ func TestAccFastlyServiceV1_createDefaultTTL(t *testing.T) {
 func TestAccFastlyServiceV1_createZeroDefaultTTL(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
-	domain := fmt.Sprintf("terraform-acc-test-%s.com", acctest.RandString(10))
+	domain := fmt.Sprintf("fastly-test.tf-%s.com", acctest.RandString(10))
 	backendName := fmt.Sprintf("%s.aws.amazon.com", acctest.RandString(3))
 
 	resource.Test(t, resource.TestCase{

--- a/fastly/resource_fastly_service_v1_versionless_test.go
+++ b/fastly/resource_fastly_service_v1_versionless_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	gofastly "github.com/fastly/go-fastly/fastly"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 )
 
@@ -16,7 +17,7 @@ func TestAccFastlyServiceV1_creation_with_versionless_resources(t *testing.T) {
 	aclName := "tf_test_acl_versionless"
 	dynamicSnippetName := "tf_test_dynamic_snippet"
 
-	domainName := "tf.test.versionlessexample.com"
+	domainName := fmt.Sprintf("fastly-test.tf-%s.com", acctest.RandString(10))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },


### PR DESCRIPTION
The acceptance tests of `fastly/resource_fastly_service_v1_syslog_test.go` are currently failing:

```
=== RUN   TestAccFastlyServiceV1_syslog_basic
--- FAIL: TestAccFastlyServiceV1_syslog_basic (3.58s)
    testing.go:569: Step 0 error: errors during apply:

        Error: 400 - Bad Request:

            Title:  Bad request
            Detail: Domain 'notadomain1.com' is already taken by another customer

          on /var/folders/n4/ggm3f3vn1wbcql74h1xqt0nr0000gn/T/tf-test305549885/main.tf line 2:
          (source code not available)


=== RUN   TestAccFastlyServiceV1_syslog_formatVersion
--- FAIL: TestAccFastlyServiceV1_syslog_formatVersion (3.17s)
    testing.go:569: Step 0 error: errors during apply:

        Error: 400 - Bad Request:

            Title:  Bad request
            Detail: Domain 'notadomain1.com' is already taken by another customer

          on /var/folders/n4/ggm3f3vn1wbcql74h1xqt0nr0000gn/T/tf-test259495287/main.tf line 2:
          (source code not available)


=== RUN   TestAccFastlyServiceV1_syslog_useTls
--- FAIL: TestAccFastlyServiceV1_syslog_useTls (3.72s)
    testing.go:569: Step 0 error: errors during apply:

        Error: 400 - Bad Request:

            Title:  Bad request
            Detail: Domain 'notadomain1.com' is already taken by another customer

          on /var/folders/n4/ggm3f3vn1wbcql74h1xqt0nr0000gn/T/tf-test063435457/main.tf line 2:
          (source code not available)
```

This PR aligns the domain `"fastly-test.tf-%s.com"` to all acceptance tests. After this PR is merged all acceptance tests use the same domain so that it can be easily replaced if it is used by another user again. 