### PR TITLE
helpers: add test helper for escaping '%'

### DIFF
--- a/fastly/block_fastly_service_v1_logging_datadog_test.go
+++ b/fastly/block_fastly_service_v1_logging_datadog_test.go
@@ -3,7 +3,6 @@ package fastly
 import (
 	"fmt"
 	"log"
-	"strings"
 	"testing"
 
 	gofastly "github.com/fastly/go-fastly/fastly"
@@ -267,12 +266,6 @@ resource "fastly_service_v1" "foo" {
 `, name, domain)
 }
 
-var (
-	// https://www.terraform.io/docs/configuration/expressions.html#string-literals
-	escapePercent          = strings.ReplaceAll(datadogDefaultFormat, "%", "%%")
-	escapeTemplateSequence = strings.ReplaceAll(escapePercent, "%%{", "%%%%{")
-)
-
 func testAccServiceV1DatadogConfig_update(name, domain string) string {
 	return fmt.Sprintf(`
 resource "fastly_service_v1" "foo" {
@@ -299,7 +292,7 @@ resource "fastly_service_v1" "foo" {
     name  = "another-datadog-endpoint"
     token = "another-token"
 		format = <<EOF
-`+escapeTemplateSequence+`
+`+escapePercentSign(datadogDefaultFormat)+`
 EOF
   }
 

--- a/fastly/block_fastly_service_v1_logging_newrelic_test.go
+++ b/fastly/block_fastly_service_v1_logging_newrelic_test.go
@@ -3,7 +3,6 @@ package fastly
 import (
 	"fmt"
 	"log"
-	"strings"
 	"testing"
 
 	gofastly "github.com/fastly/go-fastly/fastly"
@@ -45,8 +44,7 @@ func TestResourceFastlyFlattenNewRelic(t *testing.T) {
 	}
 }
 
-var (
-	newrelicDefaultFormat = `{
+var newrelicDefaultFormat = `{
   "time_elapsed":%{time.elapsed.usec}V,
   "is_tls":%{if(req.is_ssl, "true", "false")}V,
   "client_ip":"%{req.http.Fastly-Client-IP}V",
@@ -61,10 +59,6 @@ var (
   "request_accept_charset":"%{json.escape(req.http.Accept-Charset)}V",
   "cache_status":"%{regsub(fastly_info.state, "^(HIT-(SYNTH)|(HITPASS|HIT|MISS|PASS|ERROR|PIPE)).*", "\2\3") }V"
 }`
-	// https://www.terraform.io/docs/configuration/expressions.html#string-literals
-	newrelicEscapePercent          = strings.ReplaceAll(newrelicDefaultFormat, "%", "%%")
-	newrelicEscapeTemplateSequence = strings.ReplaceAll(newrelicEscapePercent, "%%{", "%%%%{")
-)
 
 func TestAccFastlyServiceV1_logging_newrelic_basic(t *testing.T) {
 	var service gofastly.ServiceDetail
@@ -226,7 +220,7 @@ resource "fastly_service_v1" "foo" {
     name  = "another-newrelic-endpoint"
     token = "another-token"
 		format = <<EOF
-`+newrelicEscapeTemplateSequence+`
+`+escapePercentSign(newrelicDefaultFormat)+`
 EOF
   }
 

--- a/fastly/fastly_test.go
+++ b/fastly/fastly_test.go
@@ -1,5 +1,7 @@
 package fastly
 
+import "strings"
+
 // pgpPublicKey returns a PEM encoded PGP public key suitable for testing.
 func pgpPublicKey() string {
 	return `-----BEGIN PGP PUBLIC KEY BLOCK-----
@@ -163,4 +165,25 @@ BgNVBAMTC0hlcm9uZyBZYW5nggEAMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEE
 BQADQQA/ugzBrjjK9jcWnDVfGHlk3icNRq0oV7Ri32z/+HQX67aRfgZu7KWdI+Ju
 Wm7DCfrPNGVwFWUQOmsPue9rZBgO
 -----END CERTIFICATE-----`
+}
+
+// escapePercentSign uses Terraform's escape syntax (i.e., repeating characters)
+// to properly escape percent signs (i.e., '%').
+//
+// There are two significant places where '%' can show up:
+// 1. Before a left curly brace (i.e., '{').
+// 2. Not before a left curly brace.
+//
+// In case #1, we have to double escape so that Terraform does not interpret Fastly's
+// configuration values as its own (e.g., https://docs.fastly.com/en/guides/custom-log-formats).
+//
+// In case #2, we only have to single escape.
+//
+// Refer to the Terraform documentation on string literals for more details:
+// https://www.terraform.io/docs/configuration/expressions.html#string-literals
+func escapePercentSign(s string) string {
+	escapeSign := strings.ReplaceAll(s, "%", "%%")
+	escapeTemplateSequence := strings.ReplaceAll(escapeSign, "%%{", "%%%%{")
+
+	return escapeTemplateSequence
 }

--- a/fastly/fastly_test.go
+++ b/fastly/fastly_test.go
@@ -1,6 +1,9 @@
 package fastly
 
-import "strings"
+import (
+	"strings"
+	"testing"
+)
 
 // pgpPublicKey returns a PEM encoded PGP public key suitable for testing.
 func pgpPublicKey() string {
@@ -186,4 +189,41 @@ func escapePercentSign(s string) string {
 	escapeTemplateSequence := strings.ReplaceAll(escapeSign, "%%{", "%%%%{")
 
 	return escapeTemplateSequence
+}
+
+func TestEscapePercentSign(t *testing.T) {
+	for _, testcase := range []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "string no percent signs should change nothing",
+			input: "abc 123",
+			want:  "abc 123",
+		},
+		{
+			name:  "one percent sign should return two percent signs",
+			input: "%",
+			want:  "%%",
+		},
+		{
+			name:  "one percent sign mid-string should return two percent signs in the same place",
+			input: "abc%123",
+			want:  "abc%%123",
+		},
+		{
+			name:  "one percent sign before left curly brace should return four percent signs then curly brace",
+			input: "%{",
+			want:  "%%%%{",
+		},
+	} {
+		t.Run(testcase.name, func(t *testing.T) {
+			got := escapePercentSign(testcase.input)
+
+			if got != testcase.want {
+				t.Errorf("escapePercentSign(%q): \n\tgot: '%+v'\n\twant: '%+v'", testcase.input, got, testcase.want)
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Proposed Change(s):

* Add a test helper to escape '%'.
   * https://github.com/terraform-providers/terraform-provider-fastly/pull/263/commits/b72e5050c754943895ddf341c9030ab49716d7e1
* Updates New Relic tests to use helper function.
   * https://github.com/terraform-providers/terraform-provider-fastly/pull/263/commits/386626c91fd48a8f7ef150d22ad952ba334794f7
* Updates Datadog tests to use helper function.
   * https://github.com/terraform-providers/terraform-provider-fastly/pull/263/commits/c9f6aa232ce14b5312c0b67bc17334554982768a

## Note(s)

* We have discussed offline that we are not ready to support a generic helper function for escaping special characters for a couple reasons:
   1. It is out of scope for now due to the possible edge cases and because we would want to update the codebase to use the helper if it existed.
   2. Terraform doesn't expose it.

## Validation

```bash
FASTLY_API_KEY="foo" TF_ACC=1 make testacc
```
