### PR TITLE
Fix support for `hash` type snippets.

### DIFF
--- a/fastly/resource_fastly_service_v1.go
+++ b/fastly/resource_fastly_service_v1.go
@@ -4509,6 +4509,8 @@ func buildSnippet(snippetMap interface{}) (*gofastly.CreateSnippetInput, error) 
 		opts.Type = gofastly.SnippetTypeInit
 	case "recv":
 		opts.Type = gofastly.SnippetTypeRecv
+	case "hash":
+		opts.Type = gofastly.SnippetTypeHash
 	case "hit":
 		opts.Type = gofastly.SnippetTypeHit
 	case "miss":
@@ -4544,6 +4546,8 @@ func buildDynamicSnippet(dynamicSnippetMap interface{}) (*gofastly.CreateSnippet
 		opts.Type = gofastly.SnippetTypeInit
 	case "recv":
 		opts.Type = gofastly.SnippetTypeRecv
+	case "hash":
+		opts.Type = gofastly.SnippetTypeHash
 	case "hit":
 		opts.Type = gofastly.SnippetTypeHit
 	case "miss":


### PR DESCRIPTION
Support for `hash` type snippets was added in PR #211, but this PR only modified the validation code. The client code was not updated, and the Terraform provider sends an empty `type` query parameter when the value is set to `hash`.

Fixes #216 