### PR TITLE
Adds Google Cloud Pub/Sub Logging Endpoint Support

### DIFF
--- a/fastly/block_fastly_service_v1_logging_googlepubsub.go
+++ b/fastly/block_fastly_service_v1_logging_googlepubsub.go
@@ -1,0 +1,221 @@
+package fastly
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/fastly/go-fastly/fastly"
+	gofastly "github.com/fastly/go-fastly/fastly"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+var googlepubsubloggingSchema = &schema.Schema{
+	Type:     schema.TypeSet,
+	Optional: true,
+	Elem: &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			// Required fields
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The unique name of the Google Cloud Pub/Sub logging endpoint.",
+			},
+
+			"user": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Your Google Cloud Platform service account email address. The client_email field in your service account authentication JSON. ",
+			},
+
+			"secret_key": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Your Google Cloud Platform account secret key. The private_key field in your service account authentication JSON.",
+			},
+
+			"project_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The ID of your Google Cloud Platform project.",
+			},
+
+			"topic": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The Google Cloud Pub/Sub topic to which logs will be published.",
+			},
+
+			// Optional
+			"format": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Apache style log formatting.",
+			},
+
+			"format_version": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      2,
+				Description:  "The version of the custom logging format used for the configured endpoint. Can be either 1 or 2. (default: 2).",
+				ValidateFunc: validateLoggingFormatVersion(),
+			},
+
+			"placement": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Description:  "Where in the generated VCL the logging call should be placed.",
+				ValidateFunc: validateLoggingPlacement(),
+			},
+
+			"response_condition": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The name of an existing condition in the configured endpoint, or leave blank to always execute.",
+			},
+		},
+	},
+}
+
+func processGooglePubSub(d *schema.ResourceData, conn *gofastly.Client, latestVersion int) error {
+	serviceID := d.Id()
+	oldLogCfg, newLogCfg := d.GetChange("logging_googlepubsub")
+
+	if oldLogCfg == nil {
+		oldLogCfg = new(schema.Set)
+	}
+	if newLogCfg == nil {
+		newLogCfg = new(schema.Set)
+	}
+
+	oldLogSet := oldLogCfg.(*schema.Set)
+	newLogSet := newLogCfg.(*schema.Set)
+
+	removeGooglePubSubLogging := oldLogSet.Difference(newLogSet).List()
+	addGooglePubSubLogging := newLogSet.Difference(oldLogSet).List()
+
+	// DELETE old Google Cloud Pub/Sub logging endpoints.
+	for _, oRaw := range removeGooglePubSubLogging {
+		of := oRaw.(map[string]interface{})
+		opts := buildDeleteGooglePubSub(of, serviceID, latestVersion)
+
+		log.Printf("[DEBUG] Fastly Google Cloud Pub/Sub logging endpoint removal opts: %#v", opts)
+
+		if err := deleteGooglePubSub(conn, opts); err != nil {
+			return err
+		}
+	}
+
+	// POST new/updated Google Cloud Pub/Sub logging endponts.
+	for _, nRaw := range addGooglePubSubLogging {
+		cfg := nRaw.(map[string]interface{})
+		opts := buildCreateGooglePubSub(cfg, serviceID, latestVersion)
+
+		log.Printf("[DEBUG] Fastly Google Cloud Pub/Sub logging addition opts: %#v", opts)
+
+		if err := createGooglePubSub(conn, opts); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func readGooglePubSub(conn *gofastly.Client, d *schema.ResourceData, s *gofastly.ServiceDetail) error {
+	// Refresh Google Cloud Pub/Sub logging endpoints.
+	log.Printf("[DEBUG] Refreshing Google Cloud Pub/Sub logging endpoints for (%s)", d.Id())
+	googlepubsubList, err := conn.ListPubsubs(&gofastly.ListPubsubsInput{
+		Service: d.Id(),
+		Version: s.ActiveVersion.Number,
+	})
+
+	if err != nil {
+		return fmt.Errorf("[ERR] Error looking up Google Cloud Pub/Sub logging endpoints for (%s), version (%v): %s", d.Id(), s.ActiveVersion.Number, err)
+	}
+
+	googlepubsubLogList := flattenGooglePubSub(googlepubsubList)
+
+	if err := d.Set("logging_googlepubsub", googlepubsubLogList); err != nil {
+		log.Printf("[WARN] Error setting Google Cloud Pub/Sublogging endpoints for (%s): %s", d.Id(), err)
+	}
+
+	return nil
+}
+
+func createGooglePubSub(conn *gofastly.Client, i *gofastly.CreatePubsubInput) error {
+	_, err := conn.CreatePubsub(i)
+	return err
+}
+
+func deleteGooglePubSub(conn *gofastly.Client, i *gofastly.DeletePubsubInput) error {
+	err := conn.DeletePubsub(i)
+
+	errRes, ok := err.(*gofastly.HTTPError)
+	if !ok {
+		return err
+	}
+
+	// 404 response codes don't result in an error propagating because a 404 could
+	// indicate that a resource was deleted elsewhere.
+	if !errRes.IsNotFound() {
+		return err
+	}
+
+	return nil
+}
+
+func flattenGooglePubSub(googlepubsubList []*gofastly.Pubsub) []map[string]interface{} {
+	var flattened []map[string]interface{}
+	for _, s := range googlepubsubList {
+		// Convert logging to a map for saving to state.
+		flatGooglePubSub := map[string]interface{}{
+			"name":               s.Name,
+			"user":               s.User,
+			"secret_key":         s.SecretKey,
+			"project_id":         s.ProjectID,
+			"topic":              s.Topic,
+			"format":             s.Format,
+			"format_version":     s.FormatVersion,
+			"placement":          s.Placement,
+			"response_condition": s.ResponseCondition,
+		}
+
+		// Prune any empty values that come from the default string value in structs.
+		for k, v := range flatGooglePubSub {
+			if v == "" {
+				delete(flatGooglePubSub, k)
+			}
+		}
+
+		flattened = append(flattened, flatGooglePubSub)
+	}
+
+	return flattened
+}
+
+func buildCreateGooglePubSub(googlepubsubMap interface{}, serviceID string, serviceVersion int) *gofastly.CreatePubsubInput {
+	df := googlepubsubMap.(map[string]interface{})
+
+	return &gofastly.CreatePubsubInput{
+		Service:           serviceID,
+		Version:           serviceVersion,
+		Name:              fastly.NullString(df["name"].(string)),
+		User:              fastly.NullString(df["user"].(string)),
+		SecretKey:         fastly.NullString(df["secret_key"].(string)),
+		ProjectID:         fastly.NullString(df["project_id"].(string)),
+		Topic:             fastly.NullString(df["topic"].(string)),
+		Format:            fastly.NullString(df["format"].(string)),
+		FormatVersion:     fastly.Uint(uint(df["format_version"].(int))),
+		ResponseCondition: fastly.NullString(df["response_condition"].(string)),
+		Placement:         fastly.NullString(df["placement"].(string)),
+	}
+}
+
+func buildDeleteGooglePubSub(googlepubsubMap interface{}, serviceID string, serviceVersion int) *gofastly.DeletePubsubInput {
+	df := googlepubsubMap.(map[string]interface{})
+
+	return &gofastly.DeletePubsubInput{
+		Service: serviceID,
+		Version: serviceVersion,
+		Name:    df["name"].(string),
+	}
+}

--- a/fastly/block_fastly_service_v1_logging_googlepubsub_test.go
+++ b/fastly/block_fastly_service_v1_logging_googlepubsub_test.go
@@ -1,0 +1,276 @@
+package fastly
+
+import (
+	"fmt"
+	"log"
+	"reflect"
+	"testing"
+
+	gofastly "github.com/fastly/go-fastly/fastly"
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestResourceFastlyFlattenGooglePubSub(t *testing.T) {
+	cases := []struct {
+		remote []*gofastly.Pubsub
+		local  []map[string]interface{}
+	}{
+		{
+			remote: []*gofastly.Pubsub{
+				{
+					Version:           1,
+					Name:              "googlepubsub-endpoint",
+					User:              "user",
+					SecretKey:         privateKey(),
+					ProjectID:         "project-id",
+					Topic:             "topic",
+					ResponseCondition: "response_condition",
+					Format:            `%a %l %u %t %m %U%q %H %>s %b %T`,
+					FormatVersion:     2,
+					Placement:         "none",
+				},
+			},
+			local: []map[string]interface{}{
+				{
+					"name":               "googlepubsub-endpoint",
+					"user":               "user",
+					"secret_key":         privateKey(),
+					"project_id":         "project-id",
+					"topic":              "topic",
+					"response_condition": "response_condition",
+					"format":             `%a %l %u %t %m %U%q %H %>s %b %T`,
+					"placement":          "none",
+					"format_version":     uint(2),
+				},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		out := flattenGooglePubSub(c.remote)
+		if !reflect.DeepEqual(out, c.local) {
+			t.Fatalf("Error matching:\nexpected: %#v\n got: %#v", c.local, out)
+		}
+	}
+
+}
+
+func TestAccFastlyServiceV1_googlepubsublogging_basic(t *testing.T) {
+	var service gofastly.ServiceDetail
+	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	domain := fmt.Sprintf("fastly-test.%s.com", name)
+
+	log1 := gofastly.Pubsub{
+		Version:           1,
+		Name:              "googlepubsublogger",
+		User:              "user",
+		SecretKey:         privateKey() + "\n", // The '\n' is necessary becaue of the heredocs (i.e., EOF) in the config below.
+		ProjectID:         "project-id",
+		Topic:             "topic",
+		ResponseCondition: "response_condition_test",
+		Format:            `%a %l %u %t %m %U%q %H %>s %b %T`,
+		FormatVersion:     2,
+		Placement:         "none",
+	}
+
+	log1_after_update := gofastly.Pubsub{
+		Version:           1,
+		Name:              "googlepubsublogger",
+		User:              "newuser",
+		SecretKey:         privateKey() + "\n", // The '\n' is necessary becaue of the heredocs (i.e., EOF) in the config below.
+		ProjectID:         "new-project-id",
+		Topic:             "newtopic",
+		ResponseCondition: "response_condition_test",
+		Format:            `%a %l %u %t %m %U%q %H %>s %b %T`,
+		FormatVersion:     2,
+		Placement:         "waf_debug",
+	}
+
+	log2 := gofastly.Pubsub{
+		Version:           1,
+		Name:              "googlepubsublogger2",
+		User:              "user2",
+		SecretKey:         privateKey() + "\n", // The '\n' is necessary becaue of the heredocs (i.e., EOF) in the config below.
+		ProjectID:         "project-id",
+		Topic:             "topicb",
+		ResponseCondition: "response_condition_test",
+		Format:            `%a %l %u %t %m %U%q %H %>s %b %T`,
+		FormatVersion:     2,
+		Placement:         "none",
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckServiceV1Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServiceV1GooglePubSubConfig(name, domain),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
+					testAccCheckFastlyServiceV1GooglePubSubAttributes(&service, []*gofastly.Pubsub{&log1}),
+					resource.TestCheckResourceAttr(
+						"fastly_service_v1.foo", "name", name),
+					resource.TestCheckResourceAttr(
+						"fastly_service_v1.foo", "logging_googlepubsub.#", "1"),
+				),
+			},
+
+			{
+				Config: testAccServiceV1GooglePubSubConfig_update(name, domain),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
+					testAccCheckFastlyServiceV1GooglePubSubAttributes(&service, []*gofastly.Pubsub{&log1_after_update, &log2}),
+					resource.TestCheckResourceAttr(
+						"fastly_service_v1.foo", "name", name),
+					resource.TestCheckResourceAttr(
+						"fastly_service_v1.foo", "logging_googlepubsub.#", "2"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckFastlyServiceV1GooglePubSubAttributes(service *gofastly.ServiceDetail, googlepubsub []*gofastly.Pubsub) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+
+		conn := testAccProvider.Meta().(*FastlyClient).conn
+		googlepubsubList, err := conn.ListPubsubs(&gofastly.ListPubsubsInput{
+			Service: service.ID,
+			Version: service.ActiveVersion.Number,
+		})
+
+		if err != nil {
+			return fmt.Errorf("[ERR] Error looking up Google Cloud Pub/Sub Logging for (%s), version (%d): %s", service.Name, service.ActiveVersion.Number, err)
+		}
+
+		if len(googlepubsubList) != len(googlepubsub) {
+			return fmt.Errorf("Google Cloud Pub/Sub List count mismatch, expected (%d), got (%d)", len(googlepubsub), len(googlepubsubList))
+		}
+
+		log.Printf("[DEBUG] googlepubsubList = %#v\n", googlepubsubList)
+
+		var found int
+		for _, s := range googlepubsub {
+			for _, sl := range googlepubsubList {
+				if s.Name == sl.Name {
+					// we don't know these things ahead of time, so populate them now
+					s.ServiceID = service.ID
+					s.Version = service.ActiveVersion.Number
+					// We don't track these, so clear them out because we also wont know
+					// these ahead of time
+					sl.CreatedAt = nil
+					sl.UpdatedAt = nil
+					if diff := cmp.Diff(s, sl); diff != "" {
+						return fmt.Errorf("Bad match Google Cloud Pub/Sub logging match: %s", diff)
+					}
+					found++
+				}
+			}
+		}
+
+		if found != len(googlepubsub) {
+			return fmt.Errorf("Error matching Google Cloud Pub/Sub Logging rules")
+		}
+
+		return nil
+	}
+}
+
+func testAccServiceV1GooglePubSubConfig(name string, domain string) string {
+	return fmt.Sprintf(`
+resource "fastly_service_v1" "foo" {
+	name = "%s"
+
+	domain {
+		name    = "%s"
+		comment = "tf-googlepubsub-logging"
+	}
+
+	backend {
+		address = "aws.amazon.com"
+		name    = "amazon docs"
+	}
+
+	condition {
+    name      = "response_condition_test"
+    type      = "RESPONSE"
+    priority  = 8
+    statement = "resp.status == 418"
+  }
+
+	logging_googlepubsub {
+		name               = "googlepubsublogger"
+		user               = "user"
+		secret_key         = <<EOF
+`+privateKey()+`
+EOF
+		project_id         = "project-id"
+	  topic  						 = "topic"
+		response_condition = "response_condition_test"
+		format             = "%%a %%l %%u %%t %%m %%U%%q %%H %%>s %%b %%T"
+		format_version     = 2
+		placement          = "none"
+	}
+
+	force_destroy = true
+}
+`, name, domain)
+}
+
+func testAccServiceV1GooglePubSubConfig_update(name, domain string) string {
+	return fmt.Sprintf(`
+resource "fastly_service_v1" "foo" {
+	name = "%s"
+
+	domain {
+		name    = "%s"
+		comment = "tf-testing-domain"
+	}
+
+	backend {
+		address = "aws.amazon.com"
+		name    = "amazon docs"
+	}
+
+	condition {
+    name      = "response_condition_test"
+    type      = "RESPONSE"
+    priority  = 8
+    statement = "resp.status == 418"
+  }
+
+	logging_googlepubsub {
+		name               = "googlepubsublogger"
+		user               = "newuser"
+		secret_key         = <<EOF
+`+privateKey()+`
+EOF
+		project_id         = "new-project-id"
+	  topic  						 = "newtopic"
+		response_condition = "response_condition_test"
+		format             = "%%a %%l %%u %%t %%m %%U%%q %%H %%>s %%b %%T"
+		format_version     = 2
+		placement          = "waf_debug"
+	}
+
+	logging_googlepubsub {
+		name               = "googlepubsublogger2"
+		user               = "user2"
+		secret_key         = <<EOF
+`+privateKey()+`
+EOF
+		project_id         = "project-id"
+	  topic  						 = "topicb"
+		response_condition = "response_condition_test"
+		format             = "%%a %%l %%u %%t %%m %%U%%q %%H %%>s %%b %%T"
+		format_version     = 2
+		placement          = "none"
+	}
+
+	force_destroy = true
+}`, name, domain)
+}

--- a/fastly/resource_fastly_service_v1.go
+++ b/fastly/resource_fastly_service_v1.go
@@ -114,6 +114,7 @@ func resourceServiceV1() *schema.Resource {
 			"logging_loggly":        logglySchema,
 			"logging_newrelic":      newrelicSchema,
 			"logging_scalyr":        scalyrloggingSchema,
+			"logging_googlepubsub":  googlepubsubloggingSchema,
 
 			"response_object": responseobjectSchema,
 			"request_setting": requestsettingSchema,
@@ -197,6 +198,7 @@ func resourceServiceV1Update(d *schema.ResourceData, meta interface{}) error {
 		"logging_loggly",
 		"logging_newrelic",
 		"logging_scalyr",
+		"logging_googlepubsub",
 		"response_object",
 		"condition",
 		"request_setting",
@@ -430,6 +432,11 @@ func resourceServiceV1Update(d *schema.ResourceData, meta interface{}) error {
 				return err
 			}
 		}
+		if d.HasChange("logging_googlepubsub") {
+			if err := processGooglePubSub(d, conn, latestVersion); err != nil {
+				return err
+			}
+		}
 		if d.HasChange("response_object") {
 			if err := processResponseObject(d, conn, latestVersion); err != nil {
 				return err
@@ -624,6 +631,9 @@ func resourceServiceV1Read(d *schema.ResourceData, meta interface{}) error {
 			return err
 		}
 		if err := readScalyr(conn, d, s); err != nil {
+			return err
+		}
+		if err := readGooglePubSub(conn, d, s); err != nil {
 			return err
 		}
 		if err := readResponseObject(conn, d, s); err != nil {

--- a/website/docs/r/service_v1.html.markdown
+++ b/website/docs/r/service_v1.html.markdown
@@ -220,6 +220,8 @@ Defined below.
 Defined below.
 * `logging_scalyr` - (Optional) A Scalyr endpoint to send streaming logs to.
 Defined below.
+* `logging_googlepubsub` - (Optional) A Google Cloud Pub/Sub endpoint to send streaming logs to.
+Defined below.
 * `response_object` - (Optional) Allows you to create synthetic responses that exist entirely on the varnish machine. Useful for creating error or maintenance pages that exists outside the scope of your datacenter. Best when used with Condition objects.
 * `snippet` - (Optional) A set of custom, "regular" (non-dynamic) VCL Snippet configuration blocks.  Defined below.
 * `dynamicsnippet` - (Optional) A set of custom, "dynamic" VCL Snippet configuration blocks.  Defined below.
@@ -618,6 +620,18 @@ The `logging_scalyr` block supports:
 * `name` - (Required) The unique name of the Scalyr logging endpoint.
 * `token` - (Required) The token to use for authentication (https://www.scalyr.com/keys).
 * `region` - (Optional) The region that log data will be sent to. One of US or EU. Defaults to US if undefined.
+* `format` - (Optional) Apache-style string or VCL variables to use for log formatting.
+* `format_version` - (Optional) The version of the custom logging format used for the configured endpoint. Can be either `1` or `2`. The logging call gets placed by default in `vcl_log` if `format_version` is set to `2` and in `vcl_deliver` if `format_version` is set to `1`. Default `2`.
+* `placement` - (Optional) The name of an existing condition in the configured endpoint, or leave blank to always execute.
+* `response_condition` - (Optional) The name of the `condition` to apply. If empty, always execute.
+
+The `logging_googlepubsub` block supports:
+
+* `name` - (Required) The unique name of the Google Cloud Pub/Sub logging endpoint.
+* `user` - (Required) Your Google Cloud Platform service account email address. The client_email field in your service account authentication JSON.
+* `secret_key` - (Required) Your Google Cloud Platform account secret key. The private_key field in your service account authentication JSON.
+* `project_id` - (Required) The ID of your Google Cloud Platform project.
+* `topic` - (Required) The Google Cloud Pub/Sub topic to which logs will be published.
 * `format` - (Optional) Apache-style string or VCL variables to use for log formatting.
 * `format_version` - (Optional) The version of the custom logging format used for the configured endpoint. Can be either `1` or `2`. The logging call gets placed by default in `vcl_log` if `format_version` is set to `2` and in `vcl_deliver` if `format_version` is set to `1`. Default `2`.
 * `placement` - (Optional) The name of an existing condition in the configured endpoint, or leave blank to always execute.


### PR DESCRIPTION
## Proposed Change(s)

* Adds support for Google Cloud Pub/Sub logging endpoints.

## Validation

```
export FASTLY_API_KEY=foo; export TF_ACC=1; make testacc
```
