### PR TITLE
Cleanup all references to the old repo/module name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,12 @@
 
 BUG FIXES:
 
-* resource/fastly_service_v1: Improve performance of service read and delete logic. ([#311](https://github.com/terraform-providers/terraform-provider-fastly/pull/311))
-* resource/fastly_service_v1/logging_scalyr: Ensure `token` field is `sensitive` and thus hidden from plan. ([#310](https://github.com/terraform-providers/terraform-provider-fastly/pull/310))
+* resource/fastly_service_v1: Improve performance of service read and delete logic. ([#311](https://github.com/fastly/terraform-provider-fastly/pull/311))
+* resource/fastly_service_v1/logging_scalyr: Ensure `token` field is `sensitive` and thus hidden from plan. ([#310](https://github.com/fastly/terraform-provider-fastly/pull/310))
 
 NOTES:
 
-* resource/fastly_service_v1/s3logging: Document `server_side_encryption` and `server_side_encryption_kms_key_id` fields. ([#317](https://github.com/terraform-providers/terraform-provider-fastly/pull/310))
+* resource/fastly_service_v1/s3logging: Document `server_side_encryption` and `server_side_encryption_kms_key_id` fields. ([#317](https://github.com/fastly/terraform-provider-fastly/pull/310))
 
 ## 0.20.1 (September 2, 2020)
 

--- a/README.md
+++ b/README.md
@@ -16,17 +16,17 @@ Requirements
 Building The Provider
 ---------------------
 
-Clone repository to: `$GOPATH/src/github.com/terraform-providers/terraform-provider-fastly`
+Clone repository to: `$GOPATH/src/github.com/fastly/terraform-provider-fastly`
 
 ```sh
-$ mkdir -p $GOPATH/src/github.com/terraform-providers; cd $GOPATH/src/github.com/terraform-providers
-$ git clone git@github.com:terraform-providers/terraform-provider-fastly
+$ mkdir -p $GOPATH/src/github.com/fastly; cd $GOPATH/src/github.com/fastly
+$ git clone git@github.com:fastly/terraform-provider-fastly
 ```
 
 Enter the provider directory and build the provider
 
 ```sh
-$ cd $GOPATH/src/github.com/terraform-providers/terraform-provider-fastly
+$ cd $GOPATH/src/github.com/fastly/terraform-provider-fastly
 $ make build
 ```
 
@@ -83,7 +83,7 @@ Building The Documentation
 The documentation is built from components (go templates) stored in the `website_src` folder.
 Building the documentation copies the full markdown into the `website` folder, ready for deployment to Hashicorp.
 
-With the repository cloned to: `$GOPATH/src/github.com/terraform-providers/terraform-provider-fastly`:
+With the repository cloned to: `$GOPATH/src/github.com/fastly/terraform-provider-fastly`:
 
 * To build the documentation:
 `go run scripts/website/parse-templates.go `

--- a/fastly/config.go
+++ b/fastly/config.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 
 	gofastly "github.com/fastly/go-fastly/fastly"
+	"github.com/fastly/terraform-provider-fastly/version"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/logging"
 	"github.com/hashicorp/terraform-plugin-sdk/httpclient"
-	"github.com/terraform-providers/terraform-provider-fastly/version"
 )
 
 const TerraformProviderProductUserAgent = "terraform-provider-fastly"

--- a/fastly/config_test.go
+++ b/fastly/config_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	gofastly "github.com/fastly/go-fastly/fastly"
-	"github.com/terraform-providers/terraform-provider-fastly/version"
+	"github.com/fastly/terraform-provider-fastly/version"
 )
 
 func TestUserAgentContainsProviderVersion(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/terraform-providers/terraform-provider-fastly
+module github.com/fastly/terraform-provider-fastly
 
 go 1.14
 

--- a/main.go
+++ b/main.go
@@ -1,8 +1,8 @@
 package main
 
 import (
+	"github.com/fastly/terraform-provider-fastly/fastly"
 	"github.com/hashicorp/terraform-plugin-sdk/plugin"
-	"github.com/terraform-providers/terraform-provider-fastly/fastly"
 )
 
 func main() {

--- a/scripts/changelog-links.sh
+++ b/scripts/changelog-links.sh
@@ -24,7 +24,7 @@ else
   SED="sed -i.bak -r -e"
 fi
 
-PROVIDER_URL="https:\/\/github.com\/terraform-providers\/terraform-provider-fastly\/issues"
+PROVIDER_URL="https:\/\/github.com\/fastly\/terraform-provider-fastly\/issues"
 
 $SED "s/GH-([0-9]+)/\[#\1\]\($PROVIDER_URL\/\1\)/g" -e 's/\[\[#(.+)([0-9])\)]$/(\[#\1\2))/g' CHANGELOG.md
 


### PR DESCRIPTION
Cleanup all references to the old repo/module name, i.e. `s/terraform-providers/fastly/`