### PR TITLE
Keeping backends in directors when backends are modified

### DIFF
--- a/fastly/diff.go
+++ b/fastly/diff.go
@@ -1,0 +1,110 @@
+package fastly
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+// KeyFunc calculates a key from an element
+type KeyFunc func(interface{}) (interface{}, error)
+
+// SetDiff diffs two sets using a key to identify which elements have been added, changed, removed or not modified.
+//
+// This object compares sets using Terraform's schema.Set methods (e.g. Difference() and Intersection())
+// so that the same differences displayed to the user are honoured here.
+//
+// SetDiff however is able to tell if two elements from two distinct sets have the same key. This is useful to detect
+// that an element should be updated instead of recreated on the remote server.
+type SetDiff struct {
+	keyFunc KeyFunc
+}
+
+// DiffResult contains the differences between two sets
+type DiffResult struct {
+	Added      []interface{}
+	Modified   []interface{}
+	Deleted    []interface{}
+	Unmodified []interface{}
+}
+
+// NewSetDiff creates a new SetDiff with a provided KeyFunc.
+func NewSetDiff(keyFunc KeyFunc) *SetDiff {
+	return &SetDiff{
+		keyFunc: keyFunc,
+	}
+}
+
+// Diff diffs two Set objects and returns a DiffResult object containing the diffs.
+//
+// The DiffResult object will contain the elements from newSet on the Modified field.
+func (h *SetDiff) Diff(oldSet, newSet *schema.Set) (*DiffResult, error) {
+
+	// Convert the set into a map to facilitate lookup
+	oldSetMap := map[interface{}]interface{}{}
+	newSetMap := map[interface{}]interface{}{}
+
+	for _, elem := range oldSet.List() {
+		key, err := h.computeKey(elem)
+		if err != nil {
+			return nil, newElementKeyError(elem, err)
+		}
+		oldSetMap[key] = elem
+	}
+
+	for _, elem := range newSet.List() {
+		key, err := h.computeKey(elem)
+		if err != nil {
+			return nil, newElementKeyError(elem, err)
+		}
+		newSetMap[key] = elem
+	}
+
+	// Compute all added and modified elements using Terraform set comparison method.
+	var added, modified []interface{}
+	for _, newElem := range newSet.Difference(oldSet).List() {
+		key, err := h.computeKey(newElem)
+		if err != nil {
+			return nil, newElementKeyError(newElem, err)
+		}
+		if oldSetMap[key] != nil {
+			modified = append(modified, newElem)
+		} else {
+			added = append(added, newElem)
+		}
+	}
+
+	var deleted []interface{}
+	for _, oldElem := range oldSet.Difference(newSet).List() {
+		key, err := h.computeKey(oldElem)
+		if err != nil {
+			return nil, newElementKeyError(oldElem, err)
+		}
+		if newSetMap[key] == nil {
+			deleted = append(deleted, oldElem)
+		}
+	}
+
+	unmodified := oldSet.Intersection(newSet).List()
+
+	return &DiffResult{
+		Added:      added,
+		Modified:   modified,
+		Deleted:    deleted,
+		Unmodified: unmodified,
+	}, nil
+}
+
+func (h *SetDiff) computeKey(elem interface{}) (interface{}, error) {
+	key, err := h.keyFunc(elem)
+	if err != nil {
+		return nil, err
+	}
+	if key == nil {
+		return nil, fmt.Errorf("invalid key for element %v, %v", elem, err)
+	}
+	return key, nil
+}
+
+func newElementKeyError(elem interface{}, err error) error {
+	return fmt.Errorf("error computing the key for element %v, %v", elem, err)
+}

--- a/fastly/diff_test.go
+++ b/fastly/diff_test.go
@@ -1,0 +1,147 @@
+package fastly
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestSetDiff_Diff(t *testing.T) {
+	cases := []struct {
+		name               string
+		keyFunc            KeyFunc
+		oldElements        []map[string]interface{}
+		newElements        []map[string]interface{}
+		expectedAdded      []map[string]interface{}
+		expectedModified   []map[string]interface{}
+		expectedDeleted    []map[string]interface{}
+		expectedUnmodified []map[string]interface{}
+		expectedError      bool
+	}{
+		{
+			name: "should return the correct diff",
+			oldElements: []map[string]interface{}{
+				{
+					"name":  "name-a",
+					"value": "value-a",
+				},
+				{
+					"name":  "b",
+					"value": "value-b",
+				},
+				{
+					"name":  "name-d",
+					"value": "value-d",
+				},
+			},
+			newElements: []map[string]interface{}{
+				{
+					"name":  "name-a",
+					"value": "value-a-new",
+				},
+				{
+					"name":  "name-c",
+					"value": "value-c",
+				},
+				{
+					"name":  "name-d",
+					"value": "value-d",
+				},
+			},
+			expectedAdded: []map[string]interface{}{
+				{
+					"name":  "name-c",
+					"value": "value-c",
+				},
+			},
+			expectedModified: []map[string]interface{}{
+				{
+					"name":  "name-a",
+					"value": "value-a-new",
+				},
+			},
+			expectedDeleted: []map[string]interface{}{
+				{
+					"name":  "b",
+					"value": "value-b",
+				},
+			},
+			expectedUnmodified: []map[string]interface{}{
+				{
+					"name":  "name-d",
+					"value": "value-d",
+				},
+			},
+		},
+		{
+			name: "should diff empty element lists",
+		},
+		{
+			name: "should return error if key cannot be computed",
+			oldElements: []map[string]interface{}{
+				{},
+			},
+			newElements: []map[string]interface{}{
+				{},
+			},
+			expectedError: true,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(fmt.Sprintf(c.name), func(t *testing.T) {
+			var differ *SetDiff
+			if c.keyFunc != nil {
+				differ = NewSetDiff(c.keyFunc)
+			} else {
+				differ = NewSetDiff(testKeyFuncByName)
+			}
+
+			diff, err := differ.Diff(testCreateSet(c.oldElements), testCreateSet(c.newElements))
+
+			if err != nil && !c.expectedError {
+				t.Fatalf("Error not expected: %v", err)
+			}
+
+			if err == nil && c.expectedError {
+				t.Fatalf("Error expected: %v", err)
+			}
+
+			if err == nil && !c.expectedError {
+				assert.ElementsMatch(t, c.expectedAdded, diff.Added)
+				assert.ElementsMatch(t, c.expectedModified, diff.Modified)
+				assert.ElementsMatch(t, c.expectedDeleted, diff.Deleted)
+				assert.ElementsMatch(t, c.expectedUnmodified, diff.Unmodified)
+			}
+		})
+	}
+}
+
+func testKeyFuncByName(element interface{}) (interface{}, error) {
+	elemMap := element.(map[string]interface{})
+	return elemMap["name"], nil
+}
+
+func testCreateSet(items []map[string]interface{}) *schema.Set {
+	return schema.NewSet(schema.HashResource(&schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"value": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+		},
+	}), toArrayInterface(items))
+}
+
+func toArrayInterface(arrayOfMaps []map[string]interface{}) []interface{} {
+	var result []interface{}
+	for _, c := range arrayOfMaps {
+		result = append(result, c)
+	}
+	return result
+}


