### PR TITLE
Update CHANGELOG.md for v0.20.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 BUG FIXES:
 
-* resource/fastly_service_v1/bigquerylogging: Ensure BigQuery logging `email`, `secret_key` fields are required and not optional. ([#319](https://github.com/terraform-providers/terraform-provider-fastly/pull/319))
+* resource/fastly_service_v1/bigquerylogging: Ensure BigQuery logging `email`, `secret_key` fields are required and not optional. ([#319](https://github.com/fastly/terraform-provider-fastly/pull/319))
 
 ## 0.20.2 (September 22, 2020)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## 0.21.0 (Unreleased)
 
+## 0.20.3 (September 23, 2020)
+
+BUG FIXES:
+
+* resource/fastly_service_v1/bigquerylogging: Ensure BigQuery logging `email`, `secret_key` fields are required and not optional. ([#319](https://github.com/terraform-providers/terraform-provider-fastly/pull/319))
+
 ## 0.20.2 (September 22, 2020)
 
 BUG FIXES:


### PR DESCRIPTION
Update CHANGELOG.md for `v0.20.3` release:

* resource/fastly_service_v1/bigquerylogging: Ensure BigQuery logging `email`, `secret_key` fields are required and not optional. ([#319](https://github.com/terraform-providers/terraform-provider-fastly/pull/319))