### PR TITLE
Changing ACL, Dictionary, Dynamic Snippets and WAF documentation

### DIFF
--- a/website/docs/r/service_dictionary_items_v1.html.markdown
+++ b/website/docs/r/service_dictionary_items_v1.html.markdown
@@ -16,7 +16,7 @@ Defines a map of Fastly dictionary items that can be used to populate a service 
 If Terraform is being used to populate the initial content of a dictionary which you intend to manage via API or UI, then the lifecycle `ignore_changes` field can be used with the resource.  An example of this configuration is provided below.    
 
 
-## Example Usage
+## Example Usage (Terraform >= 0.12.6)
 
 Basic usage:
 
@@ -30,15 +30,15 @@ resource "fastly_service_v1" "myservice" {
   name = "demofastly"
 
   domain {
-      name    = "demo.notexample.com"
-      comment = "demo"
+    name    = "demo.notexample.com"
+    comment = "demo"
   }
 
   backend {
-      address = "demo.notexample.com.s3-website-us-west-2.amazonaws.com"
-      name    = "AWS S3 hosting"
-      port    = 80
-    }
+    address = "demo.notexample.com.s3-website-us-west-2.amazonaws.com"
+    name    = "AWS S3 hosting"
+    port    = 80
+  }
 
   dictionary {
 	name       = var.mydict_name
@@ -48,12 +48,16 @@ resource "fastly_service_v1" "myservice" {
 }
 
 resource "fastly_service_dictionary_items_v1" "items" {
-    service_id = "${fastly_service_v1.myservice.id}"
-    dictionary_id = "${{for s in fastly_service_v1.myservice.dictionary : s.name => s.dictionary_id}[var.mydict_name]}"
-    items = {
-        key1: "value1"
-        key2: "value2"
-    }
+  for_each = {
+    for d in fastly_service_v1.myservice.dictionary : d.name => d if d.name == var.mydict_name
+  }
+  service_id = fastly_service_v1.myservice.id
+  dictionary_id = each.value.dictionary_id
+
+  items = {
+    key1: "value1"
+    key2: "value2"
+  }
 }
 ```
 
@@ -90,11 +94,14 @@ resource "fastly_service_v1" "myservice" {
   }
 
   force_destroy = true
-  }
+}
 
 resource "fastly_service_dictionary_items_v1" "items" {
+  for_each = {
+    for d in fastly_service_v1.myservice.dictionary : d.name => d if d.name == var.mydict.name
+  }
   service_id = fastly_service_v1.myservice.id
-  dictionary_id = {for d in fastly_service_v1.myservice.dictionary : d.name => d.dictionary_id}[var.mydict.name]
+  dictionary_id = each.value.dictionary_id
   items = var.mydict.items
 }
 ```
@@ -102,7 +109,7 @@ resource "fastly_service_dictionary_items_v1" "items" {
 Expression and functions usage:
 
 ```hcl
-// Local variables used when formating values for the "My Project Dictionary" example
+// Local variables used when formatting values for the "My Project Dictionary" example
 locals {
   dictionary_name = "My Project Dictionary"
   host_base = "demo.ocnotexample.com"
@@ -133,11 +140,57 @@ resource "fastly_service_v1" "myservice" {
 
 // This resource is dynamically creating the items from the local variables through for expressions and functions.
 resource "fastly_service_dictionary_items_v1" "project" {
+  for_each = {
+    for d in fastly_service_v1.myservice.dictionary : d.name => d if d.name == local.dictionary_name
+  }
   service_id = fastly_service_v1.myservice.id
-  dictionary_id = {for d in fastly_service_v1.myservice.dictionary : d.name => d.dictionary_id}[local.dictionary_name]
+  dictionary_id = each.value.dictionary_id
   items = {
     for division in local.host_divisions:
       division => format("%s.%s", division, local.host_base)
+  }
+}
+```
+
+## Example Usage (Terraform >= 0.12.0 && < 0.12.6)
+
+`for_each` attributes were not available in Terraform before 0.12.6, however, users can still use `for` expressions to achieve
+similar behaviour as seen in the example below.
+
+~> **Warning:** Terraform might not properly calculate implicit dependencies on computed attributes when using `for` expressions
+
+For scenarios such as adding a Dictionary to a service and at the same time, creating the Dictionary entries (`fastly_service_dictionary_items_v1`)
+resource, Terraform will not calculate implicit dependencies correctly on `for` expressions. This will result in index lookup
+problems and the execution will fail.
+
+For those scenarios, it's recommended to split the changes into two distinct steps:
+
+1. Add the `dictionary` block to the `fastly_service_v1` and apply the changes
+2. Add the `fastly_service_dictionary_items_v1` resource with the `for` expressions to the HCL and apply the changes
+
+Usage:
+
+```hcl
+variable "mydict_name" {
+	type = string
+	default = "My Dictionary"
+}
+
+resource "fastly_service_v1" "myservice" {
+  ...
+  dictionary {
+	name       = var.mydict_name
+  }
+  ...
+}
+
+resource "fastly_service_dictionary_items_v1" "items" {
+  service_id = fastly_service_v1.myservice.id
+  dictionary_id = {for s in fastly_service_v1.myservice.dictionary : s.name => s.dictionary_id}[var.mydict_name]
+
+  items = {
+    key1: "value1"
+    key2: "value2"
   }
 }
 ```
@@ -151,16 +204,20 @@ items in a dictionary.  If, after your first deploy, the Fastly API or UI is to 
 ...
 
 resource "fastly_service_dictionary_items_v1" "items" {
-    service_id = "${fastly_service_v1.myservice.id}"
-    dictionary_id = "${{for s in fastly_service_v1.myservice.dictionary : s.name => s.dictionary_id}[var.mydict_name]}"
-    items = {
-        key1: "value1"
-        key2: "value2"
-    }
-    
-    lifecycle {
-      ignore_changes = [items,]
-    }
+  for_each = {
+    for d in fastly_service_v1.myservice.dictionary : d.name => d if d.name == var.mydict_name
+  }
+  service_id = fastly_service_v1.myservice.id
+  dictionary_id = each.value.dictionary_id
+
+  items = {
+    key1: "value1"
+    key2: "value2"
+  }
+
+  lifecycle {
+    ignore_changes = [items,]
+  }
 }
 ```
 

--- a/website/docs/r/service_dynamic_snippet_content_v1.html.markdown
+++ b/website/docs/r/service_dynamic_snippet_content_v1.html.markdown
@@ -15,42 +15,44 @@ Defines content that represents blocks of VCL logic that is inserted into your s
 If Terraform is being used to populate the initial content of a dynamic snippet which you intend to manage via the API, then the lifecycle `ignore_changes` field can be used with the resource.  An example of this configuration is provided below.
 
 
-## Example Usage
+## Example Usage (Terraform >= 0.12.6)
 
 Basic usage:
 
 ```hcl 
 resource "fastly_service_v1" "myservice" {
- name = "snippet_test"
+  name = "snippet_test"
 
- domain {
-   name    = "snippet.fastlytestdomain.com"
-   comment = "snippet test"
- }
+  domain {
+    name    = "snippet.fastlytestdomain.com"
+    comment = "snippet test"
+  }
 
- backend {
-   address = "tftesting.tftesting.net.s3-website-us-west-2.amazonaws.com"
-   name    = "AWS S3 hosting"
-   port    = 80
- }
+  backend {
+    address = "tftesting.tftesting.net.s3-website-us-west-2.amazonaws.com"
+    name    = "AWS S3 hosting"
+    port    = 80
+  }
 
- dynamicsnippet {
-   name     = "My Dynamic Snippet"
-   type     = "recv"
-   priority = 110
- }
+  dynamicsnippet {
+    name     = "My Dynamic Snippet"
+    type     = "recv"
+    priority = 110
+  }
 
- default_host = "tftesting.tftesting.net.s3-website-us-west-2.amazonaws.com"
+  default_host = "tftesting.tftesting.net.s3-website-us-west-2.amazonaws.com"
 
- force_destroy = true
+  force_destroy = true
 }
 
 resource "fastly_service_dynamic_snippet_content_v1" "my_dyn_content" {
+  for_each = {
+    for d in fastly_service_v1.myservice.dynamicsnippet : d.name => d if d.name == "My Dynamic Snippet"
+  }
+  service_id = fastly_service_v1.myservice.id
+  snippet_id = each.value.snippet_id
 
- service_id = fastly_service_v1.myservice.id
- snippet_id = { for s in fastly_service_v1.myservice.dynamicsnippet : s.name => s.snippet_id }["My Dynamic Snippet"]
-
- content = "if ( req.url ) {\n set req.http.my-snippet-test-header = \"true\";\n}"
+  content = "if ( req.url ) {\n set req.http.my-snippet-test-header = \"true\";\n}"
 
 }
 ```
@@ -59,51 +61,95 @@ Multiple dynamic snippets:
 
 ```hcl
 resource "fastly_service_v1" "myservice" {
- name = "snippet_test"
+  name = "snippet_test"
 
- domain {
-   name    = "snippet.fastlytestdomain.com"
-   comment = "snippet test"
- }
+  domain {
+    name    = "snippet.fastlytestdomain.com"
+    comment = "snippet test"
+  }
 
- backend {
-   address = "tftesting.tftesting.net.s3-website-us-west-2.amazonaws.com"
-   name    = "AWS S3 hosting"
-   port    = 80
- }
+  backend {
+    address = "tftesting.tftesting.net.s3-website-us-west-2.amazonaws.com"
+    name    = "AWS S3 hosting"
+    port    = 80
+  }
 
- dynamicsnippet {
-   name     = "My Dynamic Snippet One"
-   type     = "recv"
-   priority = 110
- }
- 
- dynamicsnippet {
-      name     = "My Dynamic Snippet Two"
-      type     = "recv"
-      priority = 110
-    }
+  dynamicsnippet {
+    name     = "My Dynamic Snippet One"
+    type     = "recv"
+    priority = 110
+  }
 
- default_host = "tftesting.tftesting.net.s3-website-us-west-2.amazonaws.com"
+  dynamicsnippet {
+       name     = "My Dynamic Snippet Two"
+       type     = "recv"
+       priority = 110
+     }
 
- force_destroy = true
+  default_host = "tftesting.tftesting.net.s3-website-us-west-2.amazonaws.com"
+
+  force_destroy = true
 }
 
 resource "fastly_service_dynamic_snippet_content_v1" "my_dyn_content_one" {
+  for_each = {
+    for d in fastly_service_v1.myservice.dynamicsnippet : d.name => d if d.name == "My Dynamic Snippet One"
+  }
 
- service_id = fastly_service_v1.myservice.id
- snippet_id = { for s in fastly_service_v1.myservice.dynamicsnippet : s.name => s.snippet_id }["My Dynamic Snippet One"]
+  service_id = fastly_service_v1.myservice.id
+  snippet_id = each.value.snippet_id
 
- content = "if ( req.url ) {\n set req.http.my-snippet-test-header-one = \"true\";\n}"
+  content = "if ( req.url ) {\n set req.http.my-snippet-test-header-one = \"true\";\n}"
 
 }
 
 resource "fastly_service_dynamic_snippet_content_v1" "my_dyn_content_two" {
+  for_each = {
+    for d in fastly_service_v1.myservice.dynamicsnippet : d.name => d if d.name == "My Dynamic Snippet Two"
+  }
 
- service_id = fastly_service_v1.myservice.id
- snippet_id = { for s in fastly_service_v1.myservice.dynamicsnippet : s.name => s.snippet_id }["My Dynamic Snippet Two"]
+  service_id = fastly_service_v1.myservice.id
+  snippet_id = each.value.snippet_id
 
- content = "if ( req.url ) {\n set req.http.my-snippet-test-header-two = \"true\";\n}"
+  content = "if ( req.url ) {\n set req.http.my-snippet-test-header-two = \"true\";\n}"
+
+}
+```
+
+## Example Usage (Terraform >= 0.12.0 && < 0.12.6)
+
+`for_each` attributes were not available in Terraform before 0.12.6, however, users can still use `for` expressions to achieve
+similar behaviour as seen in the example below.
+
+~> **Warning:** Terraform might not properly calculate implicit dependencies on computed attributes when using `for` expressions
+
+For scenarios such as adding a Dynamic Snippet to a service and at the same time, creating the Dynamic Snippets (`fastly_service_dynamic_snippet_content_v1`)
+resource, Terraform will not calculate implicit dependencies correctly on `for` expressions. This will result in index lookup
+problems and the execution will fail.
+
+For those scenarios, it's recommended to split the changes into two distinct steps:
+
+1. Add the `dynamicsnippet` block to the `fastly_service_v1` and apply the changes
+2. Add the `fastly_service_dynamic_snippet_content_v1` resource with the `for` expressions to the HCL and apply the changes
+
+Usage:
+
+```hcl
+resource "fastly_service_v1" "myservice" {
+  ...
+  dynamicsnippet {
+    name     = "My Dynamic Snippet"
+    type     = "recv"
+    priority = 110
+  }
+  ...
+}
+
+resource "fastly_service_dynamic_snippet_content_v1" "my_dyn_content" {
+  service_id = fastly_service_v1.myservice.id
+  snippet_id = { for s in fastly_service_v1.myservice.dynamicsnippet : s.name => s.snippet_id }["My Dynamic Snippet"]
+
+  content = "if ( req.url ) {\n set req.http.my-snippet-test-header = \"true\";\n}"
 
 }
 ```
@@ -117,9 +163,11 @@ content in a dynamic snippet.  If, after your first deploy, the Fastly API is to
 ...
 
 resource "fastly_service_dynamic_snippet_content_v1" "my_dyn_content" {
-
+  for_each = {
+    for d in fastly_service_v1.myservice.dynamicsnippet : d.name => d if d.name == "My Dynamic Snippet"
+  }
   service_id = fastly_service_v1.myservice.id
-  snippet_id = { for s in fastly_service_v1.myservice.dynamicsnippet : s.name => s.snippet_id }["My Dynamic Snippet"]
+  snippet_id = each.value.snippet_id
 
   content = "if ( req.url ) {\n set req.http.my-snippet-test-header = \"true\";\n}"
 

--- a/website/docs/r/service_waf_configuration.html.markdown
+++ b/website/docs/r/service_waf_configuration.html.markdown
@@ -472,6 +472,20 @@ output "rules" {
 }
 ```
 
+## Adding a WAF to an existing service
+
+~> **Warning:** A two-phase change is required when adding a WAF to an existing service
+
+When adding a `waf` to an existing `fastly_service_v1` and at the same time adding a `fastly_service_waf_configuration`
+resource with `waf_id = fastly_service_v1.demo.waf[0].waf_id` might result with the in the following error:
+
+> fastly_service_v1.demo.waf is empty list of object
+
+For this scenario, it's recommended to split the changes into two distinct steps:
+
+1. Add the `waf` block to the `fastly_service_v1` and apply the changes
+2. Add the `fastly_service_waf_configuration` to the HCL and apply the changes
+
 ## Argument Reference
 
 The following arguments are supported:

--- a/website_src/docs/r/service_dictionary_items_v1.html.markdown.tmpl
+++ b/website_src/docs/r/service_dictionary_items_v1.html.markdown.tmpl
@@ -16,7 +16,7 @@ Defines a map of Fastly dictionary items that can be used to populate a service 
 If Terraform is being used to populate the initial content of a dictionary which you intend to manage via API or UI, then the lifecycle `ignore_changes` field can be used with the resource.  An example of this configuration is provided below.    
 
 
-## Example Usage
+## Example Usage (Terraform >= 0.12.6)
 
 Basic usage:
 
@@ -30,15 +30,15 @@ resource "fastly_service_v1" "myservice" {
   name = "demofastly"
 
   domain {
-      name    = "demo.notexample.com"
-      comment = "demo"
+    name    = "demo.notexample.com"
+    comment = "demo"
   }
 
   backend {
-      address = "demo.notexample.com.s3-website-us-west-2.amazonaws.com"
-      name    = "AWS S3 hosting"
-      port    = 80
-    }
+    address = "demo.notexample.com.s3-website-us-west-2.amazonaws.com"
+    name    = "AWS S3 hosting"
+    port    = 80
+  }
 
   dictionary {
 	name       = var.mydict_name
@@ -48,12 +48,16 @@ resource "fastly_service_v1" "myservice" {
 }
 
 resource "fastly_service_dictionary_items_v1" "items" {
-    service_id = "${fastly_service_v1.myservice.id}"
-    dictionary_id = "${{"{{"}}for s in fastly_service_v1.myservice.dictionary : s.name => s.dictionary_id}[var.mydict_name]}"
-    items = {
-        key1: "value1"
-        key2: "value2"
-    }
+  for_each = {
+    for d in fastly_service_v1.myservice.dictionary : d.name => d if d.name == var.mydict_name
+  }
+  service_id = fastly_service_v1.myservice.id
+  dictionary_id = each.value.dictionary_id
+
+  items = {
+    key1: "value1"
+    key2: "value2"
+  }
 }
 ```
 
@@ -90,11 +94,14 @@ resource "fastly_service_v1" "myservice" {
   }
 
   force_destroy = true
-  }
+}
 
 resource "fastly_service_dictionary_items_v1" "items" {
+  for_each = {
+    for d in fastly_service_v1.myservice.dictionary : d.name => d if d.name == var.mydict.name
+  }
   service_id = fastly_service_v1.myservice.id
-  dictionary_id = {for d in fastly_service_v1.myservice.dictionary : d.name => d.dictionary_id}[var.mydict.name]
+  dictionary_id = each.value.dictionary_id
   items = var.mydict.items
 }
 ```
@@ -102,7 +109,7 @@ resource "fastly_service_dictionary_items_v1" "items" {
 Expression and functions usage:
 
 ```hcl
-// Local variables used when formating values for the "My Project Dictionary" example
+// Local variables used when formatting values for the "My Project Dictionary" example
 locals {
   dictionary_name = "My Project Dictionary"
   host_base = "demo.ocnotexample.com"
@@ -133,11 +140,57 @@ resource "fastly_service_v1" "myservice" {
 
 // This resource is dynamically creating the items from the local variables through for expressions and functions.
 resource "fastly_service_dictionary_items_v1" "project" {
+  for_each = {
+    for d in fastly_service_v1.myservice.dictionary : d.name => d if d.name == local.dictionary_name
+  }
   service_id = fastly_service_v1.myservice.id
-  dictionary_id = {for d in fastly_service_v1.myservice.dictionary : d.name => d.dictionary_id}[local.dictionary_name]
+  dictionary_id = each.value.dictionary_id
   items = {
     for division in local.host_divisions:
       division => format("%s.%s", division, local.host_base)
+  }
+}
+```
+
+## Example Usage (Terraform >= 0.12.0 && < 0.12.6)
+
+`for_each` attributes were not available in Terraform before 0.12.6, however, users can still use `for` expressions to achieve
+similar behaviour as seen in the example below.
+
+~> **Warning:** Terraform might not properly calculate implicit dependencies on computed attributes when using `for` expressions
+
+For scenarios such as adding a Dictionary to a service and at the same time, creating the Dictionary entries (`fastly_service_dictionary_items_v1`)
+resource, Terraform will not calculate implicit dependencies correctly on `for` expressions. This will result in index lookup
+problems and the execution will fail.
+
+For those scenarios, it's recommended to split the changes into two distinct steps:
+
+1. Add the `dictionary` block to the `fastly_service_v1` and apply the changes
+2. Add the `fastly_service_dictionary_items_v1` resource with the `for` expressions to the HCL and apply the changes
+
+Usage:
+
+```hcl
+variable "mydict_name" {
+	type = string
+	default = "My Dictionary"
+}
+
+resource "fastly_service_v1" "myservice" {
+  ...
+  dictionary {
+	name       = var.mydict_name
+  }
+  ...
+}
+
+resource "fastly_service_dictionary_items_v1" "items" {
+  service_id = fastly_service_v1.myservice.id
+  dictionary_id = {for s in fastly_service_v1.myservice.dictionary : s.name => s.dictionary_id}[var.mydict_name]
+
+  items = {
+    key1: "value1"
+    key2: "value2"
   }
 }
 ```
@@ -151,16 +204,20 @@ items in a dictionary.  If, after your first deploy, the Fastly API or UI is to 
 ...
 
 resource "fastly_service_dictionary_items_v1" "items" {
-    service_id = "${fastly_service_v1.myservice.id}"
-    dictionary_id = "${{"{{"}}for s in fastly_service_v1.myservice.dictionary : s.name => s.dictionary_id}[var.mydict_name]}"
-    items = {
-        key1: "value1"
-        key2: "value2"
-    }
-    
-    lifecycle {
-      ignore_changes = [items,]
-    }
+  for_each = {
+    for d in fastly_service_v1.myservice.dictionary : d.name => d if d.name == var.mydict_name
+  }
+  service_id = fastly_service_v1.myservice.id
+  dictionary_id = each.value.dictionary_id
+
+  items = {
+    key1: "value1"
+    key2: "value2"
+  }
+
+  lifecycle {
+    ignore_changes = [items,]
+  }
 }
 ```
 

--- a/website_src/docs/r/service_dynamic_snippet_content_v1.html.markdown.tmpl
+++ b/website_src/docs/r/service_dynamic_snippet_content_v1.html.markdown.tmpl
@@ -15,42 +15,44 @@ Defines content that represents blocks of VCL logic that is inserted into your s
 If Terraform is being used to populate the initial content of a dynamic snippet which you intend to manage via the API, then the lifecycle `ignore_changes` field can be used with the resource.  An example of this configuration is provided below.
 
 
-## Example Usage
+## Example Usage (Terraform >= 0.12.6)
 
 Basic usage:
 
 ```hcl 
 resource "fastly_service_v1" "myservice" {
- name = "snippet_test"
+  name = "snippet_test"
 
- domain {
-   name    = "snippet.fastlytestdomain.com"
-   comment = "snippet test"
- }
+  domain {
+    name    = "snippet.fastlytestdomain.com"
+    comment = "snippet test"
+  }
 
- backend {
-   address = "tftesting.tftesting.net.s3-website-us-west-2.amazonaws.com"
-   name    = "AWS S3 hosting"
-   port    = 80
- }
+  backend {
+    address = "tftesting.tftesting.net.s3-website-us-west-2.amazonaws.com"
+    name    = "AWS S3 hosting"
+    port    = 80
+  }
 
- dynamicsnippet {
-   name     = "My Dynamic Snippet"
-   type     = "recv"
-   priority = 110
- }
+  dynamicsnippet {
+    name     = "My Dynamic Snippet"
+    type     = "recv"
+    priority = 110
+  }
 
- default_host = "tftesting.tftesting.net.s3-website-us-west-2.amazonaws.com"
+  default_host = "tftesting.tftesting.net.s3-website-us-west-2.amazonaws.com"
 
- force_destroy = true
+  force_destroy = true
 }
 
 resource "fastly_service_dynamic_snippet_content_v1" "my_dyn_content" {
+  for_each = {
+    for d in fastly_service_v1.myservice.dynamicsnippet : d.name => d if d.name == "My Dynamic Snippet"
+  }
+  service_id = fastly_service_v1.myservice.id
+  snippet_id = each.value.snippet_id
 
- service_id = fastly_service_v1.myservice.id
- snippet_id = { for s in fastly_service_v1.myservice.dynamicsnippet : s.name => s.snippet_id }["My Dynamic Snippet"]
-
- content = "if ( req.url ) {\n set req.http.my-snippet-test-header = \"true\";\n}"
+  content = "if ( req.url ) {\n set req.http.my-snippet-test-header = \"true\";\n}"
 
 }
 ```
@@ -59,51 +61,95 @@ Multiple dynamic snippets:
 
 ```hcl
 resource "fastly_service_v1" "myservice" {
- name = "snippet_test"
+  name = "snippet_test"
 
- domain {
-   name    = "snippet.fastlytestdomain.com"
-   comment = "snippet test"
- }
+  domain {
+    name    = "snippet.fastlytestdomain.com"
+    comment = "snippet test"
+  }
 
- backend {
-   address = "tftesting.tftesting.net.s3-website-us-west-2.amazonaws.com"
-   name    = "AWS S3 hosting"
-   port    = 80
- }
+  backend {
+    address = "tftesting.tftesting.net.s3-website-us-west-2.amazonaws.com"
+    name    = "AWS S3 hosting"
+    port    = 80
+  }
 
- dynamicsnippet {
-   name     = "My Dynamic Snippet One"
-   type     = "recv"
-   priority = 110
- }
- 
- dynamicsnippet {
-      name     = "My Dynamic Snippet Two"
-      type     = "recv"
-      priority = 110
-    }
+  dynamicsnippet {
+    name     = "My Dynamic Snippet One"
+    type     = "recv"
+    priority = 110
+  }
 
- default_host = "tftesting.tftesting.net.s3-website-us-west-2.amazonaws.com"
+  dynamicsnippet {
+       name     = "My Dynamic Snippet Two"
+       type     = "recv"
+       priority = 110
+     }
 
- force_destroy = true
+  default_host = "tftesting.tftesting.net.s3-website-us-west-2.amazonaws.com"
+
+  force_destroy = true
 }
 
 resource "fastly_service_dynamic_snippet_content_v1" "my_dyn_content_one" {
+  for_each = {
+    for d in fastly_service_v1.myservice.dynamicsnippet : d.name => d if d.name == "My Dynamic Snippet One"
+  }
 
- service_id = fastly_service_v1.myservice.id
- snippet_id = { for s in fastly_service_v1.myservice.dynamicsnippet : s.name => s.snippet_id }["My Dynamic Snippet One"]
+  service_id = fastly_service_v1.myservice.id
+  snippet_id = each.value.snippet_id
 
- content = "if ( req.url ) {\n set req.http.my-snippet-test-header-one = \"true\";\n}"
+  content = "if ( req.url ) {\n set req.http.my-snippet-test-header-one = \"true\";\n}"
 
 }
 
 resource "fastly_service_dynamic_snippet_content_v1" "my_dyn_content_two" {
+  for_each = {
+    for d in fastly_service_v1.myservice.dynamicsnippet : d.name => d if d.name == "My Dynamic Snippet Two"
+  }
 
- service_id = fastly_service_v1.myservice.id
- snippet_id = { for s in fastly_service_v1.myservice.dynamicsnippet : s.name => s.snippet_id }["My Dynamic Snippet Two"]
+  service_id = fastly_service_v1.myservice.id
+  snippet_id = each.value.snippet_id
 
- content = "if ( req.url ) {\n set req.http.my-snippet-test-header-two = \"true\";\n}"
+  content = "if ( req.url ) {\n set req.http.my-snippet-test-header-two = \"true\";\n}"
+
+}
+```
+
+## Example Usage (Terraform >= 0.12.0 && < 0.12.6)
+
+`for_each` attributes were not available in Terraform before 0.12.6, however, users can still use `for` expressions to achieve
+similar behaviour as seen in the example below.
+
+~> **Warning:** Terraform might not properly calculate implicit dependencies on computed attributes when using `for` expressions
+
+For scenarios such as adding a Dynamic Snippet to a service and at the same time, creating the Dynamic Snippets (`fastly_service_dynamic_snippet_content_v1`)
+resource, Terraform will not calculate implicit dependencies correctly on `for` expressions. This will result in index lookup
+problems and the execution will fail.
+
+For those scenarios, it's recommended to split the changes into two distinct steps:
+
+1. Add the `dynamicsnippet` block to the `fastly_service_v1` and apply the changes
+2. Add the `fastly_service_dynamic_snippet_content_v1` resource with the `for` expressions to the HCL and apply the changes
+
+Usage:
+
+```hcl
+resource "fastly_service_v1" "myservice" {
+  ...
+  dynamicsnippet {
+    name     = "My Dynamic Snippet"
+    type     = "recv"
+    priority = 110
+  }
+  ...
+}
+
+resource "fastly_service_dynamic_snippet_content_v1" "my_dyn_content" {
+  service_id = fastly_service_v1.myservice.id
+  snippet_id = { for s in fastly_service_v1.myservice.dynamicsnippet : s.name => s.snippet_id }["My Dynamic Snippet"]
+
+  content = "if ( req.url ) {\n set req.http.my-snippet-test-header = \"true\";\n}"
 
 }
 ```
@@ -117,9 +163,11 @@ content in a dynamic snippet.  If, after your first deploy, the Fastly API is to
 ...
 
 resource "fastly_service_dynamic_snippet_content_v1" "my_dyn_content" {
-
+  for_each = {
+    for d in fastly_service_v1.myservice.dynamicsnippet : d.name => d if d.name == "My Dynamic Snippet"
+  }
   service_id = fastly_service_v1.myservice.id
-  snippet_id = { for s in fastly_service_v1.myservice.dynamicsnippet : s.name => s.snippet_id }["My Dynamic Snippet"]
+  snippet_id = each.value.snippet_id
 
   content = "if ( req.url ) {\n set req.http.my-snippet-test-header = \"true\";\n}"
 

--- a/website_src/docs/r/service_waf_configuration.html.markdown.tmpl
+++ b/website_src/docs/r/service_waf_configuration.html.markdown.tmpl
@@ -472,6 +472,20 @@ output "rules" {
 }
 ```
 
+## Adding a WAF to an existing service
+
+~> **Warning:** A two-phase change is required when adding a WAF to an existing service
+
+When adding a `waf` to an existing `fastly_service_v1` and at the same time adding a `fastly_service_waf_configuration`
+resource with `waf_id = fastly_service_v1.demo.waf[0].waf_id` might result with the in the following error:
+
+> fastly_service_v1.demo.waf is empty list of object
+
+For this scenario, it's recommended to split the changes into two distinct steps:
+
+1. Add the `waf` block to the `fastly_service_v1` and apply the changes
+2. Add the `fastly_service_waf_configuration` to the HCL and apply the changes
+
 ## Argument Reference
 
 The following arguments are supported:


### PR DESCRIPTION
Changing ACL, Dictionary and Dynamic Snippets documentation example to use [`for_each`](https://www.terraform.io/docs/configuration/resources.html#for_each-multiple-resource-instances-defined-by-a-map-or-set-of-strings) attributes instead of [_for expressions_](https://github.com/hashicorp/hcl/blob/hcl2/hclsyntax/spec.md#for-expressions).

In order to use _versionless_ resources (i.e. ACL Entries, Dictionary Items, Dynamic Snippets Content), it's required to link the ID generated from the Fastly Service (`fastly_service_v1`) to the respective field in the _versionless_ resource (i.e `fastly_service_acl_entries_v1`, `fastly_service_dictionary_items_v1`, `fastly_service_dynamic_snippet_content_v1`).

The original documentation instructed to the use of _for expressions_ to create this link. For example:

``` 
resource "fastly_service_v1" "myservice" {
  ...
  dictionary {
    name = "dict1"
  }

}
resource "fastly_service_dictionary_items_v1" "items" {
  service_id = fastly_service_v1.myservice.id
  dictionary_id = {for d in fastly_service_v1.myservice.dictionary : d.name => d.dictionary_id}["dict1"]
  ...
}
```

This seems to work for many scenarios, however, not for all. 
It fails mainly when the resource `fastly_service_v1` already exists and we add the `acl` block at the same time, we add `fastly_service_acl_entries_v1` resources (The same occur for the other _versionless_ resources).

The generated error is: `Error: Invalid index`

This seems to be due to the way Terraform evaluates *Computed* attributes inside `Sets`. When the resource doesn't exist, Terraform postpones the evaluation of the expression as the values are [not yet known](https://www.terraform.io/docs/configuration/expressions.html%23values-not-yet-known).
However, when the resource exists and the  Set attribute is being modified, Terraform tries to evaluate the expression before the all values are known causing the error. This is likely to be an issue in Terraform.

When replacing the _for expression_ with a `for_each` attribute, Terraform is able to resolve the values correctly. That is, Terraform detects that a value the computed id is still not available and postpones the expression evaluation. 

Interestingly enough, if using the _for expression_ with an `if` and `lookup`, the issue seems to also disappear. For example

```
lookup​({​for​ ​d​ in ​fastly_service_v1​.myservice.dictionary : ​d​.​name​ ​=>​ ​d​.dictionary_id ​if​ ​d​.​name == "dict1"​}, "dict1", ​""​)
```
This approach however is not as clean as the `for_each` one.

For all those reasons, the documentation was updated to recommend the `for_each` approach.

A similar issue also happens to `List` types and current affects the WAF resource. (This issue was previously raised against Terraform - see https://github.com/hashicorp/terraform/issues/23488)

For example:
```
resource "fastly_service_v1" "demo" {
  ...
  waf {
    response_object    = "WAF_Response"
  }

}

resource "fastly_service_waf_configuration" "waf" {
  waf_id = fastly_service_v1.demo.waf[0].waf_id
}
```

This will cause an error, when the `waf` block is added to an existing at the same at time that we add the `fastly_service_waf_configuration`

Unfortunately for case, there's currently no alternative approach to the index lookup. The `for_each` approach doesn't work correctly.

Therefore, WAF documentation was updated to include a warning about adding WAF to an existing service and a recommendation to do a two-phase approach in case this change is required.


Note:
For this PR, I've also tried to update the acceptance tests' HCL to reflect the `for_each` recommendation.
However, there’s apparently another issue in the Terraform Test framework that fails to destroy resources at the end of the test step if the HCL contains `for_each`. See related issue https://github.com/hashicorp/terraform-plugin-sdk/issues/264.
