### PR TITLE
Improve service read and delete logic

### DIFF
--- a/fastly/resource_fastly_service_v1_test.go
+++ b/fastly/resource_fastly_service_v1_test.go
@@ -323,15 +323,9 @@ func TestAccFastlyServiceV1_disappears(t *testing.T) {
 		}
 
 		// delete service
-		err = conn.DeleteService(&gofastly.DeleteServiceInput{
+		return conn.DeleteService(&gofastly.DeleteServiceInput{
 			ID: service.ID,
 		})
-
-		if err != nil {
-			return err
-		}
-
-		return nil
 	}
 
 	resource.Test(t, resource.TestCase{


### PR DESCRIPTION
Closes #132 #94

### TL;DR
Currently the `resourceServiceRead` and `resourceServiceDelete` logic for the service resource uses a very old and very hacky implementation of `listServices`, due to the fact the API didn't previously return a `deleted_at` property. Fast forward many years we can clean up this implementation to use `fastly.GetServiceDetails` directly and infer deleted and not found resources via the go-fastly interface. 

The currently logic is also prone to race conditions in the API and therefore leads to false positives/negatives around deletion which is painful if you use the provider in CI environments to spin up and tear down services quickly.