### PR TITLE
Add `tls_hostname` and `tls_ca_cert` fields to splunk logging

### DIFF
--- a/fastly/resource_fastly_service_v1.go
+++ b/fastly/resource_fastly_service_v1.go
@@ -1147,14 +1147,13 @@ func resourceServiceV1() *schema.Resource {
 						"tls_hostname": {
 							Type:        schema.TypeString,
 							Optional:    true,
-							Default:     "",
 							Description: "The hostname used to verify the server's certificate. It can either be the Common Name or a Subject Alternative Name (SAN).",
 						},
 						"tls_ca_cert": {
 							Type:        schema.TypeString,
 							Optional:    true,
 							DefaultFunc: schema.EnvDefaultFunc("FASTLY_SPLUNK_CA_CERT", ""),
-							Description: "A secure certificate to authenticate the server with. Must be in PEM format.",
+							Description: "A secure certificate to authenticate the server with. Must be in PEM format. You can provide this certificate via an environment variable, `FASTLY_SPLUNK_CA_CERT`.",
 						},
 					},
 				},

--- a/fastly/resource_fastly_service_v1.go
+++ b/fastly/resource_fastly_service_v1.go
@@ -1144,6 +1144,18 @@ func resourceServiceV1() *schema.Resource {
 							Optional:    true,
 							Description: "The name of the condition to apply",
 						},
+						"tls_hostname": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Default:     "",
+							Description: "The hostname used to verify the server's certificate. It can either be the Common Name or a Subject Alternative Name (SAN).",
+						},
+						"tls_ca_cert": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							DefaultFunc: schema.EnvDefaultFunc("FASTLY_SPLUNK_CA_CERT", ""),
+							Description: "A secure certificate to authenticate the server with. Must be in PEM format.",
+						},
 					},
 				},
 			},
@@ -2655,6 +2667,8 @@ func resourceServiceV1Update(d *schema.ResourceData, meta interface{}) error {
 					ResponseCondition: sf["response_condition"].(string),
 					Placement:         sf["placement"].(string),
 					Token:             sf["token"].(string),
+					TLSHostname:       sf["tls_hostname"].(string),
+					TLSCACert:         sf["tls_ca_cert"].(string),
 				}
 
 				log.Printf("[DEBUG] Splunk create opts: %#v", opts)
@@ -4253,6 +4267,8 @@ func flattenSplunks(splunkList []*gofastly.Splunk) []map[string]interface{} {
 			"response_condition": s.ResponseCondition,
 			"placement":          s.Placement,
 			"token":              s.Token,
+			"tls_hostname":       s.TLSHostname,
+			"tls_ca_cert":        s.TLSCACert,
 		}
 
 		// prune any empty values that come from the default string value in structs

--- a/fastly/resource_fastly_service_v1_splunk_test.go
+++ b/fastly/resource_fastly_service_v1_splunk_test.go
@@ -394,7 +394,7 @@ resource "fastly_service_v1" "foo" {
     format             = %q
     format_version     = 1
     placement          = "waf_debug"
-	  tls_hostname       = "example.com"
+    tls_hostname       = "example.com"
     tls_ca_cert        = %q
     response_condition = "error_response_5XX"
   }
@@ -498,8 +498,8 @@ resource "fastly_service_v1" "foo" {
     format             = %q
     format_version     = 2
     placement          = "waf_debug"
-		tls_hostname       = "example.com"
-		tls_ca_cert        = %q
+    tls_hostname       = "example.com"
+    tls_ca_cert        = %q
     response_condition = "error_response_5XX"
   }
 
@@ -510,8 +510,8 @@ resource "fastly_service_v1" "foo" {
     format             = %q
     format_version     = 2
     placement          = "waf_debug"
-		tls_hostname       = "example.com"
-		tls_ca_cert        = %q
+    tls_hostname       = "example.com"
+    tls_ca_cert        = %q
     response_condition = "ok_response_2XX"
   }
 

--- a/fastly/resource_fastly_service_v1_splunk_test.go
+++ b/fastly/resource_fastly_service_v1_splunk_test.go
@@ -579,7 +579,7 @@ func setSplunkEnv(token string, cert string, t *testing.T) func() {
 		t.Fatalf("Error setting env var FASTLY_SPLUNK_TOKEN: %s", err)
 	}
 
-	if err := os.Setenv("FASTLY_SYSLOG_CA_CERT", cert); err != nil {
+	if err := os.Setenv("FASTLY_SPLUNK_CA_CERT", cert); err != nil {
 		t.Fatalf("Error setting env var FASTLY_SPLUNK_CA_CERT: %s", err)
 	}
 

--- a/fastly/resource_fastly_service_v1_splunk_test.go
+++ b/fastly/resource_fastly_service_v1_splunk_test.go
@@ -394,8 +394,8 @@ resource "fastly_service_v1" "foo" {
     format             = %q
     format_version     = 1
     placement          = "waf_debug"
-		tls_hostname       = "example.com"
-		tls_ca_cert        = %q
+	  tls_hostname       = "example.com"
+    tls_ca_cert        = %q
     response_condition = "error_response_5XX"
   }
 

--- a/website/docs/r/service_v1.html.markdown
+++ b/website/docs/r/service_v1.html.markdown
@@ -474,6 +474,8 @@ The `splunk` block supports:
 * `format_version` - (Optional) The version of the custom logging format used for the configured endpoint. Can be either `1` or `2`. The logging call gets placed by default in `vcl_log` if `format_version` is set to `2` and in `vcl_deliver` if `format_version` is set to `1`. Default `2`.
 * `placement` - (Optional) Where in the generated VCL the logging call should be placed, overriding any `format_version` default. Can be either `none` or `waf_debug`.
 * `response_condition` - (Optional) The name of the `condition` to apply. If empty, always execute.
+* `tls_hostname` - (Optional) The hostname used to verify the server's certificate. It can either be the Common Name or a Subject Alternative Name (SAN).
+* `tls_ca_cert` - (Optional) A secure certificate to authenticate the server with. Must be in PEM format. You can provide this certificate via an environment variable, `FASTLY_SPLUNK_CA_CERT`.
 
 The `blobstoragelogging` block supports:
 


### PR DESCRIPTION
Adds `tls_hostname` and `tls_ca_cert` fields to Splunk logging configuration.