### PR TITLE
Update changelog for release (v0.18.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,24 @@
-## 0.18.0 (Unreleased)
+## 0.19.0 (Unreleased)
+## 0.18.0 (July 01, 2020)
+
+ENHANCEMENTS:
+
+* resource/fastly_service_v1/logging_digitalocean: Add DigitalOcean Spaces logging support ([#276](https://github.com/terraform-providers/terraform-provider-fastly/pull/276))
+* resource/fastly_service_v1/logging_cloudfiles: Add Rackspace Cloud Files logging support ([#275](https://github.com/terraform-providers/terraform-provider-fastly/pull/275))
+* resource/fastly_service_v1/logging_openstack: Add OpenStack logging support ([#273](https://github.com/terraform-providers/terraform-provider-fastly/pull/274))
+* resource/fastly_service_v1/logging_logshuttle: Add Log Shuttle logging support ([#273](https://github.com/terraform-providers/terraform-provider-fastly/pull/273))
+* resource/fastly_service_v1/logging_honeycomb: Add Honeycomb logging support ([#272](https://github.com/terraform-providers/terraform-provider-fastly/pull/272))
+* resource/fastly_service_v1/logging_heroku: Add Heroku logging support ([#271](https://github.com/terraform-providers/terraform-provider-fastly/pull/271))
+
+NOTES:
+
+* resource/fastly_service_v1/\*: "GZIP" -> "Gzip" ([#279](https://github.com/terraform-providers/terraform-provider-fastly/pull/279))
+* resource/fastly_service_v1/logging_sftp: Update SFTP logging to use `ValidateFunc` for validating the `message_type` field ([#278](https://github.com/terraform-providers/terraform-provider-fastly/pull/278))
+* resource/fastly_service_v1/gcslogging: Update GCS logging to use `ValidateFunc` for validating the `message_type` field ([#278](https://github.com/terraform-providers/terraform-provider-fastly/pull/278))
+* resource/fastly_service_v1/blobstoragelogging: Update Azure Blob Storage logging to use a custom `StateFunc` for trimming whitespace from the `public_key` field ([#277](https://github.com/terraform-providers/terraform-provider-fastly/pull/277))
+* resource/fastly_service_v1/logging_ftp: Update FTP logging to use a custom `StateFunc` for trimming whitespace from the `public_key` field ([#277](https://github.com/terraform-providers/terraform-provider-fastly/pull/277))
+* resource/fastly_service_v1/s3logging: Update S3 logging to use a custom `StateFunc` for trimming whitespace from the `public_key` field ([#277](https://github.com/terraform-providers/terraform-provider-fastly/pull/277))
+
 ## 0.17.1 (June 24, 2020)
 
 NOTES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,4 @@
-## 0.19.0 (Unreleased)
-## 0.18.0 (July 01, 2020)
+## 0.18.0 (Unreleased)
 
 ENHANCEMENTS:
 


### PR DESCRIPTION
:star2: 

* [Rendered Changelog](https://github.com/terraform-providers/terraform-provider-fastly/blob/38ad219e7a4add62fa9a7500cc6e94ef786d941e/CHANGELOG.md)

* [Rendered Changelog diff](https://github.com/terraform-providers/terraform-provider-fastly/pull/282/files?short_path=4ac32a7#diff-4ac32a78649ca5bdd8e0ba38b7006a1e)

## Validation

```
export FASTLY_API_KEY="foo"; export TF_ACC=1; make testacc TESTARGS='-count=1'
```

<details>
<summary> Expand for test output </summary>
<p>

```bash
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -count=1 -timeout 120m -ldflags="-X=github.com/terraform-providers/terraform-provider-fastly/version.ProviderVersion=acc"
?       github.com/terraform-providers/terraform-provider-fastly        [no test files]
=== RUN   TestResourceFastlyFlattenAcl
--- PASS: TestResourceFastlyFlattenAcl (0.00s)
=== RUN   TestAccFastlyServiceV1_acl
--- PASS: TestAccFastlyServiceV1_acl (35.82s)
=== RUN   TestResourceFastlyFlattenBigQuery
--- PASS: TestResourceFastlyFlattenBigQuery (0.09s)
=== RUN   TestAccFastlyServiceV1_bigquerylogging
--- PASS: TestAccFastlyServiceV1_bigquerylogging (35.48s)
=== RUN   TestAccFastlyServiceV1_bigquerylogging_env
--- PASS: TestAccFastlyServiceV1_bigquerylogging_env (35.51s)
=== RUN   TestResourceFastlyFlattenBlobStorage
--- PASS: TestResourceFastlyFlattenBlobStorage (0.00s)
=== RUN   TestAccFastlyServiceV1_blobstoragelogging_basic
--- PASS: TestAccFastlyServiceV1_blobstoragelogging_basic (75.86s)
=== RUN   TestAccFastlyServiceV1_blobstoragelogging_default
--- PASS: TestAccFastlyServiceV1_blobstoragelogging_default (34.56s)
=== RUN   TestAccFastlyServiceV1_blobstoragelogging_env
--- PASS: TestAccFastlyServiceV1_blobstoragelogging_env (34.75s)
=== RUN   TestResourceFastlyFlattenCacheSettings
--- PASS: TestResourceFastlyFlattenCacheSettings (0.00s)
=== RUN   TestAccFastlyServiceV1CacheSetting_basic
--- PASS: TestAccFastlyServiceV1CacheSetting_basic (74.65s)
=== RUN   TestResourceFastlyFlattenConditions
--- PASS: TestResourceFastlyFlattenConditions (0.00s)
=== RUN   TestAccFastlyServiceV1_conditional_basic
--- PASS: TestAccFastlyServiceV1_conditional_basic (35.19s)
=== RUN   TestResourceFastlyFlattenDictionary
--- PASS: TestResourceFastlyFlattenDictionary (0.00s)
=== RUN   TestAccFastlyServiceV1_dictionary
--- PASS: TestAccFastlyServiceV1_dictionary (34.34s)
=== RUN   TestAccFastlyServiceV1_dictionary_write_only
--- PASS: TestAccFastlyServiceV1_dictionary_write_only (34.84s)
=== RUN   TestAccFastlyServiceV1_dictionary_update_name
--- PASS: TestAccFastlyServiceV1_dictionary_update_name (74.33s)
=== RUN   TestAccFastlyServiceV1_dictionary_update_write_only
--- PASS: TestAccFastlyServiceV1_dictionary_update_write_only (74.46s)
=== RUN   TestResourceFastlyFlattenDirectors
--- PASS: TestResourceFastlyFlattenDirectors (0.00s)
=== RUN   TestAccFastlyServiceV1_directors_basic
--- PASS: TestAccFastlyServiceV1_directors_basic (82.12s)
=== RUN   TestResourceFastlyFlattenDynamicSnippets
--- PASS: TestResourceFastlyFlattenDynamicSnippets (0.00s)
=== RUN   TestAccFastlyServiceV1DynamicSnippet_basic
--- PASS: TestAccFastlyServiceV1DynamicSnippet_basic (74.38s)
=== RUN   TestResourceFastlyFlattenGCS
--- PASS: TestResourceFastlyFlattenGCS (0.09s)
=== RUN   TestAccFastlyServiceV1_gcslogging
--- PASS: TestAccFastlyServiceV1_gcslogging (35.01s)
=== RUN   TestAccFastlyServiceV1_gcslogging_env
--- PASS: TestAccFastlyServiceV1_gcslogging_env (35.11s)
=== RUN   TestResourceFastlyFlattenGzips
--- PASS: TestResourceFastlyFlattenGzips (0.00s)
=== RUN   TestAccFastlyServiceV1_gzips_basic
--- PASS: TestAccFastlyServiceV1_gzips_basic (75.07s)
=== RUN   TestResourceFastlyFlattenHeaders
--- PASS: TestResourceFastlyFlattenHeaders (0.00s)
=== RUN   TestFastlyServiceV1_BuildHeaders
--- PASS: TestFastlyServiceV1_BuildHeaders (0.00s)
=== RUN   TestAccFastlyServiceV1_headers_basic
--- PASS: TestAccFastlyServiceV1_headers_basic (75.73s)
=== RUN   TestResourceFastlyFlattenHealthChecks
--- PASS: TestResourceFastlyFlattenHealthChecks (0.00s)
=== RUN   TestAccFastlyServiceV1_healthcheck_basic
--- PASS: TestAccFastlyServiceV1_healthcheck_basic (73.47s)
=== RUN   TestResourceFastlyFlattenHTTPS
--- PASS: TestResourceFastlyFlattenHTTPS (0.00s)
=== RUN   TestAccFastlyServiceV1_httpslogging_basic
--- PASS: TestAccFastlyServiceV1_httpslogging_basic (75.97s)
=== RUN   TestResourceFastlyFlattenLogentries
--- PASS: TestResourceFastlyFlattenLogentries (0.00s)
=== RUN   TestAccFastlyServiceV1_logentries_basic
--- PASS: TestAccFastlyServiceV1_logentries_basic (74.96s)
=== RUN   TestAccFastlyServiceV1_logentries_formatVersion
--- PASS: TestAccFastlyServiceV1_logentries_formatVersion (35.06s)
=== RUN   TestResourceFastlyFlattenCloudfiles
--- PASS: TestResourceFastlyFlattenCloudfiles (0.00s)
=== RUN   TestAccFastlyServiceV1_logging_cloudfiles_basic
--- PASS: TestAccFastlyServiceV1_logging_cloudfiles_basic (75.81s)
=== RUN   TestResourceFastlyFlattenDatadog
--- PASS: TestResourceFastlyFlattenDatadog (0.00s)
=== RUN   TestAccFastlyServiceV1_logging_datadog_basic
--- PASS: TestAccFastlyServiceV1_logging_datadog_basic (75.02s)
=== RUN   TestResourceFastlyFlattenDigitalOcean
--- PASS: TestResourceFastlyFlattenDigitalOcean (0.00s)
=== RUN   TestAccFastlyServiceV1_logging_digitalocean_basic
--- PASS: TestAccFastlyServiceV1_logging_digitalocean_basic (76.03s)
=== RUN   TestResourceFastlyFlattenElasticsearch
--- PASS: TestResourceFastlyFlattenElasticsearch (0.00s)
=== RUN   TestAccFastlyServiceV1_logging_elasticsearch_basic
--- PASS: TestAccFastlyServiceV1_logging_elasticsearch_basic (75.96s)
=== RUN   TestResourceFastlyFlattenFTP
--- PASS: TestResourceFastlyFlattenFTP (0.00s)
=== RUN   TestAccFastlyServiceV1_logging_ftp_basic
--- PASS: TestAccFastlyServiceV1_logging_ftp_basic (74.89s)
=== RUN   TestResourceFastlyFlattenGooglePubSub
--- PASS: TestResourceFastlyFlattenGooglePubSub (0.00s)
=== RUN   TestAccFastlyServiceV1_googlepubsublogging_basic
--- PASS: TestAccFastlyServiceV1_googlepubsublogging_basic (76.08s)
=== RUN   TestResourceFastlyFlattenHeroku
--- PASS: TestResourceFastlyFlattenHeroku (0.00s)
=== RUN   TestAccFastlyServiceV1_logging_heroku_basic
--- PASS: TestAccFastlyServiceV1_logging_heroku_basic (74.71s)
=== RUN   TestResourceFastlyFlattenHoneycomb
--- PASS: TestResourceFastlyFlattenHoneycomb (0.00s)
=== RUN   TestAccFastlyServiceV1_logging_honeycomb_basic
--- PASS: TestAccFastlyServiceV1_logging_honeycomb_basic (75.92s)
=== RUN   TestResourceFastlyFlattenKafka
--- PASS: TestResourceFastlyFlattenKafka (0.00s)
=== RUN   TestAccFastlyServiceV1_kafkalogging_basic
--- PASS: TestAccFastlyServiceV1_kafkalogging_basic (83.84s)
=== RUN   TestResourceFastlyFlattenLoggly
--- PASS: TestResourceFastlyFlattenLoggly (0.00s)
=== RUN   TestAccFastlyServiceV1_logging_loggly_basic
--- PASS: TestAccFastlyServiceV1_logging_loggly_basic (76.45s)
=== RUN   TestResourceFastlyFlattenLogshuttle
--- PASS: TestResourceFastlyFlattenLogshuttle (0.00s)
=== RUN   TestAccFastlyServiceV1_logging_logshuttle_basic
--- PASS: TestAccFastlyServiceV1_logging_logshuttle_basic (75.76s)
=== RUN   TestResourceFastlyFlattenNewRelic
--- PASS: TestResourceFastlyFlattenNewRelic (0.00s)
=== RUN   TestAccFastlyServiceV1_logging_newrelic_basic
--- PASS: TestAccFastlyServiceV1_logging_newrelic_basic (74.55s)
=== RUN   TestResourceFastlyFlattenScalyr
--- PASS: TestResourceFastlyFlattenScalyr (0.00s)
=== RUN   TestAccFastlyServiceV1_scalyrlogging_basic
--- PASS: TestAccFastlyServiceV1_scalyrlogging_basic (76.87s)
=== RUN   TestResourceFastlyFlattenSFTP
--- PASS: TestResourceFastlyFlattenSFTP (0.00s)
=== RUN   TestAccFastlyServiceV1_logging_sftp_basic
--- PASS: TestAccFastlyServiceV1_logging_sftp_basic (76.97s)
=== RUN   TestAccFastlyServiceV1_logging_sftp_password_secret_key
--- PASS: TestAccFastlyServiceV1_logging_sftp_password_secret_key (2.96s)
=== RUN   TestResourceFastlyFlattenOpenstack
--- PASS: TestResourceFastlyFlattenOpenstack (0.00s)
=== RUN   TestAccFastlyServiceV1_logging_openstack_basic
--- PASS: TestAccFastlyServiceV1_logging_openstack_basic (89.56s)
=== RUN   TestResourceFastlyFlattenPapertrail
--- PASS: TestResourceFastlyFlattenPapertrail (0.00s)
=== RUN   TestAccFastlyServiceV1_papertrail_basic
--- PASS: TestAccFastlyServiceV1_papertrail_basic (74.83s)
=== RUN   TestResourceFastlyFlattenRequestSettings
--- PASS: TestResourceFastlyFlattenRequestSettings (0.00s)
=== RUN   TestAccFastlyServiceV1RequestSetting_basic
--- PASS: TestAccFastlyServiceV1RequestSetting_basic (34.61s)
=== RUN   TestResourceFastlyFlattenResponseObjects
--- PASS: TestResourceFastlyFlattenResponseObjects (0.00s)
=== RUN   TestAccFastlyServiceV1_response_object_basic
--- PASS: TestAccFastlyServiceV1_response_object_basic (74.03s)
=== RUN   TestResourceFastlyFlattenS3
--- PASS: TestResourceFastlyFlattenS3 (0.00s)
=== RUN   TestAccFastlyServiceV1_s3logging_basic
--- PASS: TestAccFastlyServiceV1_s3logging_basic (75.78s)
=== RUN   TestAccFastlyServiceV1_s3logging_domain_default
--- PASS: TestAccFastlyServiceV1_s3logging_domain_default (35.43s)
=== RUN   TestAccFastlyServiceV1_s3logging_s3_env
--- PASS: TestAccFastlyServiceV1_s3logging_s3_env (34.53s)
=== RUN   TestAccFastlyServiceV1_s3logging_formatVersion
--- PASS: TestAccFastlyServiceV1_s3logging_formatVersion (34.65s)
=== RUN   TestResourceFastlyFlattenSnippets
--- PASS: TestResourceFastlyFlattenSnippets (0.00s)
=== RUN   TestAccFastlyServiceV1Snippet_basic
--- PASS: TestAccFastlyServiceV1Snippet_basic (73.21s)
=== RUN   TestResourceFastlyFlattenSplunk
--- PASS: TestResourceFastlyFlattenSplunk (0.11s)
=== RUN   TestAccFastlyServiceV1_splunk_basic
--- PASS: TestAccFastlyServiceV1_splunk_basic (76.31s)
=== RUN   TestAccFastlyServiceV1_splunk_default
--- PASS: TestAccFastlyServiceV1_splunk_default (34.64s)
=== RUN   TestAccFastlyServiceV1_splunk_complete
--- PASS: TestAccFastlyServiceV1_splunk_complete (76.49s)
=== RUN   TestAccFastlyServiceV1_splunk_env
--- PASS: TestAccFastlyServiceV1_splunk_env (35.38s)
=== RUN   TestResourceFastlyFlattenSumologic
--- PASS: TestResourceFastlyFlattenSumologic (0.00s)
=== RUN   TestAccFastlyServiceV1_sumologic
--- PASS: TestAccFastlyServiceV1_sumologic (74.10s)
=== RUN   TestResourceFastlyFlattenSyslog
--- PASS: TestResourceFastlyFlattenSyslog (0.08s)
=== RUN   TestAccFastlyServiceV1_syslog_basic
--- PASS: TestAccFastlyServiceV1_syslog_basic (75.39s)
=== RUN   TestAccFastlyServiceV1_syslog_formatVersion
--- PASS: TestAccFastlyServiceV1_syslog_formatVersion (34.28s)
=== RUN   TestAccFastlyServiceV1_syslog_useTls
--- PASS: TestAccFastlyServiceV1_syslog_useTls (34.55s)
=== RUN   TestResourceFastlyFlattenVCLs
--- PASS: TestResourceFastlyFlattenVCLs (0.00s)
=== RUN   TestAccFastlyServiceV1_VCL_basic
--- PASS: TestAccFastlyServiceV1_VCL_basic (73.00s)
=== RUN   TestUserAgentContainsProviderVersion
--- PASS: TestUserAgentContainsProviderVersion (0.00s)
=== RUN   TestAccFastlyIPRanges
--- PASS: TestAccFastlyIPRanges (0.66s)
=== RUN   TestEscapePercentSign
=== RUN   TestEscapePercentSign/string_no_percent_signs_should_change_nothing
=== RUN   TestEscapePercentSign/one_percent_sign_should_return_two_percent_signs
=== RUN   TestEscapePercentSign/one_percent_sign_mid-string_should_return_two_percent_signs_in_the_same_place
=== RUN   TestEscapePercentSign/one_percent_sign_before_left_curly_brace_should_return_four_percent_signs_then_curly_brace
--- PASS: TestEscapePercentSign (0.00s)
    --- PASS: TestEscapePercentSign/string_no_percent_signs_should_change_nothing (0.00s)
    --- PASS: TestEscapePercentSign/one_percent_sign_should_return_two_percent_signs (0.00s)
    --- PASS: TestEscapePercentSign/one_percent_sign_mid-string_should_return_two_percent_signs_in_the_same_place (0.00s)
    --- PASS: TestEscapePercentSign/one_percent_sign_before_left_curly_brace_should_return_four_percent_signs_then_curly_brace (0.00s)
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestResourceFastlyFlattenAclEntries
--- PASS: TestResourceFastlyFlattenAclEntries (0.00s)
=== RUN   TestAccFastlyServiceAclEntriesV1_create
--- PASS: TestAccFastlyServiceAclEntriesV1_create (37.54s)
=== RUN   TestAccFastlyServiceAclEntriesV1_update
--- PASS: TestAccFastlyServiceAclEntriesV1_update (80.44s)
=== RUN   TestAccFastlyServiceAclEntriesV1_update_additional_fields
--- PASS: TestAccFastlyServiceAclEntriesV1_update_additional_fields (80.34s)
=== RUN   TestAccFastlyServiceAclEntriesV1_delete
--- PASS: TestAccFastlyServiceAclEntriesV1_delete (76.65s)
=== RUN   TestAccFastlyServiceAclEntriesV1_import
--- PASS: TestAccFastlyServiceAclEntriesV1_import (36.65s)
=== RUN   TestAccFastlyServiceAclEntriesV1_process_1001_entries
--- PASS: TestAccFastlyServiceAclEntriesV1_process_1001_entries (81.15s)
=== RUN   TestResourceFastlyFlattenDictionaryItems
--- PASS: TestResourceFastlyFlattenDictionaryItems (0.00s)
=== RUN   TestAccFastlyServiceDictionaryItemV1_create
--- PASS: TestAccFastlyServiceDictionaryItemV1_create (36.93s)
=== RUN   TestAccFastlyServiceDictionaryItemV1_create_dynamic
--- PASS: TestAccFastlyServiceDictionaryItemV1_create_dynamic (37.42s)
=== RUN   TestAccFastlyServiceDictionaryItemV1_update
--- PASS: TestAccFastlyServiceDictionaryItemV1_update (79.92s)
=== RUN   TestAccFastlyServiceDictionaryItemV1_external_item_is_removed
--- PASS: TestAccFastlyServiceDictionaryItemV1_external_item_is_removed (60.82s)
=== RUN   TestAccFastlyServiceDictionaryItemV1_external_item_deleted
--- PASS: TestAccFastlyServiceDictionaryItemV1_external_item_deleted (80.32s)
=== RUN   TestAccFastlyServiceDictionaryItemV1_batch_1001_items
--- PASS: TestAccFastlyServiceDictionaryItemV1_batch_1001_items (61.69s)
=== RUN   TestAccFastlyServiceDictionaryItemV1_import
--- PASS: TestAccFastlyServiceDictionaryItemV1_import (36.98s)
=== RUN   TestAccFastlyServiceDynamicSnippetContentV1_create
--- PASS: TestAccFastlyServiceDynamicSnippetContentV1_create (36.02s)
=== RUN   TestAccFastlyServiceDynamicSnippetContentV1_update
--- PASS: TestAccFastlyServiceDynamicSnippetContentV1_update (78.62s)
=== RUN   TestAccFastlyServiceDynamicSnippetContentV1_external_snippet_is_removed
--- PASS: TestAccFastlyServiceDynamicSnippetContentV1_external_snippet_is_removed (80.08s)
=== RUN   TestAccFastlyServiceDynamicSnippetContentV1_normal_snippet_is_not_removed
--- PASS: TestAccFastlyServiceDynamicSnippetContentV1_normal_snippet_is_not_removed (76.95s)
=== RUN   TestAccFastlyServiceDynamicSnippetContentV1_import
--- PASS: TestAccFastlyServiceDynamicSnippetContentV1_import (36.03s)
=== RUN   TestResourceFastlyFlattenDomains
--- PASS: TestResourceFastlyFlattenDomains (0.00s)
=== RUN   TestResourceFastlyFlattenBackend
--- PASS: TestResourceFastlyFlattenBackend (0.00s)
=== RUN   TestAccFastlyServiceV1_updateDomain
--- PASS: TestAccFastlyServiceV1_updateDomain (73.04s)
=== RUN   TestAccFastlyServiceV1_updateBackend
--- PASS: TestAccFastlyServiceV1_updateBackend (75.57s)
=== RUN   TestAccFastlyServiceV1_updateInvalidBackend
--- PASS: TestAccFastlyServiceV1_updateInvalidBackend (36.69s)
=== RUN   TestAccFastlyServiceV1_basic
--- PASS: TestAccFastlyServiceV1_basic (74.30s)
=== RUN   TestAccFastlyServiceV1_disappears
--- PASS: TestAccFastlyServiceV1_disappears (14.26s)
=== RUN   TestAccFastlyServiceV1_defaultTTL
--- PASS: TestAccFastlyServiceV1_defaultTTL (112.36s)
=== RUN   TestAccFastlyServiceV1_createDefaultTTL
--- PASS: TestAccFastlyServiceV1_createDefaultTTL (33.45s)
=== RUN   TestAccFastlyServiceV1_createZeroDefaultTTL
--- PASS: TestAccFastlyServiceV1_createZeroDefaultTTL (32.96s)
=== RUN   TestAccFastlyServiceV1_creation_with_versionless_resources
--- PASS: TestAccFastlyServiceV1_creation_with_versionless_resources (40.29s)
=== RUN   TestAccFastlyUserV1_basic
--- PASS: TestAccFastlyUserV1_basic (2.70s)
=== RUN   TestAccFastlyUserV1_updateLogin
--- PASS: TestAccFastlyUserV1_updateLogin (2.81s)
=== RUN   TestValidateLoggingFormatVersion
=== RUN   TestValidateLoggingFormatVersion/1
=== RUN   TestValidateLoggingFormatVersion/2
=== RUN   TestValidateLoggingFormatVersion/3
=== RUN   TestValidateLoggingFormatVersion/4
=== RUN   TestValidateLoggingFormatVersion/5
=== RUN   TestValidateLoggingFormatVersion/0
--- PASS: TestValidateLoggingFormatVersion (0.00s)
    --- PASS: TestValidateLoggingFormatVersion/1 (0.00s)
    --- PASS: TestValidateLoggingFormatVersion/2 (0.00s)
    --- PASS: TestValidateLoggingFormatVersion/3 (0.00s)
    --- PASS: TestValidateLoggingFormatVersion/4 (0.00s)
    --- PASS: TestValidateLoggingFormatVersion/5 (0.00s)
    --- PASS: TestValidateLoggingFormatVersion/0 (0.00s)
=== RUN   TestValidateLoggingMessageType
=== RUN   TestValidateLoggingMessageType/classic
=== RUN   TestValidateLoggingMessageType/loggly
=== RUN   TestValidateLoggingMessageType/logplex
=== RUN   TestValidateLoggingMessageType/blank
=== RUN   TestValidateLoggingMessageType/CLASSIC
=== RUN   TestValidateLoggingMessageType/LOGGLY
=== RUN   TestValidateLoggingMessageType/LOGPLEX
=== RUN   TestValidateLoggingMessageType/BLANK
--- PASS: TestValidateLoggingMessageType (0.00s)
    --- PASS: TestValidateLoggingMessageType/classic (0.00s)
    --- PASS: TestValidateLoggingMessageType/loggly (0.00s)
    --- PASS: TestValidateLoggingMessageType/logplex (0.00s)
    --- PASS: TestValidateLoggingMessageType/blank (0.00s)
    --- PASS: TestValidateLoggingMessageType/CLASSIC (0.00s)
    --- PASS: TestValidateLoggingMessageType/LOGGLY (0.00s)
    --- PASS: TestValidateLoggingMessageType/LOGPLEX (0.00s)
    --- PASS: TestValidateLoggingMessageType/BLANK (0.00s)
=== RUN   TestValidateLoggingPlacement
=== RUN   TestValidateLoggingPlacement/none
=== RUN   TestValidateLoggingPlacement/waf_debug
=== RUN   TestValidateLoggingPlacement/NONE
=== RUN   TestValidateLoggingPlacement/WAF_DEBUG
--- PASS: TestValidateLoggingPlacement (0.00s)
    --- PASS: TestValidateLoggingPlacement/none (0.00s)
    --- PASS: TestValidateLoggingPlacement/waf_debug (0.00s)
    --- PASS: TestValidateLoggingPlacement/NONE (0.00s)
    --- PASS: TestValidateLoggingPlacement/WAF_DEBUG (0.00s)
=== RUN   TestValidateLoggingServerSideEncryption
=== RUN   TestValidateLoggingServerSideEncryption/AES256
=== RUN   TestValidateLoggingServerSideEncryption/aws:kms
=== RUN   TestValidateLoggingServerSideEncryption/aes256
=== RUN   TestValidateLoggingServerSideEncryption/AWS:KMS
=== RUN   TestValidateLoggingServerSideEncryption/aws:KMS
=== RUN   TestValidateLoggingServerSideEncryption/AWS:kms
--- PASS: TestValidateLoggingServerSideEncryption (0.00s)
    --- PASS: TestValidateLoggingServerSideEncryption/AES256 (0.00s)
    --- PASS: TestValidateLoggingServerSideEncryption/aws:kms (0.00s)
    --- PASS: TestValidateLoggingServerSideEncryption/aes256 (0.00s)
    --- PASS: TestValidateLoggingServerSideEncryption/AWS:KMS (0.00s)
    --- PASS: TestValidateLoggingServerSideEncryption/aws:KMS (0.00s)
    --- PASS: TestValidateLoggingServerSideEncryption/AWS:kms (0.00s)
=== RUN   TestValidateDirectorQuorum
=== RUN   TestValidateDirectorQuorum/0
=== RUN   TestValidateDirectorQuorum/55
=== RUN   TestValidateDirectorQuorum/100
=== RUN   TestValidateDirectorQuorum/-1
=== RUN   TestValidateDirectorQuorum/101
=== RUN   TestValidateDirectorQuorum/150
--- PASS: TestValidateDirectorQuorum (0.00s)
    --- PASS: TestValidateDirectorQuorum/0 (0.00s)
    --- PASS: TestValidateDirectorQuorum/55 (0.00s)
    --- PASS: TestValidateDirectorQuorum/100 (0.00s)
    --- PASS: TestValidateDirectorQuorum/-1 (0.00s)
    --- PASS: TestValidateDirectorQuorum/101 (0.00s)
    --- PASS: TestValidateDirectorQuorum/150 (0.00s)
=== RUN   TestValidateDirectorType
=== RUN   TestValidateDirectorType/4
=== RUN   TestValidateDirectorType/5
=== RUN   TestValidateDirectorType/0
=== RUN   TestValidateDirectorType/1
=== RUN   TestValidateDirectorType/2
=== RUN   TestValidateDirectorType/3
--- PASS: TestValidateDirectorType (0.00s)
    --- PASS: TestValidateDirectorType/4 (0.00s)
    --- PASS: TestValidateDirectorType/5 (0.00s)
    --- PASS: TestValidateDirectorType/0 (0.00s)
    --- PASS: TestValidateDirectorType/1 (0.00s)
    --- PASS: TestValidateDirectorType/2 (0.00s)
    --- PASS: TestValidateDirectorType/3 (0.00s)
=== RUN   TestValidateConditionType
=== RUN   TestValidateConditionType/REQUEST
=== RUN   TestValidateConditionType/RESPONSE
=== RUN   TestValidateConditionType/CACHE
=== RUN   TestValidateConditionType/PREFETCH
=== RUN   TestValidateConditionType/request
=== RUN   TestValidateConditionType/response
=== RUN   TestValidateConditionType/cache
=== RUN   TestValidateConditionType/prefetch
--- PASS: TestValidateConditionType (0.00s)
    --- PASS: TestValidateConditionType/REQUEST (0.00s)
    --- PASS: TestValidateConditionType/RESPONSE (0.00s)
    --- PASS: TestValidateConditionType/CACHE (0.00s)
    --- PASS: TestValidateConditionType/PREFETCH (0.00s)
    --- PASS: TestValidateConditionType/request (0.00s)
    --- PASS: TestValidateConditionType/response (0.00s)
    --- PASS: TestValidateConditionType/cache (0.00s)
    --- PASS: TestValidateConditionType/prefetch (0.00s)
=== RUN   TestValidateHeaderAction
=== RUN   TestValidateHeaderAction/set
=== RUN   TestValidateHeaderAction/append
=== RUN   TestValidateHeaderAction/delete
=== RUN   TestValidateHeaderAction/regex
=== RUN   TestValidateHeaderAction/regex_repeat
=== RUN   TestValidateHeaderAction/SET
=== RUN   TestValidateHeaderAction/APPEND
=== RUN   TestValidateHeaderAction/DELETE
=== RUN   TestValidateHeaderAction/REGEX
=== RUN   TestValidateHeaderAction/REGEX_REPEAT
--- PASS: TestValidateHeaderAction (0.00s)
    --- PASS: TestValidateHeaderAction/set (0.00s)
    --- PASS: TestValidateHeaderAction/append (0.00s)
    --- PASS: TestValidateHeaderAction/delete (0.00s)
    --- PASS: TestValidateHeaderAction/regex (0.00s)
    --- PASS: TestValidateHeaderAction/regex_repeat (0.00s)
    --- PASS: TestValidateHeaderAction/SET (0.00s)
    --- PASS: TestValidateHeaderAction/APPEND (0.00s)
    --- PASS: TestValidateHeaderAction/DELETE (0.00s)
    --- PASS: TestValidateHeaderAction/REGEX (0.00s)
    --- PASS: TestValidateHeaderAction/REGEX_REPEAT (0.00s)
=== RUN   TestValidateHeaderType
=== RUN   TestValidateHeaderType/request
=== RUN   TestValidateHeaderType/fetch
=== RUN   TestValidateHeaderType/cache
=== RUN   TestValidateHeaderType/response
=== RUN   TestValidateHeaderType/REQUEST
=== RUN   TestValidateHeaderType/FETCH
=== RUN   TestValidateHeaderType/CACHE
=== RUN   TestValidateHeaderType/RESPONSE
--- PASS: TestValidateHeaderType (0.00s)
    --- PASS: TestValidateHeaderType/request (0.00s)
    --- PASS: TestValidateHeaderType/fetch (0.00s)
    --- PASS: TestValidateHeaderType/cache (0.00s)
    --- PASS: TestValidateHeaderType/response (0.00s)
    --- PASS: TestValidateHeaderType/REQUEST (0.00s)
    --- PASS: TestValidateHeaderType/FETCH (0.00s)
    --- PASS: TestValidateHeaderType/CACHE (0.00s)
    --- PASS: TestValidateHeaderType/RESPONSE (0.00s)
=== RUN   TestValidateSnippetType
=== RUN   TestValidateSnippetType/init
=== RUN   TestValidateSnippetType/recv
=== RUN   TestValidateSnippetType/hit
=== RUN   TestValidateSnippetType/miss
=== RUN   TestValidateSnippetType/pass
=== RUN   TestValidateSnippetType/hash
=== RUN   TestValidateSnippetType/fetch
=== RUN   TestValidateSnippetType/error
=== RUN   TestValidateSnippetType/deliver
=== RUN   TestValidateSnippetType/log
=== RUN   TestValidateSnippetType/none
=== RUN   TestValidateSnippetType/INIT
=== RUN   TestValidateSnippetType/RECV
=== RUN   TestValidateSnippetType/HIT
=== RUN   TestValidateSnippetType/MISS
=== RUN   TestValidateSnippetType/PASS
=== RUN   TestValidateSnippetType/FETCH
=== RUN   TestValidateSnippetType/HASH
=== RUN   TestValidateSnippetType/ERROR
=== RUN   TestValidateSnippetType/DELIVER
=== RUN   TestValidateSnippetType/LOG
=== RUN   TestValidateSnippetType/NONE
--- PASS: TestValidateSnippetType (0.00s)
    --- PASS: TestValidateSnippetType/init (0.00s)
    --- PASS: TestValidateSnippetType/recv (0.00s)
    --- PASS: TestValidateSnippetType/hit (0.00s)
    --- PASS: TestValidateSnippetType/miss (0.00s)
    --- PASS: TestValidateSnippetType/pass (0.00s)
    --- PASS: TestValidateSnippetType/hash (0.00s)
    --- PASS: TestValidateSnippetType/fetch (0.00s)
    --- PASS: TestValidateSnippetType/error (0.00s)
    --- PASS: TestValidateSnippetType/deliver (0.00s)
    --- PASS: TestValidateSnippetType/log (0.00s)
    --- PASS: TestValidateSnippetType/none (0.00s)
    --- PASS: TestValidateSnippetType/INIT (0.00s)
    --- PASS: TestValidateSnippetType/RECV (0.00s)
    --- PASS: TestValidateSnippetType/HIT (0.00s)
    --- PASS: TestValidateSnippetType/MISS (0.00s)
    --- PASS: TestValidateSnippetType/PASS (0.00s)
    --- PASS: TestValidateSnippetType/FETCH (0.00s)
    --- PASS: TestValidateSnippetType/HASH (0.00s)
    --- PASS: TestValidateSnippetType/ERROR (0.00s)
    --- PASS: TestValidateSnippetType/DELIVER (0.00s)
    --- PASS: TestValidateSnippetType/LOG (0.00s)
    --- PASS: TestValidateSnippetType/NONE (0.00s)
=== RUN   TestValidateDictionaryItemMaxSize
=== RUN   TestValidateDictionaryItemMaxSize/Ten_hundred_dictionary_items
=== RUN   TestValidateDictionaryItemMaxSize/Ten_thousand_dictionary_items
=== RUN   TestValidateDictionaryItemMaxSize/Ten_thousand_and_one_dictionary_items
--- PASS: TestValidateDictionaryItemMaxSize (0.01s)
    --- PASS: TestValidateDictionaryItemMaxSize/Ten_hundred_dictionary_items (0.00s)
    --- PASS: TestValidateDictionaryItemMaxSize/Ten_thousand_dictionary_items (0.00s)
    --- PASS: TestValidateDictionaryItemMaxSize/Ten_thousand_and_one_dictionary_items (0.00s)
=== RUN   TestValidateUserRole
=== RUN   TestValidateUserRole/user
=== RUN   TestValidateUserRole/billing
=== RUN   TestValidateUserRole/engineer
=== RUN   TestValidateUserRole/superuser
=== RUN   TestValidateUserRole/USER
=== RUN   TestValidateUserRole/BILLING
=== RUN   TestValidateUserRole/ENGINEER
=== RUN   TestValidateUserRole/SUPERUSER
--- PASS: TestValidateUserRole (0.00s)
    --- PASS: TestValidateUserRole/user (0.00s)
    --- PASS: TestValidateUserRole/billing (0.00s)
    --- PASS: TestValidateUserRole/engineer (0.00s)
    --- PASS: TestValidateUserRole/superuser (0.00s)
    --- PASS: TestValidateUserRole/USER (0.00s)
    --- PASS: TestValidateUserRole/BILLING (0.00s)
    --- PASS: TestValidateUserRole/ENGINEER (0.00s)
    --- PASS: TestValidateUserRole/SUPERUSER (0.00s)
=== RUN   TestValidateHTTPSURL
=== RUN   TestValidateHTTPSURL/https://api.fastly.com
=== RUN   TestValidateHTTPSURL/http://example.com
--- PASS: TestValidateHTTPSURL (0.00s)
    --- PASS: TestValidateHTTPSURL/https://api.fastly.com (0.00s)
    --- PASS: TestValidateHTTPSURL/http://example.com (0.00s)
PASS
ok      github.com/terraform-providers/terraform-provider-fastly/fastly 4923.344s
?       github.com/terraform-providers/terraform-provider-fastly/version        [no test files]
make testacc TESTARGS='-count=1'  251.87s user 55.68s system 6% cpu 1:22:05.81 total
```

</p>
</details>