### PR TITLE
data: Add ACL entries data source.

### DIFF
--- a/fastly/data_source_acl_entries.go
+++ b/fastly/data_source_acl_entries.go
@@ -1,0 +1,105 @@
+package fastly
+
+import (
+	"fmt"
+	"github.com/fastly/go-fastly/fastly"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"log"
+)
+
+type dataSourceFastlyACLEntriesResult struct {
+	ACLEntries []map[string]interface{}
+}
+
+func dataSourceFastlyACLEntries() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceFastlyACLEntriesRead,
+
+		Schema: map[string]*schema.Schema{
+			"service": {
+				Type:     schema.TypeString,
+				Required: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"acl": {
+				Type:     schema.TypeString,
+				Required: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"acl_entries": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"service_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"acl_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"ip": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"subnet": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"negated": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"comment": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceFastlyACLEntriesRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*FastlyClient).conn
+
+	log.Printf("[DEBUG] Reading ACL Entries")
+
+	aclEntriesInput := &fastly.ListACLEntriesInput{
+		Service: d.Get("service").(string),
+		ACL:     d.Get("acl").(string),
+	}
+	aclEntries, err := conn.ListACLEntries(aclEntriesInput)
+
+	if err != nil {
+		return fmt.Errorf("Error listing ACL entries for service: %s", err)
+	}
+
+	aclEntriesList := []map[string]interface{}{}
+	for _, entry := range aclEntries {
+		aclEntriesList = append(aclEntriesList, map[string]interface{}{
+			"service_id": entry.ServiceID,
+			"acl_id":     entry.ACLID,
+			"id":         entry.ID,
+			"ip":         entry.IP,
+			"subnet":     entry.Subnet,
+			"negated":    entry.Negated,
+			"comment":    entry.Comment,
+		})
+	}
+
+	d.SetId(fmt.Sprintf("%s%s", d.Get("service"), d.Get("acl")))
+
+	log.Printf("[DEBUG] ACL entries list: %v", aclEntriesList)
+	if err := d.Set("acl_entries", aclEntriesList); err != nil {
+		return fmt.Errorf("Error setting acl entries: %s", err)
+	}
+
+	return nil
+}

--- a/fastly/data_source_acl_entries_test.go
+++ b/fastly/data_source_acl_entries_test.go
@@ -1,0 +1,58 @@
+package fastly
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"testing"
+)
+
+func TestAccFastlyACLEntries(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFastlyACLEntriesConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccFastlyACLEntries("data.fastly_acl_entries.some"),
+				),
+			},
+		},
+	})
+}
+
+func testAccFastlyACLEntries(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		r := s.RootModule().Resources[n]
+		a := r.Primary.Attributes
+
+		attrsToTest := map[string]interface{}{
+			"id":      "abc",
+			"ip":      "127.0.0.1",
+			"subnet":  "32",
+			"negated": false,
+			"comment": "",
+		}
+
+		for attr, expectedValue := range attrsToTest {
+			if a[attr] != expectedValue {
+				return fmt.Errorf(
+					"%s is %s; want %s",
+					attr,
+					a[attr],
+					expectedValue,
+				)
+			}
+		}
+		return nil
+	}
+}
+
+const testAccFastlyACLEntriesConfig = `
+data "fastly_acl_entries" "some" {
+	service = "123456789"
+    acl     = "abcde12345"
+}
+`

--- a/fastly/provider.go
+++ b/fastly/provider.go
@@ -24,8 +24,9 @@ func Provider() terraform.ResourceProvider {
 			},
 		},
 		DataSourcesMap: map[string]*schema.Resource{
-			"fastly_ip_ranges": dataSourceFastlyIPRanges(),
-			"fastly_waf_rules": dataSourceFastlyWAFRules(),
+			"fastly_ip_ranges":   dataSourceFastlyIPRanges(),
+			"fastly_waf_rules":   dataSourceFastlyWAFRules(),
+			"fastly_acl_entries": dataSourceFastlyACLEntries(),
 		},
 		ResourcesMap: map[string]*schema.Resource{
 			"fastly_service_v1":                         resourceServiceV1(),


### PR DESCRIPTION
This solves the missing data source for ACL entries mentioned in issue #306

I need some help with the tests but it works.

here's a sample:

```hcl
data "fastly_acl_entries" "fastly" {
	service = "123456789"
        acl     = "abcde12345"
}

output "fastly" {
  value = data.fastly_acl_entries.fastly.acl_entries
}
``` 

```
data.fastly_acl_entries.fastly: Refreshing state...

------------------------------------------------------------------------

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:

Terraform will perform the following actions:

Plan: 0 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + fastly                     = [
      + {
          + acl_id     = "abcde12345"
          + comment    = "twatras:U01438C8A6A"
          + id         = "07L7FKeGQc6voy2EtXSePR"
          + ip         = "185.122.85.129"
          + negated    = false
          + service_id = "12T8me3tnwnjhDNfAfOmsw"
          + subnet     = "32"
        },
      + {
          + acl_id     = "abcde12345"
          + comment    = "lpetkovski:U0B4Q5FN2"
          + id         = "0INWy6fWQqfddwkIXXqPV9"
          + ip         = "89.225.102.172"
...
```

would appreciate the help with the tests and merging this so i don't have to host it myself