### PR TITLE
Adds Log Shuttle logging support

### DIFF
--- a/fastly/block_fastly_service_v1_logging_logshuttle.go
+++ b/fastly/block_fastly_service_v1_logging_logshuttle.go
@@ -1,0 +1,220 @@
+package fastly
+
+import (
+	"fmt"
+	"log"
+
+	gofastly "github.com/fastly/go-fastly/fastly"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+type LogshuttleServiceAttributeHandler struct {
+	*DefaultServiceAttributeHandler
+}
+
+func NewServiceLoggingLogshuttle() ServiceAttributeDefinition {
+	return &LogshuttleServiceAttributeHandler{
+		&DefaultServiceAttributeHandler{
+			key: "logging_logshuttle",
+		},
+	}
+}
+
+func (h *LogshuttleServiceAttributeHandler) Process(d *schema.ResourceData, latestVersion int, conn *gofastly.Client) error {
+	serviceID := d.Id()
+	ol, nl := d.GetChange(h.GetKey())
+
+	if ol == nil {
+		ol = new(schema.Set)
+	}
+	if nl == nil {
+		nl = new(schema.Set)
+	}
+
+	ols := ol.(*schema.Set)
+	nls := nl.(*schema.Set)
+
+	removeLogshuttleLogging := ols.Difference(nls).List()
+	addLogshuttleLogging := nls.Difference(ols).List()
+
+	// DELETE old Log Shuttle logging endpoints.
+	for _, oRaw := range removeLogshuttleLogging {
+		of := oRaw.(map[string]interface{})
+		opts := buildDeleteLogshuttle(of, serviceID, latestVersion)
+
+		log.Printf("[DEBUG] Fastly Log Shuttle logging endpoint removal opts: %#v", opts)
+
+		if err := deleteLogshuttle(conn, opts); err != nil {
+			return err
+		}
+	}
+
+	// POST new/updated Log Shuttle logging endpoints.
+	for _, nRaw := range addLogshuttleLogging {
+		lf := nRaw.(map[string]interface{})
+		opts := buildCreateLogshuttle(lf, serviceID, latestVersion)
+
+		log.Printf("[DEBUG] Fastly Log Shuttle logging addition opts: %#v", opts)
+
+		if err := createLogshuttle(conn, opts); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (h *LogshuttleServiceAttributeHandler) Read(d *schema.ResourceData, s *gofastly.ServiceDetail, conn *gofastly.Client) error {
+	// Refresh Log Shuttle.
+	log.Printf("[DEBUG] Refreshing Log Shuttle logging endpoints for (%s)", d.Id())
+	logshuttleList, err := conn.ListLogshuttles(&gofastly.ListLogshuttlesInput{
+		Service: d.Id(),
+		Version: s.ActiveVersion.Number,
+	})
+
+	if err != nil {
+		return fmt.Errorf("[ERR] Error looking up Log Shuttle logging endpoints for (%s), version (%v): %s", d.Id(), s.ActiveVersion.Number, err)
+	}
+
+	ell := flattenLogshuttle(logshuttleList)
+
+	if err := d.Set(h.GetKey(), ell); err != nil {
+		log.Printf("[WARN] Error setting Log Shuttle logging endpoints for (%s): %s", d.Id(), err)
+	}
+
+	return nil
+}
+
+func createLogshuttle(conn *gofastly.Client, i *gofastly.CreateLogshuttleInput) error {
+	_, err := conn.CreateLogshuttle(i)
+	return err
+}
+
+func deleteLogshuttle(conn *gofastly.Client, i *gofastly.DeleteLogshuttleInput) error {
+	err := conn.DeleteLogshuttle(i)
+
+	errRes, ok := err.(*gofastly.HTTPError)
+	if !ok {
+		return err
+	}
+
+	// 404 response codes don't result in an error propagating because a 404 could
+	// indicate that a resource was deleted elsewhere.
+	if !errRes.IsNotFound() {
+		return err
+	}
+
+	return nil
+}
+
+func flattenLogshuttle(logshuttleList []*gofastly.Logshuttle) []map[string]interface{} {
+	var lsl []map[string]interface{}
+	for _, ll := range logshuttleList {
+		// Convert Log Shuttle logging to a map for saving to state.
+		nll := map[string]interface{}{
+			"name":               ll.Name,
+			"token":              ll.Token,
+			"url":                ll.URL,
+			"format":             ll.Format,
+			"format_version":     ll.FormatVersion,
+			"placement":          ll.Placement,
+			"response_condition": ll.ResponseCondition,
+		}
+
+		// Prune any empty values that come from the default string value in structs.
+		for k, v := range nll {
+			if v == "" {
+				delete(nll, k)
+			}
+		}
+
+		lsl = append(lsl, nll)
+	}
+
+	return lsl
+}
+
+func buildCreateLogshuttle(logshuttleMap interface{}, serviceID string, serviceVersion int) *gofastly.CreateLogshuttleInput {
+	df := logshuttleMap.(map[string]interface{})
+
+	return &gofastly.CreateLogshuttleInput{
+		Service:           serviceID,
+		Version:           serviceVersion,
+		Name:              gofastly.NullString(df["name"].(string)),
+		Token:             gofastly.NullString(df["token"].(string)),
+		URL:               gofastly.NullString(df["url"].(string)),
+		Format:            gofastly.NullString(df["format"].(string)),
+		FormatVersion:     gofastly.Uint(uint(df["format_version"].(int))),
+		Placement:         gofastly.NullString(df["placement"].(string)),
+		ResponseCondition: gofastly.NullString(df["response_condition"].(string)),
+	}
+}
+
+func buildDeleteLogshuttle(logshuttleMap interface{}, serviceID string, serviceVersion int) *gofastly.DeleteLogshuttleInput {
+	df := logshuttleMap.(map[string]interface{})
+
+	return &gofastly.DeleteLogshuttleInput{
+		Service: serviceID,
+		Version: serviceVersion,
+		Name:    df["name"].(string),
+	}
+}
+
+func (h *LogshuttleServiceAttributeHandler) Register(s *schema.Resource) error {
+	s.Schema[h.GetKey()] = &schema.Schema{
+		Type:     schema.TypeSet,
+		Optional: true,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				// Required fields
+				"name": {
+					Type:        schema.TypeString,
+					Required:    true,
+					Description: "The unique name of the Log Shuttle logging endpoint.",
+				},
+
+				"token": {
+					Type:        schema.TypeString,
+					Required:    true,
+					Sensitive:   true,
+					Description: "The data authentication token associated with this endpoint.",
+				},
+
+				"url": {
+					Type:        schema.TypeString,
+					Required:    true,
+					Description: "Your Log Shuttle endpoint url.",
+				},
+
+				// Optional fields
+				"format": {
+					Type:        schema.TypeString,
+					Optional:    true,
+					Description: "Apache style log formatting.",
+				},
+
+				"format_version": {
+					Type:         schema.TypeInt,
+					Optional:     true,
+					Default:      2,
+					Description:  "The version of the custom logging format used for the configured endpoint. Can be either `1` or `2`. (default: `2`).",
+					ValidateFunc: validateLoggingFormatVersion(),
+				},
+
+				"placement": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					Description:  "Where in the generated VCL the logging call should be placed. Can be `none` or `waf_debug`.",
+					ValidateFunc: validateLoggingPlacement(),
+				},
+
+				"response_condition": {
+					Type:        schema.TypeString,
+					Optional:    true,
+					Description: "The name of an existing condition in the configured endpoint, or leave blank to always execute.",
+				},
+			},
+		},
+	}
+	return nil
+}

