### PR TITLE
Add ability to terraform fastly users

### DIFF
--- a/fastly/provider.go
+++ b/fastly/provider.go
@@ -31,6 +31,7 @@ func Provider() terraform.ResourceProvider {
 			"fastly_service_acl_entries_v1":             resourceServiceAclEntriesV1(),
 			"fastly_service_dictionary_items_v1":        resourceServiceDictionaryItemsV1(),
 			"fastly_service_dynamic_snippet_content_v1": resourceServiceDynamicSnippetContentV1(),
+			"fastly_user_v1":                            resourceUserV1(),
 		},
 	}
 

--- a/fastly/resource_fastly_user_v1.go
+++ b/fastly/resource_fastly_user_v1.go
@@ -32,7 +32,7 @@ func resourceUserV1() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Default:      "user",
-				Description:  "The user-assigned permissions role. Can be `user`, `billing`, `engineer`, or `superuser`.",
+				Description:  "The user-assigned permissions role. Can be `user` (the default), `billing`, `engineer`, or `superuser`.",
 				ValidateFunc: validateUserRole(),
 			},
 		},

--- a/fastly/resource_fastly_user_v1.go
+++ b/fastly/resource_fastly_user_v1.go
@@ -1,0 +1,109 @@
+package fastly
+
+import (
+	gofastly "github.com/fastly/go-fastly/fastly"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func resourceUserV1() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceUserV1Create,
+		Read:   resourceUserV1Read,
+		Update: resourceUserV1Update,
+		Delete: resourceUserV1Delete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"login": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The email address, which is the login name, of this user.",
+			},
+
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The real life name of the user.",
+			},
+
+			"role": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      "user",
+				Description:  "The user-assigned permissions role. Can be `user`, `billing`, `engineer`, or `superuser`.",
+				ValidateFunc: validateUserRole(),
+			},
+		},
+	}
+}
+
+func resourceUserV1Create(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*FastlyClient).conn
+
+	u, err := conn.CreateUser(&gofastly.CreateUserInput{
+		Login: d.Get("login").(string),
+		Name:  d.Get("name").(string),
+		Role:  d.Get("role").(string),
+	})
+
+	if err != nil {
+		return err
+	}
+
+	d.SetId(u.ID)
+
+	return nil
+}
+
+func resourceUserV1Read(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*FastlyClient).conn
+
+	u, err := conn.GetUser(&gofastly.GetUserInput{
+		ID: d.Id(),
+	})
+
+	if err != nil {
+		return err
+	}
+
+	d.Set("login", u.Login)
+	d.Set("name", u.Name)
+	d.Set("role", u.Role)
+
+	return nil
+}
+
+func resourceUserV1Update(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*FastlyClient).conn
+
+	// Update Name and/or Role.
+	if d.HasChange("name") || d.HasChange("role") {
+		_, err := conn.UpdateUser(&gofastly.UpdateUserInput{
+			ID:   d.Id(),
+			Name: d.Get("name").(string),
+			Role: d.Get("role").(string),
+		})
+
+		if err != nil {
+			return err
+		}
+	}
+
+	return resourceUserV1Read(d, meta)
+}
+
+func resourceUserV1Delete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*FastlyClient).conn
+
+	err := conn.DeleteUser(&gofastly.DeleteUserInput{
+		ID: d.Id(),
+	})
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/fastly/resource_fastly_user_v1.go
+++ b/fastly/resource_fastly_user_v1.go
@@ -19,6 +19,7 @@ func resourceUserV1() *schema.Resource {
 			"login": {
 				Type:        schema.TypeString,
 				Required:    true,
+				ForceNew:    true,
 				Description: "The email address, which is the login name, of this user.",
 			},
 

--- a/fastly/resource_fastly_user_v1_test.go
+++ b/fastly/resource_fastly_user_v1_test.go
@@ -41,11 +41,46 @@ func TestAccFastlyUserV1_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckUserV1Exists("fastly_user_v1.foo", &user),
 					resource.TestCheckResourceAttr(
-						"fastly_user_v1.foo", "login", login),
-					resource.TestCheckResourceAttr(
 						"fastly_user_v1.foo", "name", name2),
 					resource.TestCheckResourceAttr(
 						"fastly_user_v1.foo", "role", role2),
+				),
+			},
+		},
+	})
+}
+
+func TestAccFastlyUserV1_updateLogin(t *testing.T) {
+	var user gofastly.User
+	login := fmt.Sprintf("tf-test-%s@example.com", acctest.RandString(10))
+	login2 := fmt.Sprintf("tf-test-%s@example.com", acctest.RandString(10))
+	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	role := "engineer"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckUserV1Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccUserV1Config(login, name, role),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckUserV1Exists("fastly_user_v1.foo", &user),
+					resource.TestCheckResourceAttr(
+						"fastly_user_v1.foo", "login", login),
+					resource.TestCheckResourceAttr(
+						"fastly_user_v1.foo", "name", name),
+					resource.TestCheckResourceAttr(
+						"fastly_user_v1.foo", "role", role),
+				),
+			},
+
+			{
+				Config: testAccUserV1Config(login2, name, role),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckUserV1Exists("fastly_user_v1.foo", &user),
+					resource.TestCheckResourceAttr(
+						"fastly_user_v1.foo", "login", login2),
 				),
 			},
 		},

