### PR TITLE
Elasticsearch, FTP and SFTP Omitted Refresh

### DIFF
--- a/fastly/block_fastly_service_v1_logging_elasticsearch_test.go
+++ b/fastly/block_fastly_service_v1_logging_elasticsearch_test.go
@@ -88,9 +88,9 @@ func TestAccFastlyServiceV1_logging_elasticsearch_basic(t *testing.T) {
 		User:              "user",
 		Password:          "password",
 		Pipeline:          "my-pipeline",
-		TLSCACert:         caCert() + "\n",      // The '\n' is necessary because of the heredocs (i.e., EOF) in the config below.
-		TLSClientCert:     certificate() + "\n", // The '\n' is necessary because of the heredocs (i.e., EOF) in the config below.
-		TLSClientKey:      privateKey() + "\n",  // The '\n' is necessary because of the heredocs (i.e., EOF) in the config below.
+		TLSCACert:         appendNewLine(caCert()),
+		TLSClientCert:     appendNewLine(certificate()),
+		TLSClientKey:      appendNewLine(privateKey()),
 		TLSHostname:       "example.com",
 		ResponseCondition: "response_condition_test",
 		Placement:         "none",
@@ -108,9 +108,9 @@ func TestAccFastlyServiceV1_logging_elasticsearch_basic(t *testing.T) {
 		User:              "newuser",
 		Password:          "newpassword",
 		Pipeline:          "my-new-pipeline",
-		TLSCACert:         caCert() + "\n",      // The '\n' is necessary because of the heredocs (i.e., EOF) in the config below.
-		TLSClientCert:     certificate() + "\n", // The '\n' is necessary because of the heredocs (i.e., EOF) in the config below.
-		TLSClientKey:      privateKey() + "\n",  // The '\n' is necessary because of the heredocs (i.e., EOF) in the config below.
+		TLSCACert:         appendNewLine(caCert()),
+		TLSClientCert:     appendNewLine(certificate()),
+		TLSClientKey:      appendNewLine(privateKey()),
 		TLSHostname:       "example.com",
 		ResponseCondition: "response_condition_test",
 		Placement:         "none",
@@ -128,9 +128,9 @@ func TestAccFastlyServiceV1_logging_elasticsearch_basic(t *testing.T) {
 		User:              "username",
 		Password:          "secret-password",
 		Pipeline:          "my-new-pipeline",
-		TLSCACert:         caCert() + "\n",      // The '\n' is necessary because of the heredocs (i.e., EOF) in the config below.
-		TLSClientCert:     certificate() + "\n", // The '\n' is necessary because of the heredocs (i.e., EOF) in the config below.
-		TLSClientKey:      privateKey() + "\n",  // The '\n' is necessary because of the heredocs (i.e., EOF) in the config below.
+		TLSCACert:         appendNewLine(caCert()),
+		TLSClientCert:     appendNewLine(certificate()),
+		TLSClientKey:      appendNewLine(privateKey()),
 		TLSHostname:       "example.com",
 		ResponseCondition: "response_condition_test",
 		Placement:         "none",
@@ -333,4 +333,9 @@ EOF
   force_destroy = true
 }
 `, name, domain)
+}
+
+// appendNewLine appends a '\n' and is necessary because of the heredocs (i.e., EOF) in the TF config.
+func appendNewLine(s string) string {
+	return s + "\n"
 }

--- a/fastly/block_fastly_service_v1_logging_elasticsearch_test.go
+++ b/fastly/block_fastly_service_v1_logging_elasticsearch_test.go
@@ -88,9 +88,9 @@ func TestAccFastlyServiceV1_logging_elasticsearch_basic(t *testing.T) {
 		User:              "user",
 		Password:          "password",
 		Pipeline:          "my-pipeline",
-		TLSCACert:         caCert(),
-		TLSClientCert:     certificate(),
-		TLSClientKey:      privateKey(),
+		TLSCACert:         caCert() + "\n",      // The '\n' is necessary because of the heredocs (i.e., EOF) in the config below.
+		TLSClientCert:     certificate() + "\n", // The '\n' is necessary because of the heredocs (i.e., EOF) in the config below.
+		TLSClientKey:      privateKey() + "\n",  // The '\n' is necessary because of the heredocs (i.e., EOF) in the config below.
 		TLSHostname:       "example.com",
 		ResponseCondition: "response_condition_test",
 		Placement:         "none",
@@ -108,9 +108,9 @@ func TestAccFastlyServiceV1_logging_elasticsearch_basic(t *testing.T) {
 		User:              "newuser",
 		Password:          "newpassword",
 		Pipeline:          "my-new-pipeline",
-		TLSCACert:         caCert(),
-		TLSClientCert:     certificate(),
-		TLSClientKey:      privateKey(),
+		TLSCACert:         caCert() + "\n",      // The '\n' is necessary because of the heredocs (i.e., EOF) in the config below.
+		TLSClientCert:     certificate() + "\n", // The '\n' is necessary because of the heredocs (i.e., EOF) in the config below.
+		TLSClientKey:      privateKey() + "\n",  // The '\n' is necessary because of the heredocs (i.e., EOF) in the config below.
 		TLSHostname:       "example.com",
 		ResponseCondition: "response_condition_test",
 		Placement:         "none",
@@ -128,9 +128,9 @@ func TestAccFastlyServiceV1_logging_elasticsearch_basic(t *testing.T) {
 		User:              "username",
 		Password:          "secret-password",
 		Pipeline:          "my-new-pipeline",
-		TLSCACert:         caCert(),
-		TLSClientCert:     certificate(),
-		TLSClientKey:      privateKey(),
+		TLSCACert:         caCert() + "\n",      // The '\n' is necessary because of the heredocs (i.e., EOF) in the config below.
+		TLSClientCert:     certificate() + "\n", // The '\n' is necessary because of the heredocs (i.e., EOF) in the config below.
+		TLSClientKey:      privateKey() + "\n",  // The '\n' is necessary because of the heredocs (i.e., EOF) in the config below.
 		TLSHostname:       "example.com",
 		ResponseCondition: "response_condition_test",
 		Placement:         "none",

--- a/fastly/resource_fastly_service_v1.go
+++ b/fastly/resource_fastly_service_v1.go
@@ -391,6 +391,21 @@ func resourceServiceV1Update(d *schema.ResourceData, meta interface{}) error {
 				return err
 			}
 		}
+		if d.HasChange("logging_elasticsearch") {
+			if err := processElasticsearch(d, conn, latestVersion); err != nil {
+				return err
+			}
+		}
+		if d.HasChange("logging_ftp") {
+			if err := processFTP(d, conn, latestVersion); err != nil {
+				return err
+			}
+		}
+		if d.HasChange("logging_sftp") {
+			if err := processSFTP(d, conn, latestVersion); err != nil {
+				return err
+			}
+		}
 		if d.HasChange("logging_datadog") {
 			if err := processDatadog(d, conn, latestVersion); err != nil {
 				return err
@@ -401,28 +416,6 @@ func resourceServiceV1Update(d *schema.ResourceData, meta interface{}) error {
 				return err
 			}
 		}
-
-		// find differences in Elasticsearch logging configuration
-		if d.HasChange("logging_elasticsearch") {
-			if err := processElasticsearch(d, conn, latestVersion); err != nil {
-				return err
-			}
-		}
-
-		// find differences in FTP logging configuration
-		if d.HasChange("logging_ftp") {
-			if err := processFTP(d, conn, latestVersion); err != nil {
-				return err
-			}
-		}
-
-		// find differences in SFTP logging configurations
-		if d.HasChange("logging_sftp") {
-			if err := processSFTP(d, conn, latestVersion); err != nil {
-				return err
-			}
-		}
-
 		if d.HasChange("response_object") {
 			if err := processResponseObject(d, conn, latestVersion); err != nil {
 				return err

--- a/fastly/resource_fastly_service_v1.go
+++ b/fastly/resource_fastly_service_v1.go
@@ -598,6 +598,15 @@ func resourceServiceV1Read(d *schema.ResourceData, meta interface{}) error {
 		if err := readHTTPS(conn, d, s); err != nil {
 			return err
 		}
+		if err := readElasticsearch(conn, d, s); err != nil {
+			return err
+		}
+		if err := readFTP(conn, d, s); err != nil {
+			return err
+		}
+		if err := readSFTP(conn, d, s); err != nil {
+			return err
+		}
 		if err := readDatadog(conn, d, s); err != nil {
 			return err
 		}


### PR DESCRIPTION
## Proposed Change(s)

* FTP , SFTP and Elasticsearch need to be refreshed. I think this was mistakenly overlooked in https://github.com/terraform-providers/terraform-provider-fastly/pull/235 and https://github.com/terraform-providers/terraform-provider-fastly/pull/234.

## Validation

* Why wasn't this caught before?

   * This would only be exercised if a resource was modified outside of TF. These
   blocks are responsible for pulling in remote state. While it would probably be
   a decent investment, We may want to write a test which mocks the API with a
   remote resource state change.

cc @phamann 