### PR TITLE
Adds Honeycomb logging support

### DIFF
--- a/fastly/block_fastly_service_v1_logging_honeycomb.go
+++ b/fastly/block_fastly_service_v1_logging_honeycomb.go
@@ -1,0 +1,220 @@
+package fastly
+
+import (
+	"fmt"
+	"log"
+
+	gofastly "github.com/fastly/go-fastly/fastly"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+type HoneycombServiceAttributeHandler struct {
+	*DefaultServiceAttributeHandler
+}
+
+func NewServiceLoggingHoneycomb() ServiceAttributeDefinition {
+	return &HoneycombServiceAttributeHandler{
+		&DefaultServiceAttributeHandler{
+			key: "logging_honeycomb",
+		},
+	}
+}
+
+func (h *HoneycombServiceAttributeHandler) Process(d *schema.ResourceData, latestVersion int, conn *gofastly.Client) error {
+	serviceID := d.Id()
+	ol, nl := d.GetChange(h.GetKey())
+
+	if ol == nil {
+		ol = new(schema.Set)
+	}
+	if nl == nil {
+		nl = new(schema.Set)
+	}
+
+	ols := ol.(*schema.Set)
+	nls := nl.(*schema.Set)
+
+	removeHoneycombLogging := ols.Difference(nls).List()
+	addHoneycombLogging := nls.Difference(ols).List()
+
+	// DELETE old Honeycomb logging endpoints.
+	for _, oRaw := range removeHoneycombLogging {
+		of := oRaw.(map[string]interface{})
+		opts := buildDeleteHoneycomb(of, serviceID, latestVersion)
+
+		log.Printf("[DEBUG] Fastly Honeycomb logging endpoint removal opts: %#v", opts)
+
+		if err := deleteHoneycomb(conn, opts); err != nil {
+			return err
+		}
+	}
+
+	// POST new/updated Honeycomb logging endpoints.
+	for _, nRaw := range addHoneycombLogging {
+		lf := nRaw.(map[string]interface{})
+		opts := buildCreateHoneycomb(lf, serviceID, latestVersion)
+
+		log.Printf("[DEBUG] Fastly Honeycomb logging addition opts: %#v", opts)
+
+		if err := createHoneycomb(conn, opts); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (h *HoneycombServiceAttributeHandler) Read(d *schema.ResourceData, s *gofastly.ServiceDetail, conn *gofastly.Client) error {
+	// Refresh Honeycomb.
+	log.Printf("[DEBUG] Refreshing Honeycomb logging endpoints for (%s)", d.Id())
+	honeycombList, err := conn.ListHoneycombs(&gofastly.ListHoneycombsInput{
+		Service: d.Id(),
+		Version: s.ActiveVersion.Number,
+	})
+
+	if err != nil {
+		return fmt.Errorf("[ERR] Error looking up Honeycomb logging endpoints for (%s), version (%v): %s", d.Id(), s.ActiveVersion.Number, err)
+	}
+
+	ell := flattenHoneycomb(honeycombList)
+
+	if err := d.Set(h.GetKey(), ell); err != nil {
+		log.Printf("[WARN] Error setting Honeycomb logging endpoints for (%s): %s", d.Id(), err)
+	}
+
+	return nil
+}
+
+func createHoneycomb(conn *gofastly.Client, i *gofastly.CreateHoneycombInput) error {
+	_, err := conn.CreateHoneycomb(i)
+	return err
+}
+
+func deleteHoneycomb(conn *gofastly.Client, i *gofastly.DeleteHoneycombInput) error {
+	err := conn.DeleteHoneycomb(i)
+
+	errRes, ok := err.(*gofastly.HTTPError)
+	if !ok {
+		return err
+	}
+
+	// 404 response codes don't result in an error propagating because a 404 could
+	// indicate that a resource was deleted elsewhere.
+	if !errRes.IsNotFound() {
+		return err
+	}
+
+	return nil
+}
+
+func flattenHoneycomb(honeycombList []*gofastly.Honeycomb) []map[string]interface{} {
+	var lsl []map[string]interface{}
+	for _, ll := range honeycombList {
+		// Convert Honeycomb logging to a map for saving to state.
+		nll := map[string]interface{}{
+			"name":               ll.Name,
+			"token":              ll.Token,
+			"dataset":            ll.Dataset,
+			"format":             ll.Format,
+			"format_version":     ll.FormatVersion,
+			"placement":          ll.Placement,
+			"response_condition": ll.ResponseCondition,
+		}
+
+		// Prune any empty values that come from the default string value in structs.
+		for k, v := range nll {
+			if v == "" {
+				delete(nll, k)
+			}
+		}
+
+		lsl = append(lsl, nll)
+	}
+
+	return lsl
+}
+
+func buildCreateHoneycomb(honeycombMap interface{}, serviceID string, serviceVersion int) *gofastly.CreateHoneycombInput {
+	df := honeycombMap.(map[string]interface{})
+
+	return &gofastly.CreateHoneycombInput{
+		Service:           serviceID,
+		Version:           serviceVersion,
+		Name:              gofastly.NullString(df["name"].(string)),
+		Token:             gofastly.NullString(df["token"].(string)),
+		Dataset:           gofastly.NullString(df["dataset"].(string)),
+		Format:            gofastly.NullString(df["format"].(string)),
+		FormatVersion:     gofastly.Uint(uint(df["format_version"].(int))),
+		Placement:         gofastly.NullString(df["placement"].(string)),
+		ResponseCondition: gofastly.NullString(df["response_condition"].(string)),
+	}
+}
+
+func buildDeleteHoneycomb(honeycombMap interface{}, serviceID string, serviceVersion int) *gofastly.DeleteHoneycombInput {
+	df := honeycombMap.(map[string]interface{})
+
+	return &gofastly.DeleteHoneycombInput{
+		Service: serviceID,
+		Version: serviceVersion,
+		Name:    df["name"].(string),
+	}
+}
+
+func (h *HoneycombServiceAttributeHandler) Register(s *schema.Resource) error {
+	s.Schema[h.GetKey()] = &schema.Schema{
+		Type:     schema.TypeSet,
+		Optional: true,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				// Required fields
+				"name": {
+					Type:        schema.TypeString,
+					Required:    true,
+					Description: "The unique name of the Honeycomb logging endpoint.",
+				},
+
+				"token": {
+					Type:        schema.TypeString,
+					Required:    true,
+					Sensitive:   true,
+					Description: "The Write Key from the Account page of your Honeycomb account.",
+				},
+
+				"dataset": {
+					Type:        schema.TypeString,
+					Required:    true,
+					Description: "The Honeycomb Dataset you want to log to.",
+				},
+
+				// Optional fields
+				"format": {
+					Type:        schema.TypeString,
+					Optional:    true,
+					Description: "Apache style log formatting. Your log must produce valid JSON that Honeycomb can ingest.",
+				},
+
+				"format_version": {
+					Type:         schema.TypeInt,
+					Optional:     true,
+					Default:      2,
+					Description:  "The version of the custom logging format used for the configured endpoint. Can be either `1` or `2`. (default: `2`).",
+					ValidateFunc: validateLoggingFormatVersion(),
+				},
+
+				"placement": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					Description:  "Where in the generated VCL the logging call should be placed. Can be `none` or `waf_debug`.",
+					ValidateFunc: validateLoggingPlacement(),
+				},
+
+				"response_condition": {
+					Type:        schema.TypeString,
+					Optional:    true,
+					Description: "The name of an existing condition in the configured endpoint, or leave blank to always execute.",
+				},
+			},
+		},
+	}
+	return nil
+}

