### PR TITLE
Adds Rackspace Cloud Files logging support

### DIFF
--- a/fastly/block_fastly_service_v1_logging_cloudfiles.go
+++ b/fastly/block_fastly_service_v1_logging_cloudfiles.go
@@ -1,0 +1,305 @@
+package fastly
+
+import (
+	"fmt"
+	"log"
+
+	gofastly "github.com/fastly/go-fastly/fastly"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+type CloudfilesServiceAttributeHandler struct {
+	*DefaultServiceAttributeHandler
+}
+
+func NewServiceLoggingCloudfiles() ServiceAttributeDefinition {
+	return &CloudfilesServiceAttributeHandler{
+		&DefaultServiceAttributeHandler{
+			key: "logging_cloudfiles",
+		},
+	}
+}
+
+func (h *CloudfilesServiceAttributeHandler) Process(d *schema.ResourceData, latestVersion int, conn *gofastly.Client) error {
+	serviceID := d.Id()
+	ol, nl := d.GetChange(h.GetKey())
+
+	if ol == nil {
+		ol = new(schema.Set)
+	}
+	if nl == nil {
+		nl = new(schema.Set)
+	}
+
+	ols := ol.(*schema.Set)
+	nls := nl.(*schema.Set)
+
+	removeCloudfilesLogging := ols.Difference(nls).List()
+	addCloudfilesLogging := nls.Difference(ols).List()
+
+	// DELETE old Cloud Files logging endpoints.
+	for _, oRaw := range removeCloudfilesLogging {
+		of := oRaw.(map[string]interface{})
+		opts := buildDeleteCloudfiles(of, serviceID, latestVersion)
+
+		log.Printf("[DEBUG] Fastly Cloud Files logging endpoint removal opts: %#v", opts)
+
+		if err := deleteCloudfiles(conn, opts); err != nil {
+			return err
+		}
+	}
+
+	// POST new/updated Cloud Files logging endpoints.
+	for _, nRaw := range addCloudfilesLogging {
+		lf := nRaw.(map[string]interface{})
+
+		// @HACK for a TF SDK Issue.
+		//
+		// This ensures that the required, `name`, field is present.
+		//
+		// If we have made it this far and `name` is not present, it is most-likely due
+		// to a defunct diff as noted here - https://github.com/hashicorp/terraform-plugin-sdk/issues/160#issuecomment-522935697.
+		//
+		// This is caused by using a StateFunc in a nested TypeSet. While the StateFunc
+		// properly handles setting state with the StateFunc, it returns extra entries
+		// during state Gets, specifically `GetChange("logging_cloudfiles")` in this case.
+		if v, ok := lf["name"]; !ok || v.(string) == "" {
+			continue
+		}
+		opts := buildCreateCloudfiles(lf, serviceID, latestVersion)
+
+		log.Printf("[DEBUG] Fastly Cloud Files logging addition opts: %#v", opts)
+
+		if err := createCloudfiles(conn, opts); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (h *CloudfilesServiceAttributeHandler) Read(d *schema.ResourceData, s *gofastly.ServiceDetail, conn *gofastly.Client) error {
+	// Refresh Cloud Files.
+	log.Printf("[DEBUG] Refreshing Cloud Files logging endpoints for (%s)", d.Id())
+	cloudfilesList, err := conn.ListCloudfiles(&gofastly.ListCloudfilesInput{
+		Service: d.Id(),
+		Version: s.ActiveVersion.Number,
+	})
+
+	if err != nil {
+		return fmt.Errorf("[ERR] Error looking up Cloud Files logging endpoints for (%s), version (%v): %s", d.Id(), s.ActiveVersion.Number, err)
+	}
+
+	ell := flattenCloudfiles(cloudfilesList)
+
+	if err := d.Set(h.GetKey(), ell); err != nil {
+		log.Printf("[WARN] Error setting Cloud Files logging endpoints for (%s): %s", d.Id(), err)
+	}
+
+	return nil
+}
+
+func createCloudfiles(conn *gofastly.Client, i *gofastly.CreateCloudfilesInput) error {
+	_, err := conn.CreateCloudfiles(i)
+	return err
+}
+
+func deleteCloudfiles(conn *gofastly.Client, i *gofastly.DeleteCloudfilesInput) error {
+	err := conn.DeleteCloudfiles(i)
+
+	errRes, ok := err.(*gofastly.HTTPError)
+	if !ok {
+		return err
+	}
+
+	// 404 response codes don't result in an error propagating because a 404 could
+	// indicate that a resource was deleted elsewhere.
+	if !errRes.IsNotFound() {
+		return err
+	}
+
+	return nil
+}
+
+func flattenCloudfiles(cloudfilesList []*gofastly.Cloudfiles) []map[string]interface{} {
+	var lsl []map[string]interface{}
+	for _, ll := range cloudfilesList {
+		// Convert Cloud Files logging to a map for saving to state.
+		nll := map[string]interface{}{
+			"name":               ll.Name,
+			"bucket_name":        ll.BucketName,
+			"user":               ll.User,
+			"access_key":         ll.AccessKey,
+			"public_key":         ll.PublicKey,
+			"gzip_level":         ll.GzipLevel,
+			"message_type":       ll.MessageType,
+			"path":               ll.Path,
+			"region":             ll.Region,
+			"period":             ll.Period,
+			"timestamp_format":   ll.TimestampFormat,
+			"format":             ll.Format,
+			"format_version":     ll.FormatVersion,
+			"placement":          ll.Placement,
+			"response_condition": ll.ResponseCondition,
+		}
+
+		// Prune any empty values that come from the default string value in structs.
+		for k, v := range nll {
+			if v == "" {
+				delete(nll, k)
+			}
+		}
+
+		lsl = append(lsl, nll)
+	}
+
+	return lsl
+}
+
+func buildCreateCloudfiles(cloudfilesMap interface{}, serviceID string, serviceVersion int) *gofastly.CreateCloudfilesInput {
+	df := cloudfilesMap.(map[string]interface{})
+
+	return &gofastly.CreateCloudfilesInput{
+		Service:           serviceID,
+		Version:           serviceVersion,
+		Name:              gofastly.NullString(df["name"].(string)),
+		BucketName:        gofastly.NullString(df["bucket_name"].(string)),
+		User:              gofastly.NullString(df["user"].(string)),
+		AccessKey:         gofastly.NullString(df["access_key"].(string)),
+		PublicKey:         gofastly.NullString(df["public_key"].(string)),
+		GzipLevel:         gofastly.Uint(uint(df["gzip_level"].(int))),
+		MessageType:       gofastly.NullString(df["message_type"].(string)),
+		Path:              gofastly.NullString(df["path"].(string)),
+		Region:            gofastly.NullString(df["region"].(string)),
+		Period:            gofastly.Uint(uint(df["period"].(int))),
+		TimestampFormat:   gofastly.NullString(df["timestamp_format"].(string)),
+		Format:            gofastly.NullString(df["format"].(string)),
+		FormatVersion:     gofastly.Uint(uint(df["format_version"].(int))),
+		Placement:         gofastly.NullString(df["placement"].(string)),
+		ResponseCondition: gofastly.NullString(df["response_condition"].(string)),
+	}
+}
+
+func buildDeleteCloudfiles(cloudfilesMap interface{}, serviceID string, serviceVersion int) *gofastly.DeleteCloudfilesInput {
+	df := cloudfilesMap.(map[string]interface{})
+
+	return &gofastly.DeleteCloudfilesInput{
+		Service: serviceID,
+		Version: serviceVersion,
+		Name:    df["name"].(string),
+	}
+}
+
+func (h *CloudfilesServiceAttributeHandler) Register(s *schema.Resource) error {
+	s.Schema[h.GetKey()] = &schema.Schema{
+		Type:     schema.TypeSet,
+		Optional: true,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				// Required fields
+				"name": {
+					Type:        schema.TypeString,
+					Required:    true,
+					Description: "The unique name of the Cloud Files logging endpoint.",
+				},
+
+				"bucket_name": {
+					Type:        schema.TypeString,
+					Required:    true,
+					Description: "The name of your Cloud Files container.",
+				},
+
+				"user": {
+					Type:        schema.TypeString,
+					Required:    true,
+					Description: "The username for your Cloudfile account.",
+				},
+
+				"access_key": {
+					Type:        schema.TypeString,
+					Required:    true,
+					Sensitive:   true,
+					Description: "Your Cloudfile account access key.",
+				},
+
+				// Optional fields
+				"public_key": {
+					Type:        schema.TypeString,
+					Optional:    true,
+					Description: "The PGP public key that Fastly will use to encrypt your log files before writing them to disk.",
+					// Related issue for weird behavior - https://github.com/hashicorp/terraform-plugin-sdk/issues/160
+					StateFunc: trimSpaceStateFunc,
+				},
+
+				"gzip_level": {
+					Type:        schema.TypeInt,
+					Optional:    true,
+					Default:     0,
+					Description: "What level of GZIP encoding to have when dumping logs (default 0, no compression).",
+				},
+
+				"message_type": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					Default:      "classic",
+					Description:  "How the message should be formatted. One of: classic (default), loggly, logplex or blank.",
+					ValidateFunc: validateLoggingMessageType(),
+				},
+
+				"path": {
+					Type:        schema.TypeString,
+					Optional:    true,
+					Description: "The path to upload logs to.",
+				},
+
+				"region": {
+					Type:     schema.TypeString,
+					Optional: true,
+					Description: "The region to stream logs to. One of: DFW	(Dallas), ORD (Chicago), IAD (Northern Virginia), LON (London), SYD (Sydney), HKG (Hong Kong).",
+				},
+
+				"period": {
+					Type:        schema.TypeInt,
+					Optional:    true,
+					Default:     3600,
+					Description: "How frequently log files are finalized so they can be available for reading (in seconds, default 3600).",
+				},
+
+				"timestamp_format": {
+					Type:        schema.TypeString,
+					Optional:    true,
+					Default:     "%Y-%m-%dT%H:%M:%S.000",
+					Description: "The specified format of the log's timestamp (default `%Y-%m-%dT%H:%M:%S.000`).",
+				},
+
+				"format": {
+					Type:        schema.TypeString,
+					Optional:    true,
+					Description: "Apache style log formatting.",
+				},
+
+				"format_version": {
+					Type:         schema.TypeInt,
+					Optional:     true,
+					Default:      2,
+					Description:  "The version of the custom logging format used for the configured endpoint. Can be either `1` or `2`. (default: `2`).",
+					ValidateFunc: validateLoggingFormatVersion(),
+				},
+
+				"placement": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					Description:  "Where in the generated VCL the logging call should be placed. Can be `none` or `waf_debug`.",
+					ValidateFunc: validateLoggingPlacement(),
+				},
+
+				"response_condition": {
+					Type:        schema.TypeString,
+					Optional:    true,
+					Description: "The name of an existing condition in the configured endpoint, or leave blank to always execute.",
+				},
+			},
+		},
+	}
+	return nil
+}

