### PR TITLE
Adds Heroku logging support

### DIFF
--- a/fastly/block_fastly_service_v1_logging_heroku.go
+++ b/fastly/block_fastly_service_v1_logging_heroku.go
@@ -1,0 +1,220 @@
+package fastly
+
+import (
+	"fmt"
+	"log"
+
+	gofastly "github.com/fastly/go-fastly/fastly"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+type HerokuServiceAttributeHandler struct {
+	*DefaultServiceAttributeHandler
+}
+
+func NewServiceLoggingHeroku() ServiceAttributeDefinition {
+	return &HerokuServiceAttributeHandler{
+		&DefaultServiceAttributeHandler{
+			key: "logging_heroku",
+		},
+	}
+}
+
+func (h *HerokuServiceAttributeHandler) Process(d *schema.ResourceData, latestVersion int, conn *gofastly.Client) error {
+	serviceID := d.Id()
+	ol, nl := d.GetChange(h.GetKey())
+
+	if ol == nil {
+		ol = new(schema.Set)
+	}
+	if nl == nil {
+		nl = new(schema.Set)
+	}
+
+	ols := ol.(*schema.Set)
+	nls := nl.(*schema.Set)
+
+	removeHerokuLogging := ols.Difference(nls).List()
+	addHerokuLogging := nls.Difference(ols).List()
+
+	// DELETE old Heroku logging endpoints.
+	for _, oRaw := range removeHerokuLogging {
+		of := oRaw.(map[string]interface{})
+		opts := buildDeleteHeroku(of, serviceID, latestVersion)
+
+		log.Printf("[DEBUG] Fastly Heroku logging endpoint removal opts: %#v", opts)
+
+		if err := deleteHeroku(conn, opts); err != nil {
+			return err
+		}
+	}
+
+	// POST new/updated Heroku logging endpoints.
+	for _, nRaw := range addHerokuLogging {
+		lf := nRaw.(map[string]interface{})
+		opts := buildCreateHeroku(lf, serviceID, latestVersion)
+
+		log.Printf("[DEBUG] Fastly Heroku logging addition opts: %#v", opts)
+
+		if err := createHeroku(conn, opts); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (h *HerokuServiceAttributeHandler) Read(d *schema.ResourceData, s *gofastly.ServiceDetail, conn *gofastly.Client) error {
+	// Refresh Heroku.
+	log.Printf("[DEBUG] Refreshing Heroku logging endpoints for (%s)", d.Id())
+	herokuList, err := conn.ListHerokus(&gofastly.ListHerokusInput{
+		Service: d.Id(),
+		Version: s.ActiveVersion.Number,
+	})
+
+	if err != nil {
+		return fmt.Errorf("[ERR] Error looking up Heroku logging endpoints for (%s), version (%v): %s", d.Id(), s.ActiveVersion.Number, err)
+	}
+
+	ell := flattenHeroku(herokuList)
+
+	if err := d.Set(h.GetKey(), ell); err != nil {
+		log.Printf("[WARN] Error setting Heroku logging endpoints for (%s): %s", d.Id(), err)
+	}
+
+	return nil
+}
+
+func createHeroku(conn *gofastly.Client, i *gofastly.CreateHerokuInput) error {
+	_, err := conn.CreateHeroku(i)
+	return err
+}
+
+func deleteHeroku(conn *gofastly.Client, i *gofastly.DeleteHerokuInput) error {
+	err := conn.DeleteHeroku(i)
+
+	errRes, ok := err.(*gofastly.HTTPError)
+	if !ok {
+		return err
+	}
+
+	// 404 response codes don't result in an error propagating because a 404 could
+	// indicate that a resource was deleted elsewhere.
+	if !errRes.IsNotFound() {
+		return err
+	}
+
+	return nil
+}
+
+func flattenHeroku(herokuList []*gofastly.Heroku) []map[string]interface{} {
+	var res []map[string]interface{}
+	for _, ll := range herokuList {
+		// Convert Heroku logging to a map for saving to state.
+		nll := map[string]interface{}{
+			"name":               ll.Name,
+			"token":              ll.Token,
+			"url":                ll.URL,
+			"format":             ll.Format,
+			"format_version":     ll.FormatVersion,
+			"placement":          ll.Placement,
+			"response_condition": ll.ResponseCondition,
+		}
+
+		// Prune any empty values that come from the default string value in structs.
+		for k, v := range nll {
+			if v == "" {
+				delete(nll, k)
+			}
+		}
+
+		res = append(res, nll)
+	}
+
+	return res
+}
+
+func buildCreateHeroku(herokuMap interface{}, serviceID string, serviceVersion int) *gofastly.CreateHerokuInput {
+	df := herokuMap.(map[string]interface{})
+
+	return &gofastly.CreateHerokuInput{
+		Service:           serviceID,
+		Version:           serviceVersion,
+		Name:              gofastly.NullString(df["name"].(string)),
+		Token:             gofastly.NullString(df["token"].(string)),
+		URL:               gofastly.NullString(df["url"].(string)),
+		Format:            gofastly.NullString(df["format"].(string)),
+		FormatVersion:     gofastly.Uint(uint(df["format_version"].(int))),
+		Placement:         gofastly.NullString(df["placement"].(string)),
+		ResponseCondition: gofastly.NullString(df["response_condition"].(string)),
+	}
+}
+
+func buildDeleteHeroku(herokuMap interface{}, serviceID string, serviceVersion int) *gofastly.DeleteHerokuInput {
+	df := herokuMap.(map[string]interface{})
+
+	return &gofastly.DeleteHerokuInput{
+		Service: serviceID,
+		Version: serviceVersion,
+		Name:    df["name"].(string),
+	}
+}
+
+func (h *HerokuServiceAttributeHandler) Register(s *schema.Resource) error {
+	s.Schema[h.GetKey()] = &schema.Schema{
+		Type:     schema.TypeSet,
+		Optional: true,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				// Required fields
+				"name": {
+					Type:        schema.TypeString,
+					Required:    true,
+					Description: "The unique name of the Heroku logging endpoint.",
+				},
+
+				"token": {
+					Type:        schema.TypeString,
+					Required:    true,
+					Sensitive:   true,
+					Description: "The token to use for authentication (https://www.heroku.com/docs/customer-token-authentication-token/).",
+				},
+
+				"url": {
+					Type:        schema.TypeString,
+					Required:    true,
+					Description: "The url to stream logs to.",
+				},
+
+				// Optional fields
+				"format": {
+					Type:        schema.TypeString,
+					Optional:    true,
+					Description: "Apache-style string or VCL variables to use for log formatting.",
+				},
+
+				"format_version": {
+					Type:         schema.TypeInt,
+					Optional:     true,
+					Default:      2,
+					Description:  "The version of the custom logging format used for the configured endpoint. Can be either `1` or `2`. (default: `2`).",
+					ValidateFunc: validateLoggingFormatVersion(),
+				},
+
+				"placement": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					Description:  "Where in the generated VCL the logging call should be placed. Can be `none` or `waf_debug`.",
+					ValidateFunc: validateLoggingPlacement(),
+				},
+
+				"response_condition": {
+					Type:        schema.TypeString,
+					Optional:    true,
+					Description: "The name of an existing condition in the configured endpoint, or leave blank to always execute.",
+				},
+			},
+		},
+	}
+	return nil
+}