--- a/fastly/block_fastly_service_v1_logging_honeycomb_test.go
+++ b/fastly/block_fastly_service_v1_logging_honeycomb_test.go
@@ -1,0 +1,270 @@
+package fastly
+
+import (
+	"fmt"
+	"log"
+	"testing"
+
+	gofastly "github.com/fastly/go-fastly/fastly"
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+var honeycombDefaultFormat = `{
+  "time":"%{begin:%Y-%m-%dT%H:%M:%SZ}t",
+  "data":  {
+    "service_id":"%{req.service_id}V",
+    "time_elapsed":%D,
+    "request":"%m",
+    "host":"%{Fastly-Orig-Host}i",
+    "url":"%{cstr_escape(req.url)}V",
+    "protocol":"%H",
+    "is_ipv6":%{if(req.is_ipv6, "true", "false")}V,
+    "is_tls":%{if(req.is_ssl, "true", "false")}V,
+    "is_h2":%{if(fastly_info.is_h2, "true", "false")}V,
+    "client_ip":"%h",
+    "geo_city":"%{client.geo.city.utf8}V",
+    "geo_country_code":"%{client.geo.country_code}V",
+    "server_datacenter":"%{server.datacenter}V",
+    "request_referer":"%{Referer}i",
+    "request_user_agent":"%{User-Agent}i",
+    "request_accept_content":"%{Accept}i",
+    "request_accept_language":"%{Accept-Language}i",
+    "request_accept_charset":"%{Accept-Charset}i",
+    "cache_status":"%{regsub(fastly_info.state, "^(HIT-(SYNTH)|(HITPASS|HIT|MISS|PASS|ERROR|PIPE)).*", "\\2\\3") }V",
+    "status":"%s",
+    "content_type":"%{Content-Type}o",
+    "req_header_size":%{req.header_bytes_read}V,
+    "req_body_size":%{req.body_bytes_read}V,
+    "resp_header_size":%{resp.header_bytes_written}V,
+    "resp_body_size":%{resp.body_bytes_written}V
+  }
+}`
+
+func TestResourceFastlyFlattenHoneycomb(t *testing.T) {
+	cases := []struct {
+		remote []*gofastly.Honeycomb
+		local  []map[string]interface{}
+	}{
+		{
+			remote: []*gofastly.Honeycomb{
+				{
+					Version:           1,
+					Name:              "honeycomb-endpoint",
+					Token:             "token",
+					Dataset:           "dataset",
+					Placement:         "none",
+					ResponseCondition: "always",
+					Format:            honeycombDefaultFormat,
+					FormatVersion:     2,
+				},
+			},
+			local: []map[string]interface{}{
+				{
+					"name":               "honeycomb-endpoint",
+					"token":              "token",
+					"dataset":            "dataset",
+					"placement":          "none",
+					"response_condition": "always",
+					"format":             honeycombDefaultFormat,
+					"format_version":     uint(2),
+				},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		out := flattenHoneycomb(c.remote)
+		if diff := cmp.Diff(out, c.local); diff != "" {
+			t.Fatalf("Error matching: %s", diff)
+		}
+	}
+}
+
+func TestAccFastlyServiceV1_logging_honeycomb_basic(t *testing.T) {
+	var service gofastly.ServiceDetail
+	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	domain := fmt.Sprintf("fastly-test.%s.com", name)
+
+	log1 := gofastly.Honeycomb{
+		Version:       1,
+		Name:          "honeycomb-endpoint",
+		Token:         "s3cr3t",
+		Dataset:       "dataset",
+		FormatVersion: 2,
+		Format:        appendNewLine(honeycombDefaultFormat),
+	}
+
+	log1_after_update := gofastly.Honeycomb{
+		Version:           1,
+		Name:              "honeycomb-endpoint",
+		Dataset:           "new-dataset",
+		Token:             "secret",
+		FormatVersion:     2,
+		Format:            appendNewLine(honeycombDefaultFormat),
+		Placement:         "none",
+		ResponseCondition: "response_condition_test",
+	}
+
+	log2 := gofastly.Honeycomb{
+		Version:           1,
+		Name:              "another-honeycomb-endpoint",
+		Token:             "another-token",
+		Dataset:           "another-dataset",
+		FormatVersion:     2,
+		Format:            appendNewLine(honeycombDefaultFormat),
+		Placement:         "none",
+		ResponseCondition: "response_condition_test",
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckServiceV1Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServiceV1HoneycombConfig(name, domain),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
+					testAccCheckFastlyServiceV1HoneycombAttributes(&service, []*gofastly.Honeycomb{&log1}),
+					resource.TestCheckResourceAttr(
+						"fastly_service_v1.foo", "name", name),
+					resource.TestCheckResourceAttr(
+						"fastly_service_v1.foo", "logging_honeycomb.#", "1"),
+				),
+			},
+
+			{
+				Config: testAccServiceV1HoneycombConfig_update(name, domain),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
+					testAccCheckFastlyServiceV1HoneycombAttributes(&service, []*gofastly.Honeycomb{&log1_after_update, &log2}),
+					resource.TestCheckResourceAttr(
+						"fastly_service_v1.foo", "name", name),
+					resource.TestCheckResourceAttr(
+						"fastly_service_v1.foo", "logging_honeycomb.#", "2"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckFastlyServiceV1HoneycombAttributes(service *gofastly.ServiceDetail, honeycomb []*gofastly.Honeycomb) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+
+		conn := testAccProvider.Meta().(*FastlyClient).conn
+		honeycombList, err := conn.ListHoneycombs(&gofastly.ListHoneycombsInput{
+			Service: service.ID,
+			Version: service.ActiveVersion.Number,
+		})
+
+		if err != nil {
+			return fmt.Errorf("[ERR] Error looking up Honeycomb Logging for (%s), version (%d): %s", service.Name, service.ActiveVersion.Number, err)
+		}
+
+		if len(honeycombList) != len(honeycomb) {
+			return fmt.Errorf("Honeycomb List count mismatch, expected (%d), got (%d)", len(honeycomb), len(honeycombList))
+		}
+
+		log.Printf("[DEBUG] honeycombList = %#v\n", honeycombList)
+
+		for _, e := range honeycomb {
+			for _, el := range honeycombList {
+				if e.Name == el.Name {
+					// we don't know these things ahead of time, so populate them now
+					e.ServiceID = service.ID
+					e.Version = service.ActiveVersion.Number
+					// We don't track these, so clear them out because we also wont know
+					// these ahead of time
+					el.CreatedAt = nil
+					el.UpdatedAt = nil
+					if diff := cmp.Diff(e, el); diff != "" {
+						return fmt.Errorf("Bad match Honeycomb logging match: %s", diff)
+					}
+				}
+			}
+		}
+
+		return nil
+	}
+}
+
+func testAccServiceV1HoneycombConfig(name string, domain string) string {
+	return fmt.Sprintf(`
+resource "fastly_service_v1" "foo" {
+  name = "%s"
+
+  domain {
+    name    = "%s"
+    comment = "tf-honeycomb-logging"
+  }
+
+  backend {
+    address = "aws.amazon.com"
+    name    = "amazon docs"
+  }
+
+  logging_honeycomb {
+    name   = "honeycomb-endpoint"
+    token  = "s3cr3t"
+		dataset = "dataset"
+    format = <<EOF
+`+escapePercentSign(honeycombDefaultFormat)+`
+EOF
+  }
+
+  force_destroy = true
+}
+`, name, domain)
+}
+
+func testAccServiceV1HoneycombConfig_update(name, domain string) string {
+	return fmt.Sprintf(`
+resource "fastly_service_v1" "foo" {
+  name = "%s"
+
+  domain {
+    name    = "%s"
+    comment = "tf-honeycomb-logging"
+  }
+
+  backend {
+    address = "aws.amazon.com"
+    name    = "amazon docs"
+  }
+
+  condition {
+    name      = "response_condition_test"
+    type      = "RESPONSE"
+    priority  = 8
+    statement = "resp.status == 418"
+  }
+
+  logging_honeycomb {
+    name   = "honeycomb-endpoint"
+    token  = "secret"
+		dataset = "new-dataset"
+    format = <<EOF
+`+escapePercentSign(honeycombDefaultFormat)+`
+EOF
+    response_condition = "response_condition_test"
+		placement = "none"
+  }
+
+  logging_honeycomb {
+    name   = "another-honeycomb-endpoint"
+    token  = "another-token"
+		dataset = "another-dataset"
+    format = <<EOF
+`+escapePercentSign(honeycombDefaultFormat)+`
+EOF
+    response_condition = "response_condition_test"
+		placement = "none"
+  }
+
+  force_destroy = true
+}
+`, name, domain)
+}

--- a/fastly/resource_fastly_service_v1.go
+++ b/fastly/resource_fastly_service_v1.go
@@ -38,6 +38,7 @@ var vclService = &BaseServiceDefinition{
 		NewServiceLoggingNewRelic(),
 		NewServiceLoggingKafka(),
 		NewServiceLoggingHeroku(),
+		NewServiceLoggingHoneycomb(),
 		NewServiceResponseObject(),
 		NewServiceRequestSetting(),
 		NewServiceVCL(),

--- a/website/docs/r/service_v1.html.markdown
+++ b/website/docs/r/service_v1.html.markdown
@@ -226,6 +226,8 @@ Defined below.
 Defined below.
 * `logging_heroku` - (Optional) A Heroku endpoint to send streaming logs to.
 Defined below.
+* `logging_honeycomb` - (Optional) A Honeycomb endpoint to send streaming logs to.
+Defined below.
 * `response_object` - (Optional) Allows you to create synthetic responses that exist entirely on the varnish machine. Useful for creating error or maintenance pages that exists outside the scope of your datacenter. Best when used with Condition objects.
 * `snippet` - (Optional) A set of custom, "regular" (non-dynamic) VCL Snippet configuration blocks.  Defined below.
 * `dynamicsnippet` - (Optional) A set of custom, "dynamic" VCL Snippet configuration blocks.  Defined below.
@@ -664,6 +666,16 @@ The `logging_heroku` block supports:
 * `token` - (Required) The token to use for authentication (https://devcenter.heroku.com/articles/add-on-partner-log-integration).
 * `url` - (Required) The url to stream logs to.
 * `format` - (Optional) Apache-style string or VCL variables to use for log formatting.
+* `format_version` - (Optional) The version of the custom logging format used for the configured endpoint. Can be either `1` or `2`. (default: `2`).
+* `placement` - (Optional) Where in the generated VCL the logging call should be placed. Can be `none` or `waf_debug`.
+* `response_condition` - (Optional) The name of an existing condition in the configured endpoint, or leave blank to always execute.
+
+The `logging_honeycomb` block supports:
+
+* `name` - (Required) The unique name of the Honeycomb logging endpoint.
+* `dataset` - (Required) The Honeycomb Dataset you want to log to.
+* `token` - (Required) The Write Key from the Account page of your Honeycomb account.
+* `format` - (Optional) Apache style log formatting. Your log must produce valid JSON that Honeycomb can ingest.
 * `format_version` - (Optional) The version of the custom logging format used for the configured endpoint. Can be either `1` or `2`. (default: `2`).
 * `placement` - (Optional) Where in the generated VCL the logging call should be placed. Can be `none` or `waf_debug`.
 * `response_condition` - (Optional) The name of an existing condition in the configured endpoint, or leave blank to always execute.


### PR DESCRIPTION
## Proposed Change(s)

* Adds support for provisioning Honeycomb logging endpoints.
* Updates `fastly_service_v1` docs to reflect the change.

## Relevant Link(s) / Doc(s)

* [API Docs](https://developer.fastly.com/reference/api/logging/honeycomb/)
* [Relevant Fastly API Go client library file](https://github.com/fastly/go-fastly/blob/master/fastly/honeycomb.go)

## Validation

```bash
export FASTLY_API_KEY="foo"; export TF_ACC=1; make testacc TESTARGS='-run=[hH]oneycomb'
```