### PR TITLE
Add support for SFTP logging

### DIFF
--- a/fastly/block_fastly_service_v1_logging_sftp.go
+++ b/fastly/block_fastly_service_v1_logging_sftp.go
@@ -239,7 +239,7 @@ func flattenSFTP(sftpList []*gofastly.SFTP) []map[string]interface{} {
 			"period":             sl.Period,
 			"gzip_level":         sl.GzipLevel,
 			"timestamp_format":   sl.TimestampFormat,
-			"message_type":   sl.MessageType,
+			"message_type":       sl.MessageType,
 			"format":             sl.Format,
 			"format_version":     sl.FormatVersion,
 			"response_condition": sl.ResponseCondition,

--- a/fastly/block_fastly_service_v1_logging_sftp.go
+++ b/fastly/block_fastly_service_v1_logging_sftp.go
@@ -1,0 +1,295 @@
+package fastly
+
+import (
+	"fmt"
+	"log"
+
+	gofastly "github.com/fastly/go-fastly/fastly"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+var sftpSchema = &schema.Schema{
+	Type:     schema.TypeSet,
+	Optional: true,
+	Elem: &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			// Required fields
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The unique name of the SFTP logging endpoint.",
+			},
+
+			"address": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The SFTP address to stream logs to.",
+			},
+
+			"user": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The username for the server.",
+			},
+
+			"path": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The path to upload log files to. If the path ends in / then it is treated as a directory.",
+			},
+
+			"ssh_known_hosts": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "A list of host keys for all hosts we can connect to over SFTP.",
+			},
+
+			// Optional fields
+			"port": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Default:     22,
+				Description: "The port the SFTP service listens on. (Default: 22).",
+			},
+
+			"password": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The password for the server. If both password and secret_key are passed, secret_key will be preferred.",
+				Sensitive:   true,
+			},
+
+			"secret_key": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The SSH private key for the server. If both password and secret_key are passed, secret_key will be preferred.",
+				Sensitive:   true,
+			},
+
+			"public_key": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "A PGP public key that Fastly will use to encrypt your log files before writing them to disk.",
+			},
+
+			"period": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Default:     3600,
+				Description: "How frequently log files are finalized so they can be available for reading (in seconds, default 3600).",
+			},
+
+			"gzip_level": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Default:     0,
+				Description: "What level of GZIP encoding to have when dumping logs (default 0, no compression).",
+			},
+
+			"timestamp_format": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Default:     "%Y-%m-%dT%H:%M:%S.000",
+				Description: "The strftime specified timestamp formatting (default `%Y-%m-%dT%H:%M:%S.000`).",
+			},
+
+			"message_type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Default:     "classic",
+				Description: "How the message should be formatted. One of: classic (default), loggly, logplex or blank.",
+			},
+
+			"format": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Apache-style string or VCL variables to use for log formatting.",
+			},
+
+			"format_version": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      2,
+				Description:  "The version of the custom logging format used for the configured endpoint. Can be either 1 or 2. (default: 2).",
+				ValidateFunc: validateLoggingFormatVersion(),
+			},
+
+			"placement": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Description:  "Where in the generated VCL the logging call should be placed.",
+				ValidateFunc: validateLoggingPlacement(),
+			},
+
+			"response_condition": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The name of the condition to apply.",
+			},
+		},
+	},
+}
+
+func processSFTP(d *schema.ResourceData, conn *gofastly.Client, latestVersion int) error {
+	serviceID := d.Id()
+	os, ns := d.GetChange("logging_sftp")
+
+	if os == nil {
+		os = new(schema.Set)
+	}
+	if ns == nil {
+		ns = new(schema.Set)
+	}
+
+	oss := os.(*schema.Set)
+	nss := ns.(*schema.Set)
+
+	removeSFTPLogging := oss.Difference(nss).List()
+	addSFTPLogging := nss.Difference(oss).List()
+
+	// DELETE old SFTP logging endpoints.
+	for _, oRaw := range removeSFTPLogging {
+		of := oRaw.(map[string]interface{})
+		opts := buildDeleteSFTP(of, serviceID, latestVersion)
+
+		log.Printf("[DEBUG] Fastly SFTP logging endpoint removal opts: %#v", opts)
+
+		if err := deleteSFTP(conn, opts); err != nil {
+			return err
+		}
+	}
+
+	// POST new/updated SFTP logging endpoints.
+	for _, nRaw := range addSFTPLogging {
+		sf := nRaw.(map[string]interface{})
+
+		opts := buildCreateSFTP(sf, serviceID, latestVersion)
+
+		if opts.Password == nil && opts.SecretKey == nil {
+			return fmt.Errorf("[ERR] Either password or secret_key must be set")
+		}
+
+		log.Printf("[DEBUG] Fastly SFTP logging addition opts: %#v", opts)
+
+		if err := createSFTP(conn, opts); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func readSFTP(conn *gofastly.Client, d *schema.ResourceData, s *gofastly.ServiceDetail) error {
+	// Refresh SFTP.
+	log.Printf("[DEBUG] Refreshing SFTP logging endpoints for (%s)", d.Id())
+	sftpList, err := conn.ListSFTPs(&gofastly.ListSFTPsInput{
+		Service: d.Id(),
+		Version: s.ActiveVersion.Number,
+	})
+
+	if err != nil {
+		return fmt.Errorf("[ERR] Error looking up SFTP logging endpoints for (%s), version (%v): %s", d.Id(), s.ActiveVersion.Number, err)
+	}
+
+	ell := flattenSFTP(sftpList)
+
+	if err := d.Set("logging_sftp", ell); err != nil {
+		log.Printf("[WARN] Error setting SFTP logging endpoints for (%s): %s", d.Id(), err)
+	}
+
+	return nil
+}
+
+func createSFTP(conn *gofastly.Client, i *gofastly.CreateSFTPInput) error {
+	_, err := conn.CreateSFTP(i)
+	return err
+}
+
+func deleteSFTP(conn *gofastly.Client, i *gofastly.DeleteSFTPInput) error {
+	err := conn.DeleteSFTP(i)
+
+	errRes, ok := err.(*gofastly.HTTPError)
+	if !ok {
+		return err
+	}
+
+	// 404 response codes don't result in an error propagating because a 404 could
+	// indicate that a resource was deleted elsewhere.
+	if !errRes.IsNotFound() {
+		return err
+	}
+
+	return nil
+}
+
+func flattenSFTP(sftpList []*gofastly.SFTP) []map[string]interface{} {
+	var ssl []map[string]interface{}
+	for _, sl := range sftpList {
+		// Convert SFTP logging to a map for saving to state.
+		nsl := map[string]interface{}{
+			"name":               sl.Name,
+			"address":            sl.Address,
+			"user":               sl.User,
+			"path":               sl.Path,
+			"ssh_known_hosts":    sl.SSHKnownHosts,
+			"port":               sl.Port,
+			"password":           sl.Password,
+			"secret_key":         sl.SecretKey,
+			"public_key":         sl.PublicKey,
+			"period":             sl.Period,
+			"gzip_level":         sl.GzipLevel,
+			"timestamp_format":   sl.TimestampFormat,
+			"message_type":   sl.MessageType,
+			"format":             sl.Format,
+			"format_version":     sl.FormatVersion,
+			"response_condition": sl.ResponseCondition,
+			"placement":          sl.Placement,
+		}
+
+		// prune any empty values that come from the default string value in structs
+		for k, v := range nsl {
+			if v == "" {
+				delete(nsl, k)
+			}
+		}
+
+		ssl = append(ssl, nsl)
+	}
+
+	return ssl
+}
+
+func buildCreateSFTP(sftpMap interface{}, serviceID string, serviceVersion int) *gofastly.CreateSFTPInput {
+	df := sftpMap.(map[string]interface{})
+
+	return &gofastly.CreateSFTPInput{
+		Service:           serviceID,
+		Version:           serviceVersion,
+		Address:           gofastly.NullString(df["address"].(string)),
+		Name:              gofastly.NullString(df["name"].(string)),
+		User:              gofastly.NullString(df["user"].(string)),
+		Path:              gofastly.NullString(df["path"].(string)),
+		PublicKey:         gofastly.NullString(df["public_key"].(string)),
+		SecretKey:         gofastly.NullString(df["secret_key"].(string)),
+		SSHKnownHosts:     gofastly.NullString(df["ssh_known_hosts"].(string)),
+		Port:              gofastly.Uint(uint(df["port"].(int))),
+		Password:          gofastly.NullString(df["password"].(string)),
+		GzipLevel:         gofastly.Uint(uint(df["gzip_level"].(int))),
+		TimestampFormat:   gofastly.NullString(df["timestamp_format"].(string)),
+		MessageType:       gofastly.NullString(df["message_type"].(string)),
+		Format:            gofastly.NullString(df["format"].(string)),
+		FormatVersion:     gofastly.Uint(uint(df["format_version"].(int))),
+		ResponseCondition: gofastly.NullString(df["response_condition"].(string)),
+		Placement:         gofastly.NullString(df["placement"].(string)),
+	}
+}
+
+func buildDeleteSFTP(sftpMap interface{}, serviceID string, serviceVersion int) *gofastly.DeleteSFTPInput {
+	df := sftpMap.(map[string]interface{})
+
+	return &gofastly.DeleteSFTPInput{
+		Service: serviceID,
+		Version: serviceVersion,
+		Name:    df["name"].(string),
+	}
+}

--- a/fastly/block_fastly_service_v1_logging_sftp_test.go
+++ b/fastly/block_fastly_service_v1_logging_sftp_test.go
@@ -95,6 +95,7 @@ func TestAccFastlyServiceV1_logging_sftp_basic(t *testing.T) {
 		// Defaults
 		Port:            22,
 		Period:          3600,
+		MessageType:     "classic",
 		GzipLevel:       0,
 		TimestampFormat: "%Y-%m-%dT%H:%M:%S.000",
 		FormatVersion:   2,

--- a/fastly/block_fastly_service_v1_logging_sftp_test.go
+++ b/fastly/block_fastly_service_v1_logging_sftp_test.go
@@ -1,0 +1,372 @@
+package fastly
+
+import (
+	"fmt"
+	"log"
+	"regexp"
+	"testing"
+
+	gofastly "github.com/fastly/go-fastly/fastly"
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestResourceFastlyFlattenSFTP(t *testing.T) {
+	cases := []struct {
+		remote []*gofastly.SFTP
+		local  []map[string]interface{}
+	}{
+		{
+			remote: []*gofastly.SFTP{
+				{
+					Version:           1,
+					Name:              "sftp-endpoint",
+					Address:           "sftp.example.com",
+					User:              "user",
+					Path:              "/",
+					PublicKey:         pgpPublicKey(),
+					SecretKey:         privateKey(),
+					SSHKnownHosts:     "sftp.example.com",
+					Format:            "%h %l %u %t \"%r\" %>s %b",
+					Password:          "password",
+					GzipLevel:         5,
+					MessageType:       "classic",
+					FormatVersion:     2,
+					Period:            3600,
+					Port:              22,
+					TimestampFormat:   "%Y-%m-%dT%H:%M:%S.000",
+					ResponseCondition: "response_condition",
+					Placement:         "none",
+				},
+			},
+			local: []map[string]interface{}{
+				{
+					"name":               "sftp-endpoint",
+					"address":            "sftp.example.com",
+					"user":               "user",
+					"path":               "/",
+					"ssh_known_hosts":    "sftp.example.com",
+					"public_key":         pgpPublicKey(),
+					"secret_key":         privateKey(),
+					"format":             "%h %l %u %t \"%r\" %>s %b",
+					"password":           "password",
+					"message_type":       "classic",
+					"gzip_level":         uint8(5),
+					"format_version":     uint(2),
+					"period":             uint(3600),
+					"port":               uint(22),
+					"response_condition": "response_condition",
+					"timestamp_format":   "%Y-%m-%dT%H:%M:%S.000",
+					"placement":          "none",
+				},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		out := flattenSFTP(c.remote)
+		if diff := cmp.Diff(out, c.local); diff != "" {
+			t.Fatalf("Error matching: %s", diff)
+		}
+	}
+}
+
+func TestAccFastlyServiceV1_logging_sftp_basic(t *testing.T) {
+	var service gofastly.ServiceDetail
+	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	domain := fmt.Sprintf("fastly-test.%s.com", name)
+
+	log1 := gofastly.SFTP{
+		Version: 1,
+
+		// Configured
+		Name:              "sftp-endpoint",
+		Address:           "sftp.example.com",
+		User:              "username",
+		Password:          "password",
+		PublicKey:         pgpPublicKey() + "\n", // The '\n' is necessary becaue of the heredocs (i.e., EOF) in the config below.
+		Path:              "/",
+		SSHKnownHosts:     "sftp.example.com",
+		Placement:         "none",
+		ResponseCondition: "response_condition_test",
+
+		// Defaults
+		Port:            22,
+		Period:          3600,
+		GzipLevel:       0,
+		TimestampFormat: "%Y-%m-%dT%H:%M:%S.000",
+		FormatVersion:   2,
+		Format:          "%h %l %u %t \"%r\" %>s %b",
+	}
+
+	log1_after_update := gofastly.SFTP{
+		Version:           1,
+		Name:              "sftp-endpoint",
+		Address:           "sftp.example.com",
+		User:              "user",
+		PublicKey:         pgpPublicKey() + "\n", // The '\n' is necessary becaue of the heredocs (i.e., EOF) in the config below.
+		SecretKey:         privateKey() + "\n",   // The '\n' is necessary becaue of the heredocs (i.e., EOF) in the config below.
+		Path:              "/logs/",
+		SSHKnownHosts:     "sftp.example.com",
+		MessageType:       "blank",
+		Port:              2600,
+		Format:            "%h %l %u %t \"%r\" %>s %b %T",
+		Placement:         "waf_debug",
+		ResponseCondition: "response_condition_test",
+
+		// Defaults
+		Period:          3600,
+		GzipLevel:       0,
+		TimestampFormat: "%Y-%m-%dT%H:%M:%S.000",
+		FormatVersion:   2,
+	}
+
+	log2 := gofastly.SFTP{
+		Version:           1,
+		Name:              "another-sftp-endpoint",
+		Address:           "sftp2.example.com",
+		User:              "user",
+		Path:              "/dir/",
+		PublicKey:         pgpPublicKey() + "\n", // The '\n' is necessary becaue of the heredocs (i.e., EOF) in the config below.
+		SecretKey:         privateKey() + "\n",   // The '\n' is necessary becaue of the heredocs (i.e., EOF) in the config below.
+		SSHKnownHosts:     "sftp2.example.com",
+		ResponseCondition: "response_condition_test",
+		MessageType:       "loggly",
+		Placement:         "none",
+
+		// Defaults
+		Port:            22,
+		Period:          3600,
+		GzipLevel:       0,
+		TimestampFormat: "%Y-%m-%dT%H:%M:%S.000",
+		FormatVersion:   2,
+		Format:          "%h %l %u %t \"%r\" %>s %b",
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckServiceV1Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServiceV1SFTPConfig(name, domain),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
+					testAccCheckFastlyServiceV1SFTPAttributes(&service, []*gofastly.SFTP{&log1}),
+					resource.TestCheckResourceAttr(
+						"fastly_service_v1.foo", "name", name),
+					resource.TestCheckResourceAttr(
+						"fastly_service_v1.foo", "logging_sftp.#", "1"),
+				),
+			},
+
+			{
+				Config: testAccServiceV1SFTPConfig_update(name, domain),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
+					testAccCheckFastlyServiceV1SFTPAttributes(&service, []*gofastly.SFTP{&log1_after_update, &log2}),
+					resource.TestCheckResourceAttr(
+						"fastly_service_v1.foo", "name", name),
+					resource.TestCheckResourceAttr(
+						"fastly_service_v1.foo", "logging_sftp.#", "2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccFastlyServiceV1_logging_sftp_password_secret_key(t *testing.T) {
+	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	domain := fmt.Sprintf("fastly-test.%s.com", name)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckServiceV1Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccServiceV1SFTPConfig_no_password_secret_key(name, domain),
+				ExpectError: regexp.MustCompile("Either password or secret_key must be set"),
+			},
+		},
+	})
+}
+
+func testAccCheckFastlyServiceV1SFTPAttributes(service *gofastly.ServiceDetail, sftps []*gofastly.SFTP) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+
+		conn := testAccProvider.Meta().(*FastlyClient).conn
+		sftpList, err := conn.ListSFTPs(&gofastly.ListSFTPsInput{
+			Service: service.ID,
+			Version: service.ActiveVersion.Number,
+		})
+
+		if err != nil {
+			return fmt.Errorf("[ERR] Error looking up SFTP Logging for (%s), version (%d): %s", service.Name, service.ActiveVersion.Number, err)
+		}
+
+		if len(sftpList) != len(sftps) {
+			return fmt.Errorf("SFTP List count mismatch, expected (%d), got (%d)", len(sftps), len(sftpList))
+		}
+
+		log.Printf("[DEBUG] sftpList = %#v\n", sftpList)
+
+		var found int
+		for _, s := range sftps {
+			for _, sl := range sftpList {
+				if s.Name == sl.Name {
+					// we don't know these things ahead of time, so populate them now
+					s.ServiceID = service.ID
+					s.Version = service.ActiveVersion.Number
+					// We don't track these, so clear them out because we also wont know
+					// these ahead of time
+					sl.CreatedAt = nil
+					sl.UpdatedAt = nil
+					if diff := cmp.Diff(s, sl); diff != "" {
+						return fmt.Errorf("Bad match SFTP logging match: %s", diff)
+					}
+					found++
+				}
+			}
+		}
+
+		if found != len(sftps) {
+			return fmt.Errorf("Error matching SFTP Logging rules")
+		}
+
+		return nil
+	}
+}
+
+func testAccServiceV1SFTPConfig(name string, domain string) string {
+	return fmt.Sprintf(`
+resource "fastly_service_v1" "foo" {
+	name = "%s"
+
+	domain {
+		name		= "%s"
+		comment = "tf-sftp-logging"
+	}
+
+	backend {
+		address = "aws.amazon.com"
+		name		= "amazon docs"
+	}
+
+	condition {
+    name      = "response_condition_test"
+    type      = "RESPONSE"
+    priority  = 8
+    statement = "resp.status == 418"
+  }
+
+	logging_sftp {
+		name						= "sftp-endpoint"
+		address					= "sftp.example.com"
+		user						= "username"
+		password				= "password"
+		public_key      = <<EOF
+`+pgpPublicKey()+`
+EOF
+		path						   = "/"
+		ssh_known_hosts    = "sftp.example.com"
+		message_type       = "classic"
+		placement          = "none"
+		response_condition = "response_condition_test"
+	}
+	force_destroy = true
+}
+`, name, domain)
+}
+
+func testAccServiceV1SFTPConfig_update(name, domain string) string {
+	return fmt.Sprintf(`
+resource "fastly_service_v1" "foo" {
+	name = "%s"
+
+	domain {
+		name		= "%s"
+		comment = "tf-sftp-logging"
+	}
+
+	backend {
+		address = "aws.amazon.com"
+		name		= "amazon docs"
+	}
+
+	condition {
+    name      = "response_condition_test"
+    type      = "RESPONSE"
+    priority  = 8
+    statement = "resp.status == 418"
+  }
+
+	logging_sftp {
+		name						= "sftp-endpoint"
+		address					= "sftp.example.com"
+		port						= 2600
+		user						= "user"
+		public_key      = <<EOF
+`+pgpPublicKey()+`
+EOF
+		secret_key      = <<EOF
+`+privateKey()+`
+EOF
+		path						   = "/logs/"
+		ssh_known_hosts    = "sftp.example.com"
+		format					   = "%%h %%l %%u %%t \"%%r\" %%>s %%b %%T"
+		message_type       = "blank"
+		response_condition = "response_condition_test"
+		placement          = "waf_debug"
+	}
+
+	logging_sftp {
+		name						= "another-sftp-endpoint"
+		address					= "sftp2.example.com"
+		user						= "user"
+		public_key      = <<EOF
+`+pgpPublicKey()+`
+EOF
+		secret_key      = <<EOF
+`+privateKey()+`
+EOF
+		path						   = "/dir/"
+		ssh_known_hosts    = "sftp2.example.com"
+		message_type       = "loggly"
+		response_condition = "response_condition_test"
+		placement          = "none"
+	}
+	force_destroy = true
+}
+`, name, domain)
+}
+
+func testAccServiceV1SFTPConfig_no_password_secret_key(name, domain string) string {
+	return fmt.Sprintf(`
+resource "fastly_service_v1" "foo" {
+	name = "%s"
+
+	domain {
+		name		= "%s"
+		comment = "tf-sftp-logging"
+	}
+
+	backend {
+		address = "aws.amazon.com"
+		name		= "amazon docs"
+	}
+
+	logging_sftp {
+		name						= "sftp-endpoint"
+		address					= "sftp.example.com"
+		user						= "username"
+		path						= "/"
+		ssh_known_hosts = "sftp.example.com"
+	}
+	force_destroy = true
+
+}
+`, name, domain)
+}

--- a/fastly/resource_fastly_service_v1.go
+++ b/fastly/resource_fastly_service_v1.go
@@ -1254,6 +1254,7 @@ func resourceServiceV1() *schema.Resource {
 			"httpslogging":          httpsloggingSchema,
 			"logging_elasticsearch": elasticsearchSchema,
 			"logging_ftp":           ftpSchema,
+			"logging_sftp":          sftpSchema,
 
 			"response_object": {
 				Type:     schema.TypeSet,
@@ -1560,6 +1561,7 @@ func resourceServiceV1Update(d *schema.ResourceData, meta interface{}) error {
 		"httpslogging",
 		"logging_elasticsearch",
 		"logging_ftp",
+		"logging_sftp",
 		"response_object",
 		"condition",
 		"request_setting",
@@ -2749,6 +2751,13 @@ func resourceServiceV1Update(d *schema.ResourceData, meta interface{}) error {
 		// find differences in FTP logging configuration
 		if d.HasChange("logging_ftp") {
 			if err := processFTP(d, conn, latestVersion); err != nil {
+				return err
+			}
+		}
+
+		// find differences in SFTP logging configurations
+		if d.HasChange("logging_sftp") {
+			if err := processSFTP(d, conn, latestVersion); err != nil {
 				return err
 			}
 		}

--- a/website/docs/r/service_v1.html.markdown
+++ b/website/docs/r/service_v1.html.markdown
@@ -85,8 +85,7 @@ resource "aws_s3_bucket" "website" {
 }
 ```
 
-Basic usage with [custom
-VCL](https://docs.fastly.com/vcl/custom-vcl/uploading-custom-vcl/):
+Basic usage with [custom VCL](https://docs.fastly.com/guides/vcl/uploading-custom-vcl):
 
 ```hcl
 resource "fastly_service_v1" "demo" {
@@ -209,6 +208,8 @@ Defined below.
 * `logging_elasticsearch` - (optional) An Elasticsearch endpoint to send streaming logs to.
 Defined below.
 * `logging_ftp` - (Optional) An FTP endpoint to send streaming logs to.
+Defined below.
+* `logging_sftp` - (Optional) An SFTP endpoint to send streaming logs to.
 Defined below.
 * `response_object` - (Optional) Allows you to create synthetic responses that exist entirely on the varnish machine. Useful for creating error or maintenance pages that exists outside the scope of your datacenter. Best when used with Condition objects.
 * `snippet` - (Optional) A set of custom, "regular" (non-dynamic) VCL Snippet configuration blocks.  Defined below.
@@ -553,6 +554,25 @@ The `logging_ftp` block supports:
 * `format_version` - (Optional) The version of the custom logging format used for the configured endpoint. Can be either `1` or `2`. (default: `2`).
 * `placement` - (Optional) Where in the generated VCL the logging call should be placed.
 * `response_condition` - (Optional) The name of the condition to apply.
+
+The `logging_sftp` block supports:
+
+* `name` - (Required) The unique name of the SFTP logging endpoint.
+* `address` - (Required) The SFTP address to stream logs to.
+* `path` - (Required) The path to upload log files to. If the path ends in / then it is treated as a directory.
+* `ssh_known_hosts` - (Required) A list of host keys for all hosts we can connect to over SFTP.
+* `user` - (Required) The username for the server.
+* `port` - (Optional) The port the SFTP service listens on. (Default: `22`).
+* `password` - (Optional) The password for the server. If both `password` and `secret_key` are passed, `secret_key` will be preferred.
+* `secret_key` - (Optional) The SSH private key for the server. If both `password` and `secret_key` are passed, `secret_key` will be preferred.
+* `gzip_level` - (Optional) What level of GZIP encoding to have when dumping logs (default 0, no compression).
+* `period` - (Optional) How frequently log files are finalized so they can be available for reading (in seconds, default `3600`).
+* `placement` - (Optional) Where in the generated VCL the logging call should be placed.
+* `public_key` - (Optional) A PGP public key that Fastly will use to encrypt your log files before writing them to disk.
+* `format` - (Optional) Apache-style string or VCL variables to use for log formatting.
+* `format_version` - (Optional) The version of the custom logging format used for the configured endpoint. Can be either `1` or `2`. (default: `2`).
+* `response_condition` - (Optional) The name of the condition to apply.
+* `timestamp_format` - (Optional) The strftime specified timestamp formatting (default `%Y-%m-%dT%H:%M:%S.000`).
 
 The `response_object` block supports:
 

--- a/website/docs/r/service_v1.html.markdown
+++ b/website/docs/r/service_v1.html.markdown
@@ -85,7 +85,8 @@ resource "aws_s3_bucket" "website" {
 }
 ```
 
-Basic usage with [custom VCL](https://docs.fastly.com/guides/vcl/uploading-custom-vcl):
+Basic usage with [custom
+VCL](https://docs.fastly.com/vcl/custom-vcl/uploading-custom-vcl/):
 
 ```hcl
 resource "fastly_service_v1" "demo" {
@@ -573,6 +574,7 @@ The `logging_sftp` block supports:
 * `format_version` - (Optional) The version of the custom logging format used for the configured endpoint. Can be either `1` or `2`. (default: `2`).
 * `response_condition` - (Optional) The name of the condition to apply.
 * `timestamp_format` - (Optional) The strftime specified timestamp formatting (default `%Y-%m-%dT%H:%M:%S.000`).
+* `message_type` - (Optional) How the message should be formatted. One of: classic (default), loggly, logplex or blank.
 
 The `response_object` block supports:
 


### PR DESCRIPTION
Adds support for configuring [SFTP log streaming](https://docs.fastly.com/en/guides/log-streaming-sftp) ([API docs](https://developer.fastly.com/reference/api/logging/sftp/)) to provider.

cc: @phamann 