### PR TITLE
Changing formatVersion in VCLLoggingAttributes to be a *uint

### DIFF
--- a/fastly/base_fastly_service_v1.go
+++ b/fastly/base_fastly_service_v1.go
@@ -74,7 +74,7 @@ func (h *DefaultServiceAttributeHandler) MustProcess(d *schema.ResourceData, ini
 
 type VCLLoggingAttributes struct {
 	format            string
-	formatVersion     uint
+	formatVersion     *uint
 	placement         string
 	responseCondition string
 }
@@ -89,7 +89,7 @@ func (h *DefaultServiceAttributeHandler) getVCLLoggingAttributes(data map[string
 			vla.format = val.(string)
 		}
 		if val, ok := data["format_version"]; ok {
-			vla.formatVersion = uint(val.(int))
+			vla.formatVersion = gofastly.Uint(uint(val.(int)))
 		}
 		if val, ok := data["placement"]; ok {
 			vla.placement = val.(string)

--- a/fastly/block_fastly_service_v1_blobstoragelogging.go
+++ b/fastly/block_fastly_service_v1_blobstoragelogging.go
@@ -89,7 +89,7 @@ func (h *BlobStorageLoggingServiceAttributeHandler) Process(d *schema.ResourceDa
 			PublicKey:         bslf["public_key"].(string),
 			MessageType:       bslf["message_type"].(string),
 			Format:            vla.format,
-			FormatVersion:     vla.formatVersion,
+			FormatVersion:     uintOrDefault(vla.formatVersion),
 			Placement:         vla.placement,
 			ResponseCondition: vla.responseCondition,
 		}

--- a/fastly/block_fastly_service_v1_httpslogging.go
+++ b/fastly/block_fastly_service_v1_httpslogging.go
@@ -310,7 +310,7 @@ func (h *HTTPSLoggingServiceAttributeHandler) buildCreate(httpsMap interface{}, 
 		TLSHostname:       df["tls_hostname"].(string),
 		MessageType:       df["message_type"].(string),
 		Format:            vla.format,
-		FormatVersion:     vla.formatVersion,
+		FormatVersion:     uintOrDefault(vla.formatVersion),
 		ResponseCondition: vla.responseCondition,
 		Placement:         vla.placement,
 	}

--- a/fastly/block_fastly_service_v1_logentries.go
+++ b/fastly/block_fastly_service_v1_logentries.go
@@ -68,7 +68,7 @@ func (h *LogentriesServiceAttributeHandler) Process(d *schema.ResourceData, late
 			UseTLS:            gofastly.CBool(slf["use_tls"].(bool)),
 			Token:             slf["token"].(string),
 			Format:            vla.format,
-			FormatVersion:     vla.formatVersion,
+			FormatVersion:     uintOrDefault(vla.formatVersion),
 			Placement:         vla.placement,
 			ResponseCondition: vla.responseCondition,
 		}

--- a/fastly/block_fastly_service_v1_logging_cloudfiles.go
+++ b/fastly/block_fastly_service_v1_logging_cloudfiles.go
@@ -176,7 +176,7 @@ func (h *CloudfilesServiceAttributeHandler) buildCreate(cloudfilesMap interface{
 		Period:            gofastly.Uint(uint(df["period"].(int))),
 		TimestampFormat:   gofastly.NullString(df["timestamp_format"].(string)),
 		Format:            gofastly.NullString(vla.format),
-		FormatVersion:     gofastly.Uint(vla.formatVersion),
+		FormatVersion:     vla.formatVersion,
 		Placement:         gofastly.NullString(vla.placement),
 		ResponseCondition: gofastly.NullString(vla.responseCondition),
 	}

--- a/fastly/block_fastly_service_v1_logging_cloudfiles_test.go
+++ b/fastly/block_fastly_service_v1_logging_cloudfiles_test.go
@@ -162,7 +162,7 @@ func TestAccFastlyServiceV1_logging_cloudfiles_basic(t *testing.T) {
 	})
 }
 
-func TestAccFastlyServiceV1_logging_cloudfiles_basicCompute(t *testing.T) {
+func TestAccFastlyServiceV1_logging_cloudfiles_basic_compute(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	domain := fmt.Sprintf("fastly-test.%s.com", name)

--- a/fastly/block_fastly_service_v1_logging_datadog.go
+++ b/fastly/block_fastly_service_v1_logging_datadog.go
@@ -207,7 +207,7 @@ func (h *DatadogServiceAttributeHandler) buildCreate(datadogMap interface{}, ser
 		Token:             gofastly.NullString(df["token"].(string)),
 		Region:            gofastly.NullString(df["region"].(string)),
 		Format:            gofastly.NullString(vla.format),
-		FormatVersion:     gofastly.Uint(vla.formatVersion),
+		FormatVersion:     vla.formatVersion,
 		Placement:         gofastly.NullString(vla.placement),
 		ResponseCondition: gofastly.NullString(vla.responseCondition),
 	}

--- a/fastly/block_fastly_service_v1_logging_datadog_test.go
+++ b/fastly/block_fastly_service_v1_logging_datadog_test.go
@@ -192,7 +192,7 @@ func TestAccFastlyServiceV1_logging_datadog_basic(t *testing.T) {
 	})
 }
 
-func TestAccFastlyServiceV1_logging_datadog_basicCompute(t *testing.T) {
+func TestAccFastlyServiceV1_logging_datadog_basic_compute(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	domain := fmt.Sprintf("fastly-test.%s.com", name)

--- a/fastly/block_fastly_service_v1_logging_digitalocean.go
+++ b/fastly/block_fastly_service_v1_logging_digitalocean.go
@@ -177,7 +177,7 @@ func (h *DigitalOceanServiceAttributeHandler) buildCreate(digitaloceanMap interf
 		TimestampFormat:   gofastly.NullString(df["timestamp_format"].(string)),
 		MessageType:       gofastly.NullString(df["message_type"].(string)),
 		Format:            gofastly.NullString(vla.format),
-		FormatVersion:     gofastly.Uint(vla.formatVersion),
+		FormatVersion:     vla.formatVersion,
 		Placement:         gofastly.NullString(vla.placement),
 		ResponseCondition: gofastly.NullString(vla.responseCondition),
 	}

--- a/fastly/block_fastly_service_v1_logging_digitalocean_test.go
+++ b/fastly/block_fastly_service_v1_logging_digitalocean_test.go
@@ -162,7 +162,7 @@ func TestAccFastlyServiceV1_logging_digitalocean_basic(t *testing.T) {
 	})
 }
 
-func TestAccFastlyServiceV1_logging_digitalocean_basicCompute(t *testing.T) {
+func TestAccFastlyServiceV1_logging_digitalocean_basic_compute(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	domain := fmt.Sprintf("fastly-test.%s.com", name)

--- a/fastly/block_fastly_service_v1_logging_elasticsearch.go
+++ b/fastly/block_fastly_service_v1_logging_elasticsearch.go
@@ -285,7 +285,7 @@ func (h *ElasticSearchServiceAttributeHandler) buildCreate(elasticsearchMap inte
 		TLSClientKey:      gofastly.NullString(df["tls_client_key"].(string)),
 		TLSHostname:       gofastly.NullString(df["tls_hostname"].(string)),
 		Format:            gofastly.NullString(vla.format),
-		FormatVersion:     gofastly.Uint(vla.formatVersion),
+		FormatVersion:     vla.formatVersion,
 		Placement:         gofastly.NullString(vla.placement),
 		ResponseCondition: gofastly.NullString(vla.responseCondition),
 	}

--- a/fastly/block_fastly_service_v1_logging_ftp.go
+++ b/fastly/block_fastly_service_v1_logging_ftp.go
@@ -291,7 +291,7 @@ func (h *FTPServiceAttributeHandler) buildCreate(ftpMap interface{}, serviceID s
 		TimestampFormat:   df["timestamp_format"].(string),
 		MessageType:       df["message_type"].(string),
 		Format:            vla.format,
-		FormatVersion:     vla.formatVersion,
+		FormatVersion:     uintOrDefault(vla.formatVersion),
 		Placement:         vla.placement,
 		ResponseCondition: vla.responseCondition,
 	}

--- a/fastly/block_fastly_service_v1_logging_googlepubsub.go
+++ b/fastly/block_fastly_service_v1_logging_googlepubsub.go
@@ -221,7 +221,7 @@ func (h *GooglePubSubServiceAttributeHandler) buildCreate(googlepubsubMap interf
 		ProjectID:         fastly.NullString(df["project_id"].(string)),
 		Topic:             fastly.NullString(df["topic"].(string)),
 		Format:            gofastly.NullString(vla.format),
-		FormatVersion:     gofastly.Uint(vla.formatVersion),
+		FormatVersion:     vla.formatVersion,
 		Placement:         gofastly.NullString(vla.placement),
 		ResponseCondition: gofastly.NullString(vla.responseCondition),
 	}

--- a/fastly/block_fastly_service_v1_logging_heroku.go
+++ b/fastly/block_fastly_service_v1_logging_heroku.go
@@ -146,7 +146,7 @@ func (h *HerokuServiceAttributeHandler) buildCreate(herokuMap interface{}, servi
 		Token:             gofastly.NullString(df["token"].(string)),
 		URL:               gofastly.NullString(df["url"].(string)),
 		Format:            gofastly.NullString(vla.format),
-		FormatVersion:     gofastly.Uint(vla.formatVersion),
+		FormatVersion:     vla.formatVersion,
 		Placement:         gofastly.NullString(vla.placement),
 		ResponseCondition: gofastly.NullString(vla.responseCondition),
 	}

--- a/fastly/block_fastly_service_v1_logging_heroku_test.go
+++ b/fastly/block_fastly_service_v1_logging_heroku_test.go
@@ -118,7 +118,7 @@ func TestAccFastlyServiceV1_logging_heroku_basic(t *testing.T) {
 	})
 }
 
-func TestAccFastlyServiceV1_logging_heroku_basicCompute(t *testing.T) {
+func TestAccFastlyServiceV1_logging_heroku_basic_compute(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	domain := fmt.Sprintf("fastly-test.%s.com", name)

--- a/fastly/block_fastly_service_v1_logging_honeycomb.go
+++ b/fastly/block_fastly_service_v1_logging_honeycomb.go
@@ -146,7 +146,7 @@ func (h *HoneycombServiceAttributeHandler) buildCreate(honeycombMap interface{},
 		Token:             gofastly.NullString(df["token"].(string)),
 		Dataset:           gofastly.NullString(df["dataset"].(string)),
 		Format:            gofastly.NullString(vla.format),
-		FormatVersion:     gofastly.Uint(vla.formatVersion),
+		FormatVersion:     vla.formatVersion,
 		Placement:         gofastly.NullString(vla.placement),
 		ResponseCondition: gofastly.NullString(vla.responseCondition),
 	}

--- a/fastly/block_fastly_service_v1_logging_honeycomb_test.go
+++ b/fastly/block_fastly_service_v1_logging_honeycomb_test.go
@@ -151,7 +151,7 @@ func TestAccFastlyServiceV1_logging_honeycomb_basic(t *testing.T) {
 	})
 }
 
-func TestAccFastlyServiceV1_logging_honeycomb_basicCompute(t *testing.T) {
+func TestAccFastlyServiceV1_logging_honeycomb_basic_compute(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	domain := fmt.Sprintf("fastly-test.%s.com", name)

--- a/fastly/block_fastly_service_v1_logging_kafka.go
+++ b/fastly/block_fastly_service_v1_logging_kafka.go
@@ -284,7 +284,7 @@ func (h *KafkaServiceAttributeHandler) buildCreate(kafkaMap interface{}, service
 		TLSClientKey:      fastly.NullString(df["tls_client_key"].(string)),
 		TLSHostname:       fastly.NullString(df["tls_hostname"].(string)),
 		Format:            gofastly.NullString(vla.format),
-		FormatVersion:     gofastly.Uint(vla.formatVersion),
+		FormatVersion:     vla.formatVersion,
 		Placement:         gofastly.NullString(vla.placement),
 		ResponseCondition: gofastly.NullString(vla.responseCondition),
 	}

--- a/fastly/block_fastly_service_v1_logging_loggly.go
+++ b/fastly/block_fastly_service_v1_logging_loggly.go
@@ -144,7 +144,7 @@ func (h *LogglyServiceAttributeHandler) buildCreate(logglyMap interface{}, servi
 		Name:              gofastly.NullString(df["name"].(string)),
 		Token:             gofastly.NullString(df["token"].(string)),
 		Format:            gofastly.NullString(vla.format),
-		FormatVersion:     gofastly.Uint(vla.formatVersion),
+		FormatVersion:     vla.formatVersion,
 		Placement:         gofastly.NullString(vla.placement),
 		ResponseCondition: gofastly.NullString(vla.responseCondition),
 	}

--- a/fastly/block_fastly_service_v1_logging_logshuttle.go
+++ b/fastly/block_fastly_service_v1_logging_logshuttle.go
@@ -146,7 +146,7 @@ func (h *LogshuttleServiceAttributeHandler) buildCreate(logshuttleMap interface{
 		Token:             gofastly.NullString(df["token"].(string)),
 		URL:               gofastly.NullString(df["url"].(string)),
 		Format:            gofastly.NullString(vla.format),
-		FormatVersion:     gofastly.Uint(vla.formatVersion),
+		FormatVersion:     vla.formatVersion,
 		Placement:         gofastly.NullString(vla.placement),
 		ResponseCondition: gofastly.NullString(vla.responseCondition),
 	}

--- a/fastly/block_fastly_service_v1_logging_logshuttle_test.go
+++ b/fastly/block_fastly_service_v1_logging_logshuttle_test.go
@@ -118,7 +118,7 @@ func TestAccFastlyServiceV1_logging_logshuttle_basic(t *testing.T) {
 	})
 }
 
-func TestAccFastlyServiceV1_logging_logshuttle_basicCompute(t *testing.T) {
+func TestAccFastlyServiceV1_logging_logshuttle_basic_compute(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	domain := fmt.Sprintf("fastly-test.%s.com", name)

--- a/fastly/block_fastly_service_v1_logging_newrelic.go
+++ b/fastly/block_fastly_service_v1_logging_newrelic.go
@@ -142,7 +142,7 @@ func (h *NewRelicServiceAttributeHandler) buildCreate(newrelicMap interface{}, s
 		Name:              gofastly.NullString(df["name"].(string)),
 		Token:             gofastly.NullString(df["token"].(string)),
 		Format:            gofastly.NullString(vla.format),
-		FormatVersion:     gofastly.Uint(vla.formatVersion),
+		FormatVersion:     vla.formatVersion,
 		Placement:         gofastly.NullString(vla.placement),
 		ResponseCondition: gofastly.NullString(vla.responseCondition),
 	}

--- a/fastly/block_fastly_service_v1_logging_openstack.go
+++ b/fastly/block_fastly_service_v1_logging_openstack.go
@@ -177,7 +177,7 @@ func (h *OpenstackServiceAttributeHandler) buildCreate(openstackMap interface{},
 		Period:            gofastly.Uint(uint(df["period"].(int))),
 		TimestampFormat:   gofastly.NullString(df["timestamp_format"].(string)),
 		Format:            gofastly.NullString(vla.format),
-		FormatVersion:     gofastly.Uint(vla.formatVersion),
+		FormatVersion:     vla.formatVersion,
 		Placement:         gofastly.NullString(vla.placement),
 		ResponseCondition: gofastly.NullString(vla.responseCondition),
 	}

--- a/fastly/block_fastly_service_v1_logging_openstack_test.go
+++ b/fastly/block_fastly_service_v1_logging_openstack_test.go
@@ -161,7 +161,7 @@ func TestAccFastlyServiceV1_logging_openstack_basic(t *testing.T) {
 	})
 }
 
-func TestAccFastlyServiceV1_logging_openstack_basicCompute(t *testing.T) {
+func TestAccFastlyServiceV1_logging_openstack_basic_compute(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	domain := fmt.Sprintf("fastly-test.%s.com", name)

--- a/fastly/block_fastly_service_v1_logging_scalyr.go
+++ b/fastly/block_fastly_service_v1_logging_scalyr.go
@@ -205,7 +205,7 @@ func (h *ScalyrServiceAttributeHandler) buildCreate(scalyrMap interface{}, servi
 		Region:            fastly.NullString(df["region"].(string)),
 		Token:             fastly.NullString(df["token"].(string)),
 		Format:            gofastly.NullString(vla.format),
-		FormatVersion:     gofastly.Uint(vla.formatVersion),
+		FormatVersion:     vla.formatVersion,
 		Placement:         gofastly.NullString(vla.placement),
 		ResponseCondition: gofastly.NullString(vla.responseCondition),
 	}

--- a/fastly/block_fastly_service_v1_logging_sftp.go
+++ b/fastly/block_fastly_service_v1_logging_sftp.go
@@ -316,7 +316,7 @@ func (h *SFTPServiceAttributeHandler) buildCreate(sftpMap interface{}, serviceID
 		TimestampFormat:   gofastly.NullString(df["timestamp_format"].(string)),
 		MessageType:       gofastly.NullString(df["message_type"].(string)),
 		Format:            gofastly.NullString(vla.format),
-		FormatVersion:     gofastly.Uint(vla.formatVersion),
+		FormatVersion:     vla.formatVersion,
 		Placement:         gofastly.NullString(vla.placement),
 		ResponseCondition: gofastly.NullString(vla.responseCondition),
 	}

--- a/fastly/block_fastly_service_v1_s3logging.go
+++ b/fastly/block_fastly_service_v1_s3logging.go
@@ -313,7 +313,7 @@ func (h *S3LoggingServiceAttributeHandler) buildCreate(s3Map interface{}, servic
 		PublicKey:                    df["public_key"].(string),
 		ServerSideEncryptionKMSKeyID: df["server_side_encryption_kms_key_id"].(string),
 		Format:                       vla.format,
-		FormatVersion:                vla.formatVersion,
+		FormatVersion:                uintOrDefault(vla.formatVersion),
 		ResponseCondition:            vla.responseCondition,
 		Placement:                    vla.placement,
 	}

--- a/fastly/block_fastly_service_v1_splunk.go
+++ b/fastly/block_fastly_service_v1_splunk.go
@@ -84,7 +84,7 @@ func (h *SplunkServiceAttributeHandler) Process(d *schema.ResourceData, latestVe
 			TLSHostname:       sf["tls_hostname"].(string),
 			TLSCACert:         sf["tls_ca_cert"].(string),
 			Format:            vla.format,
-			FormatVersion:     vla.formatVersion,
+			FormatVersion:     uintOrDefault(vla.formatVersion),
 			ResponseCondition: vla.responseCondition,
 			Placement:         vla.placement,
 		}

--- a/fastly/block_fastly_service_v1_sumologic.go
+++ b/fastly/block_fastly_service_v1_sumologic.go
@@ -67,7 +67,7 @@ func (h *SumologicServiceAttributeHandler) Process(d *schema.ResourceData, lates
 			URL:               sf["url"].(string),
 			MessageType:       sf["message_type"].(string),
 			Format:            vla.format,
-			FormatVersion:     int(vla.formatVersion),
+			FormatVersion:     int(uintOrDefault(vla.formatVersion)),
 			ResponseCondition: vla.responseCondition,
 			Placement:         vla.placement,
 		}

--- a/fastly/block_fastly_service_v1_syslog.go
+++ b/fastly/block_fastly_service_v1_syslog.go
@@ -74,7 +74,7 @@ func (h *SyslogServiceAttributeHandler) Process(d *schema.ResourceData, latestVe
 			TLSClientKey:      slf["tls_client_key"].(string),
 			MessageType:       slf["message_type"].(string),
 			Format:            vla.format,
-			FormatVersion:     vla.formatVersion,
+			FormatVersion:     uintOrDefault(vla.formatVersion),
 			ResponseCondition: vla.responseCondition,
 			Placement:         vla.placement,
 		}

--- a/fastly/convert.go
+++ b/fastly/convert.go
@@ -14,3 +14,10 @@ func intToPtr(i int) *int {
 func boolToPtr(i bool) *bool {
 	return &i
 }
+
+func uintOrDefault(int *uint) uint {
+	if int == nil {
+		return 0
+	}
+	return *int
+}

--- a/fastly/convert_test.go
+++ b/fastly/convert_test.go
@@ -20,3 +20,12 @@ func TestBoolPtr(t *testing.T) {
 	v := true
 	assert.Equal(t, v, *boolToPtr(v))
 }
+
+func TestDefaultUintToZero(t *testing.T) {
+	assert.Equal(t, uint(0), uintOrDefault(nil))
+}
+
+func TestDefaultUint(t *testing.T) {
+	v := uint(10)
+	assert.Equal(t, v, uintOrDefault(&v))
+}

--- a/fastly/resource_fastly_service_compute_test.go
+++ b/fastly/resource_fastly_service_compute_test.go
@@ -88,7 +88,7 @@ func TestResourceFastlyFlattenBackendCompute(t *testing.T) {
 	}
 }
 
-func TestAccFastlyServiceCompute1_basic(t *testing.T) {
+func TestAccFastlyServiceCompute_basic(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	domainName1 := fmt.Sprintf("fastly-test1.tf-%s.com", acctest.RandString(10))
@@ -96,10 +96,10 @@ func TestAccFastlyServiceCompute1_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckServiceComputeV1Destroy,
+		CheckDestroy: testAccCheckServiceComputeDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccServiceComputeV1Config(name, domainName1),
+				Config: testAccServiceComputeConfig(name, domainName1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceV1Exists("fastly_service_compute.foo", &service),
 					resource.TestCheckResourceAttr(
@@ -122,7 +122,7 @@ func TestAccFastlyServiceCompute1_basic(t *testing.T) {
 	})
 }
 
-func testAccCheckServiceComputeV1Destroy(s *terraform.State) error {
+func testAccCheckServiceComputeDestroy(s *terraform.State) error {
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "fastly_service_compute" {
 			continue
@@ -144,7 +144,7 @@ func testAccCheckServiceComputeV1Destroy(s *terraform.State) error {
 	return nil
 }
 
-func TestAccFastlyServiceComputeV1_import(t *testing.T) {
+func TestAccFastlyServiceCompute_import(t *testing.T) {
 	var service gofastly.ServiceDetail
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -152,7 +152,7 @@ func TestAccFastlyServiceComputeV1_import(t *testing.T) {
 		CheckDestroy: testAccCheckServiceV1Destroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccServiceComputeV1ImportConfig(),
+				Config: testAccServiceComputeImportConfig(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceV1Exists("fastly_service_compute.foo", &service),
 				),
@@ -169,7 +169,7 @@ func TestAccFastlyServiceComputeV1_import(t *testing.T) {
 
 }
 
-func testAccServiceComputeV1Config(name, domain string) string {
+func testAccServiceComputeConfig(name, domain string) string {
 	return fmt.Sprintf(`
 resource "fastly_service_compute" "foo" {
   name = "%s"
@@ -190,7 +190,7 @@ resource "fastly_service_compute" "foo" {
 }`, name, domain)
 }
 
-func testAccServiceComputeV1ImportConfig() string {
+func testAccServiceComputeImportConfig() string {
 	return fmt.Sprintf(`
 resource "fastly_service_compute" "foo" {
   name = "tf-test-%s"


### PR DESCRIPTION
As some logging endpoints on go-fastly use uint and some *uint, and
VCLLoggingAttributes needs to cater for both.
The most generic and recommended way to express empty value is using nil
instead of zero.
For the Request objects that are still using uint, the provider
will set the value to 0 (zero) when the VCLLoggingAttributes.formatVersion
pointer is nil. This is compatible with the previous behaviour.

Request objects using *uint which were failing before (as zero was being
sent instead of nill) are now working again.


<details><summary>Acceptance Test results</summary>
<p>

```
=== RUN   TestResourceFastlyFlattenAcl
--- PASS: TestResourceFastlyFlattenAcl (0.00s)
=== RUN   TestResourceFastlyFlattenBigQuery
--- PASS: TestResourceFastlyFlattenBigQuery (0.27s)
=== RUN   TestResourceFastlyFlattenBlobStorage
--- PASS: TestResourceFastlyFlattenBlobStorage (0.00s)
=== RUN   TestAccFastlyServiceV1_bigquerylogging
--- PASS: TestAccFastlyServiceV1_bigquerylogging (101.76s)
=== RUN   TestAccFastlyServiceV1_bigquerylogging_compute
--- PASS: TestAccFastlyServiceV1_bigquerylogging_compute (104.58s)
=== RUN   TestAccFastlyServiceV1_bigquerylogging_env
--- PASS: TestAccFastlyServiceV1_bigquerylogging_env (111.36s)
=== RUN   TestAccFastlyServiceV1_acl
--- PASS: TestAccFastlyServiceV1_acl (123.37s)
=== RUN   TestResourceFastlyFlattenCacheSettings
--- PASS: TestResourceFastlyFlattenCacheSettings (0.00s)
=== RUN   TestAccFastlyServiceV1_blobstoragelogging_basic_compute
--- PASS: TestAccFastlyServiceV1_blobstoragelogging_basic_compute (81.64s)
=== RUN   TestResourceFastlyFlattenConditions
--- PASS: TestResourceFastlyFlattenConditions (0.00s)
=== RUN   TestAccFastlyServiceV1_blobstoragelogging_default
--- PASS: TestAccFastlyServiceV1_blobstoragelogging_default (99.44s)
=== RUN   TestResourceFastlyFlattenDictionary
--- PASS: TestResourceFastlyFlattenDictionary (0.00s)
=== RUN   TestAccFastlyServiceV1_blobstoragelogging_env
--- PASS: TestAccFastlyServiceV1_blobstoragelogging_env (98.11s)
=== RUN   TestAccFastlyServiceV1_blobstoragelogging_basic
--- PASS: TestAccFastlyServiceV1_blobstoragelogging_basic (221.67s)
=== RUN   TestAccFastlyServiceV1_conditional_basic
--- PASS: TestAccFastlyServiceV1_conditional_basic (103.32s)
=== RUN   TestAccFastlyServiceV1_dictionary
--- PASS: TestAccFastlyServiceV1_dictionary (106.31s)
=== RUN   TestResourceFastlyFlattenDirectors
--- PASS: TestResourceFastlyFlattenDirectors (0.00s)
=== RUN   TestAccFastlyServiceV1_dictionary_write_only
--- PASS: TestAccFastlyServiceV1_dictionary_write_only (109.90s)
=== RUN   TestResourceFastlyFlattenDynamicSnippets
--- PASS: TestResourceFastlyFlattenDynamicSnippets (0.00s)
=== RUN   TestAccFastlyServiceV1CacheSetting_basic
--- PASS: TestAccFastlyServiceV1CacheSetting_basic (216.22s)
=== RUN   TestResourceFastlyFlattenGCS
--- PASS: TestResourceFastlyFlattenGCS (0.15s)
=== RUN   TestAccFastlyServiceV1_dictionary_update_name
--- PASS: TestAccFastlyServiceV1_dictionary_update_name (206.49s)
=== RUN   TestAccFastlyServiceV1_gcslogging
--- PASS: TestAccFastlyServiceV1_gcslogging (107.22s)
=== RUN   TestAccFastlyServiceV1_dictionary_update_write_only
--- PASS: TestAccFastlyServiceV1_dictionary_update_write_only (205.24s)
=== RUN   TestResourceFastlyFlattenGzips
--- PASS: TestResourceFastlyFlattenGzips (0.00s)
=== RUN   TestAccFastlyServiceV1DynamicSnippet_basic
--- PASS: TestAccFastlyServiceV1DynamicSnippet_basic (220.64s)
=== RUN   TestResourceFastlyFlattenHeaders
--- PASS: TestResourceFastlyFlattenHeaders (0.00s)
=== RUN   TestAccFastlyServiceV1_directors_basic
--- PASS: TestAccFastlyServiceV1_directors_basic (234.25s)
=== RUN   TestFastlyServiceV1_BuildHeaders
--- PASS: TestFastlyServiceV1_BuildHeaders (0.00s)
=== RUN   TestResourceFastlyFlattenHealthChecks
--- PASS: TestResourceFastlyFlattenHealthChecks (0.00s)
=== RUN   TestAccFastlyServiceV1_gcslogging_env
--- PASS: TestAccFastlyServiceV1_gcslogging_env (113.92s)
=== RUN   TestResourceFastlyFlattenHTTPS
--- PASS: TestResourceFastlyFlattenHTTPS (0.00s)
=== RUN   TestAccFastlyServiceV1_gcslogging_compute
--- PASS: TestAccFastlyServiceV1_gcslogging_compute (139.37s)
=== RUN   TestAccFastlyServiceV1_httpslogging_basic_compute
--- PASS: TestAccFastlyServiceV1_httpslogging_basic_compute (88.83s)
=== RUN   TestResourceFastlyFlattenLogentries
--- PASS: TestResourceFastlyFlattenLogentries (0.00s)
=== RUN   TestAccFastlyServiceV1_gzips_basic
--- PASS: TestAccFastlyServiceV1_gzips_basic (230.08s)
=== RUN   TestAccFastlyServiceV1_headers_basic
--- PASS: TestAccFastlyServiceV1_headers_basic (215.49s)
=== RUN   TestAccFastlyServiceV1_healthcheck_basic
--- PASS: TestAccFastlyServiceV1_healthcheck_basic (214.75s)
=== RUN   TestResourceFastlyFlattenCloudfiles
--- PASS: TestResourceFastlyFlattenCloudfiles (0.00s)
=== RUN   TestAccFastlyServiceV1_httpslogging_basic
--- PASS: TestAccFastlyServiceV1_httpslogging_basic (224.97s)
=== RUN   TestAccFastlyServiceV1_logentries_basic_compute
--- PASS: TestAccFastlyServiceV1_logentries_basic_compute (151.69s)
=== RUN   TestResourceFastlyFlattenDatadog
--- PASS: TestResourceFastlyFlattenDatadog (0.00s)
=== RUN   TestAccFastlyServiceV1_logentries_formatVersion
--- PASS: TestAccFastlyServiceV1_logentries_formatVersion (108.82s)
=== RUN   TestAccFastlyServiceV1_logentries_basic
--- PASS: TestAccFastlyServiceV1_logentries_basic (224.24s)
=== RUN   TestResourceFastlyFlattenDigitalOcean
--- PASS: TestResourceFastlyFlattenDigitalOcean (0.00s)
=== RUN   TestAccFastlyServiceV1_logging_cloudfiles_basic_compute
--- PASS: TestAccFastlyServiceV1_logging_cloudfiles_basic_compute (104.36s)
=== RUN   TestAccFastlyServiceV1_logging_datadog_basic_compute
--- PASS: TestAccFastlyServiceV1_logging_datadog_basic_compute (88.48s)
=== RUN   TestResourceFastlyFlattenElasticsearch
--- PASS: TestResourceFastlyFlattenElasticsearch (0.09s)
=== RUN   TestAccFastlyServiceV1_logging_digitalocean_basic_compute
--- PASS: TestAccFastlyServiceV1_logging_digitalocean_basic_compute (91.14s)
=== RUN   TestAccFastlyServiceV1_logging_cloudfiles_basic
--- PASS: TestAccFastlyServiceV1_logging_cloudfiles_basic (223.68s)
=== RUN   TestResourceFastlyFlattenFTP
--- PASS: TestResourceFastlyFlattenFTP (0.00s)
=== RUN   TestAccFastlyServiceV1_logging_datadog_basic
--- PASS: TestAccFastlyServiceV1_logging_datadog_basic (247.35s)
=== RUN   TestAccFastlyServiceV1_logging_digitalocean_basic
--- PASS: TestAccFastlyServiceV1_logging_digitalocean_basic (229.51s)
=== RUN   TestResourceFastlyFlattenGooglePubSub
--- PASS: TestResourceFastlyFlattenGooglePubSub (0.00s)
=== RUN   TestAccFastlyServiceV1_logging_elasticsearch_basic_compute
--- PASS: TestAccFastlyServiceV1_logging_elasticsearch_basic_compute (142.92s)
=== RUN   TestAccFastlyServiceV1_logging_elasticsearch_basic
--- PASS: TestAccFastlyServiceV1_logging_elasticsearch_basic (225.86s)
=== RUN   TestResourceFastlyFlattenHeroku
--- PASS: TestResourceFastlyFlattenHeroku (0.00s)
=== RUN   TestAccFastlyServiceV1_googlepubsublogging_basic_compute
--- PASS: TestAccFastlyServiceV1_googlepubsublogging_basic_compute (88.69s)
=== RUN   TestAccFastlyServiceV1_logging_ftp_basic
--- PASS: TestAccFastlyServiceV1_logging_ftp_basic (243.07s)
=== RUN   TestResourceFastlyFlattenHoneycomb
--- PASS: TestResourceFastlyFlattenHoneycomb (0.00s)
=== RUN   TestAccFastlyServiceV1_logging_ftp_basic_compute
--- PASS: TestAccFastlyServiceV1_logging_ftp_basic_compute (135.63s)
=== RUN   TestAccFastlyServiceV1_logging_heroku_basic_compute
--- PASS: TestAccFastlyServiceV1_logging_heroku_basic_compute (89.03s)
=== RUN   TestResourceFastlyFlattenKafka
--- PASS: TestResourceFastlyFlattenKafka (0.00s)
=== RUN   TestAccFastlyServiceV1_logging_honeycomb_basic_compute
--- PASS: TestAccFastlyServiceV1_logging_honeycomb_basic_compute (83.41s)
=== RUN   TestAccFastlyServiceV1_googlepubsublogging_basic
--- PASS: TestAccFastlyServiceV1_googlepubsublogging_basic (226.19s)
=== RUN   TestResourceFastlyFlattenLoggly
--- PASS: TestResourceFastlyFlattenLoggly (0.00s)
=== RUN   TestAccFastlyServiceV1_logging_heroku_basic
--- PASS: TestAccFastlyServiceV1_logging_heroku_basic (247.26s)
=== RUN   TestAccFastlyServiceV1_kafkalogging_basic_compute
--- PASS: TestAccFastlyServiceV1_kafkalogging_basic_compute (118.10s)
=== RUN   TestResourceFastlyFlattenLogshuttle
--- PASS: TestResourceFastlyFlattenLogshuttle (0.00s)
=== RUN   TestAccFastlyServiceV1_logging_logshuttle_basic
--- PASS: TestAccFastlyServiceV1_logging_logshuttle_basic (211.47s)
=== RUN   TestAccFastlyServiceV1_logging_loggly_basic_compute
--- PASS: TestAccFastlyServiceV1_logging_loggly_basic_compute (86.12s)
=== RUN   TestResourceFastlyFlattenNewRelic
--- PASS: TestResourceFastlyFlattenNewRelic (0.00s)
=== RUN   TestAccFastlyServiceV1_logging_newrelic_basic
--- PASS: TestAccFastlyServiceV1_logging_newrelic_basic (218.58s)
=== RUN   TestAccFastlyServiceV1_logging_logshuttle_basic_compute
--- PASS: TestAccFastlyServiceV1_logging_logshuttle_basic_compute (83.12s)
=== RUN   TestAccFastlyServiceV1_logging_honeycomb_basic
--- PASS: TestAccFastlyServiceV1_logging_honeycomb_basic (219.76s)
=== RUN   TestResourceFastlyFlattenOpenstack
--- PASS: TestResourceFastlyFlattenOpenstack (0.02s)
=== RUN   TestAccFastlyServiceV1_kafkalogging_basic
--- PASS: TestAccFastlyServiceV1_kafkalogging_basic (242.65s)
=== RUN   TestResourceFastlyFlattenScalyr
--- PASS: TestResourceFastlyFlattenScalyr (0.00s)
=== RUN   TestAccFastlyServiceV1_logging_newrelic_basic_compute
--- PASS: TestAccFastlyServiceV1_logging_newrelic_basic_compute (78.47s)
=== RUN   TestAccFastlyServiceV1_logging_openstack_basic_compute
--- PASS: TestAccFastlyServiceV1_logging_openstack_basic_compute (80.45s)
=== RUN   TestResourceFastlyFlattenSFTP
--- PASS: TestResourceFastlyFlattenSFTP (0.00s)
=== RUN   TestAccFastlyServiceV1_logging_loggly_basic
--- PASS: TestAccFastlyServiceV1_logging_loggly_basic (210.36s)
=== RUN   TestAccFastlyServiceV1_logging_sftp_basic_compute
--- PASS: TestAccFastlyServiceV1_logging_sftp_basic_compute (92.50s)
=== RUN   TestAccFastlyServiceV1_logging_sftp_password_secret_key
--- PASS: TestAccFastlyServiceV1_logging_sftp_password_secret_key (8.75s)
=== RUN   TestAccFastlyServiceV1_scalyrlogging_basic_compute
--- PASS: TestAccFastlyServiceV1_scalyrlogging_basic_compute (87.16s)
=== RUN   TestResourceFastlyFlattenPapertrail
--- PASS: TestResourceFastlyFlattenPapertrail (0.00s)
=== RUN   TestAccFastlyServiceV1_logging_openstack_basic
--- PASS: TestAccFastlyServiceV1_logging_openstack_basic (239.86s)
=== RUN   TestAccFastlyServiceV1_scalyrlogging_basic
--- PASS: TestAccFastlyServiceV1_scalyrlogging_basic (224.62s)
=== RUN   TestResourceFastlyFlattenRequestSettings
--- PASS: TestResourceFastlyFlattenRequestSettings (0.00s)
=== RUN   TestAccFastlyServiceV1_logging_sftp_basic
--- PASS: TestAccFastlyServiceV1_logging_sftp_basic (238.16s)
=== RUN   TestResourceFastlyFlattenResponseObjects
--- PASS: TestResourceFastlyFlattenResponseObjects (0.00s)
=== RUN   TestAccFastlyServiceV1RequestSetting_basic
--- PASS: TestAccFastlyServiceV1RequestSetting_basic (97.52s)
=== RUN   TestResourceFastlyFlattenS3
--- PASS: TestResourceFastlyFlattenS3 (0.00s)
=== RUN   TestAccFastlyServiceV1_papertrail_basic_compute
--- PASS: TestAccFastlyServiceV1_papertrail_basic_compute (91.74s)
=== RUN   TestAccFastlyServiceV1_papertrail_basic
--- PASS: TestAccFastlyServiceV1_papertrail_basic (233.89s)
=== RUN   TestAccFastlyServiceV1_package_basic
--- PASS: TestAccFastlyServiceV1_package_basic (251.73s)
=== RUN   TestAccFastlyServiceV1_s3logging_basic_compute
--- PASS: TestAccFastlyServiceV1_s3logging_basic_compute (89.74s)
=== RUN   TestAccFastlyServiceV1_response_object_basic
--- PASS: TestAccFastlyServiceV1_response_object_basic (216.39s)
=== RUN   TestResourceFastlyFlattenSnippets
--- PASS: TestResourceFastlyFlattenSnippets (0.00s)
=== RUN   TestAccFastlyServiceV1_s3logging_domain_default
--- PASS: TestAccFastlyServiceV1_s3logging_domain_default (117.99s)
=== RUN   TestResourceFastlyFlattenSplunk
--- PASS: TestResourceFastlyFlattenSplunk (0.26s)
=== RUN   TestAccFastlyServiceV1_s3logging_s3_env
--- PASS: TestAccFastlyServiceV1_s3logging_s3_env (117.47s)
=== RUN   TestAccFastlyServiceV1_s3logging_formatVersion
--- PASS: TestAccFastlyServiceV1_s3logging_formatVersion (107.45s)
=== RUN   TestAccFastlyServiceV1_s3logging_basic
--- PASS: TestAccFastlyServiceV1_s3logging_basic (247.57s)
=== RUN   TestAccFastlyServiceV1_splunk_basic_compute
--- PASS: TestAccFastlyServiceV1_splunk_basic_compute (87.39s)
=== RUN   TestAccFastlyServiceV1_splunk_default
--- PASS: TestAccFastlyServiceV1_splunk_default (111.86s)
=== RUN   TestResourceFastlyFlattenSumologic
--- PASS: TestResourceFastlyFlattenSumologic (0.00s)
=== RUN   TestAccFastlyServiceV1_splunk_env
--- PASS: TestAccFastlyServiceV1_splunk_env (107.61s)
=== RUN   TestAccFastlyServiceV1Snippet_basic
--- PASS: TestAccFastlyServiceV1Snippet_basic (230.14s)
=== RUN   TestResourceFastlyFlattenSyslog
--- PASS: TestResourceFastlyFlattenSyslog (0.13s)
=== RUN   TestAccFastlyServiceV1_splunk_basic
--- PASS: TestAccFastlyServiceV1_splunk_basic (244.21s)
=== RUN   TestAccFastlyServiceV1_splunk_complete
--- PASS: TestAccFastlyServiceV1_splunk_complete (267.76s)
=== RUN   TestAccFastlyServiceV1_sumologic_compute
--- PASS: TestAccFastlyServiceV1_sumologic_compute (122.76s)
=== RUN   TestAccFastlyServiceV1_syslog_basic_compute
--- PASS: TestAccFastlyServiceV1_syslog_basic_compute (84.02s)
=== RUN   TestResourceFastlyFlattenVCLs
--- PASS: TestResourceFastlyFlattenVCLs (0.00s)
=== RUN   TestAccFastlyServiceV1_sumologic
--- PASS: TestAccFastlyServiceV1_sumologic (244.87s)
=== RUN   TestResourceFastlyFlattenWAF
--- PASS: TestResourceFastlyFlattenWAF (0.00s)
=== RUN   TestAccFastlyServiceV1_syslog_formatVersion
--- PASS: TestAccFastlyServiceV1_syslog_formatVersion (129.05s)
=== RUN   TestAccFastlyServiceV1_syslog_useTls
--- PASS: TestAccFastlyServiceV1_syslog_useTls (131.06s)
=== RUN   TestAccFastlyServiceV1_syslog_basic
--- PASS: TestAccFastlyServiceV1_syslog_basic (247.60s)
=== RUN   TestAccFastlyServiceV1WAFAdd
=== PAUSE TestAccFastlyServiceV1WAFAdd
=== CONT  TestAccFastlyServiceV1WAFAdd
--- PASS: TestAccFastlyServiceV1WAFAdd (130.56s)
=== RUN   TestAccFastlyServiceWAFVersionV1FlattenWAFActiveRules
--- PASS: TestAccFastlyServiceWAFVersionV1FlattenWAFActiveRules (0.00s)
=== RUN   TestAccFastlyServiceWAFVersionV1FlattenWAFDeleteByModSecID
--- PASS: TestAccFastlyServiceWAFVersionV1FlattenWAFDeleteByModSecID (0.00s)
=== RUN   TestAccFastlyServiceV1_VCL_basic
--- PASS: TestAccFastlyServiceV1_VCL_basic (236.31s)
=== RUN   TestAccFastlyServiceV1WAFUpdateResponse
=== PAUSE TestAccFastlyServiceV1WAFUpdateResponse
=== CONT  TestAccFastlyServiceV1WAFUpdateResponse
--- PASS: TestAccFastlyServiceV1WAFUpdateResponse (229.26s)
=== RUN   TestAccFastlyServiceWAFVersionV1AddWithRules
=== PAUSE TestAccFastlyServiceWAFVersionV1AddWithRules
=== CONT  TestAccFastlyServiceWAFVersionV1AddWithRules
--- PASS: TestAccFastlyServiceWAFVersionV1AddWithRules (177.16s)
=== RUN   TestAccFastlyServiceV1WAFUpdateCondition
=== PAUSE TestAccFastlyServiceV1WAFUpdateCondition
=== CONT  TestAccFastlyServiceV1WAFUpdateCondition
--- PASS: TestAccFastlyServiceV1WAFUpdateCondition (235.82s)
=== RUN   TestUserAgentContainsProviderVersion
--- PASS: TestUserAgentContainsProviderVersion (0.00s)
=== RUN   TestStringPtr
--- PASS: TestStringPtr (0.00s)
=== RUN   TestIntPtr
--- PASS: TestIntPtr (0.00s)
=== RUN   TestBoolPtr
--- PASS: TestBoolPtr (0.00s)
=== RUN   TestDefaultUintToZero
--- PASS: TestDefaultUintToZero (0.00s)
=== RUN   TestDefaultUint
--- PASS: TestDefaultUint (0.00s)
=== RUN   TestAccFastlyIPRanges
--- PASS: TestAccFastlyIPRanges (3.16s)
=== RUN   TestAccFastlyWAFRulesDetermineRevision
--- PASS: TestAccFastlyWAFRulesDetermineRevision (0.00s)
=== RUN   TestAccFastlyWAFRulesFlattenWAFRules
--- PASS: TestAccFastlyWAFRulesFlattenWAFRules (0.00s)
=== RUN   TestAccFastlyWAFRulesPublisherFilter
--- PASS: TestAccFastlyWAFRulesPublisherFilter (19.91s)
=== RUN   TestAccFastlyWAFRulesExcludeFilter
--- PASS: TestAccFastlyWAFRulesExcludeFilter (12.87s)
=== RUN   TestAccFastlyWAFRulesTagFilter
--- PASS: TestAccFastlyWAFRulesTagFilter (4.84s)
=== RUN   TestEscapePercentSign
=== RUN   TestEscapePercentSign/string_no_percent_signs_should_change_nothing
=== RUN   TestEscapePercentSign/one_percent_sign_should_return_two_percent_signs
=== RUN   TestEscapePercentSign/one_percent_sign_mid-string_should_return_two_percent_signs_in_the_same_place
=== RUN   TestEscapePercentSign/one_percent_sign_before_left_curly_brace_should_return_four_percent_signs_then_curly_brace
--- PASS: TestEscapePercentSign (0.00s)
    --- PASS: TestEscapePercentSign/string_no_percent_signs_should_change_nothing (0.00s)
    --- PASS: TestEscapePercentSign/one_percent_sign_should_return_two_percent_signs (0.00s)
    --- PASS: TestEscapePercentSign/one_percent_sign_mid-string_should_return_two_percent_signs_in_the_same_place (0.00s)
    --- PASS: TestEscapePercentSign/one_percent_sign_before_left_curly_brace_should_return_four_percent_signs_then_curly_brace (0.00s)
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestResourceFastlyFlattenAclEntries
--- PASS: TestResourceFastlyFlattenAclEntries (0.00s)
=== RUN   TestAccFastlyServiceV1WAFAddAndRemove
=== PAUSE TestAccFastlyServiceV1WAFAddAndRemove
=== CONT  TestAccFastlyServiceV1WAFAddAndRemove
--- PASS: TestAccFastlyServiceV1WAFAddAndRemove (363.84s)
=== RUN   TestAccFastlyServiceWAFVersionV1ImportWithRules
--- PASS: TestAccFastlyServiceWAFVersionV1ImportWithRules (191.93s)
=== RUN   TestAccFastlyServiceWAFVersionV1UpdateRules
=== PAUSE TestAccFastlyServiceWAFVersionV1UpdateRules
=== CONT  TestAccFastlyServiceWAFVersionV1UpdateRules
--- PASS: TestAccFastlyServiceWAFVersionV1UpdateRules (335.42s)
=== RUN   TestAccFastlyServiceAclEntriesV1_create
--- PASS: TestAccFastlyServiceAclEntriesV1_create (113.93s)
=== RUN   TestAccFastlyServiceWAFVersionV1DeleteRules
=== PAUSE TestAccFastlyServiceWAFVersionV1DeleteRules
=== CONT  TestAccFastlyServiceWAFVersionV1DeleteRules
--- PASS: TestAccFastlyServiceWAFVersionV1DeleteRules (326.14s)
=== RUN   TestAccFastlyServiceAclEntriesV1_import
--- PASS: TestAccFastlyServiceAclEntriesV1_import (128.61s)
=== RUN   TestResourceFastlyFlattenBackendCompute
--- PASS: TestResourceFastlyFlattenBackendCompute (0.00s)
=== RUN   TestAccFastlyServiceCompute_basic
--- PASS: TestAccFastlyServiceCompute_basic (17.26s)
=== RUN   TestAccFastlyServiceAclEntriesV1_update
--- PASS: TestAccFastlyServiceAclEntriesV1_update (249.50s)
=== RUN   TestResourceFastlyFlattenDictionaryItems
--- PASS: TestResourceFastlyFlattenDictionaryItems (0.00s)
=== RUN   TestAccFastlyServiceCompute_import
--- PASS: TestAccFastlyServiceCompute_import (36.41s)
=== RUN   TestAccFastlyServiceAclEntriesV1_update_additional_fields
--- PASS: TestAccFastlyServiceAclEntriesV1_update_additional_fields (233.81s)
=== RUN   TestAccFastlyServiceAclEntriesV1_delete
--- PASS: TestAccFastlyServiceAclEntriesV1_delete (225.90s)
=== RUN   TestAccFastlyServiceAclEntriesV1_process_1001_entries
--- PASS: TestAccFastlyServiceAclEntriesV1_process_1001_entries (173.62s)
=== RUN   TestAccFastlyServiceDictionaryItemV1_create
--- PASS: TestAccFastlyServiceDictionaryItemV1_create (128.76s)
=== RUN   TestAccFastlyServiceDictionaryItemV1_create_dynamic
--- PASS: TestAccFastlyServiceDictionaryItemV1_create_dynamic (123.17s)
=== RUN   TestAccFastlyServiceDictionaryItemV1_external_item_is_removed
--- PASS: TestAccFastlyServiceDictionaryItemV1_external_item_is_removed (194.30s)
=== RUN   TestAccFastlyServiceDictionaryItemV1_import
--- PASS: TestAccFastlyServiceDictionaryItemV1_import (118.85s)
=== RUN   TestAccFastlyServiceDictionaryItemV1_batch_1001_items
--- PASS: TestAccFastlyServiceDictionaryItemV1_batch_1001_items (152.31s)
=== RUN   TestAccFastlyServiceDictionaryItemV1_update
--- PASS: TestAccFastlyServiceDictionaryItemV1_update (256.70s)
=== RUN   TestAccFastlyServiceDictionaryItemV1_external_item_deleted
--- PASS: TestAccFastlyServiceDictionaryItemV1_external_item_deleted (234.97s)
=== RUN   TestAccFastlyServiceDynamicSnippetContentV1_create
--- PASS: TestAccFastlyServiceDynamicSnippetContentV1_create (115.05s)
=== RUN   TestResourceFastlyFlattenDomains
--- PASS: TestResourceFastlyFlattenDomains (0.00s)
=== RUN   TestResourceFastlyFlattenBackend
--- PASS: TestResourceFastlyFlattenBackend (0.00s)
=== RUN   TestAccFastlyServiceDynamicSnippetContentV1_import
--- PASS: TestAccFastlyServiceDynamicSnippetContentV1_import (106.67s)
=== RUN   TestAccFastlyServiceDynamicSnippetContentV1_external_snippet_is_removed
--- PASS: TestAccFastlyServiceDynamicSnippetContentV1_external_snippet_is_removed (229.37s)
=== RUN   TestAccFastlyServiceDynamicSnippetContentV1_update
--- PASS: TestAccFastlyServiceDynamicSnippetContentV1_update (244.91s)
=== RUN   TestAccFastlyServiceDynamicSnippetContentV1_normal_snippet_is_not_removed
--- PASS: TestAccFastlyServiceDynamicSnippetContentV1_normal_snippet_is_not_removed (239.66s)
=== RUN   TestAccFastlyServiceV1_updateDomain
--- PASS: TestAccFastlyServiceV1_updateDomain (209.48s)
=== RUN   TestAccFastlyServiceV1_disappears
--- PASS: TestAccFastlyServiceV1_disappears (48.43s)
=== RUN   TestAccFastlyServiceV1_updateInvalidBackend
--- PASS: TestAccFastlyServiceV1_updateInvalidBackend (121.84s)
=== RUN   TestAccFastlyServiceV1_updateBackend
--- PASS: TestAccFastlyServiceV1_updateBackend (208.91s)
=== RUN   TestAccFastlyServiceV1_createDefaultTTL
--- PASS: TestAccFastlyServiceV1_createDefaultTTL (109.60s)
=== RUN   TestAccFastlyServiceV1_basic
--- PASS: TestAccFastlyServiceV1_basic (208.79s)
=== RUN   TestAccFastlyServiceWAFVersionV1DetermineVersion
--- PASS: TestAccFastlyServiceWAFVersionV1DetermineVersion (0.00s)
=== RUN   TestAccFastlyServiceV1_createZeroDefaultTTL
--- PASS: TestAccFastlyServiceV1_createZeroDefaultTTL (100.97s)
=== RUN   TestAccFastlyServiceV1_creation_with_versionless_resources
--- PASS: TestAccFastlyServiceV1_creation_with_versionless_resources (115.15s)
=== RUN   TestAccFastlyServiceV1_import
--- PASS: TestAccFastlyServiceV1_import (176.37s)
=== RUN   TestAccFastlyServiceV1_defaultTTL
--- PASS: TestAccFastlyServiceV1_defaultTTL (319.12s)
=== RUN   TestAccFastlyServiceWAFVersionV1Add
=== PAUSE TestAccFastlyServiceWAFVersionV1Add
=== CONT  TestAccFastlyServiceWAFVersionV1Add
--- PASS: TestAccFastlyServiceWAFVersionV1Add (177.28s)
=== RUN   TestAccFastlyUserV1_basic
--- PASS: TestAccFastlyUserV1_basic (8.18s)
=== RUN   TestAccFastlyUserV1_updateLogin
--- PASS: TestAccFastlyUserV1_updateLogin (10.69s)
=== RUN   TestAccFastlyServiceWAFVersionDeploymentStatus
=== RUN   TestAccFastlyServiceWAFVersionDeploymentStatus/Status_
=== RUN   TestAccFastlyServiceWAFVersionDeploymentStatus/Status_failed
=== RUN   TestAccFastlyServiceWAFVersionDeploymentStatus/Status_completed
--- PASS: TestAccFastlyServiceWAFVersionDeploymentStatus (0.41s)
    --- PASS: TestAccFastlyServiceWAFVersionDeploymentStatus/Status_ (0.00s)
    --- PASS: TestAccFastlyServiceWAFVersionDeploymentStatus/Status_failed (0.00s)
    --- PASS: TestAccFastlyServiceWAFVersionDeploymentStatus/Status_completed (0.41s)
=== RUN   TestValidateLoggingFormatVersion
=== RUN   TestValidateLoggingFormatVersion/0
=== RUN   TestValidateLoggingFormatVersion/1
=== RUN   TestValidateLoggingFormatVersion/2
=== RUN   TestValidateLoggingFormatVersion/3
=== RUN   TestValidateLoggingFormatVersion/4
=== RUN   TestValidateLoggingFormatVersion/5
--- PASS: TestValidateLoggingFormatVersion (0.00s)
    --- PASS: TestValidateLoggingFormatVersion/0 (0.00s)
    --- PASS: TestValidateLoggingFormatVersion/1 (0.00s)
    --- PASS: TestValidateLoggingFormatVersion/2 (0.00s)
    --- PASS: TestValidateLoggingFormatVersion/3 (0.00s)
    --- PASS: TestValidateLoggingFormatVersion/4 (0.00s)
    --- PASS: TestValidateLoggingFormatVersion/5 (0.00s)
=== RUN   TestValidateLoggingMessageType
=== RUN   TestValidateLoggingMessageType/classic
=== RUN   TestValidateLoggingMessageType/loggly
=== RUN   TestValidateLoggingMessageType/logplex
=== RUN   TestValidateLoggingMessageType/blank
=== RUN   TestValidateLoggingMessageType/CLASSIC
=== RUN   TestValidateLoggingMessageType/LOGGLY
=== RUN   TestValidateLoggingMessageType/LOGPLEX
=== RUN   TestValidateLoggingMessageType/BLANK
--- PASS: TestValidateLoggingMessageType (0.00s)
    --- PASS: TestValidateLoggingMessageType/classic (0.00s)
    --- PASS: TestValidateLoggingMessageType/loggly (0.00s)
    --- PASS: TestValidateLoggingMessageType/logplex (0.00s)
    --- PASS: TestValidateLoggingMessageType/blank (0.00s)
    --- PASS: TestValidateLoggingMessageType/CLASSIC (0.00s)
    --- PASS: TestValidateLoggingMessageType/LOGGLY (0.00s)
    --- PASS: TestValidateLoggingMessageType/LOGPLEX (0.00s)
    --- PASS: TestValidateLoggingMessageType/BLANK (0.00s)
=== RUN   TestValidateLoggingPlacement
=== RUN   TestValidateLoggingPlacement/none
=== RUN   TestValidateLoggingPlacement/waf_debug
=== RUN   TestValidateLoggingPlacement/NONE
=== RUN   TestValidateLoggingPlacement/WAF_DEBUG
--- PASS: TestValidateLoggingPlacement (0.00s)
    --- PASS: TestValidateLoggingPlacement/none (0.00s)
    --- PASS: TestValidateLoggingPlacement/waf_debug (0.00s)
    --- PASS: TestValidateLoggingPlacement/NONE (0.00s)
    --- PASS: TestValidateLoggingPlacement/WAF_DEBUG (0.00s)
=== RUN   TestValidateLoggingServerSideEncryption
=== RUN   TestValidateLoggingServerSideEncryption/AES256
=== RUN   TestValidateLoggingServerSideEncryption/aws:kms
=== RUN   TestValidateLoggingServerSideEncryption/aes256
=== RUN   TestValidateLoggingServerSideEncryption/AWS:KMS
=== RUN   TestValidateLoggingServerSideEncryption/aws:KMS
=== RUN   TestValidateLoggingServerSideEncryption/AWS:kms
--- PASS: TestValidateLoggingServerSideEncryption (0.00s)
    --- PASS: TestValidateLoggingServerSideEncryption/AES256 (0.00s)
    --- PASS: TestValidateLoggingServerSideEncryption/aws:kms (0.00s)
    --- PASS: TestValidateLoggingServerSideEncryption/aes256 (0.00s)
    --- PASS: TestValidateLoggingServerSideEncryption/AWS:KMS (0.00s)
    --- PASS: TestValidateLoggingServerSideEncryption/aws:KMS (0.00s)
    --- PASS: TestValidateLoggingServerSideEncryption/AWS:kms (0.00s)
=== RUN   TestValidateDirectorQuorum
=== RUN   TestValidateDirectorQuorum/0
=== RUN   TestValidateDirectorQuorum/55
=== RUN   TestValidateDirectorQuorum/100
=== RUN   TestValidateDirectorQuorum/-1
=== RUN   TestValidateDirectorQuorum/101
=== RUN   TestValidateDirectorQuorum/150
--- PASS: TestValidateDirectorQuorum (0.00s)
    --- PASS: TestValidateDirectorQuorum/0 (0.00s)
    --- PASS: TestValidateDirectorQuorum/55 (0.00s)
    --- PASS: TestValidateDirectorQuorum/100 (0.00s)
    --- PASS: TestValidateDirectorQuorum/-1 (0.00s)
    --- PASS: TestValidateDirectorQuorum/101 (0.00s)
    --- PASS: TestValidateDirectorQuorum/150 (0.00s)
=== RUN   TestValidateDirectorType
=== RUN   TestValidateDirectorType/1
=== RUN   TestValidateDirectorType/2
=== RUN   TestValidateDirectorType/3
=== RUN   TestValidateDirectorType/4
=== RUN   TestValidateDirectorType/5
=== RUN   TestValidateDirectorType/0
--- PASS: TestValidateDirectorType (0.00s)
    --- PASS: TestValidateDirectorType/1 (0.00s)
    --- PASS: TestValidateDirectorType/2 (0.00s)
    --- PASS: TestValidateDirectorType/3 (0.00s)
    --- PASS: TestValidateDirectorType/4 (0.00s)
    --- PASS: TestValidateDirectorType/5 (0.00s)
    --- PASS: TestValidateDirectorType/0 (0.00s)
=== RUN   TestValidateConditionType
=== RUN   TestValidateConditionType/REQUEST
=== RUN   TestValidateConditionType/RESPONSE
=== RUN   TestValidateConditionType/CACHE
=== RUN   TestValidateConditionType/PREFETCH
=== RUN   TestValidateConditionType/request
=== RUN   TestValidateConditionType/response
=== RUN   TestValidateConditionType/cache
=== RUN   TestValidateConditionType/prefetch
--- PASS: TestValidateConditionType (0.00s)
    --- PASS: TestValidateConditionType/REQUEST (0.00s)
    --- PASS: TestValidateConditionType/RESPONSE (0.00s)
    --- PASS: TestValidateConditionType/CACHE (0.00s)
    --- PASS: TestValidateConditionType/PREFETCH (0.00s)
    --- PASS: TestValidateConditionType/request (0.00s)
    --- PASS: TestValidateConditionType/response (0.00s)
    --- PASS: TestValidateConditionType/cache (0.00s)
    --- PASS: TestValidateConditionType/prefetch (0.00s)
=== RUN   TestValidateHeaderAction
=== RUN   TestValidateHeaderAction/set
=== RUN   TestValidateHeaderAction/append
=== RUN   TestValidateHeaderAction/delete
=== RUN   TestValidateHeaderAction/regex
=== RUN   TestValidateHeaderAction/regex_repeat
=== RUN   TestValidateHeaderAction/SET
=== RUN   TestValidateHeaderAction/APPEND
=== RUN   TestValidateHeaderAction/DELETE
=== RUN   TestValidateHeaderAction/REGEX
=== RUN   TestValidateHeaderAction/REGEX_REPEAT
--- PASS: TestValidateHeaderAction (0.00s)
    --- PASS: TestValidateHeaderAction/set (0.00s)
    --- PASS: TestValidateHeaderAction/append (0.00s)
    --- PASS: TestValidateHeaderAction/delete (0.00s)
    --- PASS: TestValidateHeaderAction/regex (0.00s)
    --- PASS: TestValidateHeaderAction/regex_repeat (0.00s)
    --- PASS: TestValidateHeaderAction/SET (0.00s)
    --- PASS: TestValidateHeaderAction/APPEND (0.00s)
    --- PASS: TestValidateHeaderAction/DELETE (0.00s)
    --- PASS: TestValidateHeaderAction/REGEX (0.00s)
    --- PASS: TestValidateHeaderAction/REGEX_REPEAT (0.00s)
=== RUN   TestValidateHeaderType
=== RUN   TestValidateHeaderType/request
=== RUN   TestValidateHeaderType/fetch
=== RUN   TestValidateHeaderType/cache
=== RUN   TestValidateHeaderType/response
=== RUN   TestValidateHeaderType/REQUEST
=== RUN   TestValidateHeaderType/FETCH
=== RUN   TestValidateHeaderType/CACHE
=== RUN   TestValidateHeaderType/RESPONSE
--- PASS: TestValidateHeaderType (0.00s)
    --- PASS: TestValidateHeaderType/request (0.00s)
    --- PASS: TestValidateHeaderType/fetch (0.00s)
    --- PASS: TestValidateHeaderType/cache (0.00s)
    --- PASS: TestValidateHeaderType/response (0.00s)
    --- PASS: TestValidateHeaderType/REQUEST (0.00s)
    --- PASS: TestValidateHeaderType/FETCH (0.00s)
    --- PASS: TestValidateHeaderType/CACHE (0.00s)
    --- PASS: TestValidateHeaderType/RESPONSE (0.00s)
=== RUN   TestValidateRuleStatusType
=== RUN   TestValidateRuleStatusType/log
=== RUN   TestValidateRuleStatusType/block
=== RUN   TestValidateRuleStatusType/score
=== RUN   TestValidateRuleStatusType/123
=== RUN   TestValidateRuleStatusType/any
=== RUN   TestValidateRuleStatusType/???
--- PASS: TestValidateRuleStatusType (0.00s)
    --- PASS: TestValidateRuleStatusType/log (0.00s)
    --- PASS: TestValidateRuleStatusType/block (0.00s)
    --- PASS: TestValidateRuleStatusType/score (0.00s)
    --- PASS: TestValidateRuleStatusType/123 (0.00s)
    --- PASS: TestValidateRuleStatusType/any (0.00s)
    --- PASS: TestValidateRuleStatusType/??? (0.00s)
=== RUN   TestValidateSnippetType
=== RUN   TestValidateSnippetType/init
=== RUN   TestValidateSnippetType/recv
=== RUN   TestValidateSnippetType/hit
=== RUN   TestValidateSnippetType/miss
=== RUN   TestValidateSnippetType/pass
=== RUN   TestValidateSnippetType/hash
=== RUN   TestValidateSnippetType/fetch
=== RUN   TestValidateSnippetType/error
=== RUN   TestValidateSnippetType/deliver
=== RUN   TestValidateSnippetType/log
=== RUN   TestValidateSnippetType/none
=== RUN   TestValidateSnippetType/INIT
=== RUN   TestValidateSnippetType/RECV
=== RUN   TestValidateSnippetType/HIT
=== RUN   TestValidateSnippetType/MISS
=== RUN   TestValidateSnippetType/PASS
=== RUN   TestValidateSnippetType/FETCH
=== RUN   TestValidateSnippetType/HASH
=== RUN   TestValidateSnippetType/ERROR
=== RUN   TestValidateSnippetType/DELIVER
=== RUN   TestValidateSnippetType/LOG
=== RUN   TestValidateSnippetType/NONE
--- PASS: TestValidateSnippetType (0.00s)
    --- PASS: TestValidateSnippetType/init (0.00s)
    --- PASS: TestValidateSnippetType/recv (0.00s)
    --- PASS: TestValidateSnippetType/hit (0.00s)
    --- PASS: TestValidateSnippetType/miss (0.00s)
    --- PASS: TestValidateSnippetType/pass (0.00s)
    --- PASS: TestValidateSnippetType/hash (0.00s)
    --- PASS: TestValidateSnippetType/fetch (0.00s)
    --- PASS: TestValidateSnippetType/error (0.00s)
    --- PASS: TestValidateSnippetType/deliver (0.00s)
    --- PASS: TestValidateSnippetType/log (0.00s)
    --- PASS: TestValidateSnippetType/none (0.00s)
    --- PASS: TestValidateSnippetType/INIT (0.00s)
    --- PASS: TestValidateSnippetType/RECV (0.00s)
    --- PASS: TestValidateSnippetType/HIT (0.00s)
    --- PASS: TestValidateSnippetType/MISS (0.00s)
    --- PASS: TestValidateSnippetType/PASS (0.00s)
    --- PASS: TestValidateSnippetType/FETCH (0.00s)
    --- PASS: TestValidateSnippetType/HASH (0.00s)
    --- PASS: TestValidateSnippetType/ERROR (0.00s)
    --- PASS: TestValidateSnippetType/DELIVER (0.00s)
    --- PASS: TestValidateSnippetType/LOG (0.00s)
    --- PASS: TestValidateSnippetType/NONE (0.00s)
=== RUN   TestValidateDictionaryItemMaxSize
=== RUN   TestValidateDictionaryItemMaxSize/Ten_hundred_dictionary_items
=== RUN   TestValidateDictionaryItemMaxSize/Ten_thousand_dictionary_items
=== RUN   TestValidateDictionaryItemMaxSize/Ten_thousand_and_one_dictionary_items
--- PASS: TestValidateDictionaryItemMaxSize (0.01s)
    --- PASS: TestValidateDictionaryItemMaxSize/Ten_hundred_dictionary_items (0.00s)
    --- PASS: TestValidateDictionaryItemMaxSize/Ten_thousand_dictionary_items (0.00s)
    --- PASS: TestValidateDictionaryItemMaxSize/Ten_thousand_and_one_dictionary_items (0.00s)
=== RUN   TestValidateUserRole
=== RUN   TestValidateUserRole/user
=== RUN   TestValidateUserRole/billing
=== RUN   TestValidateUserRole/engineer
=== RUN   TestValidateUserRole/superuser
=== RUN   TestValidateUserRole/USER
=== RUN   TestValidateUserRole/BILLING
=== RUN   TestValidateUserRole/ENGINEER
=== RUN   TestValidateUserRole/SUPERUSER
--- PASS: TestValidateUserRole (0.00s)
    --- PASS: TestValidateUserRole/user (0.00s)
    --- PASS: TestValidateUserRole/billing (0.00s)
    --- PASS: TestValidateUserRole/engineer (0.00s)
    --- PASS: TestValidateUserRole/superuser (0.00s)
    --- PASS: TestValidateUserRole/USER (0.00s)
    --- PASS: TestValidateUserRole/BILLING (0.00s)
    --- PASS: TestValidateUserRole/ENGINEER (0.00s)
    --- PASS: TestValidateUserRole/SUPERUSER (0.00s)
=== RUN   TestValidateHTTPSURL
=== RUN   TestValidateHTTPSURL/https://api.fastly.com
=== RUN   TestValidateHTTPSURL/http://example.com
--- PASS: TestValidateHTTPSURL (0.00s)
    --- PASS: TestValidateHTTPSURL/https://api.fastly.com (0.00s)
    --- PASS: TestValidateHTTPSURL/http://example.com (0.00s)
=== RUN   TestAccFastlyServiceWAFVersionV1AddExistingService
=== PAUSE TestAccFastlyServiceWAFVersionV1AddExistingService
=== CONT  TestAccFastlyServiceWAFVersionV1AddExistingService
--- PASS: TestAccFastlyServiceWAFVersionV1AddExistingService (397.61s)
=== RUN   TestAccFastlyServiceWAFVersionV1Delete
=== PAUSE TestAccFastlyServiceWAFVersionV1Delete
=== CONT  TestAccFastlyServiceWAFVersionV1Delete
--- PASS: TestAccFastlyServiceWAFVersionV1Delete (334.37s)
=== RUN   TestAccFastlyServiceWAFVersionV1Update
=== PAUSE TestAccFastlyServiceWAFVersionV1Update
=== CONT  TestAccFastlyServiceWAFVersionV1Update
--- PASS: TestAccFastlyServiceWAFVersionV1Update (381.49s)
=== RUN   TestAccFastlyServiceWAFVersionV1Import
--- PASS: TestAccFastlyServiceWAFVersionV1Import (316.69s)
PASS


```

</p>
</details>