### PR TITLE
Add support for HTTPS logging

### DIFF
--- a/fastly/block_fastly_service_v1_httpslogging.go
+++ b/fastly/block_fastly_service_v1_httpslogging.go
@@ -1,0 +1,306 @@
+package fastly
+
+import (
+	"fmt"
+	"log"
+
+	gofastly "github.com/fastly/go-fastly/fastly"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+)
+
+var httpsloggingSchema = &schema.Schema{
+	Type:     schema.TypeSet,
+	Optional: true,
+	Elem: &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			// Required fields
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The unique name of the HTTPS logging endpoint",
+			},
+			"url": {
+				Type:         schema.TypeString,
+				Required:     true,
+				Description:  "URL that log data will be sent to. Must use the https protocol.",
+				ValidateFunc: validateHTTPSURL(),
+			},
+
+			// Optional fields
+			"request_max_entries": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: "The maximum number of logs sent in one request.",
+			},
+
+			"request_max_bytes": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: "The maximum number of bytes sent in one request.",
+			},
+
+			"content_type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Content-Type header sent with the request.",
+			},
+
+			"header_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Custom header sent with the request.",
+			},
+
+			"header_value": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Value of the custom header sent with the request.",
+			},
+
+			"method": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      "POST",
+				Description:  "HTTP method used for request.",
+				ValidateFunc: validation.StringInSlice([]string{"POST", "PUT"}, false),
+			},
+
+			// NOTE: The `json_format` field's documented type is string, but it should likely be an integer.
+			"json_format": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      "0",
+				Description:  "Formats log entries as JSON. Can be either disabled (`0`), array of json (`1`), or newline delimited json (`2`).",
+				ValidateFunc: validation.StringInSlice([]string{"0", "1", "2"}, false),
+			},
+
+			"tls_ca_cert": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "A secure certificate to authenticate the server with. Must be in PEM format.",
+				Sensitive:   true,
+			},
+
+			"tls_client_cert": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The client certificate used to make authenticated requests. Must be in PEM format.",
+				Sensitive:   true,
+			},
+
+			"tls_client_key": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The client private key used to make authenticated requests. Must be in PEM format.",
+				Sensitive:   true,
+			},
+
+			"tls_hostname": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The hostname used to verify the server's certificate. It can either be the Common Name (CN) or a Subject Alternative Name (SAN).",
+			},
+
+			"format": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Apache-style string or VCL variables to use for log formatting.",
+			},
+
+			"format_version": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      2,
+				Description:  "The version of the custom logging format used for the configured endpoint. Can be either 1 or 2. (default: 2)",
+				ValidateFunc: validateLoggingFormatVersion(),
+			},
+
+			"message_type": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      "blank",
+				Description:  "How the message should be formatted",
+				ValidateFunc: validateLoggingMessageType(),
+			},
+
+			"placement": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Description:  "Where in the generated VCL the logging call should be placed",
+				ValidateFunc: validateLoggingPlacement(),
+			},
+
+			"response_condition": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The name of the condition to apply",
+			},
+		},
+	},
+}
+
+func processHTTPS(d *schema.ResourceData, conn *gofastly.Client, latestVersion int) error {
+	serviceID := d.Id()
+	oh, nh := d.GetChange("httpslogging")
+
+	if oh == nil {
+		oh = new(schema.Set)
+	}
+	if nh == nil {
+		nh = new(schema.Set)
+	}
+
+	ohs := oh.(*schema.Set)
+	nhs := nh.(*schema.Set)
+
+	removeHTTPSLogging := ohs.Difference(nhs).List()
+	addHTTPSLogging := nhs.Difference(ohs).List()
+
+	// DELETE old HTTPS logging endpoints
+	for _, oRaw := range removeHTTPSLogging {
+		of := oRaw.(map[string]interface{})
+		opts := buildDeleteHTTPS(of, serviceID, latestVersion)
+
+		log.Printf("[DEBUG] Fastly HTTPS logging endpoint removal opts: %#v", opts)
+
+		if err := deleteHTTPS(conn, opts); err != nil {
+			return err
+		}
+	}
+
+	// POST new/updated HTTPS logging endponts
+	for _, nRaw := range addHTTPSLogging {
+		hf := nRaw.(map[string]interface{})
+		opts := buildCreateHTTPS(hf, serviceID, latestVersion)
+
+		log.Printf("[DEBUG] Fastly HTTPS logging addition opts: %#v", opts)
+
+		if err := createHTTPS(conn, opts); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func readHTTPS(conn *gofastly.Client, d *schema.ResourceData, s *gofastly.ServiceDetail) error {
+	// refresh HTTPS
+	log.Printf("[DEBUG] Refreshing HTTPS logging endpoints for (%s)", d.Id())
+	httpsList, err := conn.ListHTTPS(&gofastly.ListHTTPSInput{
+		Service: d.Id(),
+		Version: s.ActiveVersion.Number,
+	})
+
+	if err != nil {
+		return fmt.Errorf("[ERR] Error looking up HTTPS logging endpoints for (%s), version (%v): %s", d.Id(), s.ActiveVersion.Number, err)
+	}
+
+	hll := flattenHTTPS(httpsList)
+
+	if err := d.Set("httpslogging", hll); err != nil {
+		log.Printf("[WARN] Error setting HTTPS logging endpoints for (%s): %s", d.Id(), err)
+	}
+
+	return nil
+}
+
+func createHTTPS(conn *gofastly.Client, i *gofastly.CreateHTTPSInput) error {
+	_, err := conn.CreateHTTPS(i)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func deleteHTTPS(conn *gofastly.Client, i *gofastly.DeleteHTTPSInput) error {
+	err := conn.DeleteHTTPS(i)
+
+	if errRes, ok := err.(*gofastly.HTTPError); ok {
+		if errRes.StatusCode != 404 {
+			return err
+		}
+	} else if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func flattenHTTPS(httpsList []*gofastly.HTTPS) []map[string]interface{} {
+	var hsl []map[string]interface{}
+	for _, hl := range httpsList {
+		// Convert HTTP logging to a map for saving to state.
+		nhl := map[string]interface{}{
+			"name":                hl.Name,
+			"response_condition":  hl.ResponseCondition,
+			"format":              hl.Format,
+			"url":                 hl.URL,
+			"request_max_entries": hl.RequestMaxEntries,
+			"request_max_bytes":   hl.RequestMaxBytes,
+			"content_type":        hl.ContentType,
+			"header_name":         hl.HeaderName,
+			"header_value":        hl.HeaderValue,
+			"method":              hl.Method,
+			"json_format":         hl.JSONFormat,
+			"placement":           hl.Placement,
+			"tls_ca_cert":         hl.TLSCACert,
+			"tls_client_cert":     hl.TLSClientCert,
+			"tls_client_key":      hl.TLSClientKey,
+			"tls_hostname":        hl.TLSHostname,
+			"message_type":        hl.MessageType,
+			"format_version":      hl.FormatVersion,
+		}
+
+		// prune any empty values that come from the default string value in structs
+		for k, v := range nhl {
+			if v == "" {
+				delete(nhl, k)
+			}
+		}
+
+		hsl = append(hsl, nhl)
+	}
+
+	return hsl
+}
+
+func buildCreateHTTPS(httpsMap interface{}, serviceID string, serviceVersion int) *gofastly.CreateHTTPSInput {
+	df := httpsMap.(map[string]interface{})
+	opts := gofastly.CreateHTTPSInput{
+		Service:           serviceID,
+		Version:           serviceVersion,
+		Name:              df["name"].(string),
+		URL:               df["url"].(string),
+		RequestMaxEntries: uint(df["request_max_entries"].(int)),
+		RequestMaxBytes:   uint(df["request_max_bytes"].(int)),
+		ContentType:       df["content_type"].(string),
+		HeaderName:        df["header_name"].(string),
+		HeaderValue:       df["header_value"].(string),
+		Method:            df["method"].(string),
+		JSONFormat:        df["json_format"].(string),
+		TLSCACert:         df["tls_ca_cert"].(string),
+		TLSClientCert:     df["tls_client_cert"].(string),
+		TLSClientKey:      df["tls_client_key"].(string),
+		TLSHostname:       df["tls_hostname"].(string),
+		Format:            df["format"].(string),
+		FormatVersion:     uint(df["format_version"].(int)),
+		MessageType:       df["message_type"].(string),
+		Placement:         df["placement"].(string),
+		ResponseCondition: df["response_condition"].(string),
+	}
+
+	return &opts
+}
+
+func buildDeleteHTTPS(httpsMap interface{}, serviceID string, serviceVersion int) *gofastly.DeleteHTTPSInput {
+	df := httpsMap.(map[string]interface{})
+
+	opts := gofastly.DeleteHTTPSInput{
+		Service: serviceID,
+		Version: serviceVersion,
+		Name:    df["name"].(string),
+	}
+
+	return &opts
+}

--- a/fastly/block_fastly_service_v1_httpslogging_test.go
+++ b/fastly/block_fastly_service_v1_httpslogging_test.go
@@ -194,7 +194,7 @@ resource "fastly_service_v1" "foo" {
 
 	httpslogging {
 		name               = "httpslogger"
-    format             = "%%a %%l %%u %%t %%m %%U%%q %%H %%>s %%b %%T"
+		format             = "%%a %%l %%u %%t %%m %%U%%q %%H %%>s %%b %%T"
 		method             = "PUT"
 		url                = "https://example.com/logs/1"
 	}
@@ -219,14 +219,14 @@ resource "fastly_service_v1" "foo" {
 
 	httpslogging {
 		name               = "httpslogger"
-    format             = "%%a %%l %%u %%t %%m %%U%%q %%H %%>s %%b"
+		format             = "%%a %%l %%u %%t %%m %%U%%q %%H %%>s %%b"
 		method             = "POST"
 		url                = "https://example.com/logs/1"
 	}
 
 	httpslogging {
 		name               = "httpslogger2"
-    format             = "%%a %%l %%u %%t %%m %%U%%q %%H %%>s %%b %%T"
+		format             = "%%a %%l %%u %%t %%m %%U%%q %%H %%>s %%b %%T"
 		method             = "POST"
 		url                = "https://example.com/logs/2"
 		request_max_bytes  = 1000

--- a/fastly/resource_fastly_service_v1.go
+++ b/fastly/resource_fastly_service_v1.go
@@ -9,6 +9,7 @@ import (
 
 	gofastly "github.com/fastly/go-fastly/fastly"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 )
 
 var fastlyNoServiceFoundErr = errors.New("No matching Fastly Service found")
@@ -1240,6 +1241,137 @@ func resourceServiceV1() *schema.Resource {
 				},
 			},
 
+			"httpslogging": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						// Required fields
+						"name": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "The unique name of the HTTPS logging endpoint",
+						},
+						"url": {
+							Type:         schema.TypeString,
+							Required:     true,
+							Description:  "URL that log data will be sent to. Must use the https protocol.",
+							ValidateFunc: validateHTTPSURL(),
+						},
+
+						// Optional fields
+						"request_max_entries": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Description: "The maximum number of logs sent in one request.",
+						},
+
+						"request_max_bytes": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Description: "The maximum number of bytes sent in one request.",
+						},
+
+						"content_type": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "Content-Type header sent with the request.",
+						},
+
+						"header_name": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "Custom header sent with the request.",
+						},
+
+						"header_value": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "Value of the custom header sent with the request.",
+						},
+
+						"method": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							Default:      "POST",
+							Description:  "HTTP method used for request.",
+							ValidateFunc: validation.StringInSlice([]string{"POST", "PUT"}, false),
+						},
+
+						// NOTE: The `json_format` field's documented type is string, but it should likely be an integer.
+						"json_format": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							Default:      "0",
+							Description:  "Formats log entries as JSON. Can be either disabled (`0`), array of json (`1`), or newline delimited json (`2`).",
+							ValidateFunc: validation.StringInSlice([]string{"0", "1", "2"}, false),
+						},
+
+						"tls_ca_cert": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "A secure certificate to authenticate the server with. Must be in PEM format.",
+							Sensitive:   true,
+						},
+
+						"tls_client_cert": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "The client certificate used to make authenticated requests. Must be in PEM format.",
+							Sensitive:   true,
+						},
+
+						"tls_client_key": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "The client private key used to make authenticated requests. Must be in PEM format.",
+							Sensitive:   true,
+						},
+
+						"tls_hostname": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "The hostname used to verify the server's certificate. It can either be the Common Name (CN) or a Subject Alternative Name (SAN).",
+						},
+
+						"format": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "Apache-style string or VCL variables to use for log formatting.",
+						},
+
+						"format_version": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							Default:      2,
+							Description:  "The version of the custom logging format used for the configured endpoint. Can be either 1 or 2. (default: 2)",
+							ValidateFunc: validateLoggingFormatVersion(),
+						},
+
+						"message_type": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							Default:      "blank",
+							Description:  "How the message should be formatted",
+							ValidateFunc: validateLoggingMessageType(),
+						},
+
+						"placement": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							Description:  "Where in the generated VCL the logging call should be placed",
+							ValidateFunc: validateLoggingPlacement(),
+						},
+
+						"response_condition": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "The name of the condition to apply",
+						},
+					},
+				},
+			},
+
 			"response_object": {
 				Type:     schema.TypeSet,
 				Optional: true,
@@ -1561,6 +1693,7 @@ func resourceServiceV1Update(d *schema.ResourceData, meta interface{}) error {
 		"logentries",
 		"splunk",
 		"blobstoragelogging",
+		"httpslogging",
 		"response_object",
 		"condition",
 		"request_setting",
@@ -2731,6 +2864,77 @@ func resourceServiceV1Update(d *schema.ResourceData, meta interface{}) error {
 			}
 		}
 
+		// find differences in HTTPS logging configuration
+		if d.HasChange("httpslogging") {
+			oh, nh := d.GetChange("httpslogging")
+			if oh == nil {
+				oh = new(schema.Set)
+			}
+			if nh == nil {
+				nh = new(schema.Set)
+			}
+
+			ohs := oh.(*schema.Set)
+			nhs := nh.(*schema.Set)
+			removeHTTPSLogging := ohs.Difference(nhs).List()
+			addHTTPSLogging := nhs.Difference(ohs).List()
+
+			// DELETE old HTTPS logging endpoints
+			for _, oRaw := range removeHTTPSLogging {
+				of := oRaw.(map[string]interface{})
+				opts := gofastly.DeleteHTTPSInput{
+					Service: d.Id(),
+					Version: latestVersion,
+					Name:    of["name"].(string),
+				}
+
+				log.Printf("[DEBUG] Fastly HTTPS logging endpoint removal opts: %#v", opts)
+				err := conn.DeleteHTTPS(&opts)
+
+				if errRes, ok := err.(*gofastly.HTTPError); ok {
+					if errRes.StatusCode != 404 {
+						return err
+					}
+				} else if err != nil {
+					return err
+				}
+			}
+
+			// POST new/updated HTTPS logging endponts
+			for _, nRaw := range addHTTPSLogging {
+				hf := nRaw.(map[string]interface{})
+				opts := gofastly.CreateHTTPSInput{
+					Service:           d.Id(),
+					Version:           latestVersion,
+					Name:              hf["name"].(string),
+					URL:               hf["url"].(string),
+					RequestMaxEntries: uint(hf["request_max_entries"].(int)),
+					RequestMaxBytes:   uint(hf["request_max_bytes"].(int)),
+					ContentType:       hf["content_type"].(string),
+					HeaderName:        hf["header_name"].(string),
+					HeaderValue:       hf["header_value"].(string),
+					Method:            hf["method"].(string),
+					JSONFormat:        hf["json_format"].(string),
+					TLSCACert:         hf["tls_ca_cert"].(string),
+					TLSClientCert:     hf["tls_client_cert"].(string),
+					TLSClientKey:      hf["tls_client_key"].(string),
+					TLSHostname:       hf["tls_hostname"].(string),
+					Format:            hf["format"].(string),
+					FormatVersion:     uint(hf["format_version"].(int)),
+					MessageType:       hf["message_type"].(string),
+					Placement:         hf["placement"].(string),
+					ResponseCondition: hf["response_condition"].(string),
+				}
+
+				log.Printf("[DEBUG] Fastly HTTPS logging create opts: %#v", opts)
+				_, err := conn.CreateHTTPS(&opts)
+
+				if err != nil {
+					return err
+				}
+			}
+		}
+
 		// find difference in Response Object
 		if d.HasChange("response_object") {
 			or, nr := d.GetChange("response_object")
@@ -3547,6 +3751,22 @@ func resourceServiceV1Read(d *schema.ResourceData, meta interface{}) error {
 			log.Printf("[WARN] Error setting Blob Storages for (%s): %s", d.Id(), err)
 		}
 
+		log.Printf("[DEBUG] Refreshing HTTPS logging endpoints for (%s)", d.Id())
+		httpsList, err := conn.ListHTTPS(&gofastly.ListHTTPSInput{
+			Service: d.Id(),
+			Version: s.ActiveVersion.Number,
+		})
+
+		if err != nil {
+			return fmt.Errorf("[ERR] Error looking up HTTPS logging endpoints for (%s), version (%v): %s", d.Id(), s.ActiveVersion.Number, err)
+		}
+
+		hll := flattenHTTPS(httpsList)
+
+		if err := d.Set("httpslogging", hll); err != nil {
+			log.Printf("[WARN] Error setting HTTPS logging endpoints for (%s): %s", d.Id(), err)
+		}
+
 		// refresh Response Objects
 		log.Printf("[DEBUG] Refreshing Response Object for (%s)", d.Id())
 		responseObjectList, err := conn.ListResponseObjects(&gofastly.ListResponseObjectsInput{
@@ -4300,6 +4520,44 @@ func flattenBlobStorages(blobStorageList []*gofastly.BlobStorage) []map[string]i
 	}
 
 	return bsl
+}
+
+func flattenHTTPS(httpsList []*gofastly.HTTPS) []map[string]interface{} {
+	var hsl []map[string]interface{}
+	for _, hl := range httpsList {
+		// Convert HTTP logging to a map for saving to state.
+		nhl := map[string]interface{}{
+			"name":                hl.Name,
+			"response_condition":  hl.ResponseCondition,
+			"format":              hl.Format,
+			"url":                 hl.URL,
+			"request_max_entries": hl.RequestMaxEntries,
+			"request_max_bytes":   hl.RequestMaxBytes,
+			"content_type":        hl.ContentType,
+			"header_name":         hl.HeaderName,
+			"header_value":        hl.HeaderValue,
+			"method":              hl.Method,
+			"json_format":         hl.JSONFormat,
+			"placement":           hl.Placement,
+			"tls_ca_cert":         hl.TLSCACert,
+			"tls_client_cert":     hl.TLSClientCert,
+			"tls_client_key":      hl.TLSClientKey,
+			"tls_hostname":        hl.TLSHostname,
+			"message_type":        hl.MessageType,
+			"format_version":      hl.FormatVersion,
+		}
+
+		// prune any empty values that come from the default string value in structs
+		for k, v := range nhl {
+			if v == "" {
+				delete(nhl, k)
+			}
+		}
+
+		hsl = append(hsl, nhl)
+	}
+
+	return hsl
 }
 
 func flattenResponseObjects(responseObjectList []*gofastly.ResponseObject) []map[string]interface{} {

--- a/fastly/resource_fastly_service_v1.go
+++ b/fastly/resource_fastly_service_v1.go
@@ -9,7 +9,6 @@ import (
 
 	gofastly "github.com/fastly/go-fastly/fastly"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 )
 
 var fastlyNoServiceFoundErr = errors.New("No matching Fastly Service found")
@@ -1241,137 +1240,7 @@ func resourceServiceV1() *schema.Resource {
 				},
 			},
 
-			"httpslogging": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						// Required fields
-						"name": {
-							Type:        schema.TypeString,
-							Required:    true,
-							Description: "The unique name of the HTTPS logging endpoint",
-						},
-						"url": {
-							Type:         schema.TypeString,
-							Required:     true,
-							Description:  "URL that log data will be sent to. Must use the https protocol.",
-							ValidateFunc: validateHTTPSURL(),
-						},
-
-						// Optional fields
-						"request_max_entries": {
-							Type:        schema.TypeInt,
-							Optional:    true,
-							Description: "The maximum number of logs sent in one request.",
-						},
-
-						"request_max_bytes": {
-							Type:        schema.TypeInt,
-							Optional:    true,
-							Description: "The maximum number of bytes sent in one request.",
-						},
-
-						"content_type": {
-							Type:        schema.TypeString,
-							Optional:    true,
-							Description: "Content-Type header sent with the request.",
-						},
-
-						"header_name": {
-							Type:        schema.TypeString,
-							Optional:    true,
-							Description: "Custom header sent with the request.",
-						},
-
-						"header_value": {
-							Type:        schema.TypeString,
-							Optional:    true,
-							Description: "Value of the custom header sent with the request.",
-						},
-
-						"method": {
-							Type:         schema.TypeString,
-							Optional:     true,
-							Default:      "POST",
-							Description:  "HTTP method used for request.",
-							ValidateFunc: validation.StringInSlice([]string{"POST", "PUT"}, false),
-						},
-
-						// NOTE: The `json_format` field's documented type is string, but it should likely be an integer.
-						"json_format": {
-							Type:         schema.TypeString,
-							Optional:     true,
-							Default:      "0",
-							Description:  "Formats log entries as JSON. Can be either disabled (`0`), array of json (`1`), or newline delimited json (`2`).",
-							ValidateFunc: validation.StringInSlice([]string{"0", "1", "2"}, false),
-						},
-
-						"tls_ca_cert": {
-							Type:        schema.TypeString,
-							Optional:    true,
-							Description: "A secure certificate to authenticate the server with. Must be in PEM format.",
-							Sensitive:   true,
-						},
-
-						"tls_client_cert": {
-							Type:        schema.TypeString,
-							Optional:    true,
-							Description: "The client certificate used to make authenticated requests. Must be in PEM format.",
-							Sensitive:   true,
-						},
-
-						"tls_client_key": {
-							Type:        schema.TypeString,
-							Optional:    true,
-							Description: "The client private key used to make authenticated requests. Must be in PEM format.",
-							Sensitive:   true,
-						},
-
-						"tls_hostname": {
-							Type:        schema.TypeString,
-							Optional:    true,
-							Description: "The hostname used to verify the server's certificate. It can either be the Common Name (CN) or a Subject Alternative Name (SAN).",
-						},
-
-						"format": {
-							Type:        schema.TypeString,
-							Optional:    true,
-							Description: "Apache-style string or VCL variables to use for log formatting.",
-						},
-
-						"format_version": {
-							Type:         schema.TypeInt,
-							Optional:     true,
-							Default:      2,
-							Description:  "The version of the custom logging format used for the configured endpoint. Can be either 1 or 2. (default: 2)",
-							ValidateFunc: validateLoggingFormatVersion(),
-						},
-
-						"message_type": {
-							Type:         schema.TypeString,
-							Optional:     true,
-							Default:      "blank",
-							Description:  "How the message should be formatted",
-							ValidateFunc: validateLoggingMessageType(),
-						},
-
-						"placement": {
-							Type:         schema.TypeString,
-							Optional:     true,
-							Description:  "Where in the generated VCL the logging call should be placed",
-							ValidateFunc: validateLoggingPlacement(),
-						},
-
-						"response_condition": {
-							Type:        schema.TypeString,
-							Optional:    true,
-							Description: "The name of the condition to apply",
-						},
-					},
-				},
-			},
-
+			"httpslogging": httpsloggingSchema,
 			"response_object": {
 				Type:     schema.TypeSet,
 				Optional: true,
@@ -2866,72 +2735,8 @@ func resourceServiceV1Update(d *schema.ResourceData, meta interface{}) error {
 
 		// find differences in HTTPS logging configuration
 		if d.HasChange("httpslogging") {
-			oh, nh := d.GetChange("httpslogging")
-			if oh == nil {
-				oh = new(schema.Set)
-			}
-			if nh == nil {
-				nh = new(schema.Set)
-			}
-
-			ohs := oh.(*schema.Set)
-			nhs := nh.(*schema.Set)
-			removeHTTPSLogging := ohs.Difference(nhs).List()
-			addHTTPSLogging := nhs.Difference(ohs).List()
-
-			// DELETE old HTTPS logging endpoints
-			for _, oRaw := range removeHTTPSLogging {
-				of := oRaw.(map[string]interface{})
-				opts := gofastly.DeleteHTTPSInput{
-					Service: d.Id(),
-					Version: latestVersion,
-					Name:    of["name"].(string),
-				}
-
-				log.Printf("[DEBUG] Fastly HTTPS logging endpoint removal opts: %#v", opts)
-				err := conn.DeleteHTTPS(&opts)
-
-				if errRes, ok := err.(*gofastly.HTTPError); ok {
-					if errRes.StatusCode != 404 {
-						return err
-					}
-				} else if err != nil {
-					return err
-				}
-			}
-
-			// POST new/updated HTTPS logging endponts
-			for _, nRaw := range addHTTPSLogging {
-				hf := nRaw.(map[string]interface{})
-				opts := gofastly.CreateHTTPSInput{
-					Service:           d.Id(),
-					Version:           latestVersion,
-					Name:              hf["name"].(string),
-					URL:               hf["url"].(string),
-					RequestMaxEntries: uint(hf["request_max_entries"].(int)),
-					RequestMaxBytes:   uint(hf["request_max_bytes"].(int)),
-					ContentType:       hf["content_type"].(string),
-					HeaderName:        hf["header_name"].(string),
-					HeaderValue:       hf["header_value"].(string),
-					Method:            hf["method"].(string),
-					JSONFormat:        hf["json_format"].(string),
-					TLSCACert:         hf["tls_ca_cert"].(string),
-					TLSClientCert:     hf["tls_client_cert"].(string),
-					TLSClientKey:      hf["tls_client_key"].(string),
-					TLSHostname:       hf["tls_hostname"].(string),
-					Format:            hf["format"].(string),
-					FormatVersion:     uint(hf["format_version"].(int)),
-					MessageType:       hf["message_type"].(string),
-					Placement:         hf["placement"].(string),
-					ResponseCondition: hf["response_condition"].(string),
-				}
-
-				log.Printf("[DEBUG] Fastly HTTPS logging create opts: %#v", opts)
-				_, err := conn.CreateHTTPS(&opts)
-
-				if err != nil {
-					return err
-				}
+			if err := processHTTPS(d, conn, latestVersion); err != nil {
+				return err
 			}
 		}
 
@@ -3751,20 +3556,9 @@ func resourceServiceV1Read(d *schema.ResourceData, meta interface{}) error {
 			log.Printf("[WARN] Error setting Blob Storages for (%s): %s", d.Id(), err)
 		}
 
-		log.Printf("[DEBUG] Refreshing HTTPS logging endpoints for (%s)", d.Id())
-		httpsList, err := conn.ListHTTPS(&gofastly.ListHTTPSInput{
-			Service: d.Id(),
-			Version: s.ActiveVersion.Number,
-		})
-
-		if err != nil {
-			return fmt.Errorf("[ERR] Error looking up HTTPS logging endpoints for (%s), version (%v): %s", d.Id(), s.ActiveVersion.Number, err)
-		}
-
-		hll := flattenHTTPS(httpsList)
-
-		if err := d.Set("httpslogging", hll); err != nil {
-			log.Printf("[WARN] Error setting HTTPS logging endpoints for (%s): %s", d.Id(), err)
+		// Refresh HTTPS
+		if err := readHTTPS(conn, d, s); err != nil {
+			return err
 		}
 
 		// refresh Response Objects
@@ -4520,44 +4314,6 @@ func flattenBlobStorages(blobStorageList []*gofastly.BlobStorage) []map[string]i
 	}
 
 	return bsl
-}
-
-func flattenHTTPS(httpsList []*gofastly.HTTPS) []map[string]interface{} {
-	var hsl []map[string]interface{}
-	for _, hl := range httpsList {
-		// Convert HTTP logging to a map for saving to state.
-		nhl := map[string]interface{}{
-			"name":                hl.Name,
-			"response_condition":  hl.ResponseCondition,
-			"format":              hl.Format,
-			"url":                 hl.URL,
-			"request_max_entries": hl.RequestMaxEntries,
-			"request_max_bytes":   hl.RequestMaxBytes,
-			"content_type":        hl.ContentType,
-			"header_name":         hl.HeaderName,
-			"header_value":        hl.HeaderValue,
-			"method":              hl.Method,
-			"json_format":         hl.JSONFormat,
-			"placement":           hl.Placement,
-			"tls_ca_cert":         hl.TLSCACert,
-			"tls_client_cert":     hl.TLSClientCert,
-			"tls_client_key":      hl.TLSClientKey,
-			"tls_hostname":        hl.TLSHostname,
-			"message_type":        hl.MessageType,
-			"format_version":      hl.FormatVersion,
-		}
-
-		// prune any empty values that come from the default string value in structs
-		for k, v := range nhl {
-			if v == "" {
-				delete(nhl, k)
-			}
-		}
-
-		hsl = append(hsl, nhl)
-	}
-
-	return hsl
 }
 
 func flattenResponseObjects(responseObjectList []*gofastly.ResponseObject) []map[string]interface{} {

--- a/fastly/resource_fastly_service_v1_httpslogging_test.go
+++ b/fastly/resource_fastly_service_v1_httpslogging_test.go
@@ -1,0 +1,236 @@
+package fastly
+
+import (
+	"fmt"
+	"log"
+	"reflect"
+	"testing"
+
+	gofastly "github.com/fastly/go-fastly/fastly"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestResourceFastlyFlattenHTTPS(t *testing.T) {
+	cases := []struct {
+		remote []*gofastly.HTTPS
+		local  []map[string]interface{}
+	}{
+		{
+			remote: []*gofastly.HTTPS{
+				{
+					Version:           1,
+					Name:              "https-endpoint",
+					URL:               "https://example.com/logs",
+					RequestMaxEntries: 10,
+					RequestMaxBytes:   10,
+					ContentType:       "application/json",
+					MessageType:       "blank",
+					FormatVersion:     2,
+				},
+			},
+			local: []map[string]interface{}{
+				{
+					"name":                "https-endpoint",
+					"url":                 "https://example.com/logs",
+					"request_max_entries": uint(10),
+					"request_max_bytes":   uint(10),
+					"content_type":        "application/json",
+					"message_type":        "blank",
+					"format_version":      uint(2),
+				},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		out := flattenHTTPS(c.remote)
+		if !reflect.DeepEqual(out, c.local) {
+			t.Fatalf("Error matching:\nexpected: %#v\n got: %#v", c.local, out)
+		}
+	}
+
+}
+
+func TestAccFastlyServiceV1_httpslogging_basic(t *testing.T) {
+	var service gofastly.ServiceDetail
+	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	domain := fmt.Sprintf("fastly-test.%s.com", name)
+
+	log1 := gofastly.HTTPS{
+		Version: 1,
+		Name:    "httpslogger",
+		URL:     "https://example.com/logs/1",
+		Method:  "PUT",
+
+		Format:            "%a %l %u %t %m %U%q %H %>s %b %T",
+		RequestMaxEntries: 0,
+		RequestMaxBytes:   0,
+		MessageType:       "blank",
+		FormatVersion:     2,
+		JSONFormat:        "0",
+	}
+
+	log1_after_update := gofastly.HTTPS{
+		Version: 1,
+		Name:    "httpslogger",
+		URL:     "https://example.com/logs/1",
+		Method:  "POST",
+
+		Format:            "%a %l %u %t %m %U%q %H %>s %b",
+		RequestMaxEntries: 0,
+		RequestMaxBytes:   0,
+		MessageType:       "blank",
+		FormatVersion:     2,
+		JSONFormat:        "0",
+	}
+
+	log2 := gofastly.HTTPS{
+		Version: 1,
+		Name:    "httpslogger2",
+		URL:     "https://example.com/logs/2",
+		Method:  "POST",
+
+		Format:            "%a %l %u %t %m %U%q %H %>s %b %T",
+		RequestMaxEntries: 0,
+		RequestMaxBytes:   1000,
+		MessageType:       "blank",
+		FormatVersion:     2,
+		JSONFormat:        "0",
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckServiceV1Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServiceV1HTTPSConfig(name, domain),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
+					testAccCheckFastlyServiceV1HTTPSAttributes(&service, []*gofastly.HTTPS{&log1}),
+					resource.TestCheckResourceAttr(
+						"fastly_service_v1.foo", "name", name),
+					resource.TestCheckResourceAttr(
+						"fastly_service_v1.foo", "httpslogging.#", "1"),
+				),
+			},
+
+			{
+				Config: testAccServiceV1HTTPSConfig_update(name, domain),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
+					testAccCheckFastlyServiceV1HTTPSAttributes(&service, []*gofastly.HTTPS{&log1_after_update, &log2}),
+					resource.TestCheckResourceAttr(
+						"fastly_service_v1.foo", "name", name),
+					resource.TestCheckResourceAttr(
+						"fastly_service_v1.foo", "httpslogging.#", "2"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckFastlyServiceV1HTTPSAttributes(service *gofastly.ServiceDetail, https []*gofastly.HTTPS) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+
+		conn := testAccProvider.Meta().(*FastlyClient).conn
+		httpsList, err := conn.ListHTTPS(&gofastly.ListHTTPSInput{
+			Service: service.ID,
+			Version: service.ActiveVersion.Number,
+		})
+
+		if err != nil {
+			return fmt.Errorf("[ERR] Error looking up HTTPS Logging for (%s), version (%d): %s", service.Name, service.ActiveVersion.Number, err)
+		}
+
+		if len(httpsList) != len(https) {
+			return fmt.Errorf("HTTPS List count mismatch, expected (%d), got (%d)", len(https), len(httpsList))
+		}
+
+		log.Printf("[DEBUG] httpsList = %#v\n", httpsList)
+
+		var found int
+		for _, h := range https {
+			for _, hl := range httpsList {
+				if h.Name == hl.Name {
+					// we don't know these things ahead of time, so populate them now
+					h.ServiceID = service.ID
+					h.Version = service.ActiveVersion.Number
+					// We don't track these, so clear them out because we also wont know
+					// these ahead of time
+					hl.CreatedAt = nil
+					hl.UpdatedAt = nil
+					if !reflect.DeepEqual(h, hl) {
+						return fmt.Errorf("Bad match HTTPS logging match,\nexpected:\n(%#v),\ngot:\n(%#v)", h, hl)
+					}
+					found++
+				}
+			}
+		}
+
+		if found != len(https) {
+			return fmt.Errorf("Error matching HTTPS Logging rules")
+		}
+
+		return nil
+	}
+}
+
+func testAccServiceV1HTTPSConfig(name string, domain string) string {
+	return fmt.Sprintf(`
+resource "fastly_service_v1" "foo" {
+	name = "%s"
+	domain {
+		name    = "%s"
+		comment = "tf-https-logging"
+	}
+
+	backend {
+		address = "aws.amazon.com"
+		name    = "amazon docs"
+	}
+
+	httpslogging {
+		name               = "httpslogger"
+    format             = "%%a %%l %%u %%t %%m %%U%%q %%H %%>s %%b %%T"
+		method             = "PUT"
+		url                = "https://example.com/logs/1"
+	}
+
+	force_destroy = true
+}
+`, name, domain)
+}
+
+func testAccServiceV1HTTPSConfig_update(name, domain string) string {
+	return fmt.Sprintf(`
+resource "fastly_service_v1" "foo" {
+	name = "%s"
+	domain {
+		name    = "%s"
+		comment = "tf-testing-domain"
+	}
+	backend {
+		address = "aws.amazon.com"
+		name    = "amazon docs"
+	}
+
+	httpslogging {
+		name               = "httpslogger"
+    format             = "%%a %%l %%u %%t %%m %%U%%q %%H %%>s %%b"
+		method             = "POST"
+		url                = "https://example.com/logs/1"
+	}
+
+	httpslogging {
+		name               = "httpslogger2"
+    format             = "%%a %%l %%u %%t %%m %%U%%q %%H %%>s %%b %%T"
+		method             = "POST"
+		url                = "https://example.com/logs/2"
+		request_max_bytes  = 1000
+	}
+	force_destroy = true
+}`, name, domain)
+}

--- a/fastly/validators.go
+++ b/fastly/validators.go
@@ -2,6 +2,7 @@ package fastly
 
 import (
 	"fmt"
+	"strings"
 
 	gofastly "github.com/fastly/go-fastly/fastly"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -119,4 +120,15 @@ func validateUserRole() schema.SchemaValidateFunc {
 		},
 		false,
 	)
+}
+
+// TODO: Use SDK's validation.IsURLWithHTTPS() after we upgrade
+func validateHTTPSURL() schema.SchemaValidateFunc {
+	return func(val interface{}, key string) (warns []string, errs []error) {
+		v := val.(string)
+		if !strings.HasPrefix(v, "https://") {
+			errs = append(errs, fmt.Errorf("%q must be https URL, got: %s", key, v))
+		}
+		return
+	}
 }

--- a/fastly/validators_test.go
+++ b/fastly/validators_test.go
@@ -341,3 +341,24 @@ func TestValidateUserRole(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateHTTPSURL(t *testing.T) {
+	for _, testcase := range []struct {
+		value          string
+		expectedWarns  int
+		expectedErrors int
+	}{
+		{"https://api.fastly.com", 0, 0},
+		{"http://example.com", 0, 1},
+	} {
+		t.Run(testcase.value, func(t *testing.T) {
+			actualWarns, actualErrors := validateHTTPSURL()(testcase.value, "url")
+			if len(actualWarns) != testcase.expectedWarns {
+				t.Errorf("expected %d warnings, actual %d ", testcase.expectedWarns, len(actualWarns))
+			}
+			if len(actualErrors) != testcase.expectedErrors {
+				t.Errorf("expected %d errors, actual %d ", testcase.expectedErrors, len(actualErrors))
+			}
+		})
+	}
+}

--- a/website/docs/r/service_v1.html.markdown
+++ b/website/docs/r/service_v1.html.markdown
@@ -205,6 +205,8 @@ Defined below.
 Defined below.
 * `blobstoragelogging` - (Optional) An Azure Blob Storage endpoint to send streaming logs too.
 Defined below.
+* `httpslogging` - (Optional) An HTTPS endpoint to send streaming logs to.
+Defined below.
 * `response_object` - (Optional) Allows you to create synthetic responses that exist entirely on the varnish machine. Useful for creating error or maintenance pages that exists outside the scope of your datacenter. Best when used with Condition objects.
 * `snippet` - (Optional) A set of custom, "regular" (non-dynamic) VCL Snippet configuration blocks.  Defined below.
 * `dynamicsnippet` - (Optional) A set of custom, "dynamic" VCL Snippet configuration blocks.  Defined below.
@@ -490,6 +492,27 @@ The `blobstoragelogging` block supports:
 * `format_version` - (Optional) The version of the custom logging format used for the configured endpoint. Can be either `1` or `2`. The logging call gets placed by default in `vcl_log` if `format_version` is set to `2` and in `vcl_deliver` if `format_version` is set to `1`. Default `2`.
 * `message_type` - (Optional) How the message should be formatted. Can be either `classic`, `loggly`, `logplex` or `blank`.  Default `classic`.
 * `placement` - (Optional) Where in the generated VCL the logging call should be placed, overriding any `format_version` default. Can be either `none` or `waf_debug`.
+* `response_condition` - (Optional) The name of the `condition` to apply. If empty, always execute.
+
+The `httpslogging` block supports:
+
+* `name` - (Required) The unique name of the HTTPS logging endpoint.
+* `url` - (Required) URL that log data will be sent to. Must use the https protocol.
+* `request_max_entries` - (Optional) The maximum number of logs sent in one request.
+* `request_max_bytes` - (Optional) The maximum number of bytes sent in one request.
+* `content_type` - (Optional) Value of the `Content-Type` header sent with the request.
+* `header_name` - (Optional) Custom header sent with the request.
+* `header_value` - (Optional) Value of the custom header sent with the request.
+* `method` - (Optional) HTTP method used for request. Can be either `POST` or `PUT`. Default `POST`.
+* `json_format` - Formats log entries as JSON. Can be either disabled (`0`), array of json (`1`), or newline delimited json (`2`).
+* `tls_hostname` - (Optional) Used during the TLS handshake to validate the certificate.
+* `tls_ca_cert` - (Optional) A secure certificate to authenticate the server with. Must be in PEM format.
+* `tls_client_cert` - (Optional) The client certificate used to make authenticated requests. Must be in PEM format.
+* `tls_client_key` - (Optional) The client private key used to make authenticated requests. Must be in PEM format.
+* `format` - (Optional) Apache-style string or VCL variables to use for log formatting.
+* `format_version` - (Optional) The version of the custom logging format used for the configured endpoint. Can be either `1` or `2`. The logging call gets placed by default in `vcl_log` if `format_version` is set to `2` and in `vcl_deliver` if `format_version` is set to `1`. Default `2`.
+* `message_type` - How the message should be formatted; one of: `classic`, `loggly`, `logplex` or `blank`.  Default `blank`.
+* `placement` - (Optional) Where in the generated VCL the logging call should be placed.
 * `response_condition` - (Optional) The name of the `condition` to apply. If empty, always execute.
 
 The `response_object` block supports:


### PR DESCRIPTION
Adds support for configuring [HTTPS log streaming](https://docs.fastly.com/en/guides/log-streaming-https) ([API docs](https://docs.fastly.com/api/logging#logging_https)) to provider.