### PR TITLE
Add support for Loggly logging

### DIFF
--- a/fastly/block_fastly_service_v1_logging_loggly.go
+++ b/fastly/block_fastly_service_v1_logging_loggly.go
@@ -1,0 +1,197 @@
+package fastly
+
+import (
+	"fmt"
+	"log"
+
+	gofastly "github.com/fastly/go-fastly/fastly"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+var logglySchema = &schema.Schema{
+	Type:     schema.TypeSet,
+	Optional: true,
+	Elem: &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			// Required fields
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The unique name of the Loggly logging endpoint.",
+			},
+
+			"token": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Sensitive:   true,
+				Description: "The token to use for authentication (https://www.loggly.com/docs/customer-token-authentication-token/).",
+			},
+
+			"format": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Apache-style string or VCL variables to use for log formatting.",
+			},
+
+			// Optional fields
+			"format_version": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      2,
+				Description:  "The version of the custom logging format used for the configured endpoint. Can be either `1` or `2`. (default: `2`).",
+				ValidateFunc: validateLoggingFormatVersion(),
+			},
+
+			"placement": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Description:  "Where in the generated VCL the logging call should be placed. Can be `none` or `waf_debug`.",
+				ValidateFunc: validateLoggingPlacement(),
+			},
+
+			"response_condition": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The name of an existing condition in the configured endpoint, or leave blank to always execute.",
+			},
+		},
+	},
+}
+
+func processLoggly(d *schema.ResourceData, conn *gofastly.Client, latestVersion int) error {
+	serviceID := d.Id()
+	ol, nl := d.GetChange("logging_loggly")
+
+	if ol == nil {
+		ol = new(schema.Set)
+	}
+	if nl == nil {
+		nl = new(schema.Set)
+	}
+
+	ols := ol.(*schema.Set)
+	nls := nl.(*schema.Set)
+
+	removeLogglyLogging := ols.Difference(nls).List()
+	addLogglyLogging := nls.Difference(ols).List()
+
+	// DELETE old Loggly logging endpoints.
+	for _, oRaw := range removeLogglyLogging {
+		of := oRaw.(map[string]interface{})
+		opts := buildDeleteLoggly(of, serviceID, latestVersion)
+
+		log.Printf("[DEBUG] Fastly Loggly logging endpoint removal opts: %#v", opts)
+
+		if err := deleteLoggly(conn, opts); err != nil {
+			return err
+		}
+	}
+
+	// POST new/updated Loggly logging endpoints.
+	for _, nRaw := range addLogglyLogging {
+		lf := nRaw.(map[string]interface{})
+		opts := buildCreateLoggly(lf, serviceID, latestVersion)
+
+		log.Printf("[DEBUG] Fastly Loggly logging addition opts: %#v", opts)
+
+		if err := createLoggly(conn, opts); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func readLoggly(conn *gofastly.Client, d *schema.ResourceData, s *gofastly.ServiceDetail) error {
+	// Refresh Loggly.
+	log.Printf("[DEBUG] Refreshing Loggly logging endpoints for (%s)", d.Id())
+	logglyList, err := conn.ListLoggly(&gofastly.ListLogglyInput{
+		Service: d.Id(),
+		Version: s.ActiveVersion.Number,
+	})
+
+	if err != nil {
+		return fmt.Errorf("[ERR] Error looking up Loggly logging endpoints for (%s), version (%v): %s", d.Id(), s.ActiveVersion.Number, err)
+	}
+
+	ell := flattenLoggly(logglyList)
+
+	if err := d.Set("logging_loggly", ell); err != nil {
+		log.Printf("[WARN] Error setting Loggly logging endpoints for (%s): %s", d.Id(), err)
+	}
+
+	return nil
+}
+
+func createLoggly(conn *gofastly.Client, i *gofastly.CreateLogglyInput) error {
+	_, err := conn.CreateLoggly(i)
+	return err
+}
+
+func deleteLoggly(conn *gofastly.Client, i *gofastly.DeleteLogglyInput) error {
+	err := conn.DeleteLoggly(i)
+
+	errRes, ok := err.(*gofastly.HTTPError)
+	if !ok {
+		return err
+	}
+
+	// 404 response codes don't result in an error propagating because a 404 could
+	// indicate that a resource was deleted elsewhere.
+	if !errRes.IsNotFound() {
+		return err
+	}
+
+	return nil
+}
+
+func flattenLoggly(logglyList []*gofastly.Loggly) []map[string]interface{} {
+	var lsl []map[string]interface{}
+	for _, ll := range logglyList {
+		// Convert Loggly logging to a map for saving to state.
+		nll := map[string]interface{}{
+			"name":               ll.Name,
+			"token":              ll.Token,
+			"format":             ll.Format,
+			"format_version":     ll.FormatVersion,
+			"placement":          ll.Placement,
+			"response_condition": ll.ResponseCondition,
+		}
+
+		// Prune any empty values that come from the default string value in structs.
+		for k, v := range nll {
+			if v == "" {
+				delete(nll, k)
+			}
+		}
+
+		lsl = append(lsl, nll)
+	}
+
+	return lsl
+}
+
+func buildCreateLoggly(logglyMap interface{}, serviceID string, serviceVersion int) *gofastly.CreateLogglyInput {
+	df := logglyMap.(map[string]interface{})
+
+	return &gofastly.CreateLogglyInput{
+		Service:           serviceID,
+		Version:           serviceVersion,
+		Name:              gofastly.NullString(df["name"].(string)),
+		Token:             gofastly.NullString(df["token"].(string)),
+		Format:            gofastly.NullString(df["format"].(string)),
+		FormatVersion:     gofastly.Uint(uint(df["format_version"].(int))),
+		Placement:         gofastly.NullString(df["placement"].(string)),
+		ResponseCondition: gofastly.NullString(df["response_condition"].(string)),
+	}
+}
+
+func buildDeleteLoggly(logglyMap interface{}, serviceID string, serviceVersion int) *gofastly.DeleteLogglyInput {
+	df := logglyMap.(map[string]interface{})
+
+	return &gofastly.DeleteLogglyInput{
+		Service: serviceID,
+		Version: serviceVersion,
+		Name:    df["name"].(string),
+	}
+}

--- a/fastly/block_fastly_service_v1_logging_loggly_test.go
+++ b/fastly/block_fastly_service_v1_logging_loggly_test.go
@@ -1,0 +1,210 @@
+package fastly
+
+import (
+	"fmt"
+	"log"
+	"testing"
+
+	gofastly "github.com/fastly/go-fastly/fastly"
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestResourceFastlyFlattenLoggly(t *testing.T) {
+	cases := []struct {
+		remote []*gofastly.Loggly
+		local  []map[string]interface{}
+	}{
+		{
+			remote: []*gofastly.Loggly{
+				{
+					Version:       1,
+					Name:          "loggly-endpoint",
+					Token:         "token",
+					FormatVersion: 2,
+				},
+			},
+			local: []map[string]interface{}{
+				{
+					"name":           "loggly-endpoint",
+					"token":          "token",
+					"format_version": uint(2),
+				},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		out := flattenLoggly(c.remote)
+		if diff := cmp.Diff(out, c.local); diff != "" {
+			t.Fatalf("Error matching: %s", diff)
+		}
+	}
+}
+
+func TestAccFastlyServiceV1_logging_loggly_basic(t *testing.T) {
+	var service gofastly.ServiceDetail
+	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	domain := fmt.Sprintf("fastly-test.%s.com", name)
+
+	log1 := gofastly.Loggly{
+		Version:       1,
+		Name:          "loggly-endpoint",
+		Token:         "s3cr3t",
+		FormatVersion: 2,
+		Format:        "%h %l %u %t \"%r\" %>s %b",
+	}
+
+	log1_after_update := gofastly.Loggly{
+		Version:       1,
+		Name:          "loggly-endpoint",
+		Token:         "secret",
+		FormatVersion: 2,
+		Format:        "%h %l %u %t \"%r\" %>s %b %T",
+	}
+
+	log2 := gofastly.Loggly{
+		Version:       1,
+		Name:          "another-loggly-endpoint",
+		Token:         "another-token",
+		FormatVersion: 2,
+		Format:        "%h %l %u %t \"%r\" %>s %b",
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckServiceV1Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServiceV1LogglyConfig(name, domain),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
+					testAccCheckFastlyServiceV1LogglyAttributes(&service, []*gofastly.Loggly{&log1}),
+					resource.TestCheckResourceAttr(
+						"fastly_service_v1.foo", "name", name),
+					resource.TestCheckResourceAttr(
+						"fastly_service_v1.foo", "logging_loggly.#", "1"),
+				),
+			},
+
+			{
+				Config: testAccServiceV1LogglyConfig_update(name, domain),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
+					testAccCheckFastlyServiceV1LogglyAttributes(&service, []*gofastly.Loggly{&log1_after_update, &log2}),
+					resource.TestCheckResourceAttr(
+						"fastly_service_v1.foo", "name", name),
+					resource.TestCheckResourceAttr(
+						"fastly_service_v1.foo", "logging_loggly.#", "2"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckFastlyServiceV1LogglyAttributes(service *gofastly.ServiceDetail, loggly []*gofastly.Loggly) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+
+		conn := testAccProvider.Meta().(*FastlyClient).conn
+		logglyList, err := conn.ListLoggly(&gofastly.ListLogglyInput{
+			Service: service.ID,
+			Version: service.ActiveVersion.Number,
+		})
+
+		if err != nil {
+			return fmt.Errorf("[ERR] Error looking up Loggly Logging for (%s), version (%d): %s", service.Name, service.ActiveVersion.Number, err)
+		}
+
+		if len(logglyList) != len(loggly) {
+			return fmt.Errorf("Loggly List count mismatch, expected (%d), got (%d)", len(loggly), len(logglyList))
+		}
+
+		log.Printf("[DEBUG] logglyList = %#v\n", logglyList)
+
+		var found int
+		for _, e := range loggly {
+			for _, el := range logglyList {
+				if e.Name == el.Name {
+					// we don't know these things ahead of time, so populate them now
+					e.ServiceID = service.ID
+					e.Version = service.ActiveVersion.Number
+					// We don't track these, so clear them out because we also wont know
+					// these ahead of time
+					el.CreatedAt = nil
+					el.UpdatedAt = nil
+					if diff := cmp.Diff(e, el); diff != "" {
+						return fmt.Errorf("Bad match Loggly logging match: %s", diff)
+					}
+					found++
+				}
+			}
+		}
+
+		if found != len(loggly) {
+			return fmt.Errorf("Error matching Loggly Logging rules")
+		}
+
+		return nil
+	}
+}
+
+func testAccServiceV1LogglyConfig(name string, domain string) string {
+	return fmt.Sprintf(`
+resource "fastly_service_v1" "foo" {
+  name = "%s"
+
+  domain {
+    name    = "%s"
+    comment = "tf-loggly-logging"
+  }
+
+  backend {
+    address = "aws.amazon.com"
+    name    = "amazon docs"
+  }
+
+  logging_loggly {
+    name   = "loggly-endpoint"
+    token  = "s3cr3t"
+    format = "%%h %%l %%u %%t \"%%r\" %%>s %%b"
+  }
+
+  force_destroy = true
+}
+`, name, domain)
+}
+
+func testAccServiceV1LogglyConfig_update(name, domain string) string {
+	return fmt.Sprintf(`
+resource "fastly_service_v1" "foo" {
+  name = "%s"
+
+  domain {
+    name    = "%s"
+    comment = "tf-loggly-logging"
+  }
+
+  backend {
+    address = "aws.amazon.com"
+    name    = "amazon docs"
+  }
+
+  logging_loggly {
+    name   = "loggly-endpoint"
+    token  = "secret"
+    format = "%%h %%l %%u %%t \"%%r\" %%>s %%b %%T"
+  }
+
+  logging_loggly {
+    name   = "another-loggly-endpoint"
+    token  = "another-token"
+    format = "%%h %%l %%u %%t \"%%r\" %%>s %%b"
+  }
+
+  force_destroy = true
+}
+`, name, domain)
+}

--- a/fastly/resource_fastly_service_v1.go
+++ b/fastly/resource_fastly_service_v1.go
@@ -111,6 +111,7 @@ func resourceServiceV1() *schema.Resource {
 			"logging_ftp":           ftpSchema,
 			"logging_sftp":          sftpSchema,
 			"logging_datadog":       datadogSchema,
+			"logging_loggly":        logglySchema,
 
 			"response_object": responseobjectSchema,
 			"request_setting": requestsettingSchema,
@@ -191,6 +192,7 @@ func resourceServiceV1Update(d *schema.ResourceData, meta interface{}) error {
 		"logging_ftp",
 		"logging_sftp",
 		"logging_datadog",
+		"logging_loggly",
 		"response_object",
 		"condition",
 		"request_setting",
@@ -389,10 +391,13 @@ func resourceServiceV1Update(d *schema.ResourceData, meta interface{}) error {
 				return err
 			}
 		}
-
-		// find differences in Datadog logging configuration
 		if d.HasChange("logging_datadog") {
 			if err := processDatadog(d, conn, latestVersion); err != nil {
+				return err
+			}
+		}
+		if d.HasChange("logging_loggly") {
+			if err := processLoggly(d, conn, latestVersion); err != nil {
 				return err
 			}
 		}
@@ -594,6 +599,9 @@ func resourceServiceV1Read(d *schema.ResourceData, meta interface{}) error {
 			return err
 		}
 		if err := readDatadog(conn, d, s); err != nil {
+			return err
+		}
+		if err := readLoggly(conn, d, s); err != nil {
 			return err
 		}
 		if err := readResponseObject(conn, d, s); err != nil {

--- a/website/docs/r/service_v1.html.markdown
+++ b/website/docs/r/service_v1.html.markdown
@@ -214,6 +214,8 @@ Defined below.
 Defined below.
 * `logging_datadog` - (Optional) A Datadog endpoint to send streaming logs to.
 Defined below.
+* `logging_loggly` - (Optional) A Loggly endpoint to send streaming logs to.
+Defined below.
 * `response_object` - (Optional) Allows you to create synthetic responses that exist entirely on the varnish machine. Useful for creating error or maintenance pages that exists outside the scope of your datacenter. Best when used with Condition objects.
 * `snippet` - (Optional) A set of custom, "regular" (non-dynamic) VCL Snippet configuration blocks.  Defined below.
 * `dynamicsnippet` - (Optional) A set of custom, "dynamic" VCL Snippet configuration blocks.  Defined below.
@@ -587,6 +589,15 @@ The `logging_datadog` block supports:
 * `format_version` - (Optional) The version of the custom logging format used for the configured endpoint. Can be either `1` or `2`. (default: `2`).
 * `placement` - (Optional) Where in the generated VCL the logging call should be placed.
 * `response_condition` - (Optional) The name of the condition to apply.
+
+The `logging_loggly` block supports:
+
+* `name` - (Required) The unique name of the Loggly logging endpoint.
+* `token` - (Required) The token to use for authentication (https://www.loggly.com/docs/customer-token-authentication-token/).
+* `format` - (Optional) Apache-style string or VCL variables to use for log formatting.
+* `format_version` - (Optional) The version of the custom logging format used for the configured endpoint. Can be either `1` or `2`. (default: `2`).
+* `placement` - (Optional) Where in the generated VCL the logging call should be placed. Can be `none` or `waf_debug`.
+* `response_condition` - (Optional) The name of an existing condition in the configured endpoint, or leave blank to always execute.
 
 The `response_object` block supports:
 


### PR DESCRIPTION
Adds support for configuring [Loggly log streaming](https://docs.fastly.com/en/guides/log-streaming-loggly) ([API docs](https://developer.fastly.com/reference/api/logging/loggly/)) to provider.

cc: @phamann @mccurdyc 