### PR DESCRIPTION
Fixes #143 

This change is based on the Option 2 described on #197 and some further analysis to determine the best option.

I've made the Diff computation a separate component so that in the future, other parts of the code can re-use it to perform updates instead of delete/create.

I've also fixed some unrelated issues with logging endpoints on the compute resource (see commit cc7bec3) which was causing the acceptance tests to fail.

<details><summary>Acceptance Test results</summary>
<p>

```
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v  -timeout 360m -ldflags="-X=github.com/fastly/terraform-provider-fastly/version.ProviderVersion=acc"
?       github.com/terraform-providers/terraform-provider-fastly        [no test files]
=== RUN   TestResourceFastlyFlattenAcl
--- PASS: TestResourceFastlyFlattenAcl (0.00s)
=== RUN   TestAccFastlyServiceV1_acl
--- PASS: TestAccFastlyServiceV1_acl (76.48s)
=== RUN   TestAccFastlyServiceV1_bigquerylogging
--- PASS: TestAccFastlyServiceV1_bigquerylogging (70.51s)
=== RUN   TestAccFastlyServiceV1_bigquerylogging_compute
--- PASS: TestAccFastlyServiceV1_bigquerylogging_compute (58.07s)
=== RUN   TestAccFastlyServiceV1_bigquerylogging_env
--- PASS: TestAccFastlyServiceV1_bigquerylogging_env (70.25s)
=== RUN   TestResourceFastlyFlattenBigQuery
--- PASS: TestResourceFastlyFlattenBigQuery (0.18s)
=== RUN   TestResourceFastlyFlattenBlobStorage
--- PASS: TestResourceFastlyFlattenBlobStorage (0.00s)
=== RUN   TestAccFastlyServiceV1_blobstoragelogging_basic
--- PASS: TestAccFastlyServiceV1_blobstoragelogging_basic (131.49s)
=== RUN   TestAccFastlyServiceV1_blobstoragelogging_basic_compute
--- PASS: TestAccFastlyServiceV1_blobstoragelogging_basic_compute (51.44s)
=== RUN   TestAccFastlyServiceV1_blobstoragelogging_default
--- PASS: TestAccFastlyServiceV1_blobstoragelogging_default (63.51s)
=== RUN   TestAccFastlyServiceV1_blobstoragelogging_env
--- PASS: TestAccFastlyServiceV1_blobstoragelogging_env (59.11s)
=== RUN   TestResourceFastlyFlattenCacheSettings
--- PASS: TestResourceFastlyFlattenCacheSettings (0.00s)
=== RUN   TestAccFastlyServiceV1CacheSetting_basic
--- PASS: TestAccFastlyServiceV1CacheSetting_basic (123.27s)
=== RUN   TestResourceFastlyFlattenConditions
--- PASS: TestResourceFastlyFlattenConditions (0.00s)
=== RUN   TestAccFastlyServiceV1_conditional_basic
--- PASS: TestAccFastlyServiceV1_conditional_basic (59.27s)
=== RUN   TestResourceFastlyFlattenDictionary
--- PASS: TestResourceFastlyFlattenDictionary (0.00s)
=== RUN   TestAccFastlyServiceV1_dictionary
--- PASS: TestAccFastlyServiceV1_dictionary (62.26s)
=== RUN   TestAccFastlyServiceV1_dictionary_write_only
--- PASS: TestAccFastlyServiceV1_dictionary_write_only (59.21s)
=== RUN   TestAccFastlyServiceV1_dictionary_update_name
--- PASS: TestAccFastlyServiceV1_dictionary_update_name (122.33s)
=== RUN   TestAccFastlyServiceV1_dictionary_update_write_only
--- PASS: TestAccFastlyServiceV1_dictionary_update_write_only (125.92s)
=== RUN   TestResourceFastlyFlattenDirectors
--- PASS: TestResourceFastlyFlattenDirectors (0.00s)
=== RUN   TestAccFastlyServiceV1_directors_basic
--- PASS: TestAccFastlyServiceV1_directors_basic (145.08s)
=== RUN   TestResourceFastlyFlattenDynamicSnippets
--- PASS: TestResourceFastlyFlattenDynamicSnippets (0.00s)
=== RUN   TestAccFastlyServiceV1DynamicSnippet_basic
--- PASS: TestAccFastlyServiceV1DynamicSnippet_basic (119.39s)
=== RUN   TestResourceFastlyFlattenGCS
--- PASS: TestResourceFastlyFlattenGCS (0.18s)
=== RUN   TestAccFastlyServiceV1_gcslogging
--- PASS: TestAccFastlyServiceV1_gcslogging (61.71s)
=== RUN   TestAccFastlyServiceV1_gcslogging_compute
--- PASS: TestAccFastlyServiceV1_gcslogging_compute (49.15s)
=== RUN   TestAccFastlyServiceV1_gcslogging_env
--- PASS: TestAccFastlyServiceV1_gcslogging_env (58.64s)
=== RUN   TestResourceFastlyFlattenGzips
--- PASS: TestResourceFastlyFlattenGzips (0.00s)
=== RUN   TestAccFastlyServiceV1_gzips_basic
--- PASS: TestAccFastlyServiceV1_gzips_basic (124.41s)
=== RUN   TestResourceFastlyFlattenHeaders
--- PASS: TestResourceFastlyFlattenHeaders (0.00s)
=== RUN   TestFastlyServiceV1_BuildHeaders
--- PASS: TestFastlyServiceV1_BuildHeaders (0.00s)
=== RUN   TestAccFastlyServiceV1_headers_basic
--- PASS: TestAccFastlyServiceV1_headers_basic (156.23s)
=== RUN   TestResourceFastlyFlattenHealthChecks
--- PASS: TestResourceFastlyFlattenHealthChecks (0.00s)
=== RUN   TestAccFastlyServiceV1_healthcheck_basic
--- PASS: TestAccFastlyServiceV1_healthcheck_basic (118.75s)
=== RUN   TestResourceFastlyFlattenHTTPS
--- PASS: TestResourceFastlyFlattenHTTPS (0.00s)
=== RUN   TestAccFastlyServiceV1_httpslogging_basic
--- PASS: TestAccFastlyServiceV1_httpslogging_basic (133.28s)
=== RUN   TestAccFastlyServiceV1_httpslogging_basic_compute
--- PASS: TestAccFastlyServiceV1_httpslogging_basic_compute (50.33s)
=== RUN   TestResourceFastlyFlattenLogentries
--- PASS: TestResourceFastlyFlattenLogentries (0.00s)
=== RUN   TestAccFastlyServiceV1_logentries_basic
--- PASS: TestAccFastlyServiceV1_logentries_basic (123.60s)
=== RUN   TestAccFastlyServiceV1_logentries_basic_compute
--- PASS: TestAccFastlyServiceV1_logentries_basic_compute (48.85s)
=== RUN   TestAccFastlyServiceV1_logentries_formatVersion
--- PASS: TestAccFastlyServiceV1_logentries_formatVersion (62.31s)
=== RUN   TestResourceFastlyFlattenCloudfiles
--- PASS: TestResourceFastlyFlattenCloudfiles (0.00s)
=== RUN   TestAccFastlyServiceV1_logging_cloudfiles_basic
--- PASS: TestAccFastlyServiceV1_logging_cloudfiles_basic (121.86s)
=== RUN   TestAccFastlyServiceV1_logging_cloudfiles_basic_compute
--- PASS: TestAccFastlyServiceV1_logging_cloudfiles_basic_compute (50.49s)
=== RUN   TestResourceFastlyFlattenDatadog
--- PASS: TestResourceFastlyFlattenDatadog (0.00s)
=== RUN   TestAccFastlyServiceV1_logging_datadog_basic
--- PASS: TestAccFastlyServiceV1_logging_datadog_basic (127.03s)
=== RUN   TestAccFastlyServiceV1_logging_datadog_basic_compute
--- PASS: TestAccFastlyServiceV1_logging_datadog_basic_compute (50.76s)
=== RUN   TestResourceFastlyFlattenDigitalOcean
--- PASS: TestResourceFastlyFlattenDigitalOcean (0.01s)
=== RUN   TestAccFastlyServiceV1_logging_digitalocean_basic
--- PASS: TestAccFastlyServiceV1_logging_digitalocean_basic (122.81s)
=== RUN   TestAccFastlyServiceV1_logging_digitalocean_basic_compute
--- PASS: TestAccFastlyServiceV1_logging_digitalocean_basic_compute (51.36s)
=== RUN   TestResourceFastlyFlattenElasticsearch
--- PASS: TestResourceFastlyFlattenElasticsearch (0.01s)
=== RUN   TestAccFastlyServiceV1_logging_elasticsearch_basic
--- PASS: TestAccFastlyServiceV1_logging_elasticsearch_basic (138.44s)
=== RUN   TestAccFastlyServiceV1_logging_elasticsearch_basic_compute
--- PASS: TestAccFastlyServiceV1_logging_elasticsearch_basic_compute (55.35s)
=== RUN   TestResourceFastlyFlattenFTP
--- PASS: TestResourceFastlyFlattenFTP (0.00s)
=== RUN   TestAccFastlyServiceV1_logging_ftp_basic
--- PASS: TestAccFastlyServiceV1_logging_ftp_basic (129.00s)
=== RUN   TestAccFastlyServiceV1_logging_ftp_basic_compute
--- PASS: TestAccFastlyServiceV1_logging_ftp_basic_compute (54.25s)
=== RUN   TestResourceFastlyFlattenGooglePubSub
--- PASS: TestResourceFastlyFlattenGooglePubSub (0.00s)
=== RUN   TestAccFastlyServiceV1_googlepubsublogging_basic
--- PASS: TestAccFastlyServiceV1_googlepubsublogging_basic (124.06s)
=== RUN   TestAccFastlyServiceV1_googlepubsublogging_basic_compute
--- PASS: TestAccFastlyServiceV1_googlepubsublogging_basic_compute (50.28s)
=== RUN   TestResourceFastlyFlattenHeroku
--- PASS: TestResourceFastlyFlattenHeroku (0.00s)
=== RUN   TestAccFastlyServiceV1_logging_heroku_basic
--- PASS: TestAccFastlyServiceV1_logging_heroku_basic (124.44s)
=== RUN   TestAccFastlyServiceV1_logging_heroku_basic_compute
--- PASS: TestAccFastlyServiceV1_logging_heroku_basic_compute (52.66s)
=== RUN   TestResourceFastlyFlattenHoneycomb
--- PASS: TestResourceFastlyFlattenHoneycomb (0.00s)
=== RUN   TestAccFastlyServiceV1_logging_honeycomb_basic
--- PASS: TestAccFastlyServiceV1_logging_honeycomb_basic (124.08s)
=== RUN   TestAccFastlyServiceV1_logging_honeycomb_basic_compute
--- PASS: TestAccFastlyServiceV1_logging_honeycomb_basic_compute (49.19s)
=== RUN   TestResourceFastlyFlattenKafka
--- PASS: TestResourceFastlyFlattenKafka (0.00s)
=== RUN   TestAccFastlyServiceV1_kafkalogging_basic
--- PASS: TestAccFastlyServiceV1_kafkalogging_basic (126.13s)
=== RUN   TestAccFastlyServiceV1_kafkalogging_basic_compute
--- PASS: TestAccFastlyServiceV1_kafkalogging_basic_compute (50.67s)
=== RUN   TestResourceFastlyFlattenLoggly
--- PASS: TestResourceFastlyFlattenLoggly (0.00s)
=== RUN   TestAccFastlyServiceV1_logging_loggly_basic
--- PASS: TestAccFastlyServiceV1_logging_loggly_basic (120.99s)
=== RUN   TestAccFastlyServiceV1_logging_loggly_basic_compute
--- PASS: TestAccFastlyServiceV1_logging_loggly_basic_compute (51.47s)
=== RUN   TestResourceFastlyFlattenLogshuttle
--- PASS: TestResourceFastlyFlattenLogshuttle (0.00s)
=== RUN   TestAccFastlyServiceV1_logging_logshuttle_basic
--- PASS: TestAccFastlyServiceV1_logging_logshuttle_basic (119.91s)
=== RUN   TestAccFastlyServiceV1_logging_logshuttle_basic_compute
--- PASS: TestAccFastlyServiceV1_logging_logshuttle_basic_compute (50.74s)
=== RUN   TestResourceFastlyFlattenNewRelic
--- PASS: TestResourceFastlyFlattenNewRelic (0.00s)
=== RUN   TestAccFastlyServiceV1_logging_newrelic_basic
--- PASS: TestAccFastlyServiceV1_logging_newrelic_basic (123.52s)
=== RUN   TestAccFastlyServiceV1_logging_newrelic_basic_compute
--- PASS: TestAccFastlyServiceV1_logging_newrelic_basic_compute (48.01s)
=== RUN   TestResourceFastlyFlattenOpenstack
--- PASS: TestResourceFastlyFlattenOpenstack (0.01s)
=== RUN   TestAccFastlyServiceV1_logging_openstack_basic
--- PASS: TestAccFastlyServiceV1_logging_openstack_basic (125.66s)
=== RUN   TestAccFastlyServiceV1_logging_openstack_basic_compute
--- PASS: TestAccFastlyServiceV1_logging_openstack_basic_compute (48.03s)
=== RUN   TestResourceFastlyFlattenScalyr
--- PASS: TestResourceFastlyFlattenScalyr (0.00s)
=== RUN   TestAccFastlyServiceV1_scalyrlogging_basic
--- PASS: TestAccFastlyServiceV1_scalyrlogging_basic (125.18s)
=== RUN   TestAccFastlyServiceV1_scalyrlogging_basic_compute
--- PASS: TestAccFastlyServiceV1_scalyrlogging_basic_compute (48.48s)
=== RUN   TestResourceFastlyFlattenSFTP
--- PASS: TestResourceFastlyFlattenSFTP (0.00s)
=== RUN   TestAccFastlyServiceV1_logging_sftp_basic
--- PASS: TestAccFastlyServiceV1_logging_sftp_basic (123.24s)
=== RUN   TestAccFastlyServiceV1_logging_sftp_basic_compute
--- PASS: TestAccFastlyServiceV1_logging_sftp_basic_compute (48.13s)
=== RUN   TestAccFastlyServiceV1_logging_sftp_password_secret_key
--- PASS: TestAccFastlyServiceV1_logging_sftp_password_secret_key (4.52s)
=== RUN   TestAccFastlyServiceV1_package_basic
--- PASS: TestAccFastlyServiceV1_package_basic (158.93s)
=== RUN   TestResourceFastlyFlattenPapertrail
--- PASS: TestResourceFastlyFlattenPapertrail (0.00s)
=== RUN   TestAccFastlyServiceV1_papertrail_basic
--- PASS: TestAccFastlyServiceV1_papertrail_basic (118.77s)
=== RUN   TestAccFastlyServiceV1_papertrail_basic_compute
--- PASS: TestAccFastlyServiceV1_papertrail_basic_compute (50.13s)
=== RUN   TestResourceFastlyFlattenRequestSettings
--- PASS: TestResourceFastlyFlattenRequestSettings (0.00s)
=== RUN   TestAccFastlyServiceV1RequestSetting_basic
--- PASS: TestAccFastlyServiceV1RequestSetting_basic (58.72s)
=== RUN   TestResourceFastlyFlattenResponseObjects
--- PASS: TestResourceFastlyFlattenResponseObjects (0.00s)
=== RUN   TestAccFastlyServiceV1_response_object_basic
--- PASS: TestAccFastlyServiceV1_response_object_basic (121.55s)
=== RUN   TestResourceFastlyFlattenS3
--- PASS: TestResourceFastlyFlattenS3 (0.00s)
=== RUN   TestAccFastlyServiceV1_s3logging_basic
--- PASS: TestAccFastlyServiceV1_s3logging_basic (134.01s)
=== RUN   TestAccFastlyServiceV1_s3logging_basic_compute
--- PASS: TestAccFastlyServiceV1_s3logging_basic_compute (48.18s)
=== RUN   TestAccFastlyServiceV1_s3logging_domain_default
--- PASS: TestAccFastlyServiceV1_s3logging_domain_default (59.59s)
=== RUN   TestAccFastlyServiceV1_s3logging_s3_env
--- PASS: TestAccFastlyServiceV1_s3logging_s3_env (57.82s)
=== RUN   TestAccFastlyServiceV1_s3logging_formatVersion
--- PASS: TestAccFastlyServiceV1_s3logging_formatVersion (58.63s)
=== RUN   TestResourceFastlyFlattenSnippets
--- PASS: TestResourceFastlyFlattenSnippets (0.00s)
=== RUN   TestAccFastlyServiceV1Snippet_basic
--- PASS: TestAccFastlyServiceV1Snippet_basic (120.47s)
=== RUN   TestResourceFastlyFlattenSplunk
--- PASS: TestResourceFastlyFlattenSplunk (0.25s)
=== RUN   TestAccFastlyServiceV1_splunk_basic
--- PASS: TestAccFastlyServiceV1_splunk_basic (122.65s)
=== RUN   TestAccFastlyServiceV1_splunk_basic_compute
--- PASS: TestAccFastlyServiceV1_splunk_basic_compute (49.70s)
=== RUN   TestAccFastlyServiceV1_splunk_default
--- PASS: TestAccFastlyServiceV1_splunk_default (58.47s)
=== RUN   TestAccFastlyServiceV1_splunk_complete
--- PASS: TestAccFastlyServiceV1_splunk_complete (125.91s)
=== RUN   TestAccFastlyServiceV1_splunk_env
--- PASS: TestAccFastlyServiceV1_splunk_env (60.03s)
=== RUN   TestResourceFastlyFlattenSumologic
--- PASS: TestResourceFastlyFlattenSumologic (0.00s)
=== RUN   TestAccFastlyServiceV1_sumologic
--- PASS: TestAccFastlyServiceV1_sumologic (147.03s)
=== RUN   TestAccFastlyServiceV1_sumologic_compute
--- PASS: TestAccFastlyServiceV1_sumologic_compute (48.34s)
=== RUN   TestResourceFastlyFlattenSyslog
--- PASS: TestResourceFastlyFlattenSyslog (0.60s)
=== RUN   TestAccFastlyServiceV1_syslog_basic
--- PASS: TestAccFastlyServiceV1_syslog_basic (128.68s)
=== RUN   TestAccFastlyServiceV1_syslog_basic_compute
--- PASS: TestAccFastlyServiceV1_syslog_basic_compute (50.44s)
=== RUN   TestAccFastlyServiceV1_syslog_formatVersion
--- PASS: TestAccFastlyServiceV1_syslog_formatVersion (60.54s)
=== RUN   TestAccFastlyServiceV1_syslog_useTls
--- PASS: TestAccFastlyServiceV1_syslog_useTls (58.35s)
=== RUN   TestResourceFastlyFlattenVCLs
--- PASS: TestResourceFastlyFlattenVCLs (0.00s)
=== RUN   TestAccFastlyServiceV1_VCL_basic
--- PASS: TestAccFastlyServiceV1_VCL_basic (128.82s)
=== RUN   TestResourceFastlyFlattenWAF
--- PASS: TestResourceFastlyFlattenWAF (0.00s)
=== RUN   TestAccFastlyServiceV1WAFAdd
=== PAUSE TestAccFastlyServiceV1WAFAdd
=== RUN   TestAccFastlyServiceV1WAFAddAndRemove
=== PAUSE TestAccFastlyServiceV1WAFAddAndRemove
=== RUN   TestAccFastlyServiceV1WAFUpdateResponse
=== PAUSE TestAccFastlyServiceV1WAFUpdateResponse
=== RUN   TestAccFastlyServiceV1WAFUpdateCondition
=== PAUSE TestAccFastlyServiceV1WAFUpdateCondition
=== RUN   TestAccFastlyServiceWAFVersionV1FlattenWAFActiveRules
--- PASS: TestAccFastlyServiceWAFVersionV1FlattenWAFActiveRules (0.00s)
=== RUN   TestAccFastlyServiceWAFVersionV1FlattenWAFDeleteByModSecID
--- PASS: TestAccFastlyServiceWAFVersionV1FlattenWAFDeleteByModSecID (0.00s)
=== RUN   TestAccFastlyServiceWAFVersionV1AddWithRules
=== PAUSE TestAccFastlyServiceWAFVersionV1AddWithRules
=== RUN   TestAccFastlyServiceWAFVersionV1UpdateRules
=== PAUSE TestAccFastlyServiceWAFVersionV1UpdateRules
=== RUN   TestAccFastlyServiceWAFVersionV1DeleteRules
=== PAUSE TestAccFastlyServiceWAFVersionV1DeleteRules
=== RUN   TestAccFastlyServiceWAFVersionV1ImportWithRules
--- PASS: TestAccFastlyServiceWAFVersionV1ImportWithRules (121.30s)
=== RUN   TestUserAgentContainsProviderVersion
--- PASS: TestUserAgentContainsProviderVersion (0.00s)
=== RUN   TestStringPtr
--- PASS: TestStringPtr (0.00s)
=== RUN   TestIntPtr
--- PASS: TestIntPtr (0.00s)
=== RUN   TestBoolPtr
--- PASS: TestBoolPtr (0.00s)
=== RUN   TestDefaultUintToZero
--- PASS: TestDefaultUintToZero (0.00s)
=== RUN   TestDefaultUint
--- PASS: TestDefaultUint (0.00s)
=== RUN   TestAccFastlyIPRanges
--- PASS: TestAccFastlyIPRanges (1.12s)
=== RUN   TestAccFastlyWAFRulesDetermineRevision
--- PASS: TestAccFastlyWAFRulesDetermineRevision (0.00s)
=== RUN   TestAccFastlyWAFRulesFlattenWAFRules
--- PASS: TestAccFastlyWAFRulesFlattenWAFRules (0.00s)
=== RUN   TestAccFastlyWAFRulesPublisherFilter
--- PASS: TestAccFastlyWAFRulesPublisherFilter (9.84s)
=== RUN   TestAccFastlyWAFRulesExcludeFilter
--- PASS: TestAccFastlyWAFRulesExcludeFilter (4.70s)
=== RUN   TestAccFastlyWAFRulesTagFilter
--- PASS: TestAccFastlyWAFRulesTagFilter (3.09s)
=== RUN   TestSetDiff_Diff
=== RUN   TestSetDiff_Diff/should_return_the_correct_diff
=== RUN   TestSetDiff_Diff/should_diff_empty_element_lists
=== RUN   TestSetDiff_Diff/should_return_error_if_key_cannot_be_computed
--- PASS: TestSetDiff_Diff (0.00s)
    --- PASS: TestSetDiff_Diff/should_return_the_correct_diff (0.00s)
    --- PASS: TestSetDiff_Diff/should_diff_empty_element_lists (0.00s)
    --- PASS: TestSetDiff_Diff/should_return_error_if_key_cannot_be_computed (0.00s)
=== RUN   TestEscapePercentSign
=== RUN   TestEscapePercentSign/string_no_percent_signs_should_change_nothing
=== RUN   TestEscapePercentSign/one_percent_sign_should_return_two_percent_signs
=== RUN   TestEscapePercentSign/one_percent_sign_mid-string_should_return_two_percent_signs_in_the_same_place
=== RUN   TestEscapePercentSign/one_percent_sign_before_left_curly_brace_should_return_four_percent_signs_then_curly_brace
--- PASS: TestEscapePercentSign (0.00s)
    --- PASS: TestEscapePercentSign/string_no_percent_signs_should_change_nothing (0.00s)
    --- PASS: TestEscapePercentSign/one_percent_sign_should_return_two_percent_signs (0.00s)
    --- PASS: TestEscapePercentSign/one_percent_sign_mid-string_should_return_two_percent_signs_in_the_same_place (0.00s)
    --- PASS: TestEscapePercentSign/one_percent_sign_before_left_curly_brace_should_return_four_percent_signs_then_curly_brace (0.00s)
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestResourceFastlyFlattenAclEntries
--- PASS: TestResourceFastlyFlattenAclEntries (0.00s)
=== RUN   TestAccFastlyServiceAclEntriesV1_create
--- PASS: TestAccFastlyServiceAclEntriesV1_create (62.44s)
=== RUN   TestAccFastlyServiceAclEntriesV1_update
--- PASS: TestAccFastlyServiceAclEntriesV1_update (128.84s)
=== RUN   TestAccFastlyServiceAclEntriesV1_update_additional_fields
--- PASS: TestAccFastlyServiceAclEntriesV1_update_additional_fields (129.73s)
=== RUN   TestAccFastlyServiceAclEntriesV1_delete
--- PASS: TestAccFastlyServiceAclEntriesV1_delete (125.34s)
=== RUN   TestAccFastlyServiceAclEntriesV1_import
--- PASS: TestAccFastlyServiceAclEntriesV1_import (63.15s)
=== RUN   TestAccFastlyServiceAclEntriesV1_process_1001_entries
--- PASS: TestAccFastlyServiceAclEntriesV1_process_1001_entries (114.74s)
=== RUN   TestResourceFastlyFlattenBackendCompute
--- PASS: TestResourceFastlyFlattenBackendCompute (0.00s)
=== RUN   TestAccFastlyServiceCompute_basic
--- PASS: TestAccFastlyServiceCompute_basic (12.30s)
=== RUN   TestAccFastlyServiceCompute_import
--- PASS: TestAccFastlyServiceCompute_import (23.49s)
=== RUN   TestResourceFastlyFlattenDictionaryItems
--- PASS: TestResourceFastlyFlattenDictionaryItems (0.00s)
=== RUN   TestAccFastlyServiceDictionaryItemV1_create
--- PASS: TestAccFastlyServiceDictionaryItemV1_create (71.88s)
=== RUN   TestAccFastlyServiceDictionaryItemV1_create_dynamic
--- PASS: TestAccFastlyServiceDictionaryItemV1_create_dynamic (63.61s)
=== RUN   TestAccFastlyServiceDictionaryItemV1_update
--- PASS: TestAccFastlyServiceDictionaryItemV1_update (127.32s)
=== RUN   TestAccFastlyServiceDictionaryItemV1_external_item_is_removed
--- PASS: TestAccFastlyServiceDictionaryItemV1_external_item_is_removed (100.41s)
=== RUN   TestAccFastlyServiceDictionaryItemV1_external_item_deleted
--- PASS: TestAccFastlyServiceDictionaryItemV1_external_item_deleted (126.42s)
=== RUN   TestAccFastlyServiceDictionaryItemV1_batch_1001_items
--- PASS: TestAccFastlyServiceDictionaryItemV1_batch_1001_items (93.96s)
=== RUN   TestAccFastlyServiceDictionaryItemV1_import
--- PASS: TestAccFastlyServiceDictionaryItemV1_import (62.26s)
=== RUN   TestAccFastlyServiceDynamicSnippetContentV1_create
--- PASS: TestAccFastlyServiceDynamicSnippetContentV1_create (60.70s)
=== RUN   TestAccFastlyServiceDynamicSnippetContentV1_update
--- PASS: TestAccFastlyServiceDynamicSnippetContentV1_update (128.86s)
=== RUN   TestAccFastlyServiceDynamicSnippetContentV1_external_snippet_is_removed
--- PASS: TestAccFastlyServiceDynamicSnippetContentV1_external_snippet_is_removed (130.00s)
=== RUN   TestAccFastlyServiceDynamicSnippetContentV1_normal_snippet_is_not_removed
--- PASS: TestAccFastlyServiceDynamicSnippetContentV1_normal_snippet_is_not_removed (122.12s)
=== RUN   TestAccFastlyServiceDynamicSnippetContentV1_import
--- PASS: TestAccFastlyServiceDynamicSnippetContentV1_import (64.67s)
=== RUN   TestResourceFastlyFlattenDomains
--- PASS: TestResourceFastlyFlattenDomains (0.00s)
=== RUN   TestResourceFastlyFlattenBackend
--- PASS: TestResourceFastlyFlattenBackend (0.00s)
=== RUN   TestAccFastlyServiceV1_updateDomain
--- PASS: TestAccFastlyServiceV1_updateDomain (119.04s)
=== RUN   TestAccFastlyServiceV1_updateBackend
--- PASS: TestAccFastlyServiceV1_updateBackend (134.10s)
=== RUN   TestAccFastlyServiceV1_updateInvalidBackend
--- PASS: TestAccFastlyServiceV1_updateInvalidBackend (61.56s)
=== RUN   TestAccFastlyServiceV1_basic
--- PASS: TestAccFastlyServiceV1_basic (119.59s)
=== RUN   TestAccFastlyServiceV1_disappears
--- PASS: TestAccFastlyServiceV1_disappears (24.06s)
=== RUN   TestAccFastlyServiceV1_defaultTTL
--- PASS: TestAccFastlyServiceV1_defaultTTL (192.78s)
=== RUN   TestAccFastlyServiceV1_createDefaultTTL
--- PASS: TestAccFastlyServiceV1_createDefaultTTL (58.17s)
=== RUN   TestAccFastlyServiceV1_createZeroDefaultTTL
--- PASS: TestAccFastlyServiceV1_createZeroDefaultTTL (56.94s)
=== RUN   TestAccFastlyServiceV1_import
--- PASS: TestAccFastlyServiceV1_import (93.77s)
=== RUN   TestAccFastlyServiceV1_creation_with_versionless_resources
--- PASS: TestAccFastlyServiceV1_creation_with_versionless_resources (67.72s)
=== RUN   TestAccFastlyServiceWAFVersionV1DetermineVersion
--- PASS: TestAccFastlyServiceWAFVersionV1DetermineVersion (0.00s)
=== RUN   TestAccFastlyServiceWAFVersionV1Add
=== PAUSE TestAccFastlyServiceWAFVersionV1Add
=== RUN   TestAccFastlyServiceWAFVersionV1AddExistingService
=== PAUSE TestAccFastlyServiceWAFVersionV1AddExistingService
=== RUN   TestAccFastlyServiceWAFVersionV1Update
=== PAUSE TestAccFastlyServiceWAFVersionV1Update
=== RUN   TestAccFastlyServiceWAFVersionV1Delete
=== PAUSE TestAccFastlyServiceWAFVersionV1Delete
=== RUN   TestAccFastlyServiceWAFVersionV1Import
--- PASS: TestAccFastlyServiceWAFVersionV1Import (152.84s)
=== RUN   TestAccFastlyUserV1_basic
--- PASS: TestAccFastlyUserV1_basic (4.88s)
=== RUN   TestAccFastlyUserV1_updateLogin
--- PASS: TestAccFastlyUserV1_updateLogin (4.61s)
=== RUN   TestAccFastlyServiceWAFVersionDeploymentStatus
=== RUN   TestAccFastlyServiceWAFVersionDeploymentStatus/Status_
=== RUN   TestAccFastlyServiceWAFVersionDeploymentStatus/Status_failed
=== RUN   TestAccFastlyServiceWAFVersionDeploymentStatus/Status_completed
--- PASS: TestAccFastlyServiceWAFVersionDeploymentStatus (0.40s)
    --- PASS: TestAccFastlyServiceWAFVersionDeploymentStatus/Status_ (0.00s)
    --- PASS: TestAccFastlyServiceWAFVersionDeploymentStatus/Status_failed (0.00s)
    --- PASS: TestAccFastlyServiceWAFVersionDeploymentStatus/Status_completed (0.40s)
=== RUN   TestValidateLoggingFormatVersion
=== RUN   TestValidateLoggingFormatVersion/0
=== RUN   TestValidateLoggingFormatVersion/1
=== RUN   TestValidateLoggingFormatVersion/2
=== RUN   TestValidateLoggingFormatVersion/3
=== RUN   TestValidateLoggingFormatVersion/4
=== RUN   TestValidateLoggingFormatVersion/5
--- PASS: TestValidateLoggingFormatVersion (0.00s)
    --- PASS: TestValidateLoggingFormatVersion/0 (0.00s)
    --- PASS: TestValidateLoggingFormatVersion/1 (0.00s)
    --- PASS: TestValidateLoggingFormatVersion/2 (0.00s)
    --- PASS: TestValidateLoggingFormatVersion/3 (0.00s)
    --- PASS: TestValidateLoggingFormatVersion/4 (0.00s)
    --- PASS: TestValidateLoggingFormatVersion/5 (0.00s)
=== RUN   TestValidateLoggingMessageType
=== RUN   TestValidateLoggingMessageType/classic
=== RUN   TestValidateLoggingMessageType/loggly
=== RUN   TestValidateLoggingMessageType/logplex
=== RUN   TestValidateLoggingMessageType/blank
=== RUN   TestValidateLoggingMessageType/CLASSIC
=== RUN   TestValidateLoggingMessageType/LOGGLY
=== RUN   TestValidateLoggingMessageType/LOGPLEX
=== RUN   TestValidateLoggingMessageType/BLANK
--- PASS: TestValidateLoggingMessageType (0.00s)
    --- PASS: TestValidateLoggingMessageType/classic (0.00s)
    --- PASS: TestValidateLoggingMessageType/loggly (0.00s)
    --- PASS: TestValidateLoggingMessageType/logplex (0.00s)
    --- PASS: TestValidateLoggingMessageType/blank (0.00s)
    --- PASS: TestValidateLoggingMessageType/CLASSIC (0.00s)
    --- PASS: TestValidateLoggingMessageType/LOGGLY (0.00s)
    --- PASS: TestValidateLoggingMessageType/LOGPLEX (0.00s)
    --- PASS: TestValidateLoggingMessageType/BLANK (0.00s)
=== RUN   TestValidateLoggingPlacement
=== RUN   TestValidateLoggingPlacement/none
=== RUN   TestValidateLoggingPlacement/waf_debug
=== RUN   TestValidateLoggingPlacement/NONE
=== RUN   TestValidateLoggingPlacement/WAF_DEBUG
--- PASS: TestValidateLoggingPlacement (0.00s)
    --- PASS: TestValidateLoggingPlacement/none (0.00s)
    --- PASS: TestValidateLoggingPlacement/waf_debug (0.00s)
    --- PASS: TestValidateLoggingPlacement/NONE (0.00s)
    --- PASS: TestValidateLoggingPlacement/WAF_DEBUG (0.00s)
=== RUN   TestValidateLoggingServerSideEncryption
=== RUN   TestValidateLoggingServerSideEncryption/AES256
=== RUN   TestValidateLoggingServerSideEncryption/aws:kms
=== RUN   TestValidateLoggingServerSideEncryption/aes256
=== RUN   TestValidateLoggingServerSideEncryption/AWS:KMS
=== RUN   TestValidateLoggingServerSideEncryption/aws:KMS
=== RUN   TestValidateLoggingServerSideEncryption/AWS:kms
--- PASS: TestValidateLoggingServerSideEncryption (0.00s)
    --- PASS: TestValidateLoggingServerSideEncryption/AES256 (0.00s)
    --- PASS: TestValidateLoggingServerSideEncryption/aws:kms (0.00s)
    --- PASS: TestValidateLoggingServerSideEncryption/aes256 (0.00s)
    --- PASS: TestValidateLoggingServerSideEncryption/AWS:KMS (0.00s)
    --- PASS: TestValidateLoggingServerSideEncryption/aws:KMS (0.00s)
    --- PASS: TestValidateLoggingServerSideEncryption/AWS:kms (0.00s)
=== RUN   TestValidateDirectorQuorum
=== RUN   TestValidateDirectorQuorum/150
=== RUN   TestValidateDirectorQuorum/0
=== RUN   TestValidateDirectorQuorum/55
=== RUN   TestValidateDirectorQuorum/100
=== RUN   TestValidateDirectorQuorum/-1
=== RUN   TestValidateDirectorQuorum/101
--- PASS: TestValidateDirectorQuorum (0.00s)
    --- PASS: TestValidateDirectorQuorum/150 (0.00s)
    --- PASS: TestValidateDirectorQuorum/0 (0.00s)
    --- PASS: TestValidateDirectorQuorum/55 (0.00s)
    --- PASS: TestValidateDirectorQuorum/100 (0.00s)
    --- PASS: TestValidateDirectorQuorum/-1 (0.00s)
    --- PASS: TestValidateDirectorQuorum/101 (0.00s)
=== RUN   TestValidateDirectorType
=== RUN   TestValidateDirectorType/1
=== RUN   TestValidateDirectorType/2
=== RUN   TestValidateDirectorType/3
=== RUN   TestValidateDirectorType/4
=== RUN   TestValidateDirectorType/5
=== RUN   TestValidateDirectorType/0
--- PASS: TestValidateDirectorType (0.00s)
    --- PASS: TestValidateDirectorType/1 (0.00s)
    --- PASS: TestValidateDirectorType/2 (0.00s)
    --- PASS: TestValidateDirectorType/3 (0.00s)
    --- PASS: TestValidateDirectorType/4 (0.00s)
    --- PASS: TestValidateDirectorType/5 (0.00s)
    --- PASS: TestValidateDirectorType/0 (0.00s)
=== RUN   TestValidateConditionType
=== RUN   TestValidateConditionType/REQUEST
=== RUN   TestValidateConditionType/RESPONSE
=== RUN   TestValidateConditionType/CACHE
=== RUN   TestValidateConditionType/PREFETCH
=== RUN   TestValidateConditionType/request
=== RUN   TestValidateConditionType/response
=== RUN   TestValidateConditionType/cache
=== RUN   TestValidateConditionType/prefetch
--- PASS: TestValidateConditionType (0.00s)
    --- PASS: TestValidateConditionType/REQUEST (0.00s)
    --- PASS: TestValidateConditionType/RESPONSE (0.00s)
    --- PASS: TestValidateConditionType/CACHE (0.00s)
    --- PASS: TestValidateConditionType/PREFETCH (0.00s)
    --- PASS: TestValidateConditionType/request (0.00s)
    --- PASS: TestValidateConditionType/response (0.00s)
    --- PASS: TestValidateConditionType/cache (0.00s)
    --- PASS: TestValidateConditionType/prefetch (0.00s)
=== RUN   TestValidateHeaderAction
=== RUN   TestValidateHeaderAction/set
=== RUN   TestValidateHeaderAction/append
=== RUN   TestValidateHeaderAction/delete
=== RUN   TestValidateHeaderAction/regex
=== RUN   TestValidateHeaderAction/regex_repeat
=== RUN   TestValidateHeaderAction/SET
=== RUN   TestValidateHeaderAction/APPEND
=== RUN   TestValidateHeaderAction/DELETE
=== RUN   TestValidateHeaderAction/REGEX
=== RUN   TestValidateHeaderAction/REGEX_REPEAT
--- PASS: TestValidateHeaderAction (0.00s)
    --- PASS: TestValidateHeaderAction/set (0.00s)
    --- PASS: TestValidateHeaderAction/append (0.00s)
    --- PASS: TestValidateHeaderAction/delete (0.00s)
    --- PASS: TestValidateHeaderAction/regex (0.00s)
    --- PASS: TestValidateHeaderAction/regex_repeat (0.00s)
    --- PASS: TestValidateHeaderAction/SET (0.00s)
    --- PASS: TestValidateHeaderAction/APPEND (0.00s)
    --- PASS: TestValidateHeaderAction/DELETE (0.00s)
    --- PASS: TestValidateHeaderAction/REGEX (0.00s)
    --- PASS: TestValidateHeaderAction/REGEX_REPEAT (0.00s)
=== RUN   TestValidateHeaderType
=== RUN   TestValidateHeaderType/request
=== RUN   TestValidateHeaderType/fetch
=== RUN   TestValidateHeaderType/cache
=== RUN   TestValidateHeaderType/response
=== RUN   TestValidateHeaderType/REQUEST
=== RUN   TestValidateHeaderType/FETCH
=== RUN   TestValidateHeaderType/CACHE
=== RUN   TestValidateHeaderType/RESPONSE
--- PASS: TestValidateHeaderType (0.00s)
    --- PASS: TestValidateHeaderType/request (0.00s)
    --- PASS: TestValidateHeaderType/fetch (0.00s)
    --- PASS: TestValidateHeaderType/cache (0.00s)
    --- PASS: TestValidateHeaderType/response (0.00s)
    --- PASS: TestValidateHeaderType/REQUEST (0.00s)
    --- PASS: TestValidateHeaderType/FETCH (0.00s)
    --- PASS: TestValidateHeaderType/CACHE (0.00s)
    --- PASS: TestValidateHeaderType/RESPONSE (0.00s)
=== RUN   TestValidateRuleStatusType
=== RUN   TestValidateRuleStatusType/log
=== RUN   TestValidateRuleStatusType/block
=== RUN   TestValidateRuleStatusType/score
=== RUN   TestValidateRuleStatusType/123
=== RUN   TestValidateRuleStatusType/any
=== RUN   TestValidateRuleStatusType/???
--- PASS: TestValidateRuleStatusType (0.00s)
    --- PASS: TestValidateRuleStatusType/log (0.00s)
    --- PASS: TestValidateRuleStatusType/block (0.00s)
    --- PASS: TestValidateRuleStatusType/score (0.00s)
    --- PASS: TestValidateRuleStatusType/123 (0.00s)
    --- PASS: TestValidateRuleStatusType/any (0.00s)
    --- PASS: TestValidateRuleStatusType/??? (0.00s)
=== RUN   TestValidateSnippetType
=== RUN   TestValidateSnippetType/init
=== RUN   TestValidateSnippetType/recv
=== RUN   TestValidateSnippetType/hit
=== RUN   TestValidateSnippetType/miss
=== RUN   TestValidateSnippetType/pass
=== RUN   TestValidateSnippetType/hash
=== RUN   TestValidateSnippetType/fetch
=== RUN   TestValidateSnippetType/error
=== RUN   TestValidateSnippetType/deliver
=== RUN   TestValidateSnippetType/log
=== RUN   TestValidateSnippetType/none
=== RUN   TestValidateSnippetType/INIT
=== RUN   TestValidateSnippetType/RECV
=== RUN   TestValidateSnippetType/HIT
=== RUN   TestValidateSnippetType/MISS
=== RUN   TestValidateSnippetType/PASS
=== RUN   TestValidateSnippetType/FETCH
=== RUN   TestValidateSnippetType/HASH
=== RUN   TestValidateSnippetType/ERROR
=== RUN   TestValidateSnippetType/DELIVER
=== RUN   TestValidateSnippetType/LOG
=== RUN   TestValidateSnippetType/NONE
--- PASS: TestValidateSnippetType (0.00s)
    --- PASS: TestValidateSnippetType/init (0.00s)
    --- PASS: TestValidateSnippetType/recv (0.00s)
    --- PASS: TestValidateSnippetType/hit (0.00s)
    --- PASS: TestValidateSnippetType/miss (0.00s)
    --- PASS: TestValidateSnippetType/pass (0.00s)
    --- PASS: TestValidateSnippetType/hash (0.00s)
    --- PASS: TestValidateSnippetType/fetch (0.00s)
    --- PASS: TestValidateSnippetType/error (0.00s)
    --- PASS: TestValidateSnippetType/deliver (0.00s)
    --- PASS: TestValidateSnippetType/log (0.00s)
    --- PASS: TestValidateSnippetType/none (0.00s)
    --- PASS: TestValidateSnippetType/INIT (0.00s)
    --- PASS: TestValidateSnippetType/RECV (0.00s)
    --- PASS: TestValidateSnippetType/HIT (0.00s)
    --- PASS: TestValidateSnippetType/MISS (0.00s)
    --- PASS: TestValidateSnippetType/PASS (0.00s)
    --- PASS: TestValidateSnippetType/FETCH (0.00s)
    --- PASS: TestValidateSnippetType/HASH (0.00s)
    --- PASS: TestValidateSnippetType/ERROR (0.00s)
    --- PASS: TestValidateSnippetType/DELIVER (0.00s)
    --- PASS: TestValidateSnippetType/LOG (0.00s)
    --- PASS: TestValidateSnippetType/NONE (0.00s)
=== RUN   TestValidateDictionaryItemMaxSize
=== RUN   TestValidateDictionaryItemMaxSize/Ten_hundred_dictionary_items
=== RUN   TestValidateDictionaryItemMaxSize/Ten_thousand_dictionary_items
=== RUN   TestValidateDictionaryItemMaxSize/Ten_thousand_and_one_dictionary_items
--- PASS: TestValidateDictionaryItemMaxSize (0.01s)
    --- PASS: TestValidateDictionaryItemMaxSize/Ten_hundred_dictionary_items (0.00s)
    --- PASS: TestValidateDictionaryItemMaxSize/Ten_thousand_dictionary_items (0.00s)
    --- PASS: TestValidateDictionaryItemMaxSize/Ten_thousand_and_one_dictionary_items (0.00s)
=== RUN   TestValidateUserRole
=== RUN   TestValidateUserRole/user
=== RUN   TestValidateUserRole/billing
=== RUN   TestValidateUserRole/engineer
=== RUN   TestValidateUserRole/superuser
=== RUN   TestValidateUserRole/USER
=== RUN   TestValidateUserRole/BILLING
=== RUN   TestValidateUserRole/ENGINEER
=== RUN   TestValidateUserRole/SUPERUSER
--- PASS: TestValidateUserRole (0.00s)
    --- PASS: TestValidateUserRole/user (0.00s)
    --- PASS: TestValidateUserRole/billing (0.00s)
    --- PASS: TestValidateUserRole/engineer (0.00s)
    --- PASS: TestValidateUserRole/superuser (0.00s)
    --- PASS: TestValidateUserRole/USER (0.00s)
    --- PASS: TestValidateUserRole/BILLING (0.00s)
    --- PASS: TestValidateUserRole/ENGINEER (0.00s)
    --- PASS: TestValidateUserRole/SUPERUSER (0.00s)
=== RUN   TestValidateHTTPSURL
=== RUN   TestValidateHTTPSURL/https://api.fastly.com
=== RUN   TestValidateHTTPSURL/http://example.com
--- PASS: TestValidateHTTPSURL (0.00s)
    --- PASS: TestValidateHTTPSURL/https://api.fastly.com (0.00s)
    --- PASS: TestValidateHTTPSURL/http://example.com (0.00s)
=== CONT  TestAccFastlyServiceV1WAFAdd
=== CONT  TestAccFastlyServiceWAFVersionV1DeleteRules
=== CONT  TestAccFastlyServiceWAFVersionV1Update
=== CONT  TestAccFastlyServiceWAFVersionV1AddExistingService
=== CONT  TestAccFastlyServiceV1WAFUpdateCondition
=== CONT  TestAccFastlyServiceWAFVersionV1UpdateRules
=== CONT  TestAccFastlyServiceWAFVersionV1AddWithRules
=== CONT  TestAccFastlyServiceWAFVersionV1Add
--- PASS: TestAccFastlyServiceV1WAFAdd (93.32s)
=== CONT  TestAccFastlyServiceV1WAFUpdateResponse
--- PASS: TestAccFastlyServiceWAFVersionV1Add (153.91s)
=== CONT  TestAccFastlyServiceV1WAFAddAndRemove
--- PASS: TestAccFastlyServiceV1WAFUpdateCondition (158.25s)
=== CONT  TestAccFastlyServiceWAFVersionV1Delete
--- PASS: TestAccFastlyServiceWAFVersionV1AddWithRules (158.74s)
--- PASS: TestAccFastlyServiceWAFVersionV1AddExistingService (219.49s)
--- PASS: TestAccFastlyServiceV1WAFUpdateResponse (128.49s)
--- PASS: TestAccFastlyServiceWAFVersionV1UpdateRules (262.54s)
--- PASS: TestAccFastlyServiceWAFVersionV1Update (264.74s)
--- PASS: TestAccFastlyServiceWAFVersionV1DeleteRules (265.82s)
--- PASS: TestAccFastlyServiceWAFVersionV1Delete (158.74s)
--- PASS: TestAccFastlyServiceV1WAFAddAndRemove (187.63s)
PASS
ok      github.com/terraform-providers/terraform-provider-fastly/fastly 10690.050s
?       github.com/terraform-providers/terraform-provider-fastly/scripts/website        [no test files]
?       github.com/terraform-providers/terraform-provider-fastly/version        [no test files]

```

</p>
</details>

