### PR TITLE
Adds message_type validation func to SFTP and GCS

### DIFF
--- a/fastly/block_fastly_service_v1_gcslogging.go
+++ b/fastly/block_fastly_service_v1_gcslogging.go
@@ -169,10 +169,11 @@ func (h *GCSLoggingServiceAttributeHandler) Register(s *schema.Resource) error {
 					Description: "Name of a condition to apply this logging.",
 				},
 				"message_type": {
-					Type:        schema.TypeString,
-					Optional:    true,
-					Default:     "classic",
-					Description: "The log message type per the fastly docs: https://docs.fastly.com/api/logging#logging_gcs",
+					Type:         schema.TypeString,
+					Optional:     true,
+					Default:      "classic",
+					Description:  "The log message type per the fastly docs: https://docs.fastly.com/api/logging#logging_gcs",
+					ValidateFunc: validateLoggingMessageType(),
 				},
 				"placement": {
 					Type:         schema.TypeString,

--- a/fastly/block_fastly_service_v1_logging_sftp.go
+++ b/fastly/block_fastly_service_v1_logging_sftp.go
@@ -111,10 +111,11 @@ func (h *SFTPServiceAttributeHandler) Register(s *schema.Resource) error {
 				},
 
 				"message_type": {
-					Type:        schema.TypeString,
-					Optional:    true,
-					Default:     "classic",
-					Description: "How the message should be formatted. One of: classic (default), loggly, logplex or blank.",
+					Type:         schema.TypeString,
+					Optional:     true,
+					Default:      "classic",
+					Description:  "How the message should be formatted. One of: classic (default), loggly, logplex or blank.",
+					ValidateFunc: validateLoggingMessageType(),
 				},
 
 				"format": {


### PR DESCRIPTION
## Proposed 

* Adds `validateLoggingMessageType` function to SFTP and GCS logging to be consistent with other logging endpoints that use the `message_type` field.

## Relevant Link(s)
* [syslog's use](https://github.com/terraform-providers/terraform-provider-fastly/blob/ae73da773f74933ad7258f76ae78f2accee49527/fastly/block_fastly_service_v1_syslog.go#L193)

## Note(s)

While not super helpful if you don't use [google/zoekt](https://github.com/google/zoekt), I ran the following query to identify resources that used the `message_type` field, but didn't have validation:

```
"message_type" "Description:\\s+\"How" -validateLoggingMessageType
```

## Validation

```bash
$ export FASTLY_API_KEY="foo"; export TF_ACC=1; make testacc TESTARGS="-run=[sS][fF][tT][pP]"
$ export FASTLY_API_KEY="foo"; export TF_ACC=1; make testacc TESTARGS="-run=[gG][cC][sS]"