### PR TITLE
Add support for New Relic logging

### DIFF
--- a/fastly/block_fastly_service_v1_logging_newrelic.go
+++ b/fastly/block_fastly_service_v1_logging_newrelic.go
@@ -1,0 +1,195 @@
+package fastly
+
+import (
+	"fmt"
+	"log"
+
+	gofastly "github.com/fastly/go-fastly/fastly"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+var newrelicSchema = &schema.Schema{
+	Type:     schema.TypeSet,
+	Optional: true,
+	Elem: &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			// Required fields
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The unique name of the New Relic logging endpoint",
+			},
+
+			"token": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Sensitive:   true,
+				Description: "The Insert API key from the Account page of your New Relic account.",
+			},
+
+			// Optional fields
+			"format": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Apache style log formatting. Your log must produce valid JSON that New Relic Logs can ingest.",
+			},
+
+			"format_version": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      2,
+				Description:  "The version of the custom logging format used for the configured endpoint. Can be either `1` or `2`. (default: `2`).",
+				ValidateFunc: validateLoggingFormatVersion(),
+			},
+
+			"placement": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Description:  "Where in the generated VCL the logging call should be placed.",
+				ValidateFunc: validateLoggingPlacement(),
+			},
+
+			"response_condition": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The name of the condition to apply.",
+			},
+		},
+	},
+}
+
+func processNewRelic(d *schema.ResourceData, conn *gofastly.Client, latestVersion int) error {
+	serviceID := d.Id()
+	od, nd := d.GetChange("logging_newrelic")
+
+	if od == nil {
+		od = new(schema.Set)
+	}
+	if nd == nil {
+		nd = new(schema.Set)
+	}
+
+	ods := od.(*schema.Set)
+	nds := nd.(*schema.Set)
+
+	removeNewRelicLogging := ods.Difference(nds).List()
+	addNewRelicLogging := nds.Difference(ods).List()
+
+	// DELETE old NewRelic logging endpoints.
+	for _, oRaw := range removeNewRelicLogging {
+		of := oRaw.(map[string]interface{})
+		opts := buildDeleteNewRelic(of, serviceID, latestVersion)
+
+		log.Printf("[DEBUG] Fastly New Relic logging endpoint removal opts: %#v", opts)
+
+		if err := deleteNewRelic(conn, opts); err != nil {
+			return err
+		}
+	}
+
+	// POST new/updated NewRelic logging endpoints.
+	for _, nRaw := range addNewRelicLogging {
+		df := nRaw.(map[string]interface{})
+		opts := buildCreateNewRelic(df, serviceID, latestVersion)
+
+		log.Printf("[DEBUG] Fastly New Relic logging addition opts: %#v", opts)
+
+		if err := createNewRelic(conn, opts); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func readNewRelic(conn *gofastly.Client, d *schema.ResourceData, s *gofastly.ServiceDetail) error {
+	// Refresh NewRelic.
+	log.Printf("[DEBUG] Refreshing New Relic logging endpoints for (%s)", d.Id())
+	newrelicList, err := conn.ListNewRelic(&gofastly.ListNewRelicInput{
+		Service: d.Id(),
+		Version: s.ActiveVersion.Number,
+	})
+
+	if err != nil {
+		return fmt.Errorf("[ERR] Error looking up New Relic logging endpoints for (%s), version (%v): %s", d.Id(), s.ActiveVersion.Number, err)
+	}
+
+	dll := flattenNewRelic(newrelicList)
+
+	if err := d.Set("logging_newrelic", dll); err != nil {
+		log.Printf("[WARN] Error setting New Relic logging endpoints for (%s): %s", d.Id(), err)
+	}
+
+	return nil
+}
+
+func createNewRelic(conn *gofastly.Client, i *gofastly.CreateNewRelicInput) error {
+	_, err := conn.CreateNewRelic(i)
+	return err
+}
+
+func deleteNewRelic(conn *gofastly.Client, i *gofastly.DeleteNewRelicInput) error {
+	err := conn.DeleteNewRelic(i)
+
+	errRes, ok := err.(*gofastly.HTTPError)
+	if !ok {
+		return err
+	}
+	// 404 response codes don't result in an error propagating because a 404 could
+	// indicate that a resource was deleted elsewhere.
+	if !errRes.IsNotFound() {
+		return err
+	}
+	return nil
+}
+
+func flattenNewRelic(newrelicList []*gofastly.NewRelic) []map[string]interface{} {
+	var dsl []map[string]interface{}
+	for _, dl := range newrelicList {
+		// Convert NewRelic logging to a map for saving to state.
+		ndl := map[string]interface{}{
+			"name":               dl.Name,
+			"token":              dl.Token,
+			"format":             dl.Format,
+			"format_version":     dl.FormatVersion,
+			"placement":          dl.Placement,
+			"response_condition": dl.ResponseCondition,
+		}
+
+		// Prune any empty values that come from the default string value in structs.
+		for k, v := range ndl {
+			if v == "" {
+				delete(ndl, k)
+			}
+		}
+
+		dsl = append(dsl, ndl)
+	}
+
+	return dsl
+}
+
+func buildCreateNewRelic(newrelicMap interface{}, serviceID string, serviceVersion int) *gofastly.CreateNewRelicInput {
+	df := newrelicMap.(map[string]interface{})
+
+	return &gofastly.CreateNewRelicInput{
+		Service:           serviceID,
+		Version:           serviceVersion,
+		Name:              gofastly.NullString(df["name"].(string)),
+		Token:             gofastly.NullString(df["token"].(string)),
+		Format:            gofastly.NullString(df["format"].(string)),
+		FormatVersion:     gofastly.Uint(uint(df["format_version"].(int))),
+		Placement:         gofastly.NullString(df["placement"].(string)),
+		ResponseCondition: gofastly.NullString(df["response_condition"].(string)),
+	}
+}
+
+func buildDeleteNewRelic(newrelicMap interface{}, serviceID string, serviceVersion int) *gofastly.DeleteNewRelicInput {
+	df := newrelicMap.(map[string]interface{})
+
+	return &gofastly.DeleteNewRelicInput{
+		Service: serviceID,
+		Version: serviceVersion,
+		Name:    df["name"].(string),
+	}
+}

--- a/fastly/block_fastly_service_v1_logging_newrelic_test.go
+++ b/fastly/block_fastly_service_v1_logging_newrelic_test.go
@@ -1,0 +1,236 @@
+package fastly
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"testing"
+
+	gofastly "github.com/fastly/go-fastly/fastly"
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestResourceFastlyFlattenNewRelic(t *testing.T) {
+	cases := []struct {
+		remote []*gofastly.NewRelic
+		local  []map[string]interface{}
+	}{
+		{
+			remote: []*gofastly.NewRelic{
+				{
+					Version:       1,
+					Name:          "newrelic-endpoint",
+					Token:         "token",
+					FormatVersion: 2,
+				},
+			},
+			local: []map[string]interface{}{
+				{
+					"name":           "newrelic-endpoint",
+					"token":          "token",
+					"format_version": uint(2),
+				},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		out := flattenNewRelic(c.remote)
+		if diff := cmp.Diff(out, c.local); diff != "" {
+			t.Fatalf("Error matching: %s", diff)
+		}
+	}
+}
+
+var (
+	newrelicDefaultFormat = `{
+  "time_elapsed":%{time.elapsed.usec}V,
+  "is_tls":%{if(req.is_ssl, "true", "false")}V,
+  "client_ip":"%{req.http.Fastly-Client-IP}V",
+  "geo_city":"%{client.geo.city}V",
+  "geo_country_code":"%{client.geo.country_code}V",
+  "request":"%{req.request}V",
+  "host":"%{req.http.Fastly-Orig-Host}V",
+  "url":"%{json.escape(req.url)}V",
+  "request_referer":"%{json.escape(req.http.Referer)}V",
+  "request_user_agent":"%{json.escape(req.http.User-Agent)}V",
+  "request_accept_language":"%{json.escape(req.http.Accept-Language)}V",
+  "request_accept_charset":"%{json.escape(req.http.Accept-Charset)}V",
+  "cache_status":"%{regsub(fastly_info.state, "^(HIT-(SYNTH)|(HITPASS|HIT|MISS|PASS|ERROR|PIPE)).*", "\2\3") }V"
+}`
+	// https://www.terraform.io/docs/configuration/expressions.html#string-literals
+	newrelicEscapePercent          = strings.ReplaceAll(newrelicDefaultFormat, "%", "%%")
+	newrelicEscapeTemplateSequence = strings.ReplaceAll(newrelicEscapePercent, "%%{", "%%%%{")
+)
+
+func TestAccFastlyServiceV1_logging_newrelic_basic(t *testing.T) {
+	var service gofastly.ServiceDetail
+	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	domain := fmt.Sprintf("fastly-test.%s.com", name)
+
+	log1 := gofastly.NewRelic{
+		Version:       1,
+		Name:          "newrelic-endpoint",
+		Token:         "token",
+		FormatVersion: 2,
+		Format:        "%h %l %u %t \"%r\" %>s %b",
+	}
+
+	log1_after_update := gofastly.NewRelic{
+		Version:       1,
+		Name:          "newrelic-endpoint",
+		Token:         "t0k3n",
+		FormatVersion: 2,
+		Format:        "%h %l %u %t \"%r\" %>s %b %T",
+	}
+
+	log2 := gofastly.NewRelic{
+		Version:       1,
+		Name:          "another-newrelic-endpoint",
+		Token:         "another-token",
+		FormatVersion: 2,
+		Format:        appendNewLine(newrelicDefaultFormat),
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckServiceV1Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServiceV1NewRelicConfig(name, domain),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
+					testAccCheckFastlyServiceV1NewRelicAttributes(&service, []*gofastly.NewRelic{&log1}),
+					resource.TestCheckResourceAttr(
+						"fastly_service_v1.foo", "name", name),
+					resource.TestCheckResourceAttr(
+						"fastly_service_v1.foo", "logging_newrelic.#", "1"),
+				),
+			},
+
+			{
+				Config: testAccServiceV1NewRelicConfig_update(name, domain),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
+					testAccCheckFastlyServiceV1NewRelicAttributes(&service, []*gofastly.NewRelic{&log1_after_update, &log2}),
+					resource.TestCheckResourceAttr(
+						"fastly_service_v1.foo", "name", name),
+					resource.TestCheckResourceAttr(
+						"fastly_service_v1.foo", "logging_newrelic.#", "2"),
+				),
+				PreventDiskCleanup: true,
+			},
+		},
+	})
+}
+
+func testAccCheckFastlyServiceV1NewRelicAttributes(service *gofastly.ServiceDetail, newrelic []*gofastly.NewRelic) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+
+		conn := testAccProvider.Meta().(*FastlyClient).conn
+		newrelicList, err := conn.ListNewRelic(&gofastly.ListNewRelicInput{
+			Service: service.ID,
+			Version: service.ActiveVersion.Number,
+		})
+
+		if err != nil {
+			return fmt.Errorf("[ERR] Error looking up NewRelic Logging for (%s), version (%d): %s", service.Name, service.ActiveVersion.Number, err)
+		}
+
+		if len(newrelicList) != len(newrelic) {
+			return fmt.Errorf("NewRelic List count mismatch, expected (%d), got (%d)", len(newrelic), len(newrelicList))
+		}
+
+		log.Printf("[DEBUG] newrelicList = %#v\n", newrelicList)
+
+		var found int
+		for _, d := range newrelic {
+			for _, dl := range newrelicList {
+				if d.Name == dl.Name {
+					// we don't know these things ahead of time, so populate them now
+					d.ServiceID = service.ID
+					d.Version = service.ActiveVersion.Number
+					// We don't track these, so clear them out because we also wont know
+					// these ahead of time
+					dl.CreatedAt = nil
+					dl.UpdatedAt = nil
+
+					if diff := cmp.Diff(d, dl); diff != "" {
+						return fmt.Errorf("Bad match NewRelic logging match: %s", diff)
+					}
+					found++
+				}
+			}
+		}
+
+		if found != len(newrelic) {
+			return fmt.Errorf("Error matching NewRelic Logging rules")
+		}
+
+		return nil
+	}
+}
+
+func testAccServiceV1NewRelicConfig(name string, domain string) string {
+	return fmt.Sprintf(`
+resource "fastly_service_v1" "foo" {
+  name = "%s"
+
+  domain {
+    name    = "%s"
+    comment = "tf-newrelic-logging"
+  }
+
+  backend {
+    address = "aws.amazon.com"
+    name    = "amazon docs"
+  }
+
+  logging_newrelic {
+    name   = "newrelic-endpoint"
+    token  = "token"
+    format = "%%h %%l %%u %%t \"%%r\" %%>s %%b"
+  }
+
+  force_destroy = true
+}
+`, name, domain)
+}
+
+func testAccServiceV1NewRelicConfig_update(name, domain string) string {
+	return fmt.Sprintf(`
+resource "fastly_service_v1" "foo" {
+  name = "%s"
+
+  domain {
+    name    = "%s"
+    comment = "tf-newrelic-logging"
+  }
+
+  backend {
+    address = "aws.amazon.com"
+    name    = "amazon docs"
+  }
+
+  logging_newrelic {
+    name   = "newrelic-endpoint"
+    token  = "t0k3n"
+    format = "%%h %%l %%u %%t \"%%r\" %%>s %%b %%T"
+  }
+
+  logging_newrelic {
+    name  = "another-newrelic-endpoint"
+    token = "another-token"
+		format = <<EOF
+`+newrelicEscapeTemplateSequence+`
+EOF
+  }
+
+  force_destroy = true
+}
+`, name, domain)
+}