--- a/fastly/block_fastly_service_v1_logging_cloudfiles_test.go
+++ b/fastly/block_fastly_service_v1_logging_cloudfiles_test.go
@@ -1,0 +1,311 @@
+package fastly
+
+import (
+	"fmt"
+	"log"
+	"testing"
+
+	gofastly "github.com/fastly/go-fastly/fastly"
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestResourceFastlyFlattenCloudfiles(t *testing.T) {
+	cases := []struct {
+		remote []*gofastly.Cloudfiles
+		local  []map[string]interface{}
+	}{
+		{
+			remote: []*gofastly.Cloudfiles{
+				{
+					Version:           1,
+					Name:              "cloudfiles-endpoint",
+					BucketName:        "bucket",
+					User:              "user",
+					AccessKey:         "secret",
+					PublicKey:         pgpPublicKey(t),
+					Format:            "%h %l %u %t \"%r\" %>s %b",
+					FormatVersion:     2,
+					GzipLevel:         0,
+					MessageType:       "classic",
+					Path:              "/",
+					Region:            "ORD",
+					Period:            3600,
+					Placement:         "none",
+					ResponseCondition: "response_condition",
+					TimestampFormat:   "%Y-%m-%dT%H:%M:%S.000",
+				},
+			},
+			local: []map[string]interface{}{
+				{
+					"name":               "cloudfiles-endpoint",
+					"bucket_name":        "bucket",
+					"user":               "user",
+					"access_key":         "secret",
+					"public_key":         pgpPublicKey(t),
+					"format":             "%h %l %u %t \"%r\" %>s %b",
+					"format_version":     uint(2),
+					"gzip_level":         uint(0),
+					"message_type":       "classic",
+					"path":               "/",
+					"region":             "ORD",
+					"period":             uint(3600),
+					"placement":          "none",
+					"response_condition": "response_condition",
+					"timestamp_format":   "%Y-%m-%dT%H:%M:%S.000",
+				},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		out := flattenCloudfiles(c.remote)
+		if diff := cmp.Diff(out, c.local); diff != "" {
+			t.Fatalf("Error matching: %s", diff)
+		}
+	}
+}
+
+func TestAccFastlyServiceV1_logging_cloudfiles_basic(t *testing.T) {
+	var service gofastly.ServiceDetail
+	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	domain := fmt.Sprintf("fastly-test.%s.com", name)
+
+	log1 := gofastly.Cloudfiles{
+		Version:           1,
+		Name:              "cloudfiles-endpoint",
+		BucketName:        "bucket",
+		User:              "user",
+		AccessKey:         "secret",
+		PublicKey:         pgpPublicKey(t),
+		Format:            "%h %l %u %t \"%r\" %>s %b",
+		FormatVersion:     2,
+		GzipLevel:         0,
+		MessageType:       "classic",
+		Path:              "/",
+		Region:            "ORD",
+		Period:            3600,
+		Placement:         "none",
+		ResponseCondition: "response_condition_test",
+		TimestampFormat:   "%Y-%m-%dT%H:%M:%S.000",
+	}
+
+	log1_after_update := gofastly.Cloudfiles{
+		Version:           1,
+		Name:              "cloudfiles-endpoint",
+		BucketName:        "bucketupdate",
+		User:              "userupdate",
+		AccessKey:         "secretupdate",
+		PublicKey:         pgpPublicKey(t),
+		Format:            "%h %l %u %t \"%r\" %>s %b %T",
+		FormatVersion:     2,
+		GzipLevel:         1,
+		MessageType:       "blank",
+		Path:              "new/",
+		Region:            "LON",
+		Period:            3601,
+		Placement:         "none",
+		ResponseCondition: "response_condition_test",
+		TimestampFormat:   "%Y-%m-%dT%H:%M:%S.000",
+	}
+
+	log2 := gofastly.Cloudfiles{
+		Version:           1,
+		Name:              "another-cloudfiles-endpoint",
+		BucketName:        "bucket2",
+		User:              "user2",
+		AccessKey:         "secret2",
+		PublicKey:         pgpPublicKey(t),
+		Format:            "%h %l %u %t \"%r\" %>s %b",
+		FormatVersion:     2,
+		GzipLevel:         0,
+		MessageType:       "classic",
+		Path:              "two/",
+		Region:            "SYD",
+		Period:            3600,
+		Placement:         "none",
+		ResponseCondition: "response_condition_test",
+		TimestampFormat:   "%Y-%m-%dT%H:%M:%S.000",
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckServiceV1Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServiceV1CloudfilesConfig(name, domain),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceV1Exists("fastly_service_v1.none", &service),
+					testAccCheckFastlyServiceV1CloudfilesAttributes(&service, []*gofastly.Cloudfiles{&log1}),
+					resource.TestCheckResourceAttr(
+						"fastly_service_v1.none", "name", name),
+					resource.TestCheckResourceAttr(
+						"fastly_service_v1.none", "logging_cloudfiles.#", "1"),
+				),
+			},
+
+			{
+				Config: testAccServiceV1CloudfilesConfig_update(name, domain),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceV1Exists("fastly_service_v1.none", &service),
+					testAccCheckFastlyServiceV1CloudfilesAttributes(&service, []*gofastly.Cloudfiles{&log1_after_update, &log2}),
+					resource.TestCheckResourceAttr(
+						"fastly_service_v1.none", "name", name),
+					resource.TestCheckResourceAttr(
+						"fastly_service_v1.none", "logging_cloudfiles.#", "2"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckFastlyServiceV1CloudfilesAttributes(service *gofastly.ServiceDetail, cloudfiles []*gofastly.Cloudfiles) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+
+		conn := testAccProvider.Meta().(*FastlyClient).conn
+		cloudfilesList, err := conn.ListCloudfiles(&gofastly.ListCloudfilesInput{
+			Service: service.ID,
+			Version: service.ActiveVersion.Number,
+		})
+
+		if err != nil {
+			return fmt.Errorf("[ERR] Error looking up Cloud Files Logging for (%s), version (%d): %s", service.Name, service.ActiveVersion.Number, err)
+		}
+
+		if len(cloudfilesList) != len(cloudfiles) {
+			return fmt.Errorf("Cloud Files List count mismatch, expected (%d), got (%d)", len(cloudfiles), len(cloudfilesList))
+		}
+
+		log.Printf("[DEBUG] cloudfilesList = %#v\n", cloudfilesList)
+
+		for _, e := range cloudfiles {
+			for _, el := range cloudfilesList {
+				if e.Name == el.Name {
+					// we don't know these things ahead of time, so populate them now
+					e.ServiceID = service.ID
+					e.Version = service.ActiveVersion.Number
+					// We don't track these, so clear them out because we also wont know
+					// these ahead of time
+					el.CreatedAt = nil
+					el.UpdatedAt = nil
+					if diff := cmp.Diff(e, el); diff != "" {
+						return fmt.Errorf("Bad match Cloud Files logging match: %s", diff)
+					}
+				}
+			}
+		}
+
+		return nil
+	}
+}
+
+func testAccServiceV1CloudfilesConfig(name string, domain string) string {
+	return fmt.Sprintf(`
+resource "fastly_service_v1" "none" {
+  name = "%s"
+
+  domain {
+    name    = "%s"
+    comment = "tf-cloudfiles-logging"
+  }
+
+  backend {
+    address = "aws.amazon.com"
+    name    = "amazon docs"
+  }
+
+  condition {
+    name      = "response_condition_test"
+    type      = "RESPONSE"
+    priority  = 8
+    statement = "resp.status == 418"
+  }
+
+  logging_cloudfiles {
+    name   = "cloudfiles-endpoint"
+    bucket_name = "bucket"
+    user = "user"
+    access_key = "secret"
+    public_key = file("test_fixtures/fastly_test_publickey")
+    format = "%%h %%l %%u %%t \"%%r\" %%>s %%b"
+		message_type = "classic"
+		path = "/"
+		region = "ORD"
+		period = 3600
+		placement = "none"
+		response_condition = "response_condition_test"
+    gzip_level = 0
+    format_version = 2
+		timestamp_format = "%%Y-%%m-%%dT%%H:%%M:%%S.000"
+  }
+
+  force_destroy = true
+}
+`, name, domain)
+}
+
+func testAccServiceV1CloudfilesConfig_update(name, domain string) string {
+	return fmt.Sprintf(`
+resource "fastly_service_v1" "none" {
+  name = "%s"
+
+  domain {
+    name    = "%s"
+    comment = "tf-cloudfiles-logging"
+  }
+
+  backend {
+    address = "aws.amazon.com"
+    name    = "amazon docs"
+  }
+
+  condition {
+    name      = "response_condition_test"
+    type      = "RESPONSE"
+    priority  = 8
+    statement = "resp.status == 418"
+  }
+
+  logging_cloudfiles {
+    name   = "cloudfiles-endpoint"
+    bucket_name = "bucketupdate"
+    user = "userupdate"
+    access_key = "secretupdate"
+    public_key = file("test_fixtures/fastly_test_publickey")
+    format = "%%h %%l %%u %%t \"%%r\" %%>s %%b %%T"
+		message_type = "blank"
+		path = "new/"
+		region = "LON"
+		period = 3601
+		placement = "none"
+		response_condition = "response_condition_test"
+    gzip_level = 1
+    format_version = 2
+		timestamp_format = "%%Y-%%m-%%dT%%H:%%M:%%S.000"
+  }
+
+  logging_cloudfiles {
+    name   = "another-cloudfiles-endpoint"
+    bucket_name = "bucket2"
+    user = "user2"
+    access_key = "secret2"
+    public_key = file("test_fixtures/fastly_test_publickey")
+    format = "%%h %%l %%u %%t \"%%r\" %%>s %%b"
+		message_type = "classic"
+		path = "two/"
+		region = "SYD"
+		period = 3600
+		placement = "none"
+		response_condition = "response_condition_test"
+    gzip_level = 0
+    format_version = 2
+		timestamp_format = "%%Y-%%m-%%dT%%H:%%M:%%S.000"
+  }
+
+  force_destroy = true
+}
+`, name, domain)
+}

--- a/fastly/resource_fastly_service_v1.go
+++ b/fastly/resource_fastly_service_v1.go
@@ -42,6 +42,7 @@ var vclService = &BaseServiceDefinition{
 		NewServiceLoggingLogshuttle(),
 		NewServiceLoggingOpenstack(),
 		NewServiceLoggingDigitalOcean(),
+		NewServiceLoggingCloudfiles(),
 		NewServiceResponseObject(),
 		NewServiceRequestSetting(),
 		NewServiceVCL(),

--- a/website/docs/r/service_v1.html.markdown
+++ b/website/docs/r/service_v1.html.markdown
@@ -234,6 +234,8 @@ Defined below.
 Defined below.
 * `logging_digitalocean` - (Optional) A DigitalOcean Spaces endpoint to send streaming logs to.
 Defined below.
+* `logging_cloudfiles` - (Optional) A Rackspace Cloud Files endpoint to send streaming logs to.
+Defined below.
 * `response_object` - (Optional) Allows you to create synthetic responses that exist entirely on the varnish machine. Useful for creating error or maintenance pages that exists outside the scope of your datacenter. Best when used with Condition objects.
 * `snippet` - (Optional) A set of custom, "regular" (non-dynamic) VCL Snippet configuration blocks.  Defined below.
 * `dynamicsnippet` - (Optional) A set of custom, "dynamic" VCL Snippet configuration blocks.  Defined below.
@@ -733,6 +735,24 @@ The `logging_digitalocean` block supports:
 * `message_type` - (Optional) How the message should be formatted. One of: classic (default), loggly, logplex or blank.
 * `placement` - (Optional) Where in the generated VCL the logging call should be placed. Can be `none` or `waf_debug`.
 * `response_condition` - (Optional) The name of an existing condition in the configured endpoint, or leave blank to always execute.
+
+The `logging_cloudfiles` block supports:
+
+* `name` - (Required) The unique name of the Rackspace Cloud Files logging endpoint.
+* `user` - (Required) The username for your Cloud Files account.
+* `bucket_name` - (Required) The name of your Cloud Files container.
+* `access_key` - (Required) Your Cloud File account access key.
+* `public_key` - (Optional) The PGP public key that Fastly will use to encrypt your log files before writing them to disk.
+* `format` - (Optional) Apache style log formatting.
+* `format_version` - (Optional) The version of the custom logging format used for the configured endpoint. Can be either `1` or `2`. (default: `2`).
+* `gzip_level` - (Optional) What level of GZIP encoding to have when dumping logs (default 0, no compression).
+* `message_type` - (Optional) How the message should be formatted. One of: classic (default), loggly, logplex or blank.
+* `path` - (Optional) The path to upload logs to.
+* `region` - (Optional) The region to stream logs to. One of: DFW (Dallas), ORD (Chicago), IAD (Northern Virginia), LON (London), SYD (Sydney), HKG (Hong Kong).
+* `period` - (Optional) How frequently log files are finalized so they can be available for reading (in seconds, default 3600).
+* `placement` - (Optional) Where in the generated VCL the logging call should be placed. Can be `none` or `waf_debug`.
+* `response_condition` - (Optional) The name of an existing condition in the configured endpoint, or leave blank to always execute.
+* `timestamp_format` - (Optional) The strftime specified timestamp formatting (default `%Y-%m-%dT%H:%M:%S.000`).
 
 The `response_object` block supports:
 


### PR DESCRIPTION
## Proposed Change(s)

* Adds support for provisioning Rackspace Cloud Files logging endpoints.
* Updates `fastly_service_v1` docs to reflect the change.

## Relevant Link(s) / Doc(s)

* [API Docs](https://developer.fastly.com/reference/api/logging/cloudfiles/)
* [Relevant Fastly API Go client library file](https://github.com/fastly/go-fastly/blob/master/fastly/cloudfiles.go)

## Validation

```bash
export FASTLY_API_KEY="foo"; export TF_ACC=1; make testacc TESTARGS='-run=[cC]loudfiles'
```