### PR TITLE
Ensure PublicKey field is using trimSpaceStateFunc

### DIFF
--- a/fastly/block_fastly_service_v1_s3logging.go
+++ b/fastly/block_fastly_service_v1_s3logging.go
@@ -49,6 +49,21 @@ func (h *S3LoggingServiceAttributeHandler) Process(d *schema.ResourceData, lates
 	// POST new/updated S3 Logging.
 	for _, sRaw := range addS3Logging {
 		opts, _ := buildCreateS3(sRaw, d.Id(), latestVersion)
+
+		// @HACK for a TF SDK Issue.
+		//
+		// This ensures that the required, `name`, field is present.
+		//
+		// If we have made it this far and `name` is not present, it is most-likely due
+		// to a defunct diff as noted here - https://github.com/hashicorp/terraform-plugin-sdk/issues/160#issuecomment-522935697.
+		//
+		// This is caused by using a StateFunc in a nested TypeSet. While the StateFunc
+		// properly handles setting state with the StateFunc, it returns extra entries
+		// during state Gets, specifically `GetChange("s3logging")` in this case.
+		if opts.Name == "" {
+			continue
+		}
+
 		err := createS3(conn, opts)
 		if err != nil {
 			return err
@@ -160,6 +175,8 @@ func (h *S3LoggingServiceAttributeHandler) Register(s *schema.Resource) error {
 					Type:        schema.TypeString,
 					Optional:    true,
 					Description: "A PGP public key that Fastly will use to encrypt your log files before writing them to disk.",
+					// Related issue for weird behavior - https://github.com/hashicorp/terraform-plugin-sdk/issues/160
+					StateFunc: trimSpaceStateFunc,
 				},
 				"response_condition": {
 					Type:        schema.TypeString,


### PR DESCRIPTION
## Proposed Change(s)

* Fixes a few places where the `trimSpaceStateFunc` was ommitted for uses of the `PublicKey` field.
  * `blobstoragelogging`
  * `s3logging`
  * `logging_ftp`

## Validation

```bash
$ export FASTLY_API_KEY="foo"; export TF_ACC=1; make testacc TESTARGS="-run=[sS]3"
$ export FASTLY_API_KEY="foo"; export TF_ACC=1; make testacc TESTARGS="-run=[bB]lob[sS]torage"
$ export FASTLY_API_KEY="foo"; export TF_ACC=1; make testacc TESTARGS="-run=[fF][tT][pP]"
```

## Note(s)

* This shouldn't introduce breaking changes for those using the `PublicKey` field already. However, it could introduce a state diff where a new line is removed.

## Thoughts

* I really dislike that this is something that you have to remember to put for these fields. This feeling is made even worse by having to remember to also include the hack.