### PR TITLE
Adds Kafka Logging Endpoint Support

### DIFF
--- a/fastly/block_fastly_service_v1_logging_kafka.go
+++ b/fastly/block_fastly_service_v1_logging_kafka.go
@@ -1,0 +1,283 @@
+package fastly
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/fastly/go-fastly/fastly"
+	gofastly "github.com/fastly/go-fastly/fastly"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+var kafkaloggingSchema = &schema.Schema{
+	Type:     schema.TypeSet,
+	Optional: true,
+	Elem: &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			// Required fields
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The unique name of the Kafka logging endpoint.",
+			},
+
+			"topic": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The Kafka topic to send logs to.",
+			},
+
+			"brokers": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "A comma-separated list of IP addresses or hostnames of Kafka brokers.",
+			},
+
+			// Optional
+			"compression_codec": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The codec used for compression of your logs. One of: gzip, snappy, lz4.",
+			},
+
+			"required_acks": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Description: "The Number of acknowledgements a leader must receive before a write is considered successful. One of: 1 (default) One server needs to respond. 0 No servers need to respond. -1	Wait for all in-sync replicas to respond.",
+			},
+
+			"use_tls": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: "Whether to use TLS for secure logging. Can be either true or false.",
+			},
+
+			"tls_ca_cert": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "A secure certificate to authenticate the server with. Must be in PEM format.",
+				Sensitive:   true,
+				// Related issue for weird behavior - https://github.com/hashicorp/terraform-plugin-sdk/issues/160
+				StateFunc: trimSpaceStateFunc,
+			},
+
+			"tls_client_cert": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The client certificate used to make authenticated requests. Must be in PEM format.",
+				Sensitive:   true,
+				// Related issue for weird behavior - https://github.com/hashicorp/terraform-plugin-sdk/issues/160
+				StateFunc: trimSpaceStateFunc,
+			},
+
+			"tls_client_key": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The client private key used to make authenticated requests. Must be in PEM format.",
+				Sensitive:   true,
+				// Related issue for weird behavior - https://github.com/hashicorp/terraform-plugin-sdk/issues/160
+				StateFunc: trimSpaceStateFunc,
+			},
+
+			"tls_hostname": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The hostname used to verify the server's certificate. It can either be the Common Name or a Subject Alternative Name (SAN).",
+			},
+
+			"format": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Apache style log formatting.",
+			},
+
+			"format_version": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      2,
+				Description:  "The version of the custom logging format used for the configured endpoint. Can be either 1 or 2. (default: 2).",
+				ValidateFunc: validateLoggingFormatVersion(),
+			},
+
+			"placement": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Description:  "Where in the generated VCL the logging call should be placed.",
+				ValidateFunc: validateLoggingPlacement(),
+			},
+
+			"response_condition": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The name of an existing condition in the configured endpoint, or leave blank to always execute.",
+			},
+		},
+	},
+}
+
+func processKafka(d *schema.ResourceData, conn *gofastly.Client, latestVersion int) error {
+	serviceID := d.Id()
+	oldLogCfg, newLogCfg := d.GetChange("logging_kafka")
+
+	if oldLogCfg == nil {
+		oldLogCfg = new(schema.Set)
+	}
+	if newLogCfg == nil {
+		newLogCfg = new(schema.Set)
+	}
+
+	oldLogSet := oldLogCfg.(*schema.Set)
+	newLogSet := newLogCfg.(*schema.Set)
+
+	removeKafkaLogging := oldLogSet.Difference(newLogSet).List()
+	addKafkaLogging := newLogSet.Difference(oldLogSet).List()
+
+	// DELETE old Kafka logging endpoints
+	for _, oRaw := range removeKafkaLogging {
+		of := oRaw.(map[string]interface{})
+		opts := buildDeleteKafka(of, serviceID, latestVersion)
+
+		log.Printf("[DEBUG] Fastly Kafka logging endpoint removal opts: %#v", opts)
+
+		if err := deleteKafka(conn, opts); err != nil {
+			return err
+		}
+	}
+
+	// POST new/updated Kafka logging endponts
+	for _, nRaw := range addKafkaLogging {
+		cfg := nRaw.(map[string]interface{})
+
+		// @HACK for a TF SDK Issue.
+		//
+		// This ensures that the required, `name`, field is present.
+		//
+		// If we have made it this far and `name` is not present, it is most-likely due
+		// to a defunct diff as noted here - https://github.com/hashicorp/terraform-plugin-sdk/issues/160#issuecomment-522935697.
+		//
+		// This is caused by using a StateFunc in a nested TypeSet. While the StateFunc
+		// properly handles setting state with the StateFunc, it returns extra entries
+		// during state Gets, specifically `GetChange("logging_kafka")` in this case.
+		if v, ok := cfg["name"]; !ok || v.(string) == "" {
+			continue
+		}
+
+		opts := buildCreateKafka(cfg, serviceID, latestVersion)
+
+		log.Printf("[DEBUG] Fastly Kafka logging addition opts: %#v", opts)
+
+		if err := createKafka(conn, opts); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func readKafka(conn *gofastly.Client, d *schema.ResourceData, s *gofastly.ServiceDetail) error {
+	// refresh Kafka
+	log.Printf("[DEBUG] Refreshing Kafka logging endpoints for (%s)", d.Id())
+	kafkaList, err := conn.ListKafkas(&gofastly.ListKafkasInput{
+		Service: d.Id(),
+		Version: s.ActiveVersion.Number,
+	})
+
+	if err != nil {
+		return fmt.Errorf("[ERR] Error looking up Kafka logging endpoints for (%s), version (%v): %s", d.Id(), s.ActiveVersion.Number, err)
+	}
+
+	kafkaLogList := flattenKafka(kafkaList)
+
+	if err := d.Set("logging_kafka", kafkaLogList); err != nil {
+		log.Printf("[WARN] Error setting Kafka logging endpoints for (%s): %s", d.Id(), err)
+	}
+
+	return nil
+}
+
+func createKafka(conn *gofastly.Client, i *gofastly.CreateKafkaInput) error {
+	_, err := conn.CreateKafka(i)
+	return err
+}
+
+func deleteKafka(conn *gofastly.Client, i *gofastly.DeleteKafkaInput) error {
+	err := conn.DeleteKafka(i)
+
+	if errRes, ok := err.(*gofastly.HTTPError); ok {
+		if errRes.StatusCode != 404 {
+			return err
+		}
+	} else if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func flattenKafka(kafkaList []*gofastly.Kafka) []map[string]interface{} {
+	var flattened []map[string]interface{}
+	for _, s := range kafkaList {
+		// Convert logging to a map for saving to state.
+		flatKafka := map[string]interface{}{
+			"name":               s.Name,
+			"topic":              s.Topic,
+			"brokers":            s.Brokers,
+			"compression_codec":  s.CompressionCodec,
+			"required_acks":      s.RequiredACKs,
+			"use_tls":            s.UseTLS,
+			"tls_ca_cert":        s.TLSCACert,
+			"tls_client_cert":    s.TLSClientCert,
+			"tls_client_key":     s.TLSClientKey,
+			"tls_hostname":       s.TLSHostname,
+			"format":             s.Format,
+			"format_version":     s.FormatVersion,
+			"placement":          s.Placement,
+			"response_condition": s.ResponseCondition,
+		}
+
+		// prune any empty values that come from the default string value in structs
+		for k, v := range flatKafka {
+			if v == "" {
+				delete(flatKafka, k)
+			}
+		}
+
+		flattened = append(flattened, flatKafka)
+	}
+
+	return flattened
+}
+
+func buildCreateKafka(kafkaMap interface{}, serviceID string, serviceVersion int) *gofastly.CreateKafkaInput {
+	df := kafkaMap.(map[string]interface{})
+
+	return &gofastly.CreateKafkaInput{
+		Service:           serviceID,
+		Version:           serviceVersion,
+		Name:              fastly.NullString(df["name"].(string)),
+		Brokers:           fastly.NullString(df["brokers"].(string)),
+		Topic:             fastly.NullString(df["topic"].(string)),
+		RequiredACKs:      fastly.NullString(df["required_acks"].(string)),
+		UseTLS:            fastly.CBool(df["use_tls"].(bool)),
+		CompressionCodec:  fastly.NullString(df["compression_codec"].(string)),
+		TLSCACert:         fastly.NullString(df["tls_ca_cert"].(string)),
+		TLSClientCert:     fastly.NullString(df["tls_client_cert"].(string)),
+		TLSClientKey:      fastly.NullString(df["tls_client_key"].(string)),
+		TLSHostname:       fastly.NullString(df["tls_hostname"].(string)),
+		Format:            fastly.NullString(df["format"].(string)),
+		FormatVersion:     fastly.Uint(uint(df["format_version"].(int))),
+		ResponseCondition: fastly.NullString(df["response_condition"].(string)),
+		Placement:         fastly.NullString(df["placement"].(string)),
+	}
+}
+
+func buildDeleteKafka(kafkaMap interface{}, serviceID string, serviceVersion int) *gofastly.DeleteKafkaInput {
+	df := kafkaMap.(map[string]interface{})
+
+	return &gofastly.DeleteKafkaInput{
+		Service: serviceID,
+		Version: serviceVersion,
+		Name:    df["name"].(string),
+	}
+}

--- a/fastly/block_fastly_service_v1_logging_kafka_test.go
+++ b/fastly/block_fastly_service_v1_logging_kafka_test.go
@@ -1,0 +1,326 @@
+package fastly
+
+import (
+	"fmt"
+	"log"
+	"testing"
+
+	gofastly "github.com/fastly/go-fastly/fastly"
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestResourceFastlyFlattenKafka(t *testing.T) {
+	cases := []struct {
+		remote []*gofastly.Kafka
+		local  []map[string]interface{}
+	}{
+		{
+			remote: []*gofastly.Kafka{
+				{
+					Version:           1,
+					Name:              "kafka-endpoint",
+					Topic:             "topic",
+					Brokers:           "127.0.0.1,127.0.0.2",
+					CompressionCodec:  "snappy",
+					RequiredACKs:      "-1",
+					UseTLS:            true,
+					TLSCACert:         caCert(),
+					TLSClientCert:     certificate(),
+					TLSClientKey:      privateKey(),
+					TLSHostname:       "example.com",
+					ResponseCondition: "response_condition",
+					Format:            `%a %l %u %t %m %U%q %H %>s %b %T`,
+					FormatVersion:     2,
+					Placement:         "none",
+				},
+			},
+			local: []map[string]interface{}{
+				{
+					"name":               "kafka-endpoint",
+					"topic":              "topic",
+					"brokers":            "127.0.0.1,127.0.0.2",
+					"compression_codec":  "snappy",
+					"required_acks":      "-1",
+					"use_tls":            true,
+					"tls_ca_cert":        caCert(),
+					"tls_client_cert":    certificate(),
+					"tls_client_key":     privateKey(),
+					"tls_hostname":       "example.com",
+					"response_condition": "response_condition",
+					"format":             `%a %l %u %t %m %U%q %H %>s %b %T`,
+					"placement":          "none",
+					"format_version":     uint(2),
+				},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		out := flattenKafka(c.remote)
+		if diff := cmp.Diff(out, c.local); diff != "" {
+			t.Fatalf("Error matching: %s", diff)
+		}
+	}
+}
+
+func TestAccFastlyServiceV1_kafkalogging_basic(t *testing.T) {
+	var service gofastly.ServiceDetail
+	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	domain := fmt.Sprintf("fastly-test.%s.com", name)
+
+	log1 := gofastly.Kafka{
+		Version:           1,
+		Name:              "kafkalogger",
+		Topic:             "topic",
+		Brokers:           "127.0.0.1,127.0.0.2",
+		CompressionCodec:  "snappy",
+		RequiredACKs:      "-1",
+		UseTLS:            true,
+		TLSCACert:         caCert(),
+		TLSClientCert:     certificate(),
+		TLSClientKey:      privateKey(),
+		TLSHostname:       "example.com",
+		ResponseCondition: "response_condition_test",
+		Format:            `%a %l %u %t %m %U%q %H %>s %b %T`,
+		FormatVersion:     2,
+		Placement:         "none",
+	}
+
+	log1_after_update := gofastly.Kafka{
+		Version:           1,
+		Name:              "kafkalogger",
+		Topic:             "newtopic",
+		Brokers:           "127.0.0.3,127.0.0.4",
+		CompressionCodec:  "lz4",
+		RequiredACKs:      "0",
+		UseTLS:            false,
+		TLSCACert:         caCert(),
+		TLSClientCert:     certificate(),
+		TLSClientKey:      privateKey(),
+		TLSHostname:       "example2.com",
+		ResponseCondition: "response_condition_test",
+		Format:            `%a %l %u %t %m %U%q %H %>s %b %T`,
+		FormatVersion:     2,
+		Placement:         "waf_debug",
+	}
+
+	log2 := gofastly.Kafka{
+		Version:           1,
+		Name:              "kafkalogger2",
+		Topic:             "topicb",
+		Brokers:           "127.0.0.3,127.0.0.4",
+		CompressionCodec:  "gzip",
+		RequiredACKs:      "1",
+		UseTLS:            true,
+		TLSCACert:         caCert(),
+		TLSClientCert:     certificate(),
+		TLSClientKey:      privateKey(),
+		TLSHostname:       "example.com",
+		ResponseCondition: "response_condition_test",
+		Format:            `%a %l %u %t %m %U%q %H %>s %b %T`,
+		FormatVersion:     2,
+		Placement:         "none",
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckServiceV1Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServiceV1KafkaConfig(name, domain),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
+					testAccCheckFastlyServiceV1KafkaAttributes(&service, []*gofastly.Kafka{&log1}),
+					resource.TestCheckResourceAttr(
+						"fastly_service_v1.foo", "name", name),
+					resource.TestCheckResourceAttr(
+						"fastly_service_v1.foo", "logging_kafka.#", "1"),
+				),
+			},
+
+			{
+				Config: testAccServiceV1KafkaConfig_update(name, domain),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
+					testAccCheckFastlyServiceV1KafkaAttributes(&service, []*gofastly.Kafka{&log1_after_update, &log2}),
+					resource.TestCheckResourceAttr(
+						"fastly_service_v1.foo", "name", name),
+					resource.TestCheckResourceAttr(
+						"fastly_service_v1.foo", "logging_kafka.#", "2"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckFastlyServiceV1KafkaAttributes(service *gofastly.ServiceDetail, kafka []*gofastly.Kafka) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+
+		conn := testAccProvider.Meta().(*FastlyClient).conn
+		kafkaList, err := conn.ListKafkas(&gofastly.ListKafkasInput{
+			Service: service.ID,
+			Version: service.ActiveVersion.Number,
+		})
+
+		if err != nil {
+			return fmt.Errorf("[ERR] Error looking up Kafka Logging for (%s), version (%d): %s", service.Name, service.ActiveVersion.Number, err)
+		}
+
+		if len(kafkaList) != len(kafka) {
+			return fmt.Errorf("Kafka List count mismatch, expected (%d), got (%d)", len(kafka), len(kafkaList))
+		}
+
+		log.Printf("[DEBUG] kafkaList = %#v\n", kafkaList)
+
+		var found int
+		for _, s := range kafka {
+			for _, sl := range kafkaList {
+				if s.Name == sl.Name {
+					// we don't know these things ahead of time, so populate them now
+					s.ServiceID = service.ID
+					s.Version = service.ActiveVersion.Number
+					// We don't track these, so clear them out because we also wont know
+					// these ahead of time
+					sl.CreatedAt = nil
+					sl.UpdatedAt = nil
+					if diff := cmp.Diff(s, sl); diff != "" {
+						return fmt.Errorf("Bad match Kafka logging match: %s", diff)
+					}
+					found++
+				}
+			}
+		}
+
+		if found != len(kafka) {
+			return fmt.Errorf("Error matching Kafka Logging rules")
+		}
+
+		return nil
+	}
+}
+
+func testAccServiceV1KafkaConfig(name string, domain string) string {
+	return fmt.Sprintf(`
+resource "fastly_service_v1" "foo" {
+	name = "%s"
+
+	domain {
+		name    = "%s"
+		comment = "tf-kafka-logging"
+	}
+
+	backend {
+		address = "aws.amazon.com"
+		name    = "amazon docs"
+	}
+
+	condition {
+    name      = "response_condition_test"
+    type      = "RESPONSE"
+    priority  = 8
+    statement = "resp.status == 418"
+  }
+
+	logging_kafka {
+		name               = "kafkalogger"
+	  topic  						 = "topic"
+		brokers            = "127.0.0.1,127.0.0.2"
+		compression_codec  = "snappy"
+		required_acks      = "-1"
+		use_tls            = true
+		tls_ca_cert        = <<EOF
+`+caCert()+`
+EOF
+		tls_client_cert    = <<EOF
+`+certificate()+`
+EOF
+		tls_client_key     = <<EOF
+`+privateKey()+`
+EOF
+		tls_hostname       = "example.com"
+		response_condition = "response_condition_test"
+		format             = "%%a %%l %%u %%t %%m %%U%%q %%H %%>s %%b %%T"
+		format_version     = 2
+		placement          = "none"
+	}
+
+	force_destroy = true
+}
+`, name, domain)
+}
+
+func testAccServiceV1KafkaConfig_update(name, domain string) string {
+	return fmt.Sprintf(`
+resource "fastly_service_v1" "foo" {
+	name = "%s"
+
+	domain {
+		name    = "%s"
+		comment = "tf-testing-domain"
+	}
+
+	backend {
+		address = "aws.amazon.com"
+		name    = "amazon docs"
+	}
+
+	condition {
+    name      = "response_condition_test"
+    type      = "RESPONSE"
+    priority  = 8
+    statement = "resp.status == 418"
+  }
+
+	logging_kafka {
+		name               = "kafkalogger"
+	  topic  						 = "newtopic"
+		brokers            = "127.0.0.3,127.0.0.4"
+		compression_codec  = "lz4"
+		required_acks      = "0"
+		use_tls            = false
+		tls_ca_cert        = <<EOF
+`+caCert()+`
+EOF
+		tls_client_cert    = <<EOF
+`+certificate()+`
+EOF
+		tls_client_key     = <<EOF
+`+privateKey()+`
+EOF
+		tls_hostname       = "example2.com"
+		response_condition = "response_condition_test"
+		format             = "%%a %%l %%u %%t %%m %%U%%q %%H %%>s %%b %%T"
+		format_version     = 2
+		placement          = "waf_debug"
+	}
+
+	logging_kafka {
+		name               = "kafkalogger2"
+	  topic  						 = "topicb"
+		brokers            = "127.0.0.3,127.0.0.4"
+		compression_codec  = "gzip"
+		required_acks      = "1"
+		use_tls            = true
+		tls_ca_cert        = <<EOF
+`+caCert()+`
+EOF
+		tls_client_cert    = <<EOF
+`+certificate()+`
+EOF
+		tls_client_key     = <<EOF
+`+privateKey()+`
+EOF
+		tls_hostname       = "example.com"
+		response_condition = "response_condition_test"
+		format             = "%%a %%l %%u %%t %%m %%U%%q %%H %%>s %%b %%T"
+		format_version     = 2
+		placement          = "none"
+	}
+
+	force_destroy = true
+}`, name, domain)
+}

--- a/fastly/fastly_test.go
+++ b/fastly/fastly_test.go
@@ -8,7 +8,6 @@ import (
 // pgpPublicKey returns a PEM encoded PGP public key suitable for testing.
 func pgpPublicKey() string {
 	return `-----BEGIN PGP PUBLIC KEY BLOCK-----
-
 mQINBFtsXH8BEAC5kwHMmO2e8pVxM9md8jZK+EqvWpZRTbDel3vzJeMrm8Iq/QUU
 I/BpNN8stBR7Qz1ZNG9XV2RMRSfNWmilMUwNE1ng6nz7K94GWU/odgJTDRIw3fgS
 qtPqRVPDavmsiJ0xdV6eFxlF9BDvcAWf9j5/DQe9gzQhcVxLYigSjC38xhULS9wI

--- a/fastly/resource_fastly_service_v1.go
+++ b/fastly/resource_fastly_service_v1.go
@@ -115,6 +115,7 @@ func resourceServiceV1() *schema.Resource {
 			"logging_newrelic":      newrelicSchema,
 			"logging_scalyr":        scalyrloggingSchema,
 			"logging_googlepubsub":  googlepubsubloggingSchema,
+			"logging_kafka":         kafkaloggingSchema,
 
 			"response_object": responseobjectSchema,
 			"request_setting": requestsettingSchema,
@@ -199,6 +200,7 @@ func resourceServiceV1Update(d *schema.ResourceData, meta interface{}) error {
 		"logging_newrelic",
 		"logging_scalyr",
 		"logging_googlepubsub",
+		"logging_kafka",
 		"response_object",
 		"condition",
 		"request_setting",
@@ -422,7 +424,6 @@ func resourceServiceV1Update(d *schema.ResourceData, meta interface{}) error {
 				return err
 			}
 		}
-<<<<<<< HEAD
 		if d.HasChange("logging_newrelic") {
 			if err := processNewRelic(d, conn, latestVersion); err != nil {
 				return err
@@ -435,6 +436,11 @@ func resourceServiceV1Update(d *schema.ResourceData, meta interface{}) error {
 		}
 		if d.HasChange("logging_googlepubsub") {
 			if err := processGooglePubSub(d, conn, latestVersion); err != nil {
+				return err
+			}
+		}
+		if d.HasChange("logging_kafka") {
+			if err := processKafka(d, conn, latestVersion); err != nil {
 				return err
 			}
 		}
@@ -635,6 +641,9 @@ func resourceServiceV1Read(d *schema.ResourceData, meta interface{}) error {
 			return err
 		}
 		if err := readGooglePubSub(conn, d, s); err != nil {
+			return err
+		}
+		if err := readKafka(conn, d, s); err != nil {
 			return err
 		}
 		if err := readResponseObject(conn, d, s); err != nil {

--- a/fastly/resource_fastly_service_v1.go
+++ b/fastly/resource_fastly_service_v1.go
@@ -422,6 +422,7 @@ func resourceServiceV1Update(d *schema.ResourceData, meta interface{}) error {
 				return err
 			}
 		}
+<<<<<<< HEAD
 		if d.HasChange("logging_newrelic") {
 			if err := processNewRelic(d, conn, latestVersion); err != nil {
 				return err

--- a/website/docs/r/service_v1.html.markdown
+++ b/website/docs/r/service_v1.html.markdown
@@ -222,6 +222,8 @@ Defined below.
 Defined below.
 * `logging_googlepubsub` - (Optional) A Google Cloud Pub/Sub endpoint to send streaming logs to.
 Defined below.
+* `logging_kafka` - (Optional) A Kafka endpoint to send streaming logs to.
+Defined below.
 * `response_object` - (Optional) Allows you to create synthetic responses that exist entirely on the varnish machine. Useful for creating error or maintenance pages that exists outside the scope of your datacenter. Best when used with Condition objects.
 * `snippet` - (Optional) A set of custom, "regular" (non-dynamic) VCL Snippet configuration blocks.  Defined below.
 * `dynamicsnippet` - (Optional) A set of custom, "dynamic" VCL Snippet configuration blocks.  Defined below.
@@ -632,6 +634,23 @@ The `logging_googlepubsub` block supports:
 * `secret_key` - (Required) Your Google Cloud Platform account secret key. The private_key field in your service account authentication JSON.
 * `project_id` - (Required) The ID of your Google Cloud Platform project.
 * `topic` - (Required) The Google Cloud Pub/Sub topic to which logs will be published.
+* `format` - (Optional) Apache-style string or VCL variables to use for log formatting.
+* `format_version` - (Optional) The version of the custom logging format used for the configured endpoint. Can be either `1` or `2`. The logging call gets placed by default in `vcl_log` if `format_version` is set to `2` and in `vcl_deliver` if `format_version` is set to `1`. Default `2`.
+* `placement` - (Optional) The name of an existing condition in the configured endpoint, or leave blank to always execute.
+* `response_condition` - (Optional) The name of the `condition` to apply. If empty, always execute.
+
+The `logging_kafka` block supports:
+
+* `name` - (Required) The unique name of the Kafka logging endpoint.
+* `topic` - (Required) The Kafka topic to send logs to.
+* `brokers` - (Required) A comma-separated list of IP addresses or hostnames of Kafka brokers.
+* `compression_codec` - (Optional) The codec used for compression of your logs. One of: gzip, snappy, lz4.
+* `required_acks` - (Optional) The Number of acknowledgements a leader must receive before a write is considered successful. One of: 1 (default) One server needs to respond. 0 No servers need to respond. -1	Wait for all in-sync replicas to respond.
+* `use_tls` - (Optional) Whether to use TLS for secure logging. Can be either true or false.
+* `tls_ca_cert` - (Optional) A secure certificate to authenticate the server with. Must be in PEM format.
+* `tls_client_cert` - (Optional) The client certificate used to make authenticated requests. Must be in PEM format.
+* `tls_client_key` - (Optional) The client private key used to make authenticated requests. Must be in PEM format.
+* `tls_hostname` - (Optional) The hostname used to verify the server's certificate. It can either be the Common Name or a Subject Alternative Name (SAN).
 * `format` - (Optional) Apache-style string or VCL variables to use for log formatting.
 * `format_version` - (Optional) The version of the custom logging format used for the configured endpoint. Can be either `1` or `2`. The logging call gets placed by default in `vcl_log` if `format_version` is set to `2` and in `vcl_deliver` if `format_version` is set to `1`. Default `2`.
 * `placement` - (Optional) The name of an existing condition in the configured endpoint, or leave blank to always execute.


### PR DESCRIPTION
## Proposed Changes

* Adds Kafka logging endpoint support.
* Adds test helpers for mocking `tls_ca_cert`, `tls_client_cert` and `tls_client_key`.
* Updates tests to use `google/go-cmp` for resource comparisons in tests.
  * https://github.com/terraform-providers/terraform-provider-fastly/pull/254/commits/21f28af72e653f98e7bbb300d139539aab099008

## Relevant Link(s) / Documentation

* [API Docs](https://developer.fastly.com/reference/api/logging/kafka/)
* [go-fastly test helpers](https://github.com/fastly/go-fastly/blob/c4599a1109042341c60e096b8acd025bb9cecd9b/fastly/fastly_test.go#L258)

## Validation

* `export FASTLY_API_KEY=foo; export TF_ACC=1; make testacc`

## Notes

* Blocked by https://github.com/terraform-providers/terraform-provider-fastly/pull/264 and https://github.com/terraform-providers/terraform-provider-fastly/pull/263 (Hence why this is still marked as a DRAFT).