### PR TITLE
scalyr token should be hidden from plan output

### DIFF
--- a/fastly/block_fastly_service_v1_logging_scalyr.go
+++ b/fastly/block_fastly_service_v1_logging_scalyr.go
@@ -35,6 +35,7 @@ func (h *ScalyrServiceAttributeHandler) Register(s *schema.Resource) error {
 			Type:        schema.TypeString,
 			Required:    true,
 			Description: "The token to use for authentication (https://www.scalyr.com/keys).",
+			Sensitive:   true,
 		},
 
 		// Optional


### PR DESCRIPTION
The scalyr log token shouldn't be display from terraform plan output and should be marked as sensitive.
