### PR TITLE
Fix resource references in compute documentation

### DIFF
--- a/website/docs/r/service_compute.html.markdown
+++ b/website/docs/r/service_compute.html.markdown
@@ -20,26 +20,25 @@ Basic usage:
 
 ```hcl
 resource "fastly_service_compute" "demo" {
-name = "demofastly"
+    name = "demofastly"
 
-domain {
-  name    = "demo.notexample.com"
-  comment = "demo"
-}
+    domain {
+      name    = "demo.notexample.com"
+      comment = "demo"
+    }
 
-backend {
-  address = "127.0.0.1"
-  name    = "localhost"
-  port    = 80
-}
+    backend {
+      address = "127.0.0.1"
+      name    = "localhost"
+      port    = 80
+    }
 
-package {
-  filename = "package.tar.gz"
-  source_code_hash = filesha512("package.tar.gz")
-}
+    package {
+      filename = "package.tar.gz"
+      source_code_hash = filesha512("package.tar.gz")
+    }
 
-force_destroy = true
-
+    force_destroy = true
 }
 ```
 

--- a/website/docs/r/service_compute.html.markdown
+++ b/website/docs/r/service_compute.html.markdown
@@ -19,7 +19,7 @@ on their documentation site for guidance.
 Basic usage:
 
 ```hcl
-resource "fastly_service_v1" "demo" {
+resource "fastly_service_compute" "demo" {
 name = "demofastly"
 
 domain {
@@ -39,6 +39,7 @@ package {
 }
 
 force_destroy = true
+
 }
 ```
 
@@ -479,6 +480,7 @@ In addition to the arguments listed above, the following attributes are exported
 
 Fastly Service can be imported using their service ID, e.g.
 
+
 ```
-$ terraform import fastly_service_v1.demo xxxxxxxxxxxxxxxxxxxx
+$ terraform import fastly_service_compute.demo xxxxxxxxxxxxxxxxxxxx
 ```

--- a/website/docs/r/service_v1.html.markdown
+++ b/website/docs/r/service_v1.html.markdown
@@ -832,3 +832,4 @@ Fastly Service can be imported using their service ID, e.g.
 ```
 $ terraform import fastly_service_v1.demo xxxxxxxxxxxxxxxxxxxx
 ```
+

--- a/website_src/docs/r/components/footer.markdown.tmpl
+++ b/website_src/docs/r/components/footer.markdown.tmpl
@@ -8,6 +8,9 @@
 
 Fastly Service can be imported using their service ID, e.g.
 
-```
+{{ if eq .Data.ServiceType "vcl"}}```
 $ terraform import fastly_service_v1.demo xxxxxxxxxxxxxxxxxxxx
 ```{{end}}
+{{ if eq .Data.ServiceType "wasm"}}```
+$ terraform import fastly_service_compute.demo xxxxxxxxxxxxxxxxxxxx
+```{{end}}{{end}}

--- a/website_src/docs/r/service_compute.html.markdown.tmpl
+++ b/website_src/docs/r/service_compute.html.markdown.tmpl
@@ -20,26 +20,25 @@ Basic usage:
 
 ```hcl
 resource "fastly_service_compute" "demo" {
-name = "demofastly"
+    name = "demofastly"
 
-domain {
-  name    = "demo.notexample.com"
-  comment = "demo"
-}
+    domain {
+      name    = "demo.notexample.com"
+      comment = "demo"
+    }
 
-backend {
-  address = "127.0.0.1"
-  name    = "localhost"
-  port    = 80
-}
+    backend {
+      address = "127.0.0.1"
+      name    = "localhost"
+      port    = 80
+    }
 
-package {
-  filename = "package.tar.gz"
-  source_code_hash = filesha512("package.tar.gz")
-}
+    package {
+      filename = "package.tar.gz"
+      source_code_hash = filesha512("package.tar.gz")
+    }
 
-force_destroy = true
-
+    force_destroy = true
 }
 ```
 

--- a/website_src/docs/r/service_compute.html.markdown.tmpl
+++ b/website_src/docs/r/service_compute.html.markdown.tmpl
@@ -19,7 +19,7 @@ on their documentation site for guidance.
 Basic usage:
 
 ```hcl
-resource "fastly_service_v1" "demo" {
+resource "fastly_service_compute" "demo" {
 name = "demofastly"
 
 domain {
@@ -39,6 +39,7 @@ package {
 }
 
 force_destroy = true
+
 }
 ```
 


### PR DESCRIPTION
### TL;DR
More fixes for the `fastly_service_compute` documentation.

- Fixes copy/paste errors referencing the resource name `s/fastly_service_v1/fastly_service_compute/`
- Fixes footer template for importing `s/fastly_service_v1/fastly_service_compute/`
- Fixes whitespace indentation in example