### PR TITLE
Adds DigitalOcean Spaces logging endpoint support

### DIFF
--- a/fastly/block_fastly_service_v1_logging_digitalocean.go
+++ b/fastly/block_fastly_service_v1_logging_digitalocean.go
@@ -1,0 +1,305 @@
+package fastly
+
+import (
+	"fmt"
+	"log"
+
+	gofastly "github.com/fastly/go-fastly/fastly"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+type DigitalOceanServiceAttributeHandler struct {
+	*DefaultServiceAttributeHandler
+}
+
+func NewServiceLoggingDigitalOcean() ServiceAttributeDefinition {
+	return &DigitalOceanServiceAttributeHandler{
+		&DefaultServiceAttributeHandler{
+			key: "logging_digitalocean",
+		},
+	}
+}
+
+func (h *DigitalOceanServiceAttributeHandler) Process(d *schema.ResourceData, latestVersion int, conn *gofastly.Client) error {
+	serviceID := d.Id()
+	ol, nl := d.GetChange(h.GetKey())
+
+	if ol == nil {
+		ol = new(schema.Set)
+	}
+	if nl == nil {
+		nl = new(schema.Set)
+	}
+
+	ols := ol.(*schema.Set)
+	nls := nl.(*schema.Set)
+
+	removeDigitalOceanLogging := ols.Difference(nls).List()
+	addDigitalOceanLogging := nls.Difference(ols).List()
+
+	// DELETE old DigitalOcean Spaces logging endpoints.
+	for _, oRaw := range removeDigitalOceanLogging {
+		of := oRaw.(map[string]interface{})
+		opts := buildDeleteDigitalOcean(of, serviceID, latestVersion)
+
+		log.Printf("[DEBUG] Fastly DigitalOcean Spaces logging endpoint removal opts: %#v", opts)
+
+		if err := deleteDigitalOcean(conn, opts); err != nil {
+			return err
+		}
+	}
+
+	// POST new/updated DigitalOcean Spaces logging endpoints.
+	for _, nRaw := range addDigitalOceanLogging {
+		lf := nRaw.(map[string]interface{})
+
+		// @HACK for a TF SDK Issue.
+		//
+		// This ensures that the required, `name`, field is present.
+		//
+		// If we have made it this far and `name` is not present, it is most-likely due
+		// to a defunct diff as noted here - https://github.com/hashicorp/terraform-plugin-sdk/issues/160#issuecomment-522935697.
+		//
+		// This is caused by using a StateFunc in a nested TypeSet. While the StateFunc
+		// properly handles setting state with the StateFunc, it returns extra entries
+		// during state Gets, specifically `GetChange("logging_digitalocean")` in this case.
+		if v, ok := lf["name"]; !ok || v.(string) == "" {
+			continue
+		}
+
+		opts := buildCreateDigitalOcean(lf, serviceID, latestVersion)
+
+		log.Printf("[DEBUG] Fastly DigitalOcean Spaces logging addition opts: %#v", opts)
+
+		if err := createDigitalOcean(conn, opts); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (h *DigitalOceanServiceAttributeHandler) Read(d *schema.ResourceData, s *gofastly.ServiceDetail, conn *gofastly.Client) error {
+	// Refresh DigitalOcean Spaces.
+	log.Printf("[DEBUG] Refreshing DigitalOcean Spaces logging endpoints for (%s)", d.Id())
+	digitaloceanList, err := conn.ListDigitalOceans(&gofastly.ListDigitalOceansInput{
+		Service: d.Id(),
+		Version: s.ActiveVersion.Number,
+	})
+
+	if err != nil {
+		return fmt.Errorf("[ERR] Error looking up DigitalOcean Spaces logging endpoints for (%s), version (%v): %s", d.Id(), s.ActiveVersion.Number, err)
+	}
+
+	ell := flattenDigitalOcean(digitaloceanList)
+
+	if err := d.Set(h.GetKey(), ell); err != nil {
+		log.Printf("[WARN] Error setting DigitalOcean Spaces logging endpoints for (%s): %s", d.Id(), err)
+	}
+
+	return nil
+}
+
+func createDigitalOcean(conn *gofastly.Client, i *gofastly.CreateDigitalOceanInput) error {
+	_, err := conn.CreateDigitalOcean(i)
+	return err
+}
+
+func deleteDigitalOcean(conn *gofastly.Client, i *gofastly.DeleteDigitalOceanInput) error {
+	err := conn.DeleteDigitalOcean(i)
+
+	errRes, ok := err.(*gofastly.HTTPError)
+	if !ok {
+		return err
+	}
+
+	// 404 response codes don't result in an error propagating because a 404 could
+	// indicate that a resource was deleted elsewhere.
+	if !errRes.IsNotFound() {
+		return err
+	}
+
+	return nil
+}
+
+func flattenDigitalOcean(digitaloceanList []*gofastly.DigitalOcean) []map[string]interface{} {
+	var lsl []map[string]interface{}
+	for _, ll := range digitaloceanList {
+		// Convert DigitalOcean Spaces logging to a map for saving to state.
+		nll := map[string]interface{}{
+			"name":               ll.Name,
+			"bucket_name":        ll.BucketName,
+			"domain":             ll.Domain,
+			"access_key":         ll.AccessKey,
+			"secret_key":         ll.SecretKey,
+			"public_key":         ll.PublicKey,
+			"path":               ll.Path,
+			"period":             ll.Period,
+			"timestamp_format":   ll.TimestampFormat,
+			"gzip_level":         ll.GzipLevel,
+			"format":             ll.Format,
+			"format_version":     ll.FormatVersion,
+			"message_type":       ll.MessageType,
+			"placement":          ll.Placement,
+			"response_condition": ll.ResponseCondition,
+		}
+
+		// Prune any empty values that come from the default string value in structs.
+		for k, v := range nll {
+			if v == "" {
+				delete(nll, k)
+			}
+		}
+
+		lsl = append(lsl, nll)
+	}
+
+	return lsl
+}
+
+func buildCreateDigitalOcean(digitaloceanMap interface{}, serviceID string, serviceVersion int) *gofastly.CreateDigitalOceanInput {
+	df := digitaloceanMap.(map[string]interface{})
+
+	return &gofastly.CreateDigitalOceanInput{
+		Service:           serviceID,
+		Version:           serviceVersion,
+		Name:              gofastly.NullString(df["name"].(string)),
+		BucketName:        gofastly.NullString(df["bucket_name"].(string)),
+		Domain:            gofastly.NullString(df["domain"].(string)),
+		AccessKey:         gofastly.NullString(df["access_key"].(string)),
+		SecretKey:         gofastly.NullString(df["secret_key"].(string)),
+		PublicKey:         gofastly.NullString(df["public_key"].(string)),
+		Path:              gofastly.NullString(df["path"].(string)),
+		Period:            gofastly.Uint(uint(df["period"].(int))),
+		GzipLevel:         gofastly.Uint(uint(df["gzip_level"].(int))),
+		Format:            gofastly.NullString(df["format"].(string)),
+		FormatVersion:     gofastly.Uint(uint(df["format_version"].(int))),
+		TimestampFormat:   gofastly.NullString(df["timestamp_format"].(string)),
+		MessageType:       gofastly.NullString(df["message_type"].(string)),
+		Placement:         gofastly.NullString(df["placement"].(string)),
+		ResponseCondition: gofastly.NullString(df["response_condition"].(string)),
+	}
+}
+
+func buildDeleteDigitalOcean(digitaloceanMap interface{}, serviceID string, serviceVersion int) *gofastly.DeleteDigitalOceanInput {
+	df := digitaloceanMap.(map[string]interface{})
+
+	return &gofastly.DeleteDigitalOceanInput{
+		Service: serviceID,
+		Version: serviceVersion,
+		Name:    df["name"].(string),
+	}
+}
+
+func (h *DigitalOceanServiceAttributeHandler) Register(s *schema.Resource) error {
+	s.Schema[h.GetKey()] = &schema.Schema{
+		Type:     schema.TypeSet,
+		Optional: true,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				// Required fields
+				"name": {
+					Type:        schema.TypeString,
+					Required:    true,
+					Description: "The unique name of the DigitalOcean Spaces logging endpoint.",
+				},
+
+				"bucket_name": {
+					Type:        schema.TypeString,
+					Required:    true,
+					Description: "The name of the DigitalOcean Space.",
+				},
+
+				"access_key": {
+					Type:        schema.TypeString,
+					Required:    true,
+					Sensitive:   true,
+					Description: "Your DigitalOcean Spaces account access key.",
+				},
+
+				"secret_key": {
+					Type:        schema.TypeString,
+					Required:    true,
+					Sensitive:   true,
+					Description: "Your DigitalOcean Spaces account secret key.",
+				},
+
+				// Optional fields
+				"domain": {
+					Type:        schema.TypeString,
+					Optional:    true,
+					Description: "The domain of the DigitalOcean Spaces endpoint (default: nyc3.digitaloceanspaces.com).",
+					Default:     "nyc3.digitaloceanspaces.com",
+				},
+
+				"public_key": {
+					Type:        schema.TypeString,
+					Optional:    true,
+					Description: "A PGP public key that Fastly will use to encrypt your log files before writing them to disk.",
+					// Related issue for weird behavior - https://github.com/hashicorp/terraform-plugin-sdk/issues/160
+					StateFunc: trimSpaceStateFunc,
+				},
+
+				"path": {
+					Type:        schema.TypeString,
+					Optional:    true,
+					Description: "The path to upload logs to.",
+				},
+
+				"period": {
+					Type:        schema.TypeInt,
+					Optional:    true,
+					Description: "How frequently log files are finalized so they can be available for reading (in seconds, default 3600).",
+				},
+
+				"timestamp_format": {
+					Type:        schema.TypeString,
+					Optional:    true,
+					Description: "strftime specified timestamp formatting (default `%Y-%m-%dT%H:%M:%S.000`).",
+				},
+
+				"gzip_level": {
+					Type:        schema.TypeInt,
+					Optional:    true,
+					Description: "What level of GZIP encoding to have when dumping logs (default 0, no compression).",
+				},
+
+				"format": {
+					Type:        schema.TypeString,
+					Optional:    true,
+					Description: "Apache style log formatting.",
+				},
+
+				"format_version": {
+					Type:         schema.TypeInt,
+					Optional:     true,
+					Default:      2,
+					Description:  "The version of the custom logging format used for the configured endpoint. Can be either `1` or `2`. (default: `2`).",
+					ValidateFunc: validateLoggingFormatVersion(),
+				},
+
+				"placement": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					Description:  "Where in the generated VCL the logging call should be placed. Can be `none` or `waf_debug`.",
+					ValidateFunc: validateLoggingPlacement(),
+				},
+
+				"message_type": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					Default:      "classic",
+					Description:  "How the message should be formatted.",
+					ValidateFunc: validateLoggingMessageType(),
+				},
+
+				"response_condition": {
+					Type:        schema.TypeString,
+					Optional:    true,
+					Description: "The name of an existing condition in the configured endpoint, or leave blank to always execute.",
+				},
+			},
+		},
+	}
+	return nil
+}