--- a/fastly/resource_fastly_user_v1_test.go
+++ b/fastly/resource_fastly_user_v1_test.go
@@ -1,0 +1,113 @@
+package fastly
+
+import (
+	"fmt"
+	"testing"
+
+	gofastly "github.com/fastly/go-fastly/fastly"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestAccFastlyUserV1_basic(t *testing.T) {
+	var user gofastly.User
+	login := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	role := "engineer"
+	name2 := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	role2 := "superuser"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckUserV1Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccUserV1Config(login, name, role),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckUserV1Exists("fastly_user_v1.foo", &user),
+					resource.TestCheckResourceAttr(
+						"fastly_user_v1.foo", "login", login),
+					resource.TestCheckResourceAttr(
+						"fastly_user_v1.foo", "name", name),
+					resource.TestCheckResourceAttr(
+						"fastly_user_v1.foo", "role", role),
+				),
+			},
+
+			{
+				Config: testAccUserV1Config(login, name2, role2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckUserV1Exists("fastly_user_v1.foo", &user),
+					resource.TestCheckResourceAttr(
+						"fastly_user_v1.foo", "login", login),
+					resource.TestCheckResourceAttr(
+						"fastly_user_v1.foo", "name", name2),
+					resource.TestCheckResourceAttr(
+						"fastly_user_v1.foo", "role", role2),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckUserV1Exists(n string, user *gofastly.User) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No User ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*FastlyClient).conn
+		latest, err := conn.GetUser(&gofastly.GetUserInput{
+			ID: rs.Primary.ID,
+		})
+
+		if err != nil {
+			return err
+		}
+
+		*user = *latest
+
+		return nil
+	}
+}
+
+func testAccCheckUserV1Destroy(s *terraform.State) error {
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "fastly_user_v1" {
+			continue
+		}
+
+		conn := testAccProvider.Meta().(*FastlyClient).conn
+		u, err := conn.GetCurrentUser()
+		l, err := conn.ListCustomerUsers(&gofastly.ListCustomerUsersInput{
+			CustomerID: u.CustomerID,
+		})
+		if err != nil {
+			return fmt.Errorf("[WARN] Error listing users when deleting Fastly User (%s): %s", rs.Primary.ID, err)
+		}
+
+		for _, u := range l {
+			if u.ID == rs.Primary.ID {
+				// user still found
+				return fmt.Errorf("[WARN] Tried deleting User (%s), but was still found", rs.Primary.ID)
+			}
+		}
+	}
+	return nil
+}
+
+func testAccUserV1Config(login, name, role string) string {
+	return fmt.Sprintf(`
+resource "fastly_user_v1" "foo" {
+	login = "%s"
+	name  = "%s"
+	role  = "%s"
+}`, login, name, role)
+}

