### PR TITLE
Adds Scalyr Logging Endpoint Support

### DIFF
--- a/fastly/block_fastly_service_v1_logging_scalyr.go
+++ b/fastly/block_fastly_service_v1_logging_scalyr.go
@@ -1,0 +1,204 @@
+package fastly
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/fastly/go-fastly/fastly"
+	gofastly "github.com/fastly/go-fastly/fastly"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+var scalyrloggingSchema = &schema.Schema{
+	Type:     schema.TypeSet,
+	Optional: true,
+	Elem: &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			// Required fields
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The unique name of the Scalyr logging endpoint.",
+			},
+
+			"token": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The token to use for authentication (https://www.scalyr.com/keys).",
+			},
+
+			// Optional
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Default:     "US",
+				Description: "The region that log data will be sent to. One of US or EU. Defaults to US if undefined.",
+			},
+
+			"format": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Apache style log formatting.",
+			},
+
+			"format_version": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      2,
+				Description:  "The version of the custom logging format used for the configured endpoint. Can be either 1 or 2. (default: 2).",
+				ValidateFunc: validateLoggingFormatVersion(),
+			},
+
+			"placement": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Description:  "Where in the generated VCL the logging call should be placed.",
+				ValidateFunc: validateLoggingPlacement(),
+			},
+
+			"response_condition": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The name of an existing condition in the configured endpoint, or leave blank to always execute.",
+			},
+		},
+	},
+}
+
+func processScalyr(d *schema.ResourceData, conn *gofastly.Client, latestVersion int) error {
+	serviceID := d.Id()
+	oldLogCfg, newLogCfg := d.GetChange("logging_scalyr")
+
+	if oldLogCfg == nil {
+		oldLogCfg = new(schema.Set)
+	}
+	if newLogCfg == nil {
+		newLogCfg = new(schema.Set)
+	}
+
+	oldLogSet := oldLogCfg.(*schema.Set)
+	newLogSet := newLogCfg.(*schema.Set)
+
+	removeScalyrLogging := oldLogSet.Difference(newLogSet).List()
+	addScalyrLogging := newLogSet.Difference(oldLogSet).List()
+
+	// DELETE old Scalyr logging endpoints.
+	for _, oRaw := range removeScalyrLogging {
+		of := oRaw.(map[string]interface{})
+		opts := buildDeleteScalyr(of, serviceID, latestVersion)
+
+		log.Printf("[DEBUG] Fastly Scalyr logging endpoint removal opts: %#v", opts)
+
+		if err := deleteScalyr(conn, opts); err != nil {
+			return err
+		}
+	}
+
+	// POST new/updated Scalyr logging endponts.
+	for _, nRaw := range addScalyrLogging {
+		cfg := nRaw.(map[string]interface{})
+		opts := buildCreateScalyr(cfg, serviceID, latestVersion)
+
+		log.Printf("[DEBUG] Fastly Scalyr logging addition opts: %#v", opts)
+
+		if err := createScalyr(conn, opts); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func readScalyr(conn *gofastly.Client, d *schema.ResourceData, s *gofastly.ServiceDetail) error {
+	// Refresh Scalyr.
+	log.Printf("[DEBUG] Refreshing Scalyr logging endpoints for (%s)", d.Id())
+	scalyrList, err := conn.ListScalyrs(&gofastly.ListScalyrsInput{
+		Service: d.Id(),
+		Version: s.ActiveVersion.Number,
+	})
+
+	if err != nil {
+		return fmt.Errorf("[ERR] Error looking up Scalyr logging endpoints for (%s), version (%v): %s", d.Id(), s.ActiveVersion.Number, err)
+	}
+
+	scalyrLogList := flattenScalyr(scalyrList)
+
+	if err := d.Set("logging_scalyr", scalyrLogList); err != nil {
+		log.Printf("[WARN] Error setting Scalyr logging endpoints for (%s): %s", d.Id(), err)
+	}
+
+	return nil
+}
+
+func createScalyr(conn *gofastly.Client, i *gofastly.CreateScalyrInput) error {
+	_, err := conn.CreateScalyr(i)
+	return err
+}
+
+func deleteScalyr(conn *gofastly.Client, i *gofastly.DeleteScalyrInput) error {
+	err := conn.DeleteScalyr(i)
+
+	errRes, ok := err.(*gofastly.HTTPError)
+	if !ok {
+		return err
+	}
+	// 404 response codes don't result in an error propagating because a 404 could
+	// indicate that a resource was deleted elsewhere.
+	if !errRes.IsNotFound() {
+		return err
+	}
+	return nil
+}
+
+func flattenScalyr(scalyrList []*gofastly.Scalyr) []map[string]interface{} {
+	var flattened []map[string]interface{}
+	for _, s := range scalyrList {
+		// Convert logging to a map for saving to state.
+		flatScalyr := map[string]interface{}{
+			"name":               s.Name,
+			"region":             s.Region,
+			"token":              s.Token,
+			"response_condition": s.ResponseCondition,
+			"format":             s.Format,
+			"placement":          s.Placement,
+			"format_version":     s.FormatVersion,
+		}
+
+		// Prune any empty values that come from the default string value in structs.
+		for k, v := range flatScalyr {
+			if v == "" {
+				delete(flatScalyr, k)
+			}
+		}
+
+		flattened = append(flattened, flatScalyr)
+	}
+
+	return flattened
+}
+
+func buildCreateScalyr(scalyrMap interface{}, serviceID string, serviceVersion int) *gofastly.CreateScalyrInput {
+	df := scalyrMap.(map[string]interface{})
+
+	return &gofastly.CreateScalyrInput{
+		Service:           serviceID,
+		Version:           serviceVersion,
+		Name:              fastly.NullString(df["name"].(string)),
+		Region:            fastly.NullString(df["region"].(string)),
+		Token:             fastly.NullString(df["token"].(string)),
+		Format:            fastly.NullString(df["format"].(string)),
+		FormatVersion:     fastly.Uint(uint(df["format_version"].(int))),
+		Placement:         fastly.NullString(df["placement"].(string)),
+		ResponseCondition: fastly.NullString(df["response_condition"].(string)),
+	}
+}
+
+func buildDeleteScalyr(scalyrMap interface{}, serviceID string, serviceVersion int) *gofastly.DeleteScalyrInput {
+	df := scalyrMap.(map[string]interface{})
+
+	return &gofastly.DeleteScalyrInput{
+		Service: serviceID,
+		Version: serviceVersion,
+		Name:    df["name"].(string),
+	}
+}

--- a/fastly/block_fastly_service_v1_logging_scalyr_test.go
+++ b/fastly/block_fastly_service_v1_logging_scalyr_test.go
@@ -1,0 +1,254 @@
+package fastly
+
+import (
+	"fmt"
+	"log"
+	"testing"
+
+	gofastly "github.com/fastly/go-fastly/fastly"
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestResourceFastlyFlattenScalyr(t *testing.T) {
+	cases := []struct {
+		remote []*gofastly.Scalyr
+		local  []map[string]interface{}
+	}{
+		{
+			remote: []*gofastly.Scalyr{
+				{
+					Version:           1,
+					Name:              "scalyr-endpoint",
+					Region:            "US",
+					Token:             "tkn",
+					ResponseCondition: "response_condition",
+					Format:            `%a %l %u %t %m %U%q %H %>s %b %T`,
+					FormatVersion:     2,
+					Placement:         "none",
+				},
+			},
+			local: []map[string]interface{}{
+				{
+					"name":               "scalyr-endpoint",
+					"region":             "US",
+					"token":              "tkn",
+					"response_condition": "response_condition",
+					"format":             `%a %l %u %t %m %U%q %H %>s %b %T`,
+					"placement":          "none",
+					"format_version":     uint(2),
+				},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		out := flattenScalyr(c.remote)
+		if diff := cmp.Diff(out, c.local); diff != "" {
+			t.Fatalf("Error matching: %s", diff)
+		}
+	}
+
+}
+
+func TestAccFastlyServiceV1_scalyrlogging_basic(t *testing.T) {
+	var service gofastly.ServiceDetail
+	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	domain := fmt.Sprintf("fastly-test.%s.com", name)
+
+	log1 := gofastly.Scalyr{
+		Version:           1,
+		Name:              "scalyrlogger",
+		Token:             "tkn",
+		Placement:         "none",
+		Format:            `%a %l %u %t %m %U%q %H %>s %b %T`,
+		ResponseCondition: "response_condition_test",
+
+		Region:        "US",
+		FormatVersion: 2,
+	}
+
+	log1_after_update := gofastly.Scalyr{
+		Version:           1,
+		Name:              "scalyrlogger",
+		Region:            "EU",
+		Token:             "newtkn",
+		Placement:         "waf_debug",
+		Format:            `%a %l %u %t %m %U%q %H %>s %b %T`,
+		ResponseCondition: "response_condition_test",
+
+		FormatVersion: 2,
+	}
+
+	log2 := gofastly.Scalyr{
+		Version:   1,
+		Name:      "another-scalyrlogger",
+		Token:     "tknb",
+		Placement: "none",
+		Format:    `%a %l %u %t %m %U%q %H %>s %b %T`,
+
+		Region:        "US",
+		FormatVersion: 2,
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckServiceV1Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServiceV1ScalyrConfig(name, domain),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
+					testAccCheckFastlyServiceV1ScalyrAttributes(&service, []*gofastly.Scalyr{&log1}),
+					resource.TestCheckResourceAttr(
+						"fastly_service_v1.foo", "name", name),
+					resource.TestCheckResourceAttr(
+						"fastly_service_v1.foo", "logging_scalyr.#", "1"),
+				),
+			},
+
+			{
+				Config: testAccServiceV1ScalyrConfig_update(name, domain),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
+					testAccCheckFastlyServiceV1ScalyrAttributes(&service, []*gofastly.Scalyr{&log1_after_update, &log2}),
+					resource.TestCheckResourceAttr(
+						"fastly_service_v1.foo", "name", name),
+					resource.TestCheckResourceAttr(
+						"fastly_service_v1.foo", "logging_scalyr.#", "2"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckFastlyServiceV1ScalyrAttributes(service *gofastly.ServiceDetail, scalyr []*gofastly.Scalyr) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+
+		conn := testAccProvider.Meta().(*FastlyClient).conn
+		scalyrList, err := conn.ListScalyrs(&gofastly.ListScalyrsInput{
+			Service: service.ID,
+			Version: service.ActiveVersion.Number,
+		})
+
+		if err != nil {
+			return fmt.Errorf("[ERR] Error looking up Scalyr Logging for (%s), version (%d): %s", service.Name, service.ActiveVersion.Number, err)
+		}
+
+		if len(scalyrList) != len(scalyr) {
+			return fmt.Errorf("Scalyr List count mismatch, expected (%d), got (%d)", len(scalyr), len(scalyrList))
+		}
+
+		log.Printf("[DEBUG] scalyrList = %#v\n", scalyrList)
+
+		var found int
+		for _, s := range scalyr {
+			for _, sl := range scalyrList {
+				if s.Name == sl.Name {
+					// we don't know these things ahead of time, so populate them now
+					s.ServiceID = service.ID
+					s.Version = service.ActiveVersion.Number
+					// We don't track these, so clear them out because we also wont know
+					// these ahead of time
+					sl.CreatedAt = nil
+					sl.UpdatedAt = nil
+					if diff := cmp.Diff(s, sl); diff != "" {
+						return fmt.Errorf("Bad match Scalyr logging match: %s", diff)
+					}
+					found++
+				}
+			}
+		}
+
+		if found != len(scalyr) {
+			return fmt.Errorf("Error matching Scalyr Logging rules")
+		}
+
+		return nil
+	}
+}
+
+func testAccServiceV1ScalyrConfig(name string, domain string) string {
+	return fmt.Sprintf(`
+resource "fastly_service_v1" "foo" {
+	name = "%s"
+
+	domain {
+		name    = "%s"
+		comment = "tf-scalyr-logging"
+	}
+
+	backend {
+		address = "aws.amazon.com"
+		name    = "amazon docs"
+	}
+
+	condition {
+    name      = "response_condition_test"
+    type      = "RESPONSE"
+    priority  = 8
+    statement = "resp.status == 418"
+  }
+
+	logging_scalyr {
+		name               = "scalyrlogger"
+		region             = "US"
+		token              = "tkn"
+		response_condition = "response_condition_test"
+		format             = "%%a %%l %%u %%t %%m %%U%%q %%H %%>s %%b %%T"
+		format_version 		 = 2
+		placement 				 = "none"
+	}
+
+	force_destroy = true
+}
+`, name, domain)
+}
+
+func testAccServiceV1ScalyrConfig_update(name, domain string) string {
+	return fmt.Sprintf(`
+resource "fastly_service_v1" "foo" {
+	name = "%s"
+
+	domain {
+		name    = "%s"
+		comment = "tf-testing-domain"
+	}
+
+	backend {
+		address = "aws.amazon.com"
+		name    = "amazon docs"
+	}
+
+	condition {
+    name      = "response_condition_test"
+    type      = "RESPONSE"
+    priority  = 8
+    statement = "resp.status == 418"
+  }
+
+	logging_scalyr {
+		name               = "scalyrlogger"
+		region             = "EU"
+		token              = "newtkn"
+		format             = "%%a %%l %%u %%t %%m %%U%%q %%H %%>s %%b %%T"
+		format_version 		 = 2
+		response_condition = "response_condition_test"
+		placement 				 = "waf_debug"
+	}
+
+	logging_scalyr {
+		name               = "another-scalyrlogger"
+		format             = "%%a %%l %%u %%t %%m %%U%%q %%H %%>s %%b %%T"
+		region             = "US"
+		token              = "tknb"
+		format_version 		 = 2
+		placement 				 = "none"
+	}
+
+	force_destroy = true
+}`, name, domain)
+}

--- a/fastly/resource_fastly_service_v1.go
+++ b/fastly/resource_fastly_service_v1.go
@@ -113,6 +113,7 @@ func resourceServiceV1() *schema.Resource {
 			"logging_datadog":       datadogSchema,
 			"logging_loggly":        logglySchema,
 			"logging_newrelic":      newrelicSchema,
+			"logging_scalyr":        scalyrloggingSchema,
 
 			"response_object": responseobjectSchema,
 			"request_setting": requestsettingSchema,
@@ -195,6 +196,7 @@ func resourceServiceV1Update(d *schema.ResourceData, meta interface{}) error {
 		"logging_datadog",
 		"logging_loggly",
 		"logging_newrelic",
+		"logging_scalyr",
 		"response_object",
 		"condition",
 		"request_setting",
@@ -423,6 +425,11 @@ func resourceServiceV1Update(d *schema.ResourceData, meta interface{}) error {
 				return err
 			}
 		}
+		if d.HasChange("logging_scalyr") {
+			if err := processScalyr(d, conn, latestVersion); err != nil {
+				return err
+			}
+		}
 		if d.HasChange("response_object") {
 			if err := processResponseObject(d, conn, latestVersion); err != nil {
 				return err
@@ -614,6 +621,9 @@ func resourceServiceV1Read(d *schema.ResourceData, meta interface{}) error {
 			return err
 		}
 		if err := readNewRelic(conn, d, s); err != nil {
+			return err
+		}
+		if err := readScalyr(conn, d, s); err != nil {
 			return err
 		}
 		if err := readResponseObject(conn, d, s); err != nil {

--- a/website/docs/r/service_v1.html.markdown
+++ b/website/docs/r/service_v1.html.markdown
@@ -218,6 +218,8 @@ Defined below.
 Defined below.
 * `logging_newrelic` - (Optional) A New Relic endpoint to send streaming logs to.
 Defined below.
+* `logging_scalyr` - (Optional) A Scalyr endpoint to send streaming logs to.
+Defined below.
 * `response_object` - (Optional) Allows you to create synthetic responses that exist entirely on the varnish machine. Useful for creating error or maintenance pages that exists outside the scope of your datacenter. Best when used with Condition objects.
 * `snippet` - (Optional) A set of custom, "regular" (non-dynamic) VCL Snippet configuration blocks.  Defined below.
 * `dynamicsnippet` - (Optional) A set of custom, "dynamic" VCL Snippet configuration blocks.  Defined below.
@@ -610,6 +612,16 @@ The `logging_newrelic` block supports:
 * `format_version` - (Optional) The version of the custom logging format used for the configured endpoint. Can be either `1` or `2`. (default: `2`).
 * `placement` - (Optional) Where in the generated VCL the logging call should be placed.
 * `response_condition` - (Optional) The name of the condition to apply.
+
+The `logging_scalyr` block supports:
+
+* `name` - (Required) The unique name of the Scalyr logging endpoint.
+* `token` - (Required) The token to use for authentication (https://www.scalyr.com/keys).
+* `region` - (Optional) The region that log data will be sent to. One of US or EU. Defaults to US if undefined.
+* `format` - (Optional) Apache-style string or VCL variables to use for log formatting.
+* `format_version` - (Optional) The version of the custom logging format used for the configured endpoint. Can be either `1` or `2`. The logging call gets placed by default in `vcl_log` if `format_version` is set to `2` and in `vcl_deliver` if `format_version` is set to `1`. Default `2`.
+* `placement` - (Optional) The name of an existing condition in the configured endpoint, or leave blank to always execute.
+* `response_condition` - (Optional) The name of the `condition` to apply. If empty, always execute.
 
 The `response_object` block supports:
 


### PR DESCRIPTION
## Proposed Changes

* Adds Scalyr logging endpoint support.

## Relevant Link(s) / Documentation

* [API Docs](https://developer.fastly.com/reference/api/logging/scalyr/)

## Validation

`export FASTLY_API_KEY=foo; export TF_ACC=1; make testacc`

cc @phamann @ezkl 