--- a/fastly/block_fastly_service_v1_logging_digitalocean_test.go
+++ b/fastly/block_fastly_service_v1_logging_digitalocean_test.go
@@ -1,0 +1,308 @@
+package fastly
+
+import (
+	"fmt"
+	"log"
+	"testing"
+
+	gofastly "github.com/fastly/go-fastly/fastly"
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestResourceFastlyFlattenDigitalOcean(t *testing.T) {
+	cases := []struct {
+		remote []*gofastly.DigitalOcean
+		local  []map[string]interface{}
+	}{
+		{
+			remote: []*gofastly.DigitalOcean{
+				{
+					Version:           1,
+					Name:              "digitalocean-endpoint",
+					BucketName:        "bucket",
+					AccessKey:         "access",
+					SecretKey:         "secret",
+					Domain:            "nyc3.digitaloceanspaces.com",
+					PublicKey:         pgpPublicKey(t),
+					Path:              "/",
+					Period:            3600,
+					TimestampFormat:   "%Y-%m-%dT%H:%M:%S.000",
+					GzipLevel:         1,
+					Format:            "%h %l %u %t \"%r\" %>s %b",
+					FormatVersion:     2,
+					MessageType:       "classic",
+					Placement:         "none",
+					ResponseCondition: "always",
+				},
+			},
+			local: []map[string]interface{}{
+				{
+					"name":               "digitalocean-endpoint",
+					"bucket_name":        "bucket",
+					"access_key":         "access",
+					"secret_key":         "secret",
+					"domain":             "nyc3.digitaloceanspaces.com",
+					"public_key":         pgpPublicKey(t),
+					"path":               "/",
+					"period":             uint(3600),
+					"timestamp_format":   "%Y-%m-%dT%H:%M:%S.000",
+					"gzip_level":         uint(1),
+					"format":             "%h %l %u %t \"%r\" %>s %b",
+					"format_version":     uint(2),
+					"message_type":       "classic",
+					"placement":          "none",
+					"response_condition": "always",
+				},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		out := flattenDigitalOcean(c.remote)
+		if diff := cmp.Diff(out, c.local); diff != "" {
+			t.Fatalf("Error matching: %s", diff)
+		}
+	}
+}
+
+func TestAccFastlyServiceV1_logging_digitalocean_basic(t *testing.T) {
+	var service gofastly.ServiceDetail
+	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	domain := fmt.Sprintf("fastly-test.%s.com", name)
+
+	log1 := gofastly.DigitalOcean{
+		Version:           1,
+		Name:              "digitalocean-endpoint",
+		BucketName:        "bucket",
+		AccessKey:         "access",
+		SecretKey:         "secret",
+		Domain:            "nyc3.digitaloceanspaces.com",
+		PublicKey:         pgpPublicKey(t),
+		Path:              "/",
+		Period:            3600,
+		TimestampFormat:   "%Y-%m-%dT%H:%M:%S.000",
+		GzipLevel:         0,
+		Format:            "%h %l %u %t \"%r\" %>s %b",
+		FormatVersion:     2,
+		MessageType:       "classic",
+		Placement:         "none",
+		ResponseCondition: "response_condition_test",
+	}
+
+	log1_after_update := gofastly.DigitalOcean{
+		Version:           1,
+		Name:              "digitalocean-endpoint",
+		BucketName:        "bucketupdate",
+		AccessKey:         "accessupdate",
+		SecretKey:         "secretupdate",
+		Domain:            "nyc4.digitaloceanspaces.com",
+		PublicKey:         pgpPublicKey(t),
+		Path:              "new/",
+		Period:            3601,
+		Format:            "%h %l %u %t \"%r\" %>s %b %T",
+		TimestampFormat:   "%Y-%m-%dT%H:%M:%S.000",
+		GzipLevel:         2,
+		FormatVersion:     2,
+		MessageType:       "blank",
+		Placement:         "none",
+		ResponseCondition: "response_condition_test",
+	}
+
+	log2 := gofastly.DigitalOcean{
+		Version:           1,
+		Name:              "another-digitalocean-endpoint",
+		BucketName:        "bucket2",
+		AccessKey:         "access2",
+		SecretKey:         "secret2",
+		Domain:            "nyc3.digitaloceanspaces.com",
+		PublicKey:         pgpPublicKey(t),
+		Path:              "two/",
+		Period:            3600,
+		Format:            "%h %l %u %t \"%r\" %>s %b",
+		TimestampFormat:   "%Y-%m-%dT%H:%M:%S.000",
+		GzipLevel:         1,
+		FormatVersion:     2,
+		MessageType:       "classic",
+		Placement:         "none",
+		ResponseCondition: "response_condition_test",
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckServiceV1Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServiceV1DigitalOceanConfig(name, domain),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
+					testAccCheckFastlyServiceV1DigitalOceanAttributes(&service, []*gofastly.DigitalOcean{&log1}),
+					resource.TestCheckResourceAttr(
+						"fastly_service_v1.foo", "name", name),
+					resource.TestCheckResourceAttr(
+						"fastly_service_v1.foo", "logging_digitalocean.#", "1"),
+				),
+			},
+
+			{
+				Config: testAccServiceV1DigitalOceanConfig_update(name, domain),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
+					testAccCheckFastlyServiceV1DigitalOceanAttributes(&service, []*gofastly.DigitalOcean{&log1_after_update, &log2}),
+					resource.TestCheckResourceAttr(
+						"fastly_service_v1.foo", "name", name),
+					resource.TestCheckResourceAttr(
+						"fastly_service_v1.foo", "logging_digitalocean.#", "2"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckFastlyServiceV1DigitalOceanAttributes(service *gofastly.ServiceDetail, digitalocean []*gofastly.DigitalOcean) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+
+		conn := testAccProvider.Meta().(*FastlyClient).conn
+		digitaloceanList, err := conn.ListDigitalOceans(&gofastly.ListDigitalOceansInput{
+			Service: service.ID,
+			Version: service.ActiveVersion.Number,
+		})
+
+		if err != nil {
+			return fmt.Errorf("[ERR] Error looking up DigitalOcean Spaces Logging for (%s), version (%d): %s", service.Name, service.ActiveVersion.Number, err)
+		}
+
+		if len(digitaloceanList) != len(digitalocean) {
+			return fmt.Errorf("DigitalOcean Spaces List count mismatch, expected (%d), got (%d)", len(digitalocean), len(digitaloceanList))
+		}
+
+		log.Printf("[DEBUG] digitaloceanList = %#v\n", digitaloceanList)
+
+		for _, e := range digitalocean {
+			for _, el := range digitaloceanList {
+				if e.Name == el.Name {
+					// we don't know these things ahead of time, so populate them now
+					e.ServiceID = service.ID
+					e.Version = service.ActiveVersion.Number
+					// We don't track these, so clear them out because we also wont know
+					// these ahead of time
+					el.CreatedAt = nil
+					el.UpdatedAt = nil
+					if diff := cmp.Diff(e, el); diff != "" {
+						return fmt.Errorf("Bad match DigitalOcean Spaces logging match: %s", diff)
+					}
+				}
+			}
+		}
+
+		return nil
+	}
+}
+
+func testAccServiceV1DigitalOceanConfig(name string, domain string) string {
+	return fmt.Sprintf(`
+resource "fastly_service_v1" "foo" {
+  name = "%s"
+
+  domain {
+    name    = "%s"
+    comment = "tf-digitalocean-logging"
+  }
+
+  backend {
+    address = "aws.amazon.com"
+    name    = "amazon docs"
+  }
+
+  condition {
+    name      = "response_condition_test"
+    type      = "RESPONSE"
+    priority  = 8
+    statement = "resp.status == 418"
+  }
+
+  logging_digitalocean {
+    name   = "digitalocean-endpoint"
+    bucket_name = "bucket"
+    access_key = "access"
+    secret_key = "secret"
+    domain = "nyc3.digitaloceanspaces.com"
+    public_key = file("test_fixtures/fastly_test_publickey")
+    path = "/"
+    period = 3600
+    timestamp_format = "%%Y-%%m-%%dT%%H:%%M:%%S.000"
+    gzip_level = 0
+    format = "%%h %%l %%u %%t \"%%r\" %%>s %%b"
+    message_type = "classic"
+    placement = "none"
+    response_condition = "response_condition_test"
+  }
+
+  force_destroy = true
+}
+`, name, domain)
+}
+
+func testAccServiceV1DigitalOceanConfig_update(name, domain string) string {
+	return fmt.Sprintf(`
+resource "fastly_service_v1" "foo" {
+  name = "%s"
+
+  domain {
+    name    = "%s"
+    comment = "tf-digitalocean-logging"
+  }
+
+  backend {
+    address = "aws.amazon.com"
+    name    = "amazon docs"
+  }
+
+  condition {
+    name      = "response_condition_test"
+    type      = "RESPONSE"
+    priority  = 8
+    statement = "resp.status == 418"
+  }
+
+  logging_digitalocean {
+    name   = "digitalocean-endpoint"
+    bucket_name = "bucketupdate"
+    access_key = "accessupdate"
+    secret_key = "secretupdate"
+    domain = "nyc4.digitaloceanspaces.com"
+    public_key = file("test_fixtures/fastly_test_publickey")
+    path = "new/"
+    period = 3601
+    timestamp_format = "%%Y-%%m-%%dT%%H:%%M:%%S.000"
+    gzip_level = 2
+    format = "%%h %%l %%u %%t \"%%r\" %%>s %%b %%T"
+    message_type = "blank"
+    placement = "none"
+    response_condition = "response_condition_test"
+  }
+
+  logging_digitalocean {
+    name   = "another-digitalocean-endpoint"
+    bucket_name = "bucket2"
+    access_key = "access2"
+    secret_key = "secret2"
+    domain = "nyc3.digitaloceanspaces.com"
+    public_key = file("test_fixtures/fastly_test_publickey")
+    path = "two/"
+    period = 3600
+    timestamp_format = "%%Y-%%m-%%dT%%H:%%M:%%S.000"
+    gzip_level = 1
+    format = "%%h %%l %%u %%t \"%%r\" %%>s %%b"
+    message_type = "classic"
+    placement = "none"
+    response_condition = "response_condition_test"
+  }
+
+  force_destroy = true
+}
+`, name, domain)
+}

--- a/fastly/resource_fastly_service_v1.go
+++ b/fastly/resource_fastly_service_v1.go
@@ -41,6 +41,7 @@ var vclService = &BaseServiceDefinition{
 		NewServiceLoggingHoneycomb(),
 		NewServiceLoggingLogshuttle(),
 		NewServiceLoggingOpenstack(),
+		NewServiceLoggingDigitalOcean(),
 		NewServiceResponseObject(),
 		NewServiceRequestSetting(),
 		NewServiceVCL(),

--- a/website/docs/r/service_v1.html.markdown
+++ b/website/docs/r/service_v1.html.markdown
@@ -232,6 +232,8 @@ Defined below.
 Defined below.
 * `logging_openstack` - (Optional) An OpenStack endpoint to send streaming logs to.
 Defined below.
+* `logging_digitalocean` - (Optional) A DigitalOcean Spaces endpoint to send streaming logs to.
+Defined below.
 * `response_object` - (Optional) Allows you to create synthetic responses that exist entirely on the varnish machine. Useful for creating error or maintenance pages that exists outside the scope of your datacenter. Best when used with Condition objects.
 * `snippet` - (Optional) A set of custom, "regular" (non-dynamic) VCL Snippet configuration blocks.  Defined below.
 * `dynamicsnippet` - (Optional) A set of custom, "dynamic" VCL Snippet configuration blocks.  Defined below.
@@ -713,6 +715,24 @@ seconds. Default `3600`.
 * `timestamp_format` - (Optional) The strftime specified timestamp formatting (default `%Y-%m-%dT%H:%M:%S.000`).
 * `response_condition` - (Optional) The name of an existing condition in the configured endpoint, or leave blank to always execute.
 * `placement` - (Optional) Where in the generated VCL the logging call should be placed; one of: `none` or `waf_debug`.
+
+The `logging_digitalocean` block supports:
+
+* `name` - (Required) The unique name of the DigitalOcean Spaces logging endpoint.
+* `bucket_name` - (Required) The name of the DigitalOcean Space.
+* `access_key` - (Required) Your DigitalOcean Spaces account access key.
+* `secret_key` - (Required) Your DigitalOcean Spaces account secret key.
+* `public_key` - (Optional) A PGP public key that Fastly will use to encrypt your log files before writing them to disk.
+* `domain` - (Optional) The domain of the DigitalOcean Spaces endpoint (default "nyc3.digitaloceanspaces.com").
+* `path` - (Optional) The path to upload logs to.
+* `period` - (Optional) How frequently log files are finalized so they can be available for reading (in seconds, default 3600).
+* `timestamp_format` - (Optional) The strftime specified timestamp formatting (default `%Y-%m-%dT%H:%M:%S.000`).
+* `gzip_level` - (Optional) What level of GZIP encoding to have when dumping logs (default 0, no compression).
+* `format` - (Optional) Apache-style string or VCL variables to use for log formatting.
+* `format_version` - (Optional) The version of the custom logging format used for the configured endpoint. Can be either `1` or `2`. (default: `2`).
+* `message_type` - (Optional) How the message should be formatted. One of: classic (default), loggly, logplex or blank.
+* `placement` - (Optional) Where in the generated VCL the logging call should be placed. Can be `none` or `waf_debug`.
+* `response_condition` - (Optional) The name of an existing condition in the configured endpoint, or leave blank to always execute.
 
 The `response_object` block supports:
 


### PR DESCRIPTION
## Proposed Change(s)

* Adds support for provisioning DigitalOcean Spaces as logging endpoints.
* Updates `fastly_service_v1` docs to reflect the change.

## Relevant Link(s) / Doc(s)

* [API Docs](https://developer.fastly.com/reference/api/logging/digitalocean/)
* [Relevant Fastly API Go client library file](https://github.com/fastly/go-fastly/blob/master/fastly/digitalocean.go)

## Validation

```bash
export FASTLY_API_KEY="foo"; export TF_ACC=1; make testacc TESTARGS='-run=[dD]igital[oO]cean'
```