--- a/fastly/resource_fastly_user_v1_test.go
+++ b/fastly/resource_fastly_user_v1_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestAccFastlyUserV1_basic(t *testing.T) {
 	var user gofastly.User
-	login := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	login := fmt.Sprintf("tf-test-%s@example.com", acctest.RandString(10))
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	role := "engineer"
 	name2 := fmt.Sprintf("tf-test-%s", acctest.RandString(10))

--- a/fastly/validators.go
+++ b/fastly/validators.go
@@ -2,6 +2,7 @@ package fastly
 
 import (
 	"fmt"
+
 	gofastly "github.com/fastly/go-fastly/fastly"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
@@ -106,4 +107,16 @@ func validateDictionaryItems() schema.SchemaValidateFunc {
 		return
 	}
 
+}
+
+func validateUserRole() schema.SchemaValidateFunc {
+	return validation.StringInSlice(
+		[]string{
+			"user",
+			"billing",
+			"engineer",
+			"superuser",
+		},
+		false,
+	)
 }

--- a/fastly/validators_test.go
+++ b/fastly/validators_test.go
@@ -314,3 +314,30 @@ func createTestDictionaryItems(size int) map[string]interface{} {
 
 	return dictionaryItems
 }
+
+func TestValidateUserRole(t *testing.T) {
+	for _, testcase := range []struct {
+		value          string
+		expectedWarns  int
+		expectedErrors int
+	}{
+		{"user", 0, 0},
+		{"billing", 0, 0},
+		{"engineer", 0, 0},
+		{"superuser", 0, 0},
+		{"USER", 0, 1},
+		{"BILLING", 0, 1},
+		{"ENGINEER", 0, 1},
+		{"SUPERUSER", 0, 1},
+	} {
+		t.Run(testcase.value, func(t *testing.T) {
+			actualWarns, actualErrors := validateUserRole()(testcase.value, "role")
+			if len(actualWarns) != testcase.expectedWarns {
+				t.Errorf("expected %d warnings, actual %d ", testcase.expectedWarns, len(actualWarns))
+			}
+			if len(actualErrors) != testcase.expectedErrors {
+				t.Errorf("expected %d errors, actual %d ", testcase.expectedErrors, len(actualErrors))
+			}
+		})
+	}
+}

--- a/website/docs/r/user_v1.html.markdown
+++ b/website/docs/r/user_v1.html.markdown
@@ -1,0 +1,46 @@
+---
+layout: "fastly"
+page_title: "Fastly: user_v1"
+sidebar_current: "docs-fastly-resource-user-v1"
+description: |-
+  Provides a Fastly User
+---
+
+# fastly_user_v1
+
+Provides a Fastly User, representing the configuration for a user account for interacting with Fastly.
+
+The User resource requires a login and name, and optionally a role.
+
+## Example Usage
+
+Basic usage:
+
+```hcl
+resource "fastly_user_v1" "demo" {
+  login = "demo@example.com"
+  name  = "Demo User"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `login` - (Required) The email address, which is the login name, of the User.
+* `name` - (Required) The real life name of the user.
+* `role` - (Optional) The role of this user. Can be `user` (the default), `billing`, `engineer`, or `superuser`.
+
+## Attributes Reference
+
+In addition to the arguments listed above, the following attributes are exported:
+
+* `id` – The ID of the User.
+
+## Import
+
+A Fastly User can be imported using their user ID, e.g.
+
+```
+$ terraform import fastly_user_v1.demo xxxxxxxxxxxxxxxxxxxx
+```

--- a/website/docs/r/user_v1.html.markdown
+++ b/website/docs/r/user_v1.html.markdown
@@ -29,7 +29,7 @@ The following arguments are supported:
 
 * `login` - (Required, Forces new resource) The email address, which is the login name, of the User.
 * `name` - (Required) The real life name of the user.
-* `role` - (Optional) The role of this user. Can be `user` (the default), `billing`, `engineer`, or `superuser`.
+* `role` - (Optional) The role of this user. Can be `user` (the default), `billing`, `engineer`, or `superuser`. For detailed information on the abilities granted to each role, see [Fastly's Documentation on User roles](https://docs.fastly.com/en/guides/configuring-user-roles-and-permissions#user-roles-and-what-they-can-do).
 
 ## Attributes Reference
 

--- a/website/docs/r/user_v1.html.markdown
+++ b/website/docs/r/user_v1.html.markdown
@@ -27,7 +27,7 @@ resource "fastly_user_v1" "demo" {
 
 The following arguments are supported:
 
-* `login` - (Required) The email address, which is the login name, of the User.
+* `login` - (Required, Forces new resource) The email address, which is the login name, of the User.
 * `name` - (Required) The real life name of the user.
 * `role` - (Optional) The role of this user. Can be `user` (the default), `billing`, `engineer`, or `superuser`.
 

--- a/website/fastly.erb
+++ b/website/fastly.erb
@@ -35,6 +35,9 @@
                         <li<%= sidebar_current("docs-fastly-resource-service-dynamic-snippet-content-v1") %>>
                             <a href="/docs/providers/fastly/r/service_dynamic_snippet_content_v1.html">fastly_service_dynamic_snippet_content_v1</a>
                         </li>
+                        <li<%= sidebar_current("docs-fastly-resource-user-v1") %>>
+                            <a href="/docs/providers/fastly/r/user_v1.html">fastly_user_v1</a>
+                        </li>
                     </ul>
 
                 </li>


### PR DESCRIPTION
related: #134 

(I think) this PR adds support for basic user crud operations -- and updates the docs

a separate PR would be needed add support for configuring service access for the "engineer" role (and probably requires additional support in go-fastly)

please let me know what else might be needed to get this minimum viable support merged @philippschulte :-)

acceptance tests...
```
make testacc TESTARGS='-run=TestAccFastlyUserV1'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccFastlyUserV1 -timeout 120m -ldflags="-X=github.com/terraform-providers/terraform-provider-fastly/version.ProviderVersion=acc"
?   	github.com/terraform-providers/terraform-provider-fastly	[no test files]
=== RUN   TestAccFastlyUserV1_basic
--- PASS: TestAccFastlyUserV1_basic (6.49s)
=== RUN   TestAccFastlyUserV1_updateLogin
--- PASS: TestAccFastlyUserV1_updateLogin (5.87s)
PASS
```
