### PR TITLE
have docs recommend override_host for s3 buckets

### DIFF
--- a/website/docs/r/service_v1.html.markdown
+++ b/website/docs/r/service_v1.html.markdown
@@ -54,6 +54,7 @@ resource "fastly_service_v1" "demo" {
     address = "demo.notexample.com.s3-website-us-west-2.amazonaws.com"
     name    = "AWS S3 hosting"
     port    = 80
+    override_host = "demo.notexample.com.s3-website-us-west-2.amazonaws.com"
   }
 
   header {
@@ -68,8 +69,6 @@ resource "fastly_service_v1" "demo" {
     extensions    = ["css", "js"]
     content_types = ["text/html", "text/css"]
   }
-
-  default_host = "${aws_s3_bucket.website.name}.s3-website-us-west-2.amazonaws.com"
 
   force_destroy = true
 }
@@ -205,8 +204,8 @@ resource "fastly_service_v1" "demo" {
 ```
 
 -> **Note:** For an AWS S3 Bucket, the Backend address is
-`<domain>.s3-website-<region>.amazonaws.com`. The `default_host` attribute
-should be set to `<bucket_name>.s3-website-<region>.amazonaws.com`. See the
+`<domain>.s3-website-<region>.amazonaws.com`. The `override_host` attribute
+should be set to `<bucket_name>.s3-website-<region>.amazonaws.com` in the `backend` block. See the
 Fastly documentation on [Amazon S3][fastly-s3].
 
 ## Argument Reference

--- a/website_src/docs/r/service_v1.html.markdown.tmpl
+++ b/website_src/docs/r/service_v1.html.markdown.tmpl
@@ -54,6 +54,7 @@ resource "fastly_service_v1" "demo" {
     address = "demo.notexample.com.s3-website-us-west-2.amazonaws.com"
     name    = "AWS S3 hosting"
     port    = 80
+    override_host = "demo.notexample.com.s3-website-us-west-2.amazonaws.com"
   }
 
   header {
@@ -68,8 +69,6 @@ resource "fastly_service_v1" "demo" {
     extensions    = ["css", "js"]
     content_types = ["text/html", "text/css"]
   }
-
-  default_host = "${aws_s3_bucket.website.name}.s3-website-us-west-2.amazonaws.com"
 
   force_destroy = true
 }
@@ -205,8 +204,8 @@ resource "fastly_service_v1" "demo" {
 ```
 
 -> **Note:** For an AWS S3 Bucket, the Backend address is
-`<domain>.s3-website-<region>.amazonaws.com`. The `default_host` attribute
-should be set to `<bucket_name>.s3-website-<region>.amazonaws.com`. See the
+`<domain>.s3-website-<region>.amazonaws.com`. The `override_host` attribute
+should be set to `<bucket_name>.s3-website-<region>.amazonaws.com` in the `backend` block. See the
 Fastly documentation on [Amazon S3][fastly-s3].
 
 ## Argument Reference


### PR DESCRIPTION
override_host is a better way to do this to avoid the workaround for shielding where it is necessary to add the backend to the configured domains on the service. 

this would also help users to avoid the known bug where default_host is not removed properly: https://github.com/fastly/terraform-provider-fastly/issues/85