--- a/fastly/block_fastly_service_v1_logging_heroku_test.go
+++ b/fastly/block_fastly_service_v1_logging_heroku_test.go
@@ -1,0 +1,229 @@
+package fastly
+
+import (
+	"fmt"
+	"log"
+	"testing"
+
+	gofastly "github.com/fastly/go-fastly/fastly"
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestResourceFastlyFlattenHeroku(t *testing.T) {
+	cases := []struct {
+		remote []*gofastly.Heroku
+		local  []map[string]interface{}
+	}{
+		{
+			remote: []*gofastly.Heroku{
+				{
+					Version:           1,
+					Name:              "heroku-endpoint",
+					URL:               "https://example.com",
+					Token:             "token",
+					Placement:         "none",
+					ResponseCondition: "always",
+					Format:            "%h %l %u %t \"%r\" %>s %b",
+					FormatVersion:     2,
+				},
+			},
+			local: []map[string]interface{}{
+				{
+					"name":               "heroku-endpoint",
+					"token":              "token",
+					"url":                "https://example.com",
+					"placement":          "none",
+					"format":             "%h %l %u %t \"%r\" %>s %b",
+					"response_condition": "always",
+					"format_version":     uint(2),
+				},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		out := flattenHeroku(c.remote)
+		if diff := cmp.Diff(out, c.local); diff != "" {
+			t.Fatalf("Error matching: %s", diff)
+		}
+	}
+}
+
+func TestAccFastlyServiceV1_logging_heroku_basic(t *testing.T) {
+	var service gofastly.ServiceDetail
+	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	domain := fmt.Sprintf("fastly-test.%s.com", name)
+
+	log1 := gofastly.Heroku{
+		Version:       1,
+		Name:          "heroku-endpoint",
+		URL:           "https://example.com",
+		Token:         "s3cr3t",
+		FormatVersion: 2,
+		Format:        "%h %l %u %t \"%r\" %>s %b",
+	}
+
+	log1_after_update := gofastly.Heroku{
+		Version:           1,
+		Name:              "heroku-endpoint",
+		URL:               "https://example.com",
+		Placement:         "none",
+		ResponseCondition: "response_condition_test",
+		Token:             "secret",
+		FormatVersion:     2,
+		Format:            "%h %l %u %t \"%r\" %>s %b %T",
+	}
+
+	log2 := gofastly.Heroku{
+		Version:       1,
+		Name:          "another-heroku-endpoint",
+		URL:           "https://new.example.com",
+		Token:         "another-token",
+		FormatVersion: 2,
+		Format:        "%h %l %u %t \"%r\" %>s %b",
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckServiceV1Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServiceV1HerokuConfig(name, domain),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
+					testAccCheckFastlyServiceV1HerokuAttributes(&service, []*gofastly.Heroku{&log1}),
+					resource.TestCheckResourceAttr(
+						"fastly_service_v1.foo", "name", name),
+					resource.TestCheckResourceAttr(
+						"fastly_service_v1.foo", "logging_heroku.#", "1"),
+				),
+			},
+
+			{
+				Config: testAccServiceV1HerokuConfig_update(name, domain),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
+					testAccCheckFastlyServiceV1HerokuAttributes(&service, []*gofastly.Heroku{&log1_after_update, &log2}),
+					resource.TestCheckResourceAttr(
+						"fastly_service_v1.foo", "name", name),
+					resource.TestCheckResourceAttr(
+						"fastly_service_v1.foo", "logging_heroku.#", "2"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckFastlyServiceV1HerokuAttributes(service *gofastly.ServiceDetail, heroku []*gofastly.Heroku) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+
+		conn := testAccProvider.Meta().(*FastlyClient).conn
+		herokuList, err := conn.ListHerokus(&gofastly.ListHerokusInput{
+			Service: service.ID,
+			Version: service.ActiveVersion.Number,
+		})
+
+		if err != nil {
+			return fmt.Errorf("[ERR] Error looking up Heroku Logging for (%s), version (%d): %s", service.Name, service.ActiveVersion.Number, err)
+		}
+
+		if len(herokuList) != len(heroku) {
+			return fmt.Errorf("Heroku List count mismatch, expected (%d), got (%d)", len(heroku), len(herokuList))
+		}
+
+		log.Printf("[DEBUG] herokuList = %#v\n", herokuList)
+
+		for _, e := range heroku {
+			for _, el := range herokuList {
+				if e.Name == el.Name {
+					// we don't know these things ahead of time, so populate them now
+					e.ServiceID = service.ID
+					e.Version = service.ActiveVersion.Number
+					// We don't track these, so clear them out because we also wont know
+					// these ahead of time
+					el.CreatedAt = nil
+					el.UpdatedAt = nil
+					if diff := cmp.Diff(e, el); diff != "" {
+						return fmt.Errorf("Bad match Heroku logging match: %s", diff)
+					}
+				}
+			}
+		}
+
+		return nil
+	}
+}
+
+func testAccServiceV1HerokuConfig(name string, domain string) string {
+	return fmt.Sprintf(`
+resource "fastly_service_v1" "foo" {
+  name = "%s"
+
+  domain {
+    name    = "%s"
+    comment = "tf-heroku-logging"
+  }
+
+  backend {
+    address = "aws.amazon.com"
+    name    = "amazon docs"
+  }
+
+  logging_heroku {
+    name   = "heroku-endpoint"
+    token  = "s3cr3t"
+		url    = "https://example.com"
+    format = "%%h %%l %%u %%t \"%%r\" %%>s %%b"
+  }
+
+  force_destroy = true
+}
+`, name, domain)
+}
+
+func testAccServiceV1HerokuConfig_update(name, domain string) string {
+	return fmt.Sprintf(`
+resource "fastly_service_v1" "foo" {
+  name = "%s"
+
+  domain {
+    name    = "%s"
+    comment = "tf-heroku-logging"
+  }
+
+  backend {
+    address = "aws.amazon.com"
+    name    = "amazon docs"
+  }
+
+  condition {
+    name      = "response_condition_test"
+    type      = "RESPONSE"
+    priority  = 8
+    statement = "resp.status == 418"
+  }
+
+  logging_heroku {
+    name               = "heroku-endpoint"
+    url                = "https://example.com"
+    placement          = "none"
+    token              = "secret"
+    format             = "%%h %%l %%u %%t \"%%r\" %%>s %%b %%T"
+		response_condition = "response_condition_test"
+  }
+
+  logging_heroku {
+    name   = "another-heroku-endpoint"
+    token  = "another-token"
+    url    = "https://new.example.com"
+    format = "%%h %%l %%u %%t \"%%r\" %%>s %%b"
+  }
+
+  force_destroy = true
+}
+`, name, domain)
+}

--- a/fastly/resource_fastly_service_v1.go
+++ b/fastly/resource_fastly_service_v1.go
@@ -37,6 +37,7 @@ var vclService = &BaseServiceDefinition{
 		NewServiceLoggingScalyr(),
 		NewServiceLoggingNewRelic(),
 		NewServiceLoggingKafka(),
+		NewServiceLoggingHeroku(),
 		NewServiceResponseObject(),
 		NewServiceRequestSetting(),
 		NewServiceVCL(),

--- a/website/docs/r/service_v1.html.markdown
+++ b/website/docs/r/service_v1.html.markdown
@@ -224,6 +224,8 @@ Defined below.
 Defined below.
 * `logging_kafka` - (Optional) A Kafka endpoint to send streaming logs to.
 Defined below.
+* `logging_heroku` - (Optional) A Heroku endpoint to send streaming logs to.
+Defined below.
 * `response_object` - (Optional) Allows you to create synthetic responses that exist entirely on the varnish machine. Useful for creating error or maintenance pages that exists outside the scope of your datacenter. Best when used with Condition objects.
 * `snippet` - (Optional) A set of custom, "regular" (non-dynamic) VCL Snippet configuration blocks.  Defined below.
 * `dynamicsnippet` - (Optional) A set of custom, "dynamic" VCL Snippet configuration blocks.  Defined below.
@@ -655,6 +657,16 @@ The `logging_kafka` block supports:
 * `format_version` - (Optional) The version of the custom logging format used for the configured endpoint. Can be either `1` or `2`. The logging call gets placed by default in `vcl_log` if `format_version` is set to `2` and in `vcl_deliver` if `format_version` is set to `1`. Default `2`.
 * `placement` - (Optional) The name of an existing condition in the configured endpoint, or leave blank to always execute.
 * `response_condition` - (Optional) The name of the `condition` to apply. If empty, always execute.
+
+The `logging_heroku` block supports:
+
+* `name` - (Required) The unique name of the Heroku logging endpoint.
+* `token` - (Required) The token to use for authentication (https://devcenter.heroku.com/articles/add-on-partner-log-integration).
+* `url` - (Required) The url to stream logs to.
+* `format` - (Optional) Apache-style string or VCL variables to use for log formatting.
+* `format_version` - (Optional) The version of the custom logging format used for the configured endpoint. Can be either `1` or `2`. (default: `2`).
+* `placement` - (Optional) Where in the generated VCL the logging call should be placed. Can be `none` or `waf_debug`.
+* `response_condition` - (Optional) The name of an existing condition in the configured endpoint, or leave blank to always execute.
 
 The `response_object` block supports:
 


### PR DESCRIPTION
## Proposed Change(s)

* Adds support for provisioning Heroku logging endpoints.
* Updates `fastly_service_v1` docs to reflect the change.

## Relevant Link(s) / Doc(s)

* [API Docs](https://developer.fastly.com/reference/api/logging/heroku/)
* [Relevant Fastly API Go client library file](https://github.com/fastly/go-fastly/blob/master/fastly/heroku.go)

## Validation

```bash
export FASTLY_API_KEY="foo"; export TF_ACC=1; make testacc TESTARGS='-run=[hH]eroku'
```