### PR TITLE
S3 Logging PublicKey field support

### DIFF
--- a/fastly/block_fastly_service_v1_s3logging.go
+++ b/fastly/block_fastly_service_v1_s3logging.go
@@ -18,81 +18,100 @@ var s3loggingSchema = &schema.Schema{
 			"name": {
 				Type:        schema.TypeString,
 				Required:    true,
-				Description: "Unique name to refer to this logging setup",
+				Description: "The unique name of the S3 logging endpoint.",
 			},
+
 			"bucket_name": {
 				Type:        schema.TypeString,
 				Required:    true,
-				Description: "S3 Bucket name to store logs in",
+				Description: "S3 Bucket name to store logs in.",
 			},
+
 			"s3_access_key": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("FASTLY_S3_ACCESS_KEY", ""),
-				Description: "AWS Access Key",
+				Description: "AWS Access Key.",
 				Sensitive:   true,
 			},
+
 			"s3_secret_key": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("FASTLY_S3_SECRET_KEY", ""),
-				Description: "AWS Secret Key",
+				Description: "AWS Secret Key.",
 				Sensitive:   true,
 			},
+
 			// Optional fields
 			"path": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Description: "Path to store the files. Must end with a trailing slash",
+				Description: "Path to store the files. Must end with a trailing slash.",
 			},
+
 			"domain": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Description: "Bucket endpoint",
+				Description: "Bucket endpoint.",
 				Default:     "s3.amazonaws.com",
 			},
+
 			"gzip_level": {
 				Type:        schema.TypeInt,
 				Optional:    true,
 				Default:     0,
-				Description: "Gzip Compression level",
+				Description: "Gzip Compression level.",
 			},
+
 			"period": {
 				Type:        schema.TypeInt,
 				Optional:    true,
 				Default:     3600,
-				Description: "How frequently the logs should be transferred, in seconds (Default 3600)",
+				Description: "How frequently the logs should be transferred, in seconds (Default 3600).",
 			},
+
 			"format": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Default:     "%h %l %u %t %r %>s",
-				Description: "Apache-style string or VCL variables to use for log formatting",
+				Description: "Apache-style string or VCL variables to use for log formatting.",
 			},
+
 			"format_version": {
 				Type:         schema.TypeInt,
 				Optional:     true,
 				Default:      1,
-				Description:  "The version of the custom logging format used for the configured endpoint. Can be either 1 or 2. (Default: 1)",
+				Description:  "The version of the custom logging format used for the configured endpoint. Can be either 1 or 2. (Default: 1).",
 				ValidateFunc: validateLoggingFormatVersion(),
 			},
+
 			"timestamp_format": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Default:     "%Y-%m-%dT%H:%M:%S.000",
-				Description: "specified timestamp formatting (default `%Y-%m-%dT%H:%M:%S.000`)",
+				Description: "specified timestamp formatting (default `%Y-%m-%dT%H:%M:%S.000`).",
 			},
+
 			"redundancy": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "The S3 redundancy level.",
 			},
+
+			"public_key": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "A PGP public key that Fastly will use to encrypt your log files before writing them to disk.",
+			},
+
 			"response_condition": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Default:     "",
 				Description: "Name of a condition to apply this logging.",
 			},
+
 			"message_type": {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -100,22 +119,25 @@ var s3loggingSchema = &schema.Schema{
 				Description:  "How the message should be formatted.",
 				ValidateFunc: validateLoggingMessageType(),
 			},
+
 			"placement": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Description:  "Where in the generated VCL the logging call should be placed.",
 				ValidateFunc: validateLoggingPlacement(),
 			},
+
 			"server_side_encryption": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Description:  "Specify what type of server side encryption should be used. Can be either `AES256` or `aws:kms`.",
 				ValidateFunc: validateLoggingServerSideEncryption(),
 			},
+
 			"server_side_encryption_kms_key_id": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Description: "Optional server-side KMS Key Id. Must be set if server_side_encryption is set to `aws:kms`",
+				Description: "Optional server-side KMS Key Id. Must be set if server_side_encryption is set to `aws:kms`.",
 			},
 		},
 	},