--- a/fastly/block_fastly_service_v1_logging_logshuttle_test.go
+++ b/fastly/block_fastly_service_v1_logging_logshuttle_test.go
@@ -1,0 +1,229 @@
+package fastly
+
+import (
+	"fmt"
+	"log"
+	"testing"
+
+	gofastly "github.com/fastly/go-fastly/fastly"
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestResourceFastlyFlattenLogshuttle(t *testing.T) {
+	cases := []struct {
+		remote []*gofastly.Logshuttle
+		local  []map[string]interface{}
+	}{
+		{
+			remote: []*gofastly.Logshuttle{
+				{
+					Version:           1,
+					Name:              "logshuttle-endpoint",
+					Token:             "token",
+					URL:               "https://example.com",
+					Format:            "%h %l %u %t \"%r\" %>s %b %T",
+					Placement:         "none",
+					ResponseCondition: "always",
+					FormatVersion:     2,
+				},
+			},
+			local: []map[string]interface{}{
+				{
+					"name":               "logshuttle-endpoint",
+					"token":              "token",
+					"url":                "https://example.com",
+					"format":             "%h %l %u %t \"%r\" %>s %b %T",
+					"placement":          "none",
+					"response_condition": "always",
+					"format_version":     uint(2),
+				},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		out := flattenLogshuttle(c.remote)
+		if diff := cmp.Diff(out, c.local); diff != "" {
+			t.Fatalf("Error matching: %s", diff)
+		}
+	}
+}
+
+func TestAccFastlyServiceV1_logging_logshuttle_basic(t *testing.T) {
+	var service gofastly.ServiceDetail
+	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	domain := fmt.Sprintf("fastly-test.%s.com", name)
+
+	log1 := gofastly.Logshuttle{
+		Version:       1,
+		Name:          "logshuttle-endpoint",
+		Token:         "s3cr3t",
+		URL:           "https://example.com",
+		FormatVersion: 2,
+		Format:        "%h %l %u %t \"%r\" %>s %b",
+	}
+
+	log1_after_update := gofastly.Logshuttle{
+		Version:       1,
+		Name:          "logshuttle-endpoint",
+		Token:         "secret",
+		URL:           "https://new.example.com",
+		FormatVersion: 2,
+		Format:        "%h %l %u %t \"%r\" %>s %b %T",
+	}
+
+	log2 := gofastly.Logshuttle{
+		Version:           1,
+		Name:              "another-logshuttle-endpoint",
+		Token:             "another-token",
+		URL:               "https://another.example.com",
+		Placement:         "none",
+		ResponseCondition: "response_condition_test",
+		FormatVersion:     2,
+		Format:            "%h %l %u %t \"%r\" %>s %b",
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckServiceV1Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServiceV1LogshuttleConfig(name, domain),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
+					testAccCheckFastlyServiceV1LogshuttleAttributes(&service, []*gofastly.Logshuttle{&log1}),
+					resource.TestCheckResourceAttr(
+						"fastly_service_v1.foo", "name", name),
+					resource.TestCheckResourceAttr(
+						"fastly_service_v1.foo", "logging_logshuttle.#", "1"),
+				),
+			},
+
+			{
+				Config: testAccServiceV1LogshuttleConfig_update(name, domain),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
+					testAccCheckFastlyServiceV1LogshuttleAttributes(&service, []*gofastly.Logshuttle{&log1_after_update, &log2}),
+					resource.TestCheckResourceAttr(
+						"fastly_service_v1.foo", "name", name),
+					resource.TestCheckResourceAttr(
+						"fastly_service_v1.foo", "logging_logshuttle.#", "2"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckFastlyServiceV1LogshuttleAttributes(service *gofastly.ServiceDetail, logshuttle []*gofastly.Logshuttle) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+
+		conn := testAccProvider.Meta().(*FastlyClient).conn
+		logshuttleList, err := conn.ListLogshuttles(&gofastly.ListLogshuttlesInput{
+			Service: service.ID,
+			Version: service.ActiveVersion.Number,
+		})
+
+		if err != nil {
+			return fmt.Errorf("[ERR] Error looking up Log Shuttle Logging for (%s), version (%d): %s", service.Name, service.ActiveVersion.Number, err)
+		}
+
+		if len(logshuttleList) != len(logshuttle) {
+			return fmt.Errorf("Log Shuttle List count mismatch, expected (%d), got (%d)", len(logshuttle), len(logshuttleList))
+		}
+
+		log.Printf("[DEBUG] logshuttleList = %#v\n", logshuttleList)
+
+		for _, e := range logshuttle {
+			for _, el := range logshuttleList {
+				if e.Name == el.Name {
+					// we don't know these things ahead of time, so populate them now
+					e.ServiceID = service.ID
+					e.Version = service.ActiveVersion.Number
+					// We don't track these, so clear them out because we also wont know
+					// these ahead of time
+					el.CreatedAt = nil
+					el.UpdatedAt = nil
+					if diff := cmp.Diff(e, el); diff != "" {
+						return fmt.Errorf("Bad match Log Shuttle logging match: %s", diff)
+					}
+				}
+			}
+		}
+
+		return nil
+	}
+}
+
+func testAccServiceV1LogshuttleConfig(name string, domain string) string {
+	return fmt.Sprintf(`
+resource "fastly_service_v1" "foo" {
+  name = "%s"
+
+  domain {
+    name    = "%s"
+    comment = "tf-logshuttle-logging"
+  }
+
+  backend {
+    address = "aws.amazon.com"
+    name    = "amazon docs"
+  }
+
+  logging_logshuttle {
+    name   = "logshuttle-endpoint"
+    token  = "s3cr3t"
+		url    = "https://example.com"
+    format = "%%h %%l %%u %%t \"%%r\" %%>s %%b"
+  }
+
+  force_destroy = true
+}
+`, name, domain)
+}
+
+func testAccServiceV1LogshuttleConfig_update(name, domain string) string {
+	return fmt.Sprintf(`
+resource "fastly_service_v1" "foo" {
+  name = "%s"
+
+  domain {
+    name    = "%s"
+    comment = "tf-logshuttle-logging"
+  }
+
+  backend {
+    address = "aws.amazon.com"
+    name    = "amazon docs"
+  }
+
+  condition {
+    name      = "response_condition_test"
+    type      = "RESPONSE"
+    priority  = 8
+    statement = "resp.status == 418"
+  }
+
+  logging_logshuttle {
+    name   = "logshuttle-endpoint"
+    token  = "secret"
+    url    = "https://new.example.com"
+    format = "%%h %%l %%u %%t \"%%r\" %%>s %%b %%T"
+  }
+
+  logging_logshuttle {
+    name   = "another-logshuttle-endpoint"
+    token  = "another-token"
+		url    = "https://another.example.com"
+    placement = "none" 
+		response_condition = "response_condition_test"
+    format = "%%h %%l %%u %%t \"%%r\" %%>s %%b"
+  }
+
+  force_destroy = true
+}
+`, name, domain)
+}

--- a/fastly/resource_fastly_service_v1.go
+++ b/fastly/resource_fastly_service_v1.go
@@ -39,6 +39,7 @@ var vclService = &BaseServiceDefinition{
 		NewServiceLoggingKafka(),
 		NewServiceLoggingHeroku(),
 		NewServiceLoggingHoneycomb(),
+		NewServiceLoggingLogshuttle(),
 		NewServiceResponseObject(),
 		NewServiceRequestSetting(),
 		NewServiceVCL(),

--- a/website/docs/r/service_v1.html.markdown
+++ b/website/docs/r/service_v1.html.markdown
@@ -228,6 +228,8 @@ Defined below.
 Defined below.
 * `logging_honeycomb` - (Optional) A Honeycomb endpoint to send streaming logs to.
 Defined below.
+* `logging_logshuttle` - (Optional) A Log Shuttle endpoint to send streaming logs to.
+Defined below.
 * `response_object` - (Optional) Allows you to create synthetic responses that exist entirely on the varnish machine. Useful for creating error or maintenance pages that exists outside the scope of your datacenter. Best when used with Condition objects.
 * `snippet` - (Optional) A set of custom, "regular" (non-dynamic) VCL Snippet configuration blocks.  Defined below.
 * `dynamicsnippet` - (Optional) A set of custom, "dynamic" VCL Snippet configuration blocks.  Defined below.
@@ -676,6 +678,16 @@ The `logging_honeycomb` block supports:
 * `dataset` - (Required) The Honeycomb Dataset you want to log to.
 * `token` - (Required) The Write Key from the Account page of your Honeycomb account.
 * `format` - (Optional) Apache style log formatting. Your log must produce valid JSON that Honeycomb can ingest.
+* `format_version` - (Optional) The version of the custom logging format used for the configured endpoint. Can be either `1` or `2`. (default: `2`).
+* `placement` - (Optional) Where in the generated VCL the logging call should be placed. Can be `none` or `waf_debug`.
+* `response_condition` - (Optional) The name of an existing condition in the configured endpoint, or leave blank to always execute.
+
+The `logging_logshuttle` block supports:
+
+* `name` - (Required) The unique name of the Logshuttle logging endpoint.
+* `token` - (Required) The data authentication token associated with this endpoint.
+* `url` - (Required) Your Log Shuttle endpoint url.
+* `format` - (Optional) Apache style log formatting.
 * `format_version` - (Optional) The version of the custom logging format used for the configured endpoint. Can be either `1` or `2`. (default: `2`).
 * `placement` - (Optional) Where in the generated VCL the logging call should be placed. Can be `none` or `waf_debug`.
 * `response_condition` - (Optional) The name of an existing condition in the configured endpoint, or leave blank to always execute.


### PR DESCRIPTION
## Proposed Change(s)

* Adds support for provisioning Log Shuttle logging endpoints.
* Updates `fastly_service_v1` docs to reflect the change.

## Relevant Link(s) / Doc(s)

* [API Docs](https://developer.fastly.com/reference/api/logging/logshuttle/)
* [Relevant Fastly API Go client library file](https://github.com/fastly/go-fastly/blob/master/fastly/logshuttle.go)

## Validation

```bash
export FASTLY_API_KEY="foo"; export TF_ACC=1; make testacc TESTARGS='-run=[lL]ogshuttle'
```