### PR TITLE
mod: upgrade fastly/go-fastly v1.14.0 -> v1.15.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.14
 
 require (
 	github.com/ajg/form v0.0.0-20160822230020-523a5da1a92f // indirect
-	github.com/fastly/go-fastly v1.14.0
+	github.com/fastly/go-fastly v1.15.0
 	github.com/google/jsonapi v0.0.0-20180313013858-2dcc18f43696 // indirect
 	github.com/hashicorp/terraform-plugin-sdk v1.1.0
 )

--- a/go.sum
+++ b/go.sum
@@ -40,8 +40,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dnaeon/go-vcr v1.0.1 h1:r8L/HqC0Hje5AXMu1ooW8oyQyOFv4GxqpL0nRP7SLLY=
 github.com/dnaeon/go-vcr v1.0.1/go.mod h1:aBB1+wY4s93YsC3HHjMBMrwTj2R9FHDzUr9KyGc8n1E=
-github.com/fastly/go-fastly v1.14.0 h1:d7dCLAPp2A/wneeej42bc7JomGjhYlQSBgJ3Nt0YY9Y=
-github.com/fastly/go-fastly v1.14.0/go.mod h1:jILbTQnU/K/7XHQNzQWd1O7hbXIcp6dKrxfRWqU6xfk=
+github.com/fastly/go-fastly v1.15.0 h1:t7f0ZnQy0rKYN8FCql4wHkfZNHajxDs1hT/phazOpp8=
+github.com/fastly/go-fastly v1.15.0/go.mod h1:jILbTQnU/K/7XHQNzQWd1O7hbXIcp6dKrxfRWqU6xfk=
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=

--- a/vendor/github.com/fastly/go-fastly/fastly/client.go
+++ b/vendor/github.com/fastly/go-fastly/fastly/client.go
@@ -44,7 +44,7 @@ const DefaultRealtimeStatsEndpoint = "https://rt.fastly.com"
 var ProjectURL = "github.com/fastly/go-fastly"
 
 // ProjectVersion is the version of this library.
