### PR TITLE
Update CHANGELOG.md for v0.19.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 ## 0.20.0 (Unreleased)
+## 0.19.3 (July 30, 2020)
+
+NOTES:
+
+* provider: Initial release to the [Terraform Registry](https://registry.terraform.io/)
+
 ## 0.19.2 (July 22, 2020)
 
 NOTES:


### PR DESCRIPTION
### TL;DR
Updates the CHANGELOG.md for the inaugural release to the [Terraform Registry](https://registry.terraform.io/) 🎉

### Notes:
Per HashiCorp's recommendations, your first registry release should only be a patch with no changes to ensure documentation etc is all redirected appropriately.