### PR TITLE
Add support for Datadog logging

### DIFF
--- a/fastly/block_fastly_service_v1_logging_datadog.go
+++ b/fastly/block_fastly_service_v1_logging_datadog.go
@@ -1,0 +1,206 @@
+package fastly
+
+import (
+	"fmt"
+	"log"
+
+	gofastly "github.com/fastly/go-fastly/fastly"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+var datadogSchema = &schema.Schema{
+	Type:     schema.TypeSet,
+	Optional: true,
+	Elem: &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			// Required fields
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The unique name of the Datadog logging endpoint.",
+			},
+
+			"token": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Sensitive:   true,
+				Description: "The API key from your Datadog account.",
+			},
+
+			// Optional fields
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Default:     "US",
+				Description: "The region that log data will be sent to. One of `US` or `EU`. Defaults to `US` if undefined.",
+			},
+
+			"format": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Apache-style string or VCL variables to use for log formatting.",
+			},
+
+			"format_version": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      2,
+				Description:  "The version of the custom logging format used for the configured endpoint. Can be either `1` or `2`. (default: `2`).",
+				ValidateFunc: validateLoggingFormatVersion(),
+			},
+
+			"placement": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Description:  "Where in the generated VCL the logging call should be placed.",
+				ValidateFunc: validateLoggingPlacement(),
+			},
+
+			"response_condition": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The name of the condition to apply.",
+			},
+		},
+	},
+}
+
+func processDatadog(d *schema.ResourceData, conn *gofastly.Client, latestVersion int) error {
+	serviceID := d.Id()
+	od, nd := d.GetChange("logging_datadog")
+
+	if od == nil {
+		od = new(schema.Set)
+	}
+	if nd == nil {
+		nd = new(schema.Set)
+	}
+
+	ods := od.(*schema.Set)
+	nds := nd.(*schema.Set)
+
+	removeDatadogLogging := ods.Difference(nds).List()
+	addDatadogLogging := nds.Difference(ods).List()
+
+	// DELETE old Datadog logging endpoints.
+	for _, oRaw := range removeDatadogLogging {
+		of := oRaw.(map[string]interface{})
+		opts := buildDeleteDatadog(of, serviceID, latestVersion)
+
+		log.Printf("[DEBUG] Fastly Datadog logging endpoint removal opts: %#v", opts)
+
+		if err := deleteDatadog(conn, opts); err != nil {
+			return err
+		}
+	}
+
+	// POST new/updated Datadog logging endpoints.
+	for _, nRaw := range addDatadogLogging {
+		df := nRaw.(map[string]interface{})
+		opts := buildCreateDatadog(df, serviceID, latestVersion)
+
+		log.Printf("[DEBUG] Fastly Datadog logging addition opts: %#v", opts)
+
+		if err := createDatadog(conn, opts); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func readDatadog(conn *gofastly.Client, d *schema.ResourceData, s *gofastly.ServiceDetail) error {
+	// Refresh Datadog.
+	log.Printf("[DEBUG] Refreshing Datadog logging endpoints for (%s)", d.Id())
+	datadogList, err := conn.ListDatadog(&gofastly.ListDatadogInput{
+		Service: d.Id(),
+		Version: s.ActiveVersion.Number,
+	})
+
+	if err != nil {
+		return fmt.Errorf("[ERR] Error looking up Datadog logging endpoints for (%s), version (%v): %s", d.Id(), s.ActiveVersion.Number, err)
+	}
+
+	dll := flattenDatadog(datadogList)
+
+	if err := d.Set("logging_datadog", dll); err != nil {
+		log.Printf("[WARN] Error setting Datadog logging endpoints for (%s): %s", d.Id(), err)
+	}
+
+	return nil
+}
+
+func createDatadog(conn *gofastly.Client, i *gofastly.CreateDatadogInput) error {
+	_, err := conn.CreateDatadog(i)
+	return err
+}
+
+func deleteDatadog(conn *gofastly.Client, i *gofastly.DeleteDatadogInput) error {
+	err := conn.DeleteDatadog(i)
+
+	errRes, ok := err.(*gofastly.HTTPError)
+	if !ok {
+		return err
+	}
+
+	// 404 response codes don't result in an error propagating because a 404 could
+	// indicate that a resource was deleted elsewhere.
+	if !errRes.IsNotFound() {
+		return err
+	}
+
+	return nil
+}
+
+func flattenDatadog(datadogList []*gofastly.Datadog) []map[string]interface{} {
+	var dsl []map[string]interface{}
+	for _, dl := range datadogList {
+		// Convert Datadog logging to a map for saving to state.
+		ndl := map[string]interface{}{
+			"name":               dl.Name,
+			"token":              dl.Token,
+			"region":             dl.Region,
+			"format":             dl.Format,
+			"format_version":     dl.FormatVersion,
+			"placement":          dl.Placement,
+			"response_condition": dl.ResponseCondition,
+		}
+
+		// Prune any empty values that come from the default string value in structs.
+		for k, v := range ndl {
+			if v == "" {
+				delete(ndl, k)
+			}
+		}
+
+		dsl = append(dsl, ndl)
+	}
+
+	return dsl
+}
+
+func buildCreateDatadog(datadogMap interface{}, serviceID string, serviceVersion int) *gofastly.CreateDatadogInput {
+	df := datadogMap.(map[string]interface{})
+
+	return &gofastly.CreateDatadogInput{
+		Service:           serviceID,
+		Version:           serviceVersion,
+		Name:              gofastly.NullString(df["name"].(string)),
+		Token:             gofastly.NullString(df["token"].(string)),
+		Region:            gofastly.NullString(df["region"].(string)),
+		Format:            gofastly.NullString(df["format"].(string)),
+		FormatVersion:     gofastly.Uint(uint(df["format_version"].(int))),
+		Placement:         gofastly.NullString(df["placement"].(string)),
+		ResponseCondition: gofastly.NullString(df["response_condition"].(string)),
+	}
+}
+
+func buildDeleteDatadog(datadogMap interface{}, serviceID string, serviceVersion int) *gofastly.DeleteDatadogInput {
+	df := datadogMap.(map[string]interface{})
+
+	return &gofastly.DeleteDatadogInput{
+		Service: serviceID,
+		Version: serviceVersion,
+		Name:    df["name"].(string),
+	}
+}

--- a/fastly/block_fastly_service_v1_logging_datadog_test.go
+++ b/fastly/block_fastly_service_v1_logging_datadog_test.go
@@ -1,0 +1,309 @@
+package fastly
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"testing"
+
+	gofastly "github.com/fastly/go-fastly/fastly"
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestResourceFastlyFlattenDatadog(t *testing.T) {
+	cases := []struct {
+		remote []*gofastly.Datadog
+		local  []map[string]interface{}
+	}{
+		{
+			remote: []*gofastly.Datadog{
+				{
+					Version:       1,
+					Name:          "datadog-endpoint",
+					Token:         "token",
+					Region:        "US",
+					FormatVersion: 2,
+				},
+			},
+			local: []map[string]interface{}{
+				{
+					"name":           "datadog-endpoint",
+					"token":          "token",
+					"region":         "US",
+					"format_version": uint(2),
+				},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		out := flattenDatadog(c.remote)
+		if diff := cmp.Diff(out, c.local); diff != "" {
+			t.Fatalf("Error matching: %s", diff)
+		}
+	}
+}
+
+var datadogDefaultFormat = `{
+  "ddsource": "fastly",
+  "service": "%{req.service_id}V",
+  "date": "%{begin:%Y-%m-%dT%H:%M:%S%Z}t",
+  "time_start": "%{begin:%Y-%m-%dT%H:%M:%S%Z}t",
+  "time_end": "%{end:%Y-%m-%dT%H:%M:%S%Z}t",
+  "http": {
+    "request_time_ms": %D,
+    "method": "%m",
+    "url": "%{json.escape(req.url)}V",
+    "useragent": "%{User-Agent}i",
+    "referer": "%{Referer}i",
+    "protocol": "%H",
+    "request_x_forwarded_for": "%{X-Forwarded-For}i",
+    "status_code": "%s"
+  },
+  "network": {
+    "client": {
+     "ip": "%h",
+     "name": "%{client.as.name}V",
+     "number": "%{client.as.number}V",
+     "connection_speed": "%{client.geo.conn_speed}V"
+    },
+   "destination": {
+     "ip": "%A"
+    },
+  "geoip": {
+  "geo_city": "%{client.geo.city.utf8}V",
+  "geo_country_code": "%{client.geo.country_code}V",
+  "geo_continent_code": "%{client.geo.continent_code}V",
+  "geo_region": "%{client.geo.region}V"
+  },
+  "bytes_written": %B,
+  "bytes_read": %{req.body_bytes_read}V
+  },
+  "host": "%{Fastly-Orig-Host}i",
+  "origin_host": "%v",
+  "is_ipv6": %{if(req.is_ipv6, "true", "false")}V,
+  "is_tls": %{if(req.is_ssl, "true", "false")}V,
+  "tls_client_protocol": "%{json.escape(tls.client.protocol)}V",
+  "tls_client_servername": "%{json.escape(tls.client.servername)}V",
+  "tls_client_cipher": "%{json.escape(tls.client.cipher)}V",
+  "tls_client_cipher_sha": "%{json.escape(tls.client.ciphers_sha)}V",
+  "tls_client_tlsexts_sha": "%{json.escape(tls.client.tlsexts_sha)}V",
+  "is_h2": %{if(fastly_info.is_h2, "true", "false")}V,
+  "is_h2_push": %{if(fastly_info.h2.is_push, "true", "false")}V,
+  "h2_stream_id": "%{fastly_info.h2.stream_id}V",
+  "request_accept_content": "%{Accept}i",
+  "request_accept_language": "%{Accept-Language}i",
+  "request_accept_encoding": "%{Accept-Encoding}i",
+  "request_accept_charset": "%{Accept-Charset}i",
+  "request_connection": "%{Connection}i",
+  "request_dnt": "%{DNT}i",
+  "request_forwarded": "%{Forwarded}i",
+  "request_via": "%{Via}i",
+  "request_cache_control": "%{Cache-Control}i",
+  "request_x_requested_with": "%{X-Requested-With}i",
+  "request_x_att_device_id": "%{X-ATT-Device-Id}i",
+  "content_type": "%{Content-Type}o",
+  "is_cacheable": %{if(fastly_info.state~"^(HIT|MISS)$", "true","false")}V,
+  "response_age": "%{Age}o",
+  "response_cache_control": "%{Cache-Control}o",
+  "response_expires": "%{Expires}o",
+  "response_last_modified": "%{Last-Modified}o",
+  "response_tsv": "%{TSV}o",
+  "server_datacenter": "%{server.datacenter}V",
+  "req_header_size": %{req.header_bytes_read}V,
+  "resp_header_size": %{resp.header_bytes_written}V,
+  "socket_cwnd": %{client.socket.cwnd}V,
+  "socket_nexthop": "%{client.socket.nexthop}V",
+  "socket_tcpi_rcv_mss": %{client.socket.tcpi_rcv_mss}V,
+  "socket_tcpi_snd_mss": %{client.socket.tcpi_snd_mss}V,
+  "socket_tcpi_rtt": %{client.socket.tcpi_rtt}V,
+  "socket_tcpi_rttvar": %{client.socket.tcpi_rttvar}V,
+  "socket_tcpi_rcv_rtt": %{client.socket.tcpi_rcv_rtt}V,
+  "socket_tcpi_rcv_space": %{client.socket.tcpi_rcv_space}V,
+  "socket_tcpi_last_data_sent": %{client.socket.tcpi_last_data_sent}V,
+  "socket_tcpi_total_retrans": %{client.socket.tcpi_total_retrans}V,
+  "socket_tcpi_delta_retrans": %{client.socket.tcpi_delta_retrans}V,
+  "socket_ploss": %{client.socket.ploss}V
+}`
+
+func TestAccFastlyServiceV1_logging_datadog_basic(t *testing.T) {
+	var service gofastly.ServiceDetail
+	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	domain := fmt.Sprintf("fastly-test.%s.com", name)
+
+	log1 := gofastly.Datadog{
+		Version:       1,
+		Name:          "datadog-endpoint",
+		Token:         "token",
+		Region:        "US",
+		FormatVersion: 2,
+		Format:        "%h %l %u %t \"%r\" %>s %b",
+	}
+
+	log1_after_update := gofastly.Datadog{
+		Version:       1,
+		Name:          "datadog-endpoint",
+		Token:         "t0k3n",
+		Region:        "EU",
+		FormatVersion: 2,
+		Format:        "%h %l %u %t \"%r\" %>s %b %T",
+	}
+
+	log2 := gofastly.Datadog{
+		Version:       1,
+		Name:          "another-datadog-endpoint",
+		Token:         "another-token",
+		Region:        "US",
+		FormatVersion: 2,
+		Format:        datadogDefaultFormat + "\n",
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckServiceV1Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServiceV1DatadogConfig(name, domain),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
+					testAccCheckFastlyServiceV1DatadogAttributes(&service, []*gofastly.Datadog{&log1}),
+					resource.TestCheckResourceAttr(
+						"fastly_service_v1.foo", "name", name),
+					resource.TestCheckResourceAttr(
+						"fastly_service_v1.foo", "logging_datadog.#", "1"),
+				),
+			},
+
+			{
+				Config: testAccServiceV1DatadogConfig_update(name, domain),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
+					testAccCheckFastlyServiceV1DatadogAttributes(&service, []*gofastly.Datadog{&log1_after_update, &log2}),
+					resource.TestCheckResourceAttr(
+						"fastly_service_v1.foo", "name", name),
+					resource.TestCheckResourceAttr(
+						"fastly_service_v1.foo", "logging_datadog.#", "2"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckFastlyServiceV1DatadogAttributes(service *gofastly.ServiceDetail, datadog []*gofastly.Datadog) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+
+		conn := testAccProvider.Meta().(*FastlyClient).conn
+		datadogList, err := conn.ListDatadog(&gofastly.ListDatadogInput{
+			Service: service.ID,
+			Version: service.ActiveVersion.Number,
+		})
+
+		if err != nil {
+			return fmt.Errorf("[ERR] Error looking up Datadog Logging for (%s), version (%d): %s", service.Name, service.ActiveVersion.Number, err)
+		}
+
+		if len(datadogList) != len(datadog) {
+			return fmt.Errorf("Datadog List count mismatch, expected (%d), got (%d)", len(datadog), len(datadogList))
+		}
+
+		log.Printf("[DEBUG] datadogList = %#v\n", datadogList)
+
+		var found int
+		for _, d := range datadog {
+			for _, dl := range datadogList {
+				if d.Name == dl.Name {
+					// we don't know these things ahead of time, so populate them now
+					d.ServiceID = service.ID
+					d.Version = service.ActiveVersion.Number
+					// We don't track these, so clear them out because we also wont know
+					// these ahead of time
+					dl.CreatedAt = nil
+					dl.UpdatedAt = nil
+
+					if diff := cmp.Diff(d, dl); diff != "" {
+						return fmt.Errorf("Bad match Datadog logging match: %s", diff)
+					}
+					found++
+				}
+			}
+		}
+
+		if found != len(datadog) {
+			return fmt.Errorf("Error matching Datadog Logging rules")
+		}
+
+		return nil
+	}
+}
+
+func testAccServiceV1DatadogConfig(name string, domain string) string {
+	return fmt.Sprintf(`
+resource "fastly_service_v1" "foo" {
+  name = "%s"
+
+  domain {
+    name    = "%s"
+    comment = "tf-datadog-logging"
+  }
+
+  backend {
+    address = "aws.amazon.com"
+    name    = "amazon docs"
+  }
+
+  logging_datadog {
+    name   = "datadog-endpoint"
+    token  = "token"
+    region = "US"
+    format = "%%h %%l %%u %%t \"%%r\" %%>s %%b"
+  }
+
+  force_destroy = true
+}
+`, name, domain)
+}
+
+var (
+	// https://www.terraform.io/docs/configuration/expressions.html#string-literals
+	escapePercent          = strings.ReplaceAll(datadogDefaultFormat, "%", "%%")
+	escapeTemplateSequence = strings.ReplaceAll(escapePercent, "%%{", "%%%%{")
+)
+
+func testAccServiceV1DatadogConfig_update(name, domain string) string {
+	return fmt.Sprintf(`
+resource "fastly_service_v1" "foo" {
+  name = "%s"
+
+  domain {
+    name    = "%s"
+    comment = "tf-datadog-logging"
+  }
+
+  backend {
+    address = "aws.amazon.com"
+    name    = "amazon docs"
+  }
+
+  logging_datadog {
+    name   = "datadog-endpoint"
+    token  = "t0k3n"
+    region = "EU"
+    format = "%%h %%l %%u %%t \"%%r\" %%>s %%b %%T"
+  }
+
+  logging_datadog {
+    name  = "another-datadog-endpoint"
+    token = "another-token"
+		format = <<EOF
+`+escapeTemplateSequence+`
+EOF
+  }
+
+  force_destroy = true
+}
+`, name, domain)
+}

--- a/fastly/resource_fastly_service_v1.go
+++ b/fastly/resource_fastly_service_v1.go
@@ -110,6 +110,7 @@ func resourceServiceV1() *schema.Resource {
 			"logging_elasticsearch": elasticsearchSchema,
 			"logging_ftp":           ftpSchema,
 			"logging_sftp":          sftpSchema,
+			"logging_datadog":       datadogSchema,
 
 			"response_object": responseobjectSchema,
 			"request_setting": requestsettingSchema,
@@ -189,6 +190,7 @@ func resourceServiceV1Update(d *schema.ResourceData, meta interface{}) error {
 		"logging_elasticsearch",
 		"logging_ftp",
 		"logging_sftp",
+		"logging_datadog",
 		"response_object",
 		"condition",
 		"request_setting",
@@ -388,6 +390,13 @@ func resourceServiceV1Update(d *schema.ResourceData, meta interface{}) error {
 			}
 		}
 
+		// find differences in Datadog logging configuration
+		if d.HasChange("logging_datadog") {
+			if err := processDatadog(d, conn, latestVersion); err != nil {
+				return err
+			}
+		}
+
 		// find differences in Elasticsearch logging configuration
 		if d.HasChange("logging_elasticsearch") {
 			if err := processElasticsearch(d, conn, latestVersion); err != nil {
@@ -582,6 +591,9 @@ func resourceServiceV1Read(d *schema.ResourceData, meta interface{}) error {
 			return err
 		}
 		if err := readHTTPS(conn, d, s); err != nil {
+			return err
+		}
+		if err := readDatadog(conn, d, s); err != nil {
 			return err
 		}
 		if err := readResponseObject(conn, d, s); err != nil {

--- a/website/docs/r/service_v1.html.markdown
+++ b/website/docs/r/service_v1.html.markdown
@@ -212,6 +212,8 @@ Defined below.
 Defined below.
 * `logging_sftp` - (Optional) An SFTP endpoint to send streaming logs to.
 Defined below.
+* `logging_datadog` - (Optional) A Datadog endpoint to send streaming logs to.
+Defined below.
 * `response_object` - (Optional) Allows you to create synthetic responses that exist entirely on the varnish machine. Useful for creating error or maintenance pages that exists outside the scope of your datacenter. Best when used with Condition objects.
 * `snippet` - (Optional) A set of custom, "regular" (non-dynamic) VCL Snippet configuration blocks.  Defined below.
 * `dynamicsnippet` - (Optional) A set of custom, "dynamic" VCL Snippet configuration blocks.  Defined below.
@@ -575,6 +577,16 @@ The `logging_sftp` block supports:
 * `response_condition` - (Optional) The name of the condition to apply.
 * `timestamp_format` - (Optional) The strftime specified timestamp formatting (default `%Y-%m-%dT%H:%M:%S.000`).
 * `message_type` - (Optional) How the message should be formatted. One of: classic (default), loggly, logplex or blank.
+
+The `logging_datadog` block supports:
+
+* `name` - (Required) The unique name of the Datadog logging endpoint.
+* `token` - (Required) The API key from your Datadog account.
+* `region` - (Optional) The region that log data will be sent to. One of `US` or `EU`. Defaults to `US` if undefined.
+* `format` - (Optional) Apache-style string or VCL variables to use for log formatting.
+* `format_version` - (Optional) The version of the custom logging format used for the configured endpoint. Can be either `1` or `2`. (default: `2`).
+* `placement` - (Optional) Where in the generated VCL the logging call should be placed.
+* `response_condition` - (Optional) The name of the condition to apply.
 
 The `response_object` block supports:
 


### PR DESCRIPTION
Adds support for configuring [Datadog log streaming](https://docs.fastly.com/en/guides/log-streaming-datadog) ([API docs](https://developer.fastly.com/reference/api/logging/datadog/)) to provider.

cc: @phamann @mccurdyc 