-var ProjectVersion = "1.14.0"
+var ProjectVersion = "1.15.0"
 
 // UserAgent is the user agent for this particular client.
 var UserAgent = fmt.Sprintf("FastlyGo/%s (+%s; %s)",

--- a/vendor/github.com/fastly/go-fastly/fastly/cloudfiles.go
+++ b/vendor/github.com/fastly/go-fastly/fastly/cloudfiles.go
@@ -171,6 +171,7 @@ type UpdateCloudfilesInput struct {
 	Name string
 
 	NewName           *string `form:"name,omitempty"`
+	User              *string `form:"user,omitempty"`
 	AccessKey         *string `form:"access_key,omitempty"`
 	BucketName        *string `form:"bucket_name,omitempty"`
 	Path              *string `form:"path,omitempty"`

--- a/vendor/github.com/fastly/go-fastly/fastly/gcs.go
+++ b/vendor/github.com/fastly/go-fastly/fastly/gcs.go
@@ -175,6 +175,7 @@ type UpdateGCSInput struct {
 	FormatVersion     uint   `form:"format_version,omitempty"`
 	GzipLevel         uint8  `form:"gzip_level,omitempty"`
 	Format            string `form:"format,omitempty"`
+	MessageType       string `form:"message_type,omitempty"`
 	ResponseCondition string `form:"response_condition,omitempty"`
 	TimestampFormat   string `form:"timestamp_format,omitempty"`
 	Placement         string `form:"placement,omitempty"`

--- a/vendor/github.com/fastly/go-fastly/fastly/kafka.go
+++ b/vendor/github.com/fastly/go-fastly/fastly/kafka.go
@@ -91,7 +91,6 @@ type CreateKafkaInput struct {
 	FormatVersion     *uint        `form:"format_version,omitempty"`
 	ResponseCondition *string      `form:"response_condition,omitempty"`
 	Placement         *string      `form:"placement,omitempty"`
-	Token             *string      `form:"token,omitempty"`
 	TLSCACert         *string      `form:"tls_ca_cert,omitempty"`
 	TLSHostname       *string      `form:"tls_hostname,omitempty"`
 	TLSClientCert     *string      `form:"tls_client_cert,omitempty"`
@@ -179,7 +178,6 @@ type UpdateKafkaInput struct {
 	FormatVersion     *uint        `form:"format_version,omitempty"`
 	ResponseCondition *string      `form:"response_condition,omitempty"`
 	Placement         *string      `form:"placement,omitempty"`
-	Token             *string      `form:"token,omitempty"`
 	TLSCACert         *string      `form:"tls_ca_cert,omitempty"`
 	TLSHostname       *string      `form:"tls_hostname,omitempty"`
 	TLSClientCert     *string      `form:"tls_client_cert,omitempty"`

--- a/vendor/github.com/fastly/go-fastly/fastly/s3.go
+++ b/vendor/github.com/fastly/go-fastly/fastly/s3.go
@@ -36,6 +36,7 @@ type S3 struct {
 	MessageType                  string                 `mapstructure:"message_type"`
 	TimestampFormat              string                 `mapstructure:"timestamp_format"`
 	Placement                    string                 `mapstructure:"placement"`
+	PublicKey                    string                 `mapstructure:"public_key"`
 	Redundancy                   S3Redundancy           `mapstructure:"redundancy"`
 	ServerSideEncryptionKMSKeyID string                 `mapstructure:"server_side_encryption_kms_key_id"`
 	ServerSideEncryption         S3ServerSideEncryption `mapstructure:"server_side_encryption"`
@@ -109,6 +110,7 @@ type CreateS3Input struct {
 	TimestampFormat              string                 `form:"timestamp_format,omitempty"`
 	Redundancy                   S3Redundancy           `form:"redundancy,omitempty"`
 	Placement                    string                 `form:"placement,omitempty"`
+	PublicKey                    string                 `form:"public_key,omitempty"`
 	ServerSideEncryptionKMSKeyID string                 `form:"server_side_encryption_kms_key_id,omitempty"`
 	ServerSideEncryption         S3ServerSideEncryption `form:"server_side_encryption,omitempty"`
 }
@@ -203,6 +205,7 @@ type UpdateS3Input struct {
 	TimestampFormat              string                 `form:"timestamp_format,omitempty"`
 	Redundancy                   S3Redundancy           `form:"redundancy,omitempty"`
 	Placement                    string                 `form:"placement,omitempty"`
+	PublicKey                    string                 `form:"public_key,omitempty"`
 	ServerSideEncryptionKMSKeyID string                 `form:"server_side_encryption_kms_key_id,omitempty"`
 	ServerSideEncryption         S3ServerSideEncryption `form:"server_side_encryption,omitempty"`
 }

--- a/vendor/github.com/fastly/go-fastly/fastly/scalyr.go
+++ b/vendor/github.com/fastly/go-fastly/fastly/scalyr.go
@@ -16,6 +16,7 @@ type Scalyr struct {
 	Format            string     `mapstructure:"format"`
 	FormatVersion     uint       `mapstructure:"format_version"`
 	Token             string     `mapstructure:"token"`
+	Region            string     `mapstructure:"region"`
 	ResponseCondition string     `mapstructure:"response_condition"`
 	Placement         string     `mapstructure:"placement"`
 	CreatedAt         *time.Time `mapstructure:"created_at"`
@@ -77,6 +78,7 @@ type CreateScalyrInput struct {
 	Format            *string `form:"format,omitempty"`
 	FormatVersion     *uint   `form:"format_version,omitempty"`
 	Token             *string `form:"token,omitempty"`
+	Region            *string `form:"region,omitempty"`
 	ResponseCondition *string `form:"response_condition,omitempty"`
 	Placement         *string `form:"placement,omitempty"`
 }
@@ -156,6 +158,7 @@ type UpdateScalyrInput struct {
 	Format            *string `form:"format,omitempty"`
 	FormatVersion     *uint   `form:"format_version,omitempty"`
 	Token             *string `form:"token,omitempty"`
+	Region            *string `form:"region,omitempty"`
 	ResponseCondition *string `form:"response_condition,omitempty"`
 	Placement         *string `form:"placement,omitempty"`
 }

--- a/vendor/github.com/fastly/go-fastly/fastly/sftp.go
+++ b/vendor/github.com/fastly/go-fastly/fastly/sftp.go
@@ -27,6 +27,7 @@ type SFTP struct {
 	FormatVersion     uint       `mapstructure:"format_version"`
 	ResponseCondition string     `mapstructure:"response_condition"`
 	TimestampFormat   string     `mapstructure:"timestamp_format"`
+	MessageType       string     `mapstructure:"message_type"`
 	Placement         string     `mapstructure:"placement"`
 	CreatedAt         *time.Time `mapstructure:"created_at"`
 	UpdatedAt         *time.Time `mapstructure:"updated_at"`
@@ -98,6 +99,7 @@ type CreateSFTPInput struct {
 	Format            *string `form:"format,omitempty"`
 	ResponseCondition *string `form:"response_condition,omitempty"`
 	TimestampFormat   *string `form:"timestamp_format,omitempty"`
+	MessageType       *string `form:"message_type,omitempty"`
 	Placement         *string `form:"placement,omitempty"`
 }
 
@@ -187,6 +189,7 @@ type UpdateSFTPInput struct {
 	Format            *string `form:"format,omitempty"`
 	ResponseCondition *string `form:"response_condition,omitempty"`
 	TimestampFormat   *string `form:"timestamp_format,omitempty"`
+	MessageType       *string `form:"message_type,omitempty"`
 	Placement         *string `form:"placement,omitempty"`
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -59,7 +59,7 @@ github.com/bgentry/go-netrc/netrc
 github.com/bgentry/speakeasy
 # github.com/davecgh/go-spew v1.1.1
 github.com/davecgh/go-spew/spew
-# github.com/fastly/go-fastly v1.14.0
+# github.com/fastly/go-fastly v1.15.0
 ## explicit
 github.com/fastly/go-fastly/fastly
 # github.com/fatih/color v1.7.0


### PR DESCRIPTION
Update `fastly/go-fastly` to [v1.15.0](https://github.com/fastly/go-fastly/releases/tag/v1.15.0).

## Validation

```bash
$ env FASTLY_API_KEY="foo" TF_ACC=1 make testacc
```

cc @phamann 