### PR TITLE
Fix error check in s3_logging which was causing runtime panic

### DIFF
--- a/fastly/block_fastly_service_v1_s3logging.go
+++ b/fastly/block_fastly_service_v1_s3logging.go
@@ -49,7 +49,10 @@ func (h *S3LoggingServiceAttributeHandler) Process(d *schema.ResourceData, lates
 
 	// POST new/updated S3 Logging.
 	for _, sRaw := range addS3Logging {
-		opts, _ := h.buildCreate(sRaw, d.Id(), latestVersion)
+		opts, err := h.buildCreate(sRaw, d.Id(), latestVersion)
+		if err != nil {
+			return err
+		}
 
 		// @HACK for a TF SDK Issue.
 		//
@@ -65,7 +68,7 @@ func (h *S3LoggingServiceAttributeHandler) Process(d *schema.ResourceData, lates
 			continue
 		}
 
-		err := createS3(conn, opts)
+		err = createS3(conn, opts)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
### TL;DR
Fixes a missing error check within s3logging which was causing a runtime panic if the credential properties (`s3_access_key`, `s3_secret_key`) were omitted. 

Fixes: #289 