--- a/fastly/resource_fastly_service_v1.go
+++ b/fastly/resource_fastly_service_v1.go
@@ -112,6 +112,7 @@ func resourceServiceV1() *schema.Resource {
 			"logging_sftp":          sftpSchema,
 			"logging_datadog":       datadogSchema,
 			"logging_loggly":        logglySchema,
+			"logging_newrelic":      newrelicSchema,
 
 			"response_object": responseobjectSchema,
 			"request_setting": requestsettingSchema,
@@ -193,6 +194,7 @@ func resourceServiceV1Update(d *schema.ResourceData, meta interface{}) error {
 		"logging_sftp",
 		"logging_datadog",
 		"logging_loggly",
+		"logging_newrelic",
 		"response_object",
 		"condition",
 		"request_setting",
@@ -416,6 +418,11 @@ func resourceServiceV1Update(d *schema.ResourceData, meta interface{}) error {
 				return err
 			}
 		}
+		if d.HasChange("logging_newrelic") {
+			if err := processNewRelic(d, conn, latestVersion); err != nil {
+				return err
+			}
+		}
 		if d.HasChange("response_object") {
 			if err := processResponseObject(d, conn, latestVersion); err != nil {
 				return err
@@ -604,6 +611,9 @@ func resourceServiceV1Read(d *schema.ResourceData, meta interface{}) error {
 			return err
 		}
 		if err := readLoggly(conn, d, s); err != nil {
+			return err
+		}
+		if err := readNewRelic(conn, d, s); err != nil {
 			return err
 		}
 		if err := readResponseObject(conn, d, s); err != nil {

--- a/website/docs/r/service_v1.html.markdown
+++ b/website/docs/r/service_v1.html.markdown
@@ -216,6 +216,8 @@ Defined below.
 Defined below.
 * `logging_loggly` - (Optional) A Loggly endpoint to send streaming logs to.
 Defined below.
+* `logging_newrelic` - (Optional) A New Relic endpoint to send streaming logs to.
+Defined below.
 * `response_object` - (Optional) Allows you to create synthetic responses that exist entirely on the varnish machine. Useful for creating error or maintenance pages that exists outside the scope of your datacenter. Best when used with Condition objects.
 * `snippet` - (Optional) A set of custom, "regular" (non-dynamic) VCL Snippet configuration blocks.  Defined below.
 * `dynamicsnippet` - (Optional) A set of custom, "dynamic" VCL Snippet configuration blocks.  Defined below.
@@ -599,6 +601,15 @@ The `logging_loggly` block supports:
 * `format_version` - (Optional) The version of the custom logging format used for the configured endpoint. Can be either `1` or `2`. (default: `2`).
 * `placement` - (Optional) Where in the generated VCL the logging call should be placed. Can be `none` or `waf_debug`.
 * `response_condition` - (Optional) The name of an existing condition in the configured endpoint, or leave blank to always execute.
+
+The `logging_newrelic` block supports:
+
+* `name` - (Required) The unique name of the New Relic logging endpoint.
+* `token` - (Required) The Insert API key from the Account page of your New Relic account.
+* `format` - (Optional) Apache style log formatting. Your log must produce valid JSON that New Relic Logs can ingest.
+* `format_version` - (Optional) The version of the custom logging format used for the configured endpoint. Can be either `1` or `2`. (default: `2`).
+* `placement` - (Optional) Where in the generated VCL the logging call should be placed.
+* `response_condition` - (Optional) The name of the condition to apply.
 
 The `response_object` block supports:
 


### PR DESCRIPTION
Adds support for configuring [New Relic log streaming](https://docs.fastly.com/en/guides/log-streaming-newrelic-logs) ([API docs](https://developer.fastly.com/reference/api/logging/new-relic/)) to provider.

cc: @phamann @mccurdyc 