@@ -137,7 +159,7 @@ func processS3(d *schema.ResourceData, conn *gofastly.Client, latestVersion int)
 	removeS3Logging := oss.Difference(nss).List()
 	addS3Logging := nss.Difference(oss).List()
 
-	// DELETE old S3 Log configurations
+	// DELETE old S3 Log configurations.
 	for _, sRaw := range removeS3Logging {
 		sf := sRaw.(map[string]interface{})
 		opts := buildDeleteS3(sf, serviceID, latestVersion)
@@ -149,7 +171,7 @@ func processS3(d *schema.ResourceData, conn *gofastly.Client, latestVersion int)
 		}
 	}
 
-	// POST new/updated S3 Logging
+	// POST new/updated S3 Logging.
 	for _, sRaw := range addS3Logging {
 		sf := sRaw.(map[string]interface{})
 
@@ -168,7 +190,7 @@ func processS3(d *schema.ResourceData, conn *gofastly.Client, latestVersion int)
 }
 
 func readS3(conn *gofastly.Client, d *schema.ResourceData, s *gofastly.ServiceDetail) error {
-	// refresh S3
+	// Refresh S3.
 	log.Printf("[DEBUG] Refreshing S3 Logging for (%s)", d.Id())
 	s3List, err := conn.ListS3s(&gofastly.ListS3sInput{
 		Service: d.Id(),
@@ -196,11 +218,14 @@ func createS3(conn *gofastly.Client, i *gofastly.CreateS3Input) error {
 func deleteS3(conn *gofastly.Client, i *gofastly.DeleteS3Input) error {
 	err := conn.DeleteS3(i)
 
-	if errRes, ok := err.(*gofastly.HTTPError); ok {
-		if errRes.StatusCode != 404 {
-			return err
-		}
-	} else if err != nil {
+	errRes, ok := err.(*gofastly.HTTPError)
+	if !ok {
+		return err
+	}
+
+	// 404 response codes don't result in an error propagating because a 404 could
+	// indicate that a resource was deleted elsewhere.
+	if !errRes.IsNotFound() {
 		return err
 	}
 
@@ -226,12 +251,13 @@ func flattenS3s(s3List []*gofastly.S3) []map[string]interface{} {
 			"redundancy":                        s.Redundancy,
 			"response_condition":                s.ResponseCondition,
 			"message_type":                      s.MessageType,
+			"public_key":                        s.PublicKey,
 			"placement":                         s.Placement,
 			"server_side_encryption":            s.ServerSideEncryption,
 			"server_side_encryption_kms_key_id": s.ServerSideEncryptionKMSKeyID,
 		}
 
-		// prune any empty values that come from the default string value in structs
+		// Prune any empty values that come from the default string value in structs.
 		for k, v := range ns {
 			if v == "" {
 				delete(ns, k)
@@ -246,8 +272,8 @@ func flattenS3s(s3List []*gofastly.S3) []map[string]interface{} {
 
 func buildCreateS3(s3Map interface{}, serviceID string, serviceVersion int) (*gofastly.CreateS3Input, error) {
 	df := s3Map.(map[string]interface{})
-	// Fastly API will not error if these are omitted, so we throw an error
-	// if any of these are empty
+	// The Fastly API will not error if these are omitted, so we throw an error
+	// if any of these are empty.
 	for _, sk := range []string{"s3_access_key", "s3_secret_key"} {
 		if df[sk].(string) == "" {
 			return nil, fmt.Errorf("[ERR] No %s found for S3 Log stream setup for Service (%s)", sk, serviceID)
@@ -270,6 +296,7 @@ func buildCreateS3(s3Map interface{}, serviceID string, serviceVersion int) (*go
 		TimestampFormat:              df["timestamp_format"].(string),
 		ResponseCondition:            df["response_condition"].(string),
 		MessageType:                  df["message_type"].(string),
+		PublicKey:                    df["public_key"].(string),
 		Placement:                    df["placement"].(string),
 		ServerSideEncryptionKMSKeyID: df["server_side_encryption_kms_key_id"].(string),
 	}
@@ -296,11 +323,9 @@ func buildCreateS3(s3Map interface{}, serviceID string, serviceVersion int) (*go
 func buildDeleteS3(s3Map interface{}, serviceID string, serviceVersion int) *gofastly.DeleteS3Input {
 	df := s3Map.(map[string]interface{})
 
-	opts := gofastly.DeleteS3Input{
+	return &gofastly.DeleteS3Input{
 		Service: serviceID,
 		Version: serviceVersion,
 		Name:    df["name"].(string),
 	}
-
-	return &opts
 }

--- a/fastly/resource_fastly_service_v1.go
+++ b/fastly/resource_fastly_service_v1.go
@@ -342,7 +342,7 @@ func resourceServiceV1Update(d *schema.ResourceData, meta interface{}) error {
 			}
 		}
 		if d.HasChange("s3logging") {
-			if err := processS3Logging(d, conn, latestVersion); err != nil {
+			if err := processS3(d, conn, latestVersion); err != nil {
 				return err
 			}
 		}
@@ -561,7 +561,7 @@ func resourceServiceV1Read(d *schema.ResourceData, meta interface{}) error {
 		if err := readHealthCheck(conn, d, s); err != nil {
 			return err
 		}
-		if err := readS3Logging(conn, d, s); err != nil {
+		if err := readS3(conn, d, s); err != nil {
 			return err
 		}
 		if err := readPapertrail(conn, d, s); err != nil {

--- a/website/docs/r/service_v1.html.markdown
+++ b/website/docs/r/service_v1.html.markdown
@@ -366,7 +366,7 @@ Fastly-Geo-Region into the request headers.
 
 The `s3logging` block supports:
 
-* `name` - (Required) A unique name to identify this S3 Logging Bucket.
+* `name` - (Required) The unique name of the S3 logging endpoint.
 * `bucket_name` - (Required) The name of the bucket in which to store the logs.
 * `s3_access_key` - (Required) AWS Access Key of an account with the required
 permissions to post logs. It is **strongly** recommended you create a separate
@@ -380,12 +380,13 @@ not be encrypted. You can provide this secret via an environment variable, `FAST
 If this field is left empty, the files will be saved in the bucket's root path.
 * `domain` - (Optional) If you created the S3 bucket outside of `us-east-1`,
 then specify the corresponding bucket endpoint. Example: `s3-us-west-2.amazonaws.com`.
+* `public_key` - (Optional) A PGP public key that Fastly will use to encrypt your log files before writing them to disk.
 * `period` - (Optional) How frequently the logs should be transferred, in
 seconds. Default `3600`.
 * `gzip_level` - (Optional) Level of GZIP compression, from `0-9`. `0` is no
 compression. `1` is fastest and least compressed, `9` is slowest and most
 compressed. Default `0`.
-* `format` - (Optional) Apache-style string or VCL variables to use for log formatting. Defaults to Apache Common Log format (`%h %l %u %t %r %>s`)
+* `format` - (Optional) Apache-style string or VCL variables to use for log formatting. Defaults to Apache Common Log format (`%h %l %u %t %r %>s`).
 * `format_version` - (Optional) The version of the custom logging format used for the configured endpoint. Can be either 1 (the default, version 1 log format) or 2 (the version 2 log format).
 * `message_type` - (Optional) How the message should be formatted; one of: `classic`, `loggly`, `logplex` or `blank`.  Default `classic`.
 * `timestamp_format` - (Optional) `strftime` specified timestamp formatting (default `%Y-%m-%dT%H:%M:%S.000`).


### PR DESCRIPTION
## Proposed Changes

* Adds support for configuring the PGP `public_key` field for `s3logging`.
    * https://github.com/terraform-providers/terraform-provider-fastly/pull/249/commits/73753b43c26ed5af927bc55281127ecc9f674d3a
* Updates `s3logging` to use new block pattern.
    * https://github.com/terraform-providers/terraform-provider-fastly/pull/249/commits/0f3fa7a853aea6824da506d52b48dc9faaa231b1

## Relevant Link(s) / Documentation

* [API Docs](https://developer.fastly.com/reference/api/logging/s3/)

## Validation

```bash
env FASTLY_API_KEY="foo" TF_ACC=1 make testacc TESTARGS='-run=[Ss]3'
```

cc @ezkl @phamann 