### PR TITLE
bigquerylogging: email, secret_key are required

### DIFF
--- a/fastly/block_fastly_service_v1_bigquerylogging.go
+++ b/fastly/block_fastly_service_v1_bigquerylogging.go
@@ -143,23 +143,23 @@ func (h *BigQueryLoggingServiceAttributeHandler) Register(s *schema.Resource) er
 			Required:    true,
 			Description: "The ID of your BigQuery table",
 		},
-		// Optional fields
 		"email": {
 			Type:        schema.TypeString,
-			Optional:    true,
+			Required:    true,
 			DefaultFunc: schema.EnvDefaultFunc("FASTLY_BQ_EMAIL", ""),
 			Description: "The email address associated with the target BigQuery dataset on your account.",
 			Sensitive:   true,
 		},
 		"secret_key": {
 			Type:        schema.TypeString,
-			Optional:    true,
+			Required:    true,
 			DefaultFunc: schema.EnvDefaultFunc("FASTLY_BQ_SECRET_KEY", ""),
 			Description: "The secret key associated with the target BigQuery dataset on your account.",
 			Sensitive:   true,
 			// Related issue for weird behavior - https://github.com/hashicorp/terraform-plugin-sdk/issues/160
 			StateFunc: trimSpaceStateFunc,
 		},
+		// Optional fields
 		"template": {
 			Type:        schema.TypeString,
 			Optional:    true,

--- a/website/docs/r/service_compute.html.markdown
+++ b/website/docs/r/service_compute.html.markdown
@@ -233,8 +233,8 @@ The `bigquerylogging` block supports:
 * `project_id` - (Required) The ID of your GCP project.
 * `dataset` - (Required) The ID of your BigQuery dataset.
 * `table` - (Required) The ID of your BigQuery table.
-* `email` - (Optional) The email for the service account with write access to your BigQuery dataset. If not provided, this will be pulled from a `FASTLY_BQ_EMAIL` environment variable.
-* `secret_key` - (Optional) The secret key associated with the sservice account that has write access to your BigQuery table. If not provided, this will be pulled from the `FASTLY_BQ_SECRET_KEY` environment variable. Typical format for this is a private key in a string with newlines.
+* `email` - (Required) The email for the service account with write access to your BigQuery dataset. If not provided, this will be pulled from a `FASTLY_BQ_EMAIL` environment variable.
+* `secret_key` - (Required) The secret key associated with the sservice account that has write access to your BigQuery table. If not provided, this will be pulled from the `FASTLY_BQ_SECRET_KEY` environment variable. Typical format for this is a private key in a string with newlines.
 
 
 The `syslog` block supports:

--- a/website/docs/r/service_v1.html.markdown
+++ b/website/docs/r/service_v1.html.markdown
@@ -514,8 +514,8 @@ The `bigquerylogging` block supports:
 * `project_id` - (Required) The ID of your GCP project.
 * `dataset` - (Required) The ID of your BigQuery dataset.
 * `table` - (Required) The ID of your BigQuery table.
-* `email` - (Optional) The email for the service account with write access to your BigQuery dataset. If not provided, this will be pulled from a `FASTLY_BQ_EMAIL` environment variable.
-* `secret_key` - (Optional) The secret key associated with the sservice account that has write access to your BigQuery table. If not provided, this will be pulled from the `FASTLY_BQ_SECRET_KEY` environment variable. Typical format for this is a private key in a string with newlines.
+* `email` - (Required) The email for the service account with write access to your BigQuery dataset. If not provided, this will be pulled from a `FASTLY_BQ_EMAIL` environment variable.
+* `secret_key` - (Required) The secret key associated with the sservice account that has write access to your BigQuery table. If not provided, this will be pulled from the `FASTLY_BQ_SECRET_KEY` environment variable. Typical format for this is a private key in a string with newlines.
 * `format` - (Optional) Apache style log formatting. Must produce JSON that matches the schema of your BigQuery table.
 * `response_condition` - (Optional) Name of already defined `condition` to apply. This `condition` must be of type `RESPONSE`. For detailed information about Conditionals, see [Fastly's Documentation on Conditionals][fastly-conditionals].
 * `template` - (Optional) Big query table name suffix template. If set will be interpreted as a strftime compatible string and used as the [Template Suffix for your table](https://cloud.google.com/bigquery/streaming-data-into-bigquery#template-tables).

--- a/website_src/docs/r/arguments/bigquerylogging.markdown.tmpl
+++ b/website_src/docs/r/arguments/bigquerylogging.markdown.tmpl
@@ -8,8 +8,8 @@ The `bigquerylogging` block supports:
 * `project_id` - (Required) The ID of your GCP project.
 * `dataset` - (Required) The ID of your BigQuery dataset.
 * `table` - (Required) The ID of your BigQuery table.
-* `email` - (Optional) The email for the service account with write access to your BigQuery dataset. If not provided, this will be pulled from a `FASTLY_BQ_EMAIL` environment variable.
-* `secret_key` - (Optional) The secret key associated with the sservice account that has write access to your BigQuery table. If not provided, this will be pulled from the `FASTLY_BQ_SECRET_KEY` environment variable. Typical format for this is a private key in a string with newlines.
+* `email` - (Required) The email for the service account with write access to your BigQuery dataset. If not provided, this will be pulled from a `FASTLY_BQ_EMAIL` environment variable.
+* `secret_key` - (Required) The secret key associated with the sservice account that has write access to your BigQuery table. If not provided, this will be pulled from the `FASTLY_BQ_SECRET_KEY` environment variable. Typical format for this is a private key in a string with newlines.
 {{ if eq .Data.ServiceType "vcl"}}* `format` - (Optional) Apache style log formatting. Must produce JSON that matches the schema of your BigQuery table.
 * `response_condition` - (Optional) Name of already defined `condition` to apply. This `condition` must be of type `RESPONSE`. For detailed information about Conditionals, see [Fastly's Documentation on Conditionals][fastly-conditionals].
 * `template` - (Optional) Big query table name suffix template. If set will be interpreted as a strftime compatible string and used as the [Template Suffix for your table](https://cloud.google.com/bigquery/streaming-data-into-bigquery#template-tables).


### PR DESCRIPTION
Correctly mark `email` and `secret_key` as required fields, as they are not optional:

```
Error: 400 - Bad Request:

    Title:  Bad request
    Detail: missing required user (email in ux)
```
&
```
Error: 400 - Bad Request:

    Title:  Bad request
    Detail: missing required secret_key
```