### PR TITLE
Adding WAF Rule Exclusions to WAF Configuration resource

### DIFF
--- a/fastly/block_fastly_waf_configuration_v1_active_rule_test.go
+++ b/fastly/block_fastly_waf_configuration_v1_active_rule_test.go
@@ -94,43 +94,7 @@ func TestAccFastlyServiceWAFVersionV1FlattenWAFDeleteByModSecID(t *testing.T) {
 	}
 }
 
-func TestAccFastlyServiceWAFVersionV1AddWithRules(t *testing.T) {
-	var service gofastly.ServiceDetail
-	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
-
-	rules := []gofastly.WAFActiveRule{
-		{
-			ModSecID: 2029718,
-			Status:   "log",
-			Revision: 1,
-		},
-		{
-			ModSecID: 2037405,
-			Status:   "log",
-			Revision: 1,
-		},
-	}
-	wafVerInput := testAccFastlyServiceWAFVersionV1BuildConfig(20)
-	rulesTF := testAccCheckFastlyServiceWAFVersionV1ComposeWAFRules(rules)
-	wafVer := testAccFastlyServiceWAFVersionV1ComposeConfiguration(wafVerInput, rulesTF)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckServiceV1Destroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccFastlyServiceWAFVersionV1(name, wafVer),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckServiceV1Exists(serviceRef, &service),
-					testAccCheckFastlyServiceWAFVersionV1CheckRules(&service, rules, 1),
-				),
-			},
-		},
-	})
-}
-
-func TestAccFastlyServiceWAFVersionV1UpdateRules(t *testing.T) {
+func TestAccFastlyServiceWAFVersionV1AddUpdateDeleteRules(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 
@@ -170,10 +134,10 @@ func TestAccFastlyServiceWAFVersionV1UpdateRules(t *testing.T) {
 	}
 	wafVerInput := testAccFastlyServiceWAFVersionV1BuildConfig(20)
 	rulesTF1 := testAccCheckFastlyServiceWAFVersionV1ComposeWAFRules(rules1)
-	wafVer1 := testAccFastlyServiceWAFVersionV1ComposeConfiguration(wafVerInput, rulesTF1)
+	wafVer1 := testAccFastlyServiceWAFVersionV1ComposeConfiguration(wafVerInput, rulesTF1, "")
 
 	rulesTF2 := testAccCheckFastlyServiceWAFVersionV1ComposeWAFRules(rules2)
-	wafVer2 := testAccFastlyServiceWAFVersionV1ComposeConfiguration(wafVerInput, rulesTF2)
+	wafVer2 := testAccFastlyServiceWAFVersionV1ComposeConfiguration(wafVerInput, rulesTF2, "")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -193,100 +157,6 @@ func TestAccFastlyServiceWAFVersionV1UpdateRules(t *testing.T) {
 					testAccCheckServiceV1Exists(serviceRef, &service),
 					testAccCheckFastlyServiceWAFVersionV1CheckRules(&service, rules2, 2),
 				),
-			},
-		},
-	})
-}
-
-func TestAccFastlyServiceWAFVersionV1DeleteRules(t *testing.T) {
-	var service gofastly.ServiceDetail
-	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
-
-	rules1 := []gofastly.WAFActiveRule{
-		{
-			ModSecID: 2029718,
-			Status:   "log",
-			Revision: 1,
-		},
-		{
-			ModSecID: 2037405,
-			Status:   "log",
-			Revision: 1,
-		},
-	}
-	rules2 := []gofastly.WAFActiveRule{
-		{
-			ModSecID: 2029718,
-			Status:   "block",
-			Revision: 1,
-		},
-	}
-	wafVerInput := testAccFastlyServiceWAFVersionV1BuildConfig(20)
-	rulesTF1 := testAccCheckFastlyServiceWAFVersionV1ComposeWAFRules(rules1)
-	wafVer1 := testAccFastlyServiceWAFVersionV1ComposeConfiguration(wafVerInput, rulesTF1)
-
-	rulesTF2 := testAccCheckFastlyServiceWAFVersionV1ComposeWAFRules(rules2)
-	wafVer2 := testAccFastlyServiceWAFVersionV1ComposeConfiguration(wafVerInput, rulesTF2)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckServiceV1Destroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccFastlyServiceWAFVersionV1(name, wafVer1),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckServiceV1Exists(serviceRef, &service),
-					testAccCheckFastlyServiceWAFVersionV1CheckRules(&service, rules1, 1),
-				),
-			},
-			{
-				Config: testAccFastlyServiceWAFVersionV1(name, wafVer2),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckServiceV1Exists(serviceRef, &service),
-					testAccCheckFastlyServiceWAFVersionV1CheckRules(&service, rules2, 2),
-				),
-			},
-		},
-	})
-}
-
-func TestAccFastlyServiceWAFVersionV1ImportWithRules(t *testing.T) {
-
-	var service gofastly.ServiceDetail
-	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
-
-	rules := []gofastly.WAFActiveRule{
-		{
-			ModSecID: 2029718,
-			Status:   "log",
-			Revision: 1,
-		},
-		{
-			ModSecID: 2037405,
-			Status:   "log",
-			Revision: 1,
-		},
-	}
-
-	rulesTF := testAccCheckFastlyServiceWAFVersionV1ComposeWAFRules(rules)
-	wafVer := testAccFastlyServiceWAFVersionV1ComposeConfiguration(nil, rulesTF)
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckServiceV1Destroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccFastlyServiceWAFVersionV1(name, wafVer),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckServiceV1Exists(serviceRef, &service),
-				),
-			},
-			{
-				ResourceName:      "fastly_service_waf_configuration.waf",
-				ImportState:       true,
-				ImportStateVerify: true,
 			},
 		},
 	})

--- a/fastly/block_fastly_waf_configuration_v1_exclusion.go
+++ b/fastly/block_fastly_waf_configuration_v1_exclusion.go
@@ -2,11 +2,12 @@ package fastly
 
 import (
 	"fmt"
+	"log"
+	"strconv"
+
 	gofastly "github.com/fastly/go-fastly/v2/fastly"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
-	"log"
-	"strconv"
 )
 
 var wafRuleExclusion = &schema.Schema{
@@ -33,7 +34,7 @@ var wafRuleExclusion = &schema.Schema{
 			"modsec_rule_ids": {
 				Type:        schema.TypeSet,
 				Optional:    true,
-				Description: "The modsec rule ids to exclude.",
+				Description: "The modsec rule IDs to exclude.",
 				Elem:        &schema.Schema{Type: schema.TypeInt},
 			},
 			"number": {
@@ -52,7 +53,7 @@ func readWAFRuleExclusions(meta interface{}, d *schema.ResourceData, wafVersionN
 	resp, e := conn.ListAllWAFRuleExclusions(&gofastly.ListAllWAFRuleExclusionsInput{
 		WAFID:            wafID,
 		WAFVersionNumber: wafVersionNumber,
-		Include:          strToPtr("waf_rules"),
+		Include:          []string{"waf_rules"},
 	})
 
 	if e != nil {

--- a/fastly/block_fastly_waf_configuration_v1_exclusion.go
+++ b/fastly/block_fastly_waf_configuration_v1_exclusion.go
@@ -1,0 +1,212 @@
+package fastly
+
+import (
+	"fmt"
+	gofastly "github.com/fastly/go-fastly/v2/fastly"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"log"
+	"strconv"
+)
+
+var wafExclusion = &schema.Schema{
+	Type:     schema.TypeSet,
+	Optional: true,
+	Elem: &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Name of the exclusion.",
+			},
+			"condition": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "A conditional expression in VCL used to determine if the condition is met.",
+			},
+			"exclusion_type": {
+				Type:         schema.TypeString,
+				Required:     true,
+				Description:  "The type of exclusion.",
+				ValidateFunc: validateExecutionType(),
+			},
+			"modsec_rule_ids": {
+				Type:        schema.TypeSet,
+				Optional:    true,
+				Description: "The modsec rule ids to exclude.",
+				Elem:        &schema.Schema{Type: schema.TypeInt},
+			},
+			"number": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "A sequential ID assigned to the exclusion.",
+			},
+		},
+	},
+}
+
+func readWAFExclusions(meta interface{}, d *schema.ResourceData, wafVersionNumber int) error {
+	conn := meta.(*FastlyClient).conn
+	wafID := d.Get("waf_id").(string)
+
+	resp, e := conn.ListAllWAFExclusions(&gofastly.ListAllWAFExclusionsInput{
+		WAFID:            wafID,
+		WAFVersionNumber: wafVersionNumber,
+		Include:          strToPtr("waf_rules"),
+	})
+
+	if e != nil {
+		return e
+	}
+
+	err := d.Set("exclusion", flattenWAFExclusions(resp.Items))
+
+	if err != nil {
+		log.Printf("[WARN] Error setting WAF exclusions for (%s): %s", d.Id(), err)
+	}
+
+	return nil
+}
+
+func flattenWAFExclusions(exclusions []*gofastly.WAFExclusion) []map[string]interface{} {
+	var result []map[string]interface{}
+
+	for _, exclusion := range exclusions {
+
+		m := make(map[string]interface{})
+		if exclusion.Name != nil {
+			m["name"] = *exclusion.Name
+		}
+		if exclusion.Number != nil {
+			m["number"] = *exclusion.Number
+		}
+		if exclusion.Condition != nil {
+			m["condition"] = *exclusion.Condition
+		}
+		if exclusion.ExclusionType != nil {
+			m["exclusion_type"] = *exclusion.ExclusionType
+		}
+
+		var rules []interface{}
+		for _, rule := range exclusion.Rules {
+			rules = append(rules, rule.ModSecID)
+		}
+		if len(rules) > 0 {
+			m["modsec_rule_ids"] = schema.NewSet(schema.HashInt, rules)
+		}
+		result = append(result, m)
+	}
+
+	return result
+}
+
+func updateWAFExclusions(d *schema.ResourceData, meta interface{}, wafID string, wafVersionNumber int) error {
+
+	os, ns := d.GetChange("exclusion")
+
+	if os == nil {
+		os = new(schema.Set)
+	}
+	if ns == nil {
+		ns = new(schema.Set)
+	}
+
+	oss := os.(*schema.Set)
+	nss := ns.(*schema.Set)
+
+	add := nss.Difference(oss).List()
+	remove := oss.Difference(nss).List()
+
+	var err error
+
+	err = deleteWAFExclusion(remove, meta, wafID, wafVersionNumber)
+	if err != nil {
+		return err
+	}
+
+	err = createWAFExclusion(add, meta, wafID, wafVersionNumber)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func deleteWAFExclusion(remove []interface{}, meta interface{}, wafID string, wafVersionNumber int) error {
+	conn := meta.(*FastlyClient).conn
+
+	for _, aRaw := range remove {
+		a := aRaw.(map[string]interface{})
+
+		err := conn.DeleteWAFExclusion(&gofastly.DeleteWAFExclusionInput{
+			Number:           a["number"].(int),
+			WAFID:            wafID,
+			WAFVersionNumber: wafVersionNumber,
+		})
+
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func createWAFExclusion(add []interface{}, meta interface{}, wafID string, wafVersionNumber int) error {
+	conn := meta.(*FastlyClient).conn
+
+	for _, aRaw := range add {
+		a := aRaw.(map[string]interface{})
+
+		var rules []*gofastly.WAFRule
+		if a["exclusion_type"] == gofastly.WAFExclusionTypeRule {
+			for _, ruleId := range a["modsec_rule_ids"].(*schema.Set).List() {
+				rules = append(rules, &gofastly.WAFRule{
+					ID: strconv.Itoa(ruleId.(int)),
+				})
+			}
+		} else {
+			rules = nil
+		}
+
+		_, err := conn.CreateWAFExclusion(&gofastly.CreateWAFExclusionInput{
+			WAFID:            wafID,
+			WAFVersionNumber: wafVersionNumber,
+			WAFExclusion: &gofastly.WAFExclusion{
+				Name:          strToPtr(a["name"].(string)),
+				ExclusionType: strToPtr(a["exclusion_type"].(string)),
+				Condition:     strToPtr(a["condition"].(string)),
+				Rules:         rules,
+			},
+		})
+
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateExecutionType() schema.SchemaValidateFunc {
+	return validation.StringInSlice(
+		[]string{
+			gofastly.WAFExclusionTypeRule,
+			gofastly.WAFExclusionTypeWAF,
+		},
+		false,
+	)
+}
+
+func validateWAFExclusion(d *schema.ResourceDiff) error {
+	for _, i := range d.Get("exclusion").(*schema.Set).List() {
+		wafExclusion := i.(map[string]interface{})
+
+		if wafExclusion["exclusion_type"] == gofastly.WAFExclusionTypeWAF && len(wafExclusion["modsec_rule_ids"].(*schema.Set).List()) > 0 {
+			return fmt.Errorf("must not set \"modsec_rule_ids\" with \"waf\" exclusion type in exclusion \"%s\"", wafExclusion["name"])
+		}
+		if wafExclusion["exclusion_type"] == gofastly.WAFExclusionTypeRule && len(wafExclusion["modsec_rule_ids"].(*schema.Set).List()) == 0 {
+			return fmt.Errorf("must set \"modsec_rule_ids\" with \"rule\" exclusion type in exclusion \"%s\"", wafExclusion["name"])
+		}
+	}
+	return nil
+}

--- a/fastly/block_fastly_waf_configuration_v1_exclusion_test.go
+++ b/fastly/block_fastly_waf_configuration_v1_exclusion_test.go
@@ -14,18 +14,18 @@ import (
 	"testing"
 )
 
-func TestAccFastlyServiceWAFVersionV1FlattenWAFExclusions(t *testing.T) {
+func TestAccFastlyServiceWAFVersionV1FlattenWAFRuleExclusions(t *testing.T) {
 	cases := []struct {
-		remote []*gofastly.WAFExclusion
+		remote []*gofastly.WAFRuleExclusion
 		local  []map[string]interface{}
 	}{
 		{
-			remote: []*gofastly.WAFExclusion{
+			remote: []*gofastly.WAFRuleExclusion{
 				{
 					ID:            "abc",
 					Number:        intToPtr(1),
 					Name:          strToPtr("index page"),
-					ExclusionType: strToPtr(gofastly.WAFExclusionTypeRule),
+					ExclusionType: strToPtr(gofastly.WAFRuleExclusionTypeRule),
 					Condition:     strToPtr("req.url.basename == \"index.html\""),
 					Rules: []*gofastly.WAFRule{
 						{
@@ -42,7 +42,7 @@ func TestAccFastlyServiceWAFVersionV1FlattenWAFExclusions(t *testing.T) {
 					ID:            "def",
 					Number:        intToPtr(2),
 					Name:          strToPtr("index php"),
-					ExclusionType: strToPtr(gofastly.WAFExclusionTypeRule),
+					ExclusionType: strToPtr(gofastly.WAFRuleExclusionTypeRule),
 					Condition:     strToPtr("req.url.basename == \"index.php\""),
 					Rules: []*gofastly.WAFRule{
 						{
@@ -55,7 +55,7 @@ func TestAccFastlyServiceWAFVersionV1FlattenWAFExclusions(t *testing.T) {
 					ID:            "ghi",
 					Number:        intToPtr(3),
 					Name:          strToPtr("index asp"),
-					ExclusionType: strToPtr(gofastly.WAFExclusionTypeWAF),
+					ExclusionType: strToPtr(gofastly.WAFRuleExclusionTypeWAF),
 					Condition:     strToPtr("req.url.basename == \"index.asp\""),
 				},
 			},
@@ -84,7 +84,7 @@ func TestAccFastlyServiceWAFVersionV1FlattenWAFExclusions(t *testing.T) {
 		},
 	}
 	for _, c := range cases {
-		out := flattenWAFExclusions(c.remote)
+		out := flattenWAFRuleExclusions(c.remote)
 		local := c.local
 		assertEqualsSliceOfMaps(t, out, local)
 	}
@@ -94,14 +94,14 @@ func TestAccFastlyServiceWAFVersionV1Validation(t *testing.T) {
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 
 	cases := []struct {
-		exclusions      []gofastly.WAFExclusion
+		exclusions      []gofastly.WAFRuleExclusion
 		expectedMessage string
 	}{
 		{
-			exclusions: []gofastly.WAFExclusion{
+			exclusions: []gofastly.WAFRuleExclusion{
 				{
 					Name:          strToPtr("index page"),
-					ExclusionType: strToPtr(gofastly.WAFExclusionTypeWAF),
+					ExclusionType: strToPtr(gofastly.WAFRuleExclusionTypeWAF),
 					Condition:     strToPtr("req.url.basename == \"index.html\""),
 					Rules: []*gofastly.WAFRule{
 						{
@@ -113,10 +113,10 @@ func TestAccFastlyServiceWAFVersionV1Validation(t *testing.T) {
 			expectedMessage: "must not set \"modsec_rule_ids\" with \"waf\" exclusion type in exclusion \"index page\"",
 		},
 		{
-			exclusions: []gofastly.WAFExclusion{
+			exclusions: []gofastly.WAFRuleExclusion{
 				{
 					Name:          strToPtr("index page"),
-					ExclusionType: strToPtr(gofastly.WAFExclusionTypeRule),
+					ExclusionType: strToPtr(gofastly.WAFRuleExclusionTypeRule),
 					Condition:     strToPtr("req.url.basename == \"index.html\""),
 				},
 			},
@@ -127,7 +127,7 @@ func TestAccFastlyServiceWAFVersionV1Validation(t *testing.T) {
 	for _, c := range cases {
 
 		wafVerInput := testAccFastlyServiceWAFVersionV1BuildConfig(20)
-		exclusionsTF1 := testAccCheckFastlyServiceWAFVersionV1ComposeWAFExclusions(c.exclusions)
+		exclusionsTF1 := testAccCheckFastlyServiceWAFVersionV1ComposeWAFRuleExclusions(c.exclusions)
 
 		wafVer1 := testAccFastlyServiceWAFVersionV1ComposeConfiguration(wafVerInput, "", exclusionsTF1)
 
@@ -168,10 +168,10 @@ func TestAccFastlyServiceWAFVersionV1AddUpdateDeleteExclusions(t *testing.T) {
 		},
 	}
 
-	exclusions1 := []gofastly.WAFExclusion{
+	exclusions1 := []gofastly.WAFRuleExclusion{
 		{
 			Name:          strToPtr("index page"),
-			ExclusionType: strToPtr(gofastly.WAFExclusionTypeRule),
+			ExclusionType: strToPtr(gofastly.WAFRuleExclusionTypeRule),
 			Condition:     strToPtr("req.url.basename == \"index.html\""),
 			Rules: []*gofastly.WAFRule{
 				{
@@ -184,7 +184,7 @@ func TestAccFastlyServiceWAFVersionV1AddUpdateDeleteExclusions(t *testing.T) {
 		},
 		{
 			Name:          strToPtr("index php"),
-			ExclusionType: strToPtr(gofastly.WAFExclusionTypeRule),
+			ExclusionType: strToPtr(gofastly.WAFRuleExclusionTypeRule),
 			Condition:     strToPtr("req.url.basename == \"index.php\""),
 			Rules: []*gofastly.WAFRule{
 				{
@@ -194,15 +194,15 @@ func TestAccFastlyServiceWAFVersionV1AddUpdateDeleteExclusions(t *testing.T) {
 		},
 		{
 			Name:          strToPtr("index asp"),
-			ExclusionType: strToPtr(gofastly.WAFExclusionTypeWAF),
+			ExclusionType: strToPtr(gofastly.WAFRuleExclusionTypeWAF),
 			Condition:     strToPtr("req.url.basename == \"index.asp\""),
 		},
 	}
 
-	exclusions2 := []gofastly.WAFExclusion{
+	exclusions2 := []gofastly.WAFRuleExclusion{
 		{
 			Name:          strToPtr("index page"),
-			ExclusionType: strToPtr(gofastly.WAFExclusionTypeRule),
+			ExclusionType: strToPtr(gofastly.WAFRuleExclusionTypeRule),
 			Condition:     strToPtr("req.url.basename == \"index.html\""),
 			Rules: []*gofastly.WAFRule{
 				{
@@ -212,7 +212,7 @@ func TestAccFastlyServiceWAFVersionV1AddUpdateDeleteExclusions(t *testing.T) {
 		},
 		{
 			Name:          strToPtr("index php"),
-			ExclusionType: strToPtr(gofastly.WAFExclusionTypeRule),
+			ExclusionType: strToPtr(gofastly.WAFRuleExclusionTypeRule),
 			Condition:     strToPtr("req.url.basename == \"index.php\""),
 			Rules: []*gofastly.WAFRule{
 				{
@@ -222,7 +222,7 @@ func TestAccFastlyServiceWAFVersionV1AddUpdateDeleteExclusions(t *testing.T) {
 		},
 		{
 			Name:          strToPtr("index new page"),
-			ExclusionType: strToPtr(gofastly.WAFExclusionTypeRule),
+			ExclusionType: strToPtr(gofastly.WAFRuleExclusionTypeRule),
 			Condition:     strToPtr("req.url.basename == \"index-new.html\""),
 			Rules: []*gofastly.WAFRule{
 				{
@@ -234,8 +234,8 @@ func TestAccFastlyServiceWAFVersionV1AddUpdateDeleteExclusions(t *testing.T) {
 
 	wafVerInput := testAccFastlyServiceWAFVersionV1BuildConfig(20)
 	rulesTF := testAccCheckFastlyServiceWAFVersionV1ComposeWAFRules(rules)
-	exclusionsTF1 := testAccCheckFastlyServiceWAFVersionV1ComposeWAFExclusions(exclusions1)
-	exclusionsTF2 := testAccCheckFastlyServiceWAFVersionV1ComposeWAFExclusions(exclusions2)
+	exclusionsTF1 := testAccCheckFastlyServiceWAFVersionV1ComposeWAFRuleExclusions(exclusions1)
+	exclusionsTF2 := testAccCheckFastlyServiceWAFVersionV1ComposeWAFRuleExclusions(exclusions2)
 
 	wafVer1 := testAccFastlyServiceWAFVersionV1ComposeConfiguration(wafVerInput, rulesTF, exclusionsTF1)
 	wafVer2 := testAccFastlyServiceWAFVersionV1ComposeConfiguration(wafVerInput, rulesTF, exclusionsTF2)
@@ -263,7 +263,7 @@ func TestAccFastlyServiceWAFVersionV1AddUpdateDeleteExclusions(t *testing.T) {
 	})
 }
 
-func testAccCheckFastlyServiceWAFVersionV1CheckExclusions(service *gofastly.ServiceDetail, expected []gofastly.WAFExclusion, wafVerNo int) resource.TestCheckFunc {
+func testAccCheckFastlyServiceWAFVersionV1CheckExclusions(service *gofastly.ServiceDetail, expected []gofastly.WAFRuleExclusion, wafVerNo int) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 
 		conn := testAccProvider.Meta().(*FastlyClient).conn
@@ -280,7 +280,7 @@ func testAccCheckFastlyServiceWAFVersionV1CheckExclusions(service *gofastly.Serv
 		}
 
 		waf := wafResp.Items[0]
-		exclResp, err := conn.ListAllWAFExclusions(&gofastly.ListAllWAFExclusionsInput{
+		exclResp, err := conn.ListAllWAFRuleExclusions(&gofastly.ListAllWAFRuleExclusionsInput{
 			WAFID:            waf.ID,
 			WAFVersionNumber: wafVerNo,
 			Include:          strToPtr("waf_rules"),
@@ -291,7 +291,7 @@ func testAccCheckFastlyServiceWAFVersionV1CheckExclusions(service *gofastly.Serv
 
 		actual := exclResp.Items
 		if len(expected) != len(actual) {
-			return fmt.Errorf("Error matching exclusions slice sizes :\nexpected: %#v\ngot: %#v", len(expected), len(actual))
+			return fmt.Errorf("Error matching rule exclusions slice sizes :\nexpected: %#v\ngot: %#v", len(expected), len(actual))
 		}
 
 		sort.Slice(expected, func(i, j int) bool {
@@ -340,7 +340,7 @@ func testAccCheckFastlyServiceWAFVersionV1CheckExclusions(service *gofastly.Serv
 	}
 }
 
-func testAccCheckFastlyServiceWAFVersionV1ComposeWAFExclusions(exclusions []gofastly.WAFExclusion) string {
+func testAccCheckFastlyServiceWAFVersionV1ComposeWAFRuleExclusions(exclusions []gofastly.WAFRuleExclusion) string {
 
 	var result string
 	for _, excl := range exclusions {
@@ -350,7 +350,7 @@ func testAccCheckFastlyServiceWAFVersionV1ComposeWAFExclusions(exclusions []gofa
 		}
 
 		rule := fmt.Sprintf(`
-          exclusion {
+          rule_exclusion {
             name = "%s"
             condition = "%s"
             exclusion_type = "%s"

--- a/fastly/block_fastly_waf_configuration_v1_exclusion_test.go
+++ b/fastly/block_fastly_waf_configuration_v1_exclusion_test.go
@@ -1,0 +1,362 @@
+package fastly
+
+import (
+	"fmt"
+	gofastly "github.com/fastly/go-fastly/v2/fastly"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestAccFastlyServiceWAFVersionV1FlattenWAFExclusions(t *testing.T) {
+	cases := []struct {
+		remote []*gofastly.WAFExclusion
+		local  []map[string]interface{}
+	}{
+		{
+			remote: []*gofastly.WAFExclusion{
+				{
+					ID:            "abc",
+					Number:        intToPtr(1),
+					Name:          strToPtr("index page"),
+					ExclusionType: strToPtr(gofastly.WAFExclusionTypeRule),
+					Condition:     strToPtr("req.url.basename == \"index.html\""),
+					Rules: []*gofastly.WAFRule{
+						{
+							ID:       "2029718",
+							ModSecID: 2029718,
+						},
+						{
+							ID:       "1010070",
+							ModSecID: 1010070,
+						},
+					},
+				},
+				{
+					ID:            "def",
+					Number:        intToPtr(2),
+					Name:          strToPtr("index php"),
+					ExclusionType: strToPtr(gofastly.WAFExclusionTypeRule),
+					Condition:     strToPtr("req.url.basename == \"index.php\""),
+					Rules: []*gofastly.WAFRule{
+						{
+							ID:       "1010070",
+							ModSecID: 1010070,
+						},
+					},
+				},
+				{
+					ID:            "ghi",
+					Number:        intToPtr(3),
+					Name:          strToPtr("index asp"),
+					ExclusionType: strToPtr(gofastly.WAFExclusionTypeWAF),
+					Condition:     strToPtr("req.url.basename == \"index.asp\""),
+				},
+			},
+			local: []map[string]interface{}{
+				{
+					"number":          1,
+					"name":            "index page",
+					"exclusion_type":  "rule",
+					"condition":       "req.url.basename == \"index.html\"",
+					"modsec_rule_ids": schema.NewSet(schema.HashInt, []interface{}{2029718, 1010070}),
+				},
+				{
+					"number":          2,
+					"name":            "index php",
+					"exclusion_type":  "rule",
+					"condition":       "req.url.basename == \"index.php\"",
+					"modsec_rule_ids": schema.NewSet(schema.HashInt, []interface{}{1010070}),
+				},
+				{
+					"number":         3,
+					"name":           "index asp",
+					"exclusion_type": "waf",
+					"condition":      "req.url.basename == \"index.asp\"",
+				},
+			},
+		},
+	}
+	for _, c := range cases {
+		out := flattenWAFExclusions(c.remote)
+		local := c.local
+		assertEqualsSliceOfMaps(t, out, local)
+	}
+}
+
+func TestAccFastlyServiceWAFVersionV1Validation(t *testing.T) {
+	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+
+	cases := []struct {
+		exclusions      []gofastly.WAFExclusion
+		expectedMessage string
+	}{
+		{
+			exclusions: []gofastly.WAFExclusion{
+				{
+					Name:          strToPtr("index page"),
+					ExclusionType: strToPtr(gofastly.WAFExclusionTypeWAF),
+					Condition:     strToPtr("req.url.basename == \"index.html\""),
+					Rules: []*gofastly.WAFRule{
+						{
+							ModSecID: 2029718,
+						},
+					},
+				},
+			},
+			expectedMessage: "must not set \"modsec_rule_ids\" with \"waf\" exclusion type in exclusion \"index page\"",
+		},
+		{
+			exclusions: []gofastly.WAFExclusion{
+				{
+					Name:          strToPtr("index page"),
+					ExclusionType: strToPtr(gofastly.WAFExclusionTypeRule),
+					Condition:     strToPtr("req.url.basename == \"index.html\""),
+				},
+			},
+			expectedMessage: "must set \"modsec_rule_ids\" with \"rule\" exclusion type in exclusion \"index page\"",
+		},
+	}
+
+	for _, c := range cases {
+
+		wafVerInput := testAccFastlyServiceWAFVersionV1BuildConfig(20)
+		exclusionsTF1 := testAccCheckFastlyServiceWAFVersionV1ComposeWAFExclusions(c.exclusions)
+
+		wafVer1 := testAccFastlyServiceWAFVersionV1ComposeConfiguration(wafVerInput, "", exclusionsTF1)
+
+		resource.Test(t, resource.TestCase{
+			PreCheck:     func() { testAccPreCheck(t) },
+			Providers:    testAccProviders,
+			CheckDestroy: testAccCheckServiceV1Destroy,
+			Steps: []resource.TestStep{
+				{
+					Config:      testAccFastlyServiceWAFVersionV1(name, wafVer1),
+					ExpectError: regexp.MustCompile(c.expectedMessage),
+				},
+			},
+		})
+
+	}
+}
+
+func TestAccFastlyServiceWAFVersionV1AddUpdateDeleteExclusions(t *testing.T) {
+	var service gofastly.ServiceDetail
+	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+
+	rules := []gofastly.WAFActiveRule{
+		{
+			ModSecID: 21032607,
+			Status:   "log",
+			Revision: 1,
+		},
+		{
+			ModSecID: 2029718,
+			Status:   "log",
+			Revision: 1,
+		},
+		{
+			ModSecID: 2037405,
+			Status:   "log",
+			Revision: 1,
+		},
+	}
+
+	exclusions1 := []gofastly.WAFExclusion{
+		{
+			Name:          strToPtr("index page"),
+			ExclusionType: strToPtr(gofastly.WAFExclusionTypeRule),
+			Condition:     strToPtr("req.url.basename == \"index.html\""),
+			Rules: []*gofastly.WAFRule{
+				{
+					ModSecID: 2029718,
+				},
+				{
+					ModSecID: 2037405,
+				},
+			},
+		},
+		{
+			Name:          strToPtr("index php"),
+			ExclusionType: strToPtr(gofastly.WAFExclusionTypeRule),
+			Condition:     strToPtr("req.url.basename == \"index.php\""),
+			Rules: []*gofastly.WAFRule{
+				{
+					ModSecID: 2037405,
+				},
+			},
+		},
+		{
+			Name:          strToPtr("index asp"),
+			ExclusionType: strToPtr(gofastly.WAFExclusionTypeWAF),
+			Condition:     strToPtr("req.url.basename == \"index.asp\""),
+		},
+	}
+
+	exclusions2 := []gofastly.WAFExclusion{
+		{
+			Name:          strToPtr("index page"),
+			ExclusionType: strToPtr(gofastly.WAFExclusionTypeRule),
+			Condition:     strToPtr("req.url.basename == \"index.html\""),
+			Rules: []*gofastly.WAFRule{
+				{
+					ModSecID: 21032607,
+				},
+			},
+		},
+		{
+			Name:          strToPtr("index php"),
+			ExclusionType: strToPtr(gofastly.WAFExclusionTypeRule),
+			Condition:     strToPtr("req.url.basename == \"index.php\""),
+			Rules: []*gofastly.WAFRule{
+				{
+					ModSecID: 2037405,
+				},
+			},
+		},
+		{
+			Name:          strToPtr("index new page"),
+			ExclusionType: strToPtr(gofastly.WAFExclusionTypeRule),
+			Condition:     strToPtr("req.url.basename == \"index-new.html\""),
+			Rules: []*gofastly.WAFRule{
+				{
+					ModSecID: 2037405,
+				},
+			},
+		},
+	}
+
+	wafVerInput := testAccFastlyServiceWAFVersionV1BuildConfig(20)
+	rulesTF := testAccCheckFastlyServiceWAFVersionV1ComposeWAFRules(rules)
+	exclusionsTF1 := testAccCheckFastlyServiceWAFVersionV1ComposeWAFExclusions(exclusions1)
+	exclusionsTF2 := testAccCheckFastlyServiceWAFVersionV1ComposeWAFExclusions(exclusions2)
+
+	wafVer1 := testAccFastlyServiceWAFVersionV1ComposeConfiguration(wafVerInput, rulesTF, exclusionsTF1)
+	wafVer2 := testAccFastlyServiceWAFVersionV1ComposeConfiguration(wafVerInput, rulesTF, exclusionsTF2)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckServiceV1Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFastlyServiceWAFVersionV1(name, wafVer1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceV1Exists(serviceRef, &service),
+					testAccCheckFastlyServiceWAFVersionV1CheckExclusions(&service, exclusions1, 1),
+				),
+			},
+			{
+				Config: testAccFastlyServiceWAFVersionV1(name, wafVer2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceV1Exists(serviceRef, &service),
+					testAccCheckFastlyServiceWAFVersionV1CheckExclusions(&service, exclusions2, 2),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckFastlyServiceWAFVersionV1CheckExclusions(service *gofastly.ServiceDetail, expected []gofastly.WAFExclusion, wafVerNo int) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+
+		conn := testAccProvider.Meta().(*FastlyClient).conn
+		wafResp, err := conn.ListWAFs(&gofastly.ListWAFsInput{
+			FilterService: service.ID,
+			FilterVersion: service.ActiveVersion.Number,
+		})
+		if err != nil {
+			return fmt.Errorf("[ERR] Error looking up WAF records for (%s), version (%v): %s", service.Name, service.ActiveVersion.Number, err)
+		}
+
+		if len(wafResp.Items) != 1 {
+			return fmt.Errorf("[ERR] Expected waf result size (%d), got (%d)", 1, len(wafResp.Items))
+		}
+
+		waf := wafResp.Items[0]
+		exclResp, err := conn.ListAllWAFExclusions(&gofastly.ListAllWAFExclusionsInput{
+			WAFID:            waf.ID,
+			WAFVersionNumber: wafVerNo,
+			Include:          strToPtr("waf_rules"),
+		})
+		if err != nil {
+			return fmt.Errorf("[ERR] Error looking up WAF records for (%s), version (%v): %s", service.Name, service.ActiveVersion.Number, err)
+		}
+
+		actual := exclResp.Items
+		if len(expected) != len(actual) {
+			return fmt.Errorf("Error matching exclusions slice sizes :\nexpected: %#v\ngot: %#v", len(expected), len(actual))
+		}
+
+		sort.Slice(expected, func(i, j int) bool {
+			return *expected[i].Name < *expected[j].Name
+		})
+
+		sort.Slice(actual, func(i, j int) bool {
+			return *actual[i].Name < *actual[j].Name
+		})
+
+		for i, expectedExcl := range expected {
+			actualExcl := actual[i]
+
+			if *expectedExcl.Name != *actualExcl.Name {
+				return fmt.Errorf("Error matching Name:\nexpected: %#v\ngot: %#v", *expectedExcl.Name, *actualExcl.Name)
+			}
+
+			if *expectedExcl.Condition != *actualExcl.Condition {
+				return fmt.Errorf("Error matching Condition:\nexpected: %#v\ngot: %#v", *expectedExcl.Condition, *actualExcl.Condition)
+			}
+
+			if *expectedExcl.ExclusionType != *actualExcl.ExclusionType {
+				return fmt.Errorf("Error matching ExclusionType:\nexpected: %#v\ngot: %#v", *expectedExcl.ExclusionType, *actualExcl.ExclusionType)
+			}
+
+			if len(expectedExcl.Rules) != len(actualExcl.Rules) {
+				return fmt.Errorf("Error matching rules slice sizes :\nexpected: %#v\ngot: %#v", len(expectedExcl.Rules), len(actualExcl.Rules))
+			}
+
+			sort.Slice(expectedExcl.Rules, func(i, j int) bool {
+				return expectedExcl.Rules[i].ModSecID < expectedExcl.Rules[j].ModSecID
+			})
+			sort.Slice(actualExcl.Rules, func(i, j int) bool {
+				return actualExcl.Rules[i].ModSecID < actualExcl.Rules[j].ModSecID
+			})
+
+			for k, expectedRule := range expectedExcl.Rules {
+				actualRule := actualExcl.Rules[k]
+				if expectedRule.ModSecID != actualRule.ModSecID {
+					return fmt.Errorf("Error matching Rule ModsecId:\nexpected: %#v\ngot: %#v", expectedRule.ModSecID, actualRule.ModSecID)
+				}
+			}
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckFastlyServiceWAFVersionV1ComposeWAFExclusions(exclusions []gofastly.WAFExclusion) string {
+
+	var result string
+	for _, excl := range exclusions {
+		var modsecIds []string
+		for _, r := range excl.Rules {
+			modsecIds = append(modsecIds, strconv.Itoa(r.ModSecID))
+		}
+
+		rule := fmt.Sprintf(`
+          exclusion {
+            name = "%s"
+            condition = "%s"
+            exclusion_type = "%s"
+            modsec_rule_ids = [%s]
+          }`, *excl.Name, strings.ReplaceAll(*excl.Condition, "\"", "\\\""), *excl.ExclusionType, strings.Join(modsecIds, ","))
+		result = result + rule
+	}
+	return result
+}

--- a/fastly/block_fastly_waf_configuration_v1_exclusion_test.go
+++ b/fastly/block_fastly_waf_configuration_v1_exclusion_test.go
@@ -2,16 +2,17 @@ package fastly
 
 import (
 	"fmt"
-	gofastly "github.com/fastly/go-fastly/v2/fastly"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"regexp"
 	"sort"
 	"strconv"
 	"strings"
 	"testing"
+
+	gofastly "github.com/fastly/go-fastly/v2/fastly"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
 func TestAccFastlyServiceWAFVersionV1FlattenWAFRuleExclusions(t *testing.T) {
@@ -283,7 +284,7 @@ func testAccCheckFastlyServiceWAFVersionV1CheckExclusions(service *gofastly.Serv
 		exclResp, err := conn.ListAllWAFRuleExclusions(&gofastly.ListAllWAFRuleExclusionsInput{
 			WAFID:            waf.ID,
 			WAFVersionNumber: wafVerNo,
-			Include:          strToPtr("waf_rules"),
+			Include:          []string{"waf_rules"},
 		})
 		if err != nil {
 			return fmt.Errorf("[ERR] Error looking up WAF records for (%s), version (%v): %s", service.Name, service.ActiveVersion.Number, err)

--- a/fastly/fastly_test.go
+++ b/fastly/fastly_test.go
@@ -1,9 +1,10 @@
 package fastly
 
 import (
-	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"io/ioutil"
 	"reflect"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
 import (

--- a/fastly/resource_fastly_service_waf_configuration.go
+++ b/fastly/resource_fastly_service_waf_configuration.go
@@ -20,7 +20,7 @@ func resourceServiceWAFConfigurationV1() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			State: resourceServiceWAFConfigurationV1Import,
 		},
-
+		CustomizeDiff: validateWAFConfigurationResource,
 		Schema: map[string]*schema.Schema{
 			"waf_id": {
 				Type:        schema.TypeString,
@@ -205,7 +205,8 @@ func resourceServiceWAFConfigurationV1() *schema.Resource {
 				Description:  "XSS attack threshold.",
 				ValidateFunc: validation.IntAtLeast(1),
 			},
-			"rule": activeRule,
+			"rule":      activeRule,
+			"exclusion": wafExclusion,
 		},
 	}
 }
@@ -252,6 +253,12 @@ func resourceServiceWAFConfigurationV1Update(d *schema.ResourceData, meta interf
 		}
 	}
 
+	if d.HasChange("exclusion") {
+		if err := updateWAFExclusions(d, meta, wafID, latestVersion.Number); err != nil {
+			return err
+		}
+	}
+
 	err = conn.DeployWAFVersion(&gofastly.DeployWAFVersionInput{
 		WAFID:            wafID,
 		WAFVersionNumber: latestVersion.Number,
@@ -289,6 +296,10 @@ func resourceServiceWAFConfigurationV1Read(d *schema.ResourceData, meta interfac
 	refreshWAFConfig(d, latestVersion)
 
 	if err := readWAFRules(meta, d, latestVersion.Number); err != nil {
+		return err
+	}
+
+	if err := readWAFExclusions(meta, d, latestVersion.Number); err != nil {
 		return err
 	}
 
@@ -494,4 +505,9 @@ func determineLatestVersion(versions []*gofastly.WAFVersion) (*gofastly.WAFVersi
 	})
 
 	return versions[0], nil
+}
+
+func validateWAFConfigurationResource(d *schema.ResourceDiff, meta interface{}) error {
+	err := validateWAFExclusion(d)
+	return err
 }

--- a/fastly/resource_fastly_service_waf_configuration.go
+++ b/fastly/resource_fastly_service_waf_configuration.go
@@ -205,8 +205,8 @@ func resourceServiceWAFConfigurationV1() *schema.Resource {
 				Description:  "XSS attack threshold.",
 				ValidateFunc: validation.IntAtLeast(1),
 			},
-			"rule":      activeRule,
-			"exclusion": wafExclusion,
+			"rule":           activeRule,
+			"rule_exclusion": wafRuleExclusion,
 		},
 	}
 }
@@ -253,8 +253,8 @@ func resourceServiceWAFConfigurationV1Update(d *schema.ResourceData, meta interf
 		}
 	}
 
-	if d.HasChange("exclusion") {
-		if err := updateWAFExclusions(d, meta, wafID, latestVersion.Number); err != nil {
+	if d.HasChange("rule_exclusion") {
+		if err := updateWAFRuleExclusions(d, meta, wafID, latestVersion.Number); err != nil {
 			return err
 		}
 	}
@@ -299,7 +299,7 @@ func resourceServiceWAFConfigurationV1Read(d *schema.ResourceData, meta interfac
 		return err
 	}
 
-	if err := readWAFExclusions(meta, d, latestVersion.Number); err != nil {
+	if err := readWAFRuleExclusions(meta, d, latestVersion.Number); err != nil {
 		return err
 	}
 
@@ -508,6 +508,6 @@ func determineLatestVersion(versions []*gofastly.WAFVersion) (*gofastly.WAFVersi
 }
 
 func validateWAFConfigurationResource(d *schema.ResourceDiff, meta interface{}) error {
-	err := validateWAFExclusion(d)
+	err := validateWAFRuleExclusion(d)
 	return err
 }

--- a/fastly/resource_fastly_service_waf_configuration_test.go
+++ b/fastly/resource_fastly_service_waf_configuration_test.go
@@ -67,7 +67,7 @@ func TestAccFastlyServiceWAFVersionV1Add(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	wafVerInput := testAccFastlyServiceWAFVersionV1BuildConfig(20)
-	wafVer := testAccFastlyServiceWAFVersionV1ComposeConfiguration(wafVerInput, "")
+	wafVer := testAccFastlyServiceWAFVersionV1ComposeConfiguration(wafVerInput, "", "")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -89,7 +89,7 @@ func TestAccFastlyServiceWAFVersionV1AddExistingService(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	wafVerInput := testAccFastlyServiceWAFVersionV1BuildConfig(20)
-	wafVer := testAccFastlyServiceWAFVersionV1ComposeConfiguration(wafVerInput, "")
+	wafVer := testAccFastlyServiceWAFVersionV1ComposeConfiguration(wafVerInput, "", "")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -118,10 +118,10 @@ func TestAccFastlyServiceWAFVersionV1Update(t *testing.T) {
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 
 	wafVerInput1 := testAccFastlyServiceWAFVersionV1BuildConfig(20)
-	wafVer1 := testAccFastlyServiceWAFVersionV1ComposeConfiguration(wafVerInput1, "")
+	wafVer1 := testAccFastlyServiceWAFVersionV1ComposeConfiguration(wafVerInput1, "", "")
 
 	wafVerInput2 := testAccFastlyServiceWAFVersionV1BuildConfig(22)
-	wafVer2 := testAccFastlyServiceWAFVersionV1ComposeConfiguration(wafVerInput2, "")
+	wafVer2 := testAccFastlyServiceWAFVersionV1ComposeConfiguration(wafVerInput2, "", "")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -150,7 +150,7 @@ func TestAccFastlyServiceWAFVersionV1Delete(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	wafVerInput := testAccFastlyServiceWAFVersionV1BuildConfig(20)
-	wafVer := testAccFastlyServiceWAFVersionV1ComposeConfiguration(wafVerInput, "")
+	wafVer := testAccFastlyServiceWAFVersionV1ComposeConfiguration(wafVerInput, "", "")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -184,10 +184,56 @@ func TestAccFastlyServiceWAFVersionV1Import(t *testing.T) {
 		"http_violation_score_threshold": 10,
 	}
 
-	wafVer := testAccFastlyServiceWAFVersionV1ComposeConfiguration(extraHCLMap, "")
+	rules := []gofastly.WAFActiveRule{
+		{
+			ModSecID: 2029718,
+			Status:   "log",
+			Revision: 1,
+		},
+		{
+			ModSecID: 2037405,
+			Status:   "log",
+			Revision: 1,
+		},
+	}
+
+	exclusions := []gofastly.WAFExclusion{
+		{
+			Name:          strToPtr("index page"),
+			ExclusionType: strToPtr(gofastly.WAFExclusionTypeRule),
+			Condition:     strToPtr("req.url.basename == \"index.html\""),
+			Rules: []*gofastly.WAFRule{
+				{
+					ModSecID: 2029718,
+				},
+				{
+					ModSecID: 2037405,
+				},
+			},
+		},
+		{
+			Name:          strToPtr("index php"),
+			ExclusionType: strToPtr(gofastly.WAFExclusionTypeRule),
+			Condition:     strToPtr("req.url.basename == \"index.php\""),
+			Rules: []*gofastly.WAFRule{
+				{
+					ModSecID: 2037405,
+				},
+			},
+		},
+		{
+			Name:          strToPtr("index asp"),
+			ExclusionType: strToPtr(gofastly.WAFExclusionTypeWAF),
+			Condition:     strToPtr("req.url.basename == \"index.asp\""),
+		},
+	}
+
+	rulesTF := testAccCheckFastlyServiceWAFVersionV1ComposeWAFRules(rules)
+	exclusionsTF := testAccCheckFastlyServiceWAFVersionV1ComposeWAFExclusions(exclusions)
+	wafVer := testAccFastlyServiceWAFVersionV1ComposeConfiguration(extraHCLMap, rulesTF, exclusionsTF)
 	wafSvcCfg := testAccFastlyServiceWAFVersionV1(name, wafVer)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,
@@ -311,7 +357,7 @@ func testAccFastlyServiceWAFVersionV1GetVersionNumber(versions []*gofastly.WAFVe
 	return gofastly.WAFVersion{}, fmt.Errorf("version number %d not found", number)
 }
 
-func testAccFastlyServiceWAFVersionV1ComposeConfiguration(m map[string]interface{}, rules string) string {
+func testAccFastlyServiceWAFVersionV1ComposeConfiguration(m map[string]interface{}, rules string, exclusions string) string {
 
 	hcl := `
         resource "fastly_service_waf_configuration" "waf" {
@@ -331,8 +377,11 @@ func testAccFastlyServiceWAFVersionV1ComposeConfiguration(m map[string]interface
          `, k, v)
 		}
 	}
-	return hcl + fmt.Sprintf(`%s
-        }`, rules)
+	return hcl + fmt.Sprintf(`
+          %s
+
+          %s
+        }`, rules, exclusions)
 }
 
 func testAccFastlyServiceWAFVersionV1(name, extraHCL string) string {

--- a/fastly/resource_fastly_service_waf_configuration_test.go
+++ b/fastly/resource_fastly_service_waf_configuration_test.go
@@ -197,10 +197,10 @@ func TestAccFastlyServiceWAFVersionV1Import(t *testing.T) {
 		},
 	}
 
-	exclusions := []gofastly.WAFExclusion{
+	exclusions := []gofastly.WAFRuleExclusion{
 		{
 			Name:          strToPtr("index page"),
-			ExclusionType: strToPtr(gofastly.WAFExclusionTypeRule),
+			ExclusionType: strToPtr(gofastly.WAFRuleExclusionTypeRule),
 			Condition:     strToPtr("req.url.basename == \"index.html\""),
 			Rules: []*gofastly.WAFRule{
 				{
@@ -213,7 +213,7 @@ func TestAccFastlyServiceWAFVersionV1Import(t *testing.T) {
 		},
 		{
 			Name:          strToPtr("index php"),
-			ExclusionType: strToPtr(gofastly.WAFExclusionTypeRule),
+			ExclusionType: strToPtr(gofastly.WAFRuleExclusionTypeRule),
 			Condition:     strToPtr("req.url.basename == \"index.php\""),
 			Rules: []*gofastly.WAFRule{
 				{
@@ -223,13 +223,13 @@ func TestAccFastlyServiceWAFVersionV1Import(t *testing.T) {
 		},
 		{
 			Name:          strToPtr("index asp"),
-			ExclusionType: strToPtr(gofastly.WAFExclusionTypeWAF),
+			ExclusionType: strToPtr(gofastly.WAFRuleExclusionTypeWAF),
 			Condition:     strToPtr("req.url.basename == \"index.asp\""),
 		},
 	}
 
 	rulesTF := testAccCheckFastlyServiceWAFVersionV1ComposeWAFRules(rules)
-	exclusionsTF := testAccCheckFastlyServiceWAFVersionV1ComposeWAFExclusions(exclusions)
+	exclusionsTF := testAccCheckFastlyServiceWAFVersionV1ComposeWAFRuleExclusions(exclusions)
 	wafVer := testAccFastlyServiceWAFVersionV1ComposeConfiguration(extraHCLMap, rulesTF, exclusionsTF)
 	wafSvcCfg := testAccFastlyServiceWAFVersionV1(name, wafVer)
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.14
 
 require (
 	github.com/ajg/form v0.0.0-20160822230020-523a5da1a92f // indirect
-	github.com/fastly/go-fastly/v2 v2.0.0-alpha.1
+	github.com/fastly/go-fastly/v2 v2.0.0-alpha.2
 	github.com/google/go-cmp v0.3.0
 	github.com/google/jsonapi v0.0.0-20180313013858-2dcc18f43696 // indirect
 	github.com/hashicorp/terraform-plugin-sdk v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -40,6 +40,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dnaeon/go-vcr v1.0.1 h1:r8L/HqC0Hje5AXMu1ooW8oyQyOFv4GxqpL0nRP7SLLY=
 github.com/dnaeon/go-vcr v1.0.1/go.mod h1:aBB1+wY4s93YsC3HHjMBMrwTj2R9FHDzUr9KyGc8n1E=
+github.com/fastly/go-fastly v1.17.0 h1:N92pKRkGVWt57f3zMeWijjHnYvFOtT1QvYXhE+NFIhA=
+github.com/fastly/go-fastly v1.17.0/go.mod h1:fwYSSnZ6zEClwRS65T0f57Yh83Tc4gL12GgttQwJZfA=
 github.com/fastly/go-fastly/v2 v2.0.0-alpha.1 h1:ZlYscHQgWQKaDy5WN92z+qAqhex8x7X62JVOAtHCwMk=
 github.com/fastly/go-fastly/v2 v2.0.0-alpha.1/go.mod h1:+gom+YR+9Q5I4biSk/ZjHQGWXxqpRxC3YDVYQcRpZwQ=
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=

--- a/go.sum
+++ b/go.sum
@@ -40,10 +40,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dnaeon/go-vcr v1.0.1 h1:r8L/HqC0Hje5AXMu1ooW8oyQyOFv4GxqpL0nRP7SLLY=
 github.com/dnaeon/go-vcr v1.0.1/go.mod h1:aBB1+wY4s93YsC3HHjMBMrwTj2R9FHDzUr9KyGc8n1E=
-github.com/fastly/go-fastly v1.17.0 h1:N92pKRkGVWt57f3zMeWijjHnYvFOtT1QvYXhE+NFIhA=
-github.com/fastly/go-fastly v1.17.0/go.mod h1:fwYSSnZ6zEClwRS65T0f57Yh83Tc4gL12GgttQwJZfA=
-github.com/fastly/go-fastly/v2 v2.0.0-alpha.1 h1:ZlYscHQgWQKaDy5WN92z+qAqhex8x7X62JVOAtHCwMk=
-github.com/fastly/go-fastly/v2 v2.0.0-alpha.1/go.mod h1:+gom+YR+9Q5I4biSk/ZjHQGWXxqpRxC3YDVYQcRpZwQ=
+github.com/fastly/go-fastly/v2 v2.0.0-alpha.2 h1:bPTiOsujD7AcJ/CoR0Ht4z21yqd0s8DZV09TXqxwit0=
+github.com/fastly/go-fastly/v2 v2.0.0-alpha.2/go.mod h1:+gom+YR+9Q5I4biSk/ZjHQGWXxqpRxC3YDVYQcRpZwQ=
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=

--- a/vendor/github.com/fastly/go-fastly/v2/fastly/errors.go
+++ b/vendor/github.com/fastly/go-fastly/v2/fastly/errors.go
@@ -117,13 +117,13 @@ var ErrMissingWAFVersionID = errors.New("missing required field 'WAFVersionID'")
 // requires a list of WAF active rules, but it is empty.
 var ErrMissingWAFActiveRuleList = errors.New("WAF active rules slice is empty")
 
-// ErrMissingWAFExclusionNumber is an error that is returned when an input struct
+// ErrMissingWAFRuleExclusionNumber is an error that is returned when an input struct
 // requires a "WAFExclusionNumber" key, but one was not set.
-var ErrMissingWAFExclusionNumber = errors.New("missing required field 'WAFExclusionNumber'")
+var ErrMissingWAFRuleExclusionNumber = errors.New("missing required field 'WAFExclusionNumber'")
 
-// ErrMissingWAFExclusion is an error that is returned when an input struct
-// requires a "WAFExclusion" key, but one was not set.
-var ErrMissingWAFExclusion = errors.New("missing required field 'WAFExclusion'")
+// ErrMissingWAFRuleExclusion is an error that is returned when an input struct
+// requires a "WAFRuleExclusion" key, but one was not set.
+var ErrMissingWAFRuleExclusion = errors.New("missing required field 'WAFRuleExclusion'")
 
 // ErrMissingOWASPID is an error that is returned was an input struct
 // requires a "OWASPID" key, but one was not set

--- a/vendor/github.com/fastly/go-fastly/v2/fastly/errors.go
+++ b/vendor/github.com/fastly/go-fastly/v2/fastly/errors.go
@@ -117,6 +117,14 @@ var ErrMissingWAFVersionID = errors.New("missing required field 'WAFVersionID'")
 // requires a list of WAF active rules, but it is empty.
 var ErrMissingWAFActiveRuleList = errors.New("WAF active rules slice is empty")
 
+// ErrMissingWAFExclusionNumber is an error that is returned when an input struct
+// requires a "WAFExclusionNumber" key, but one was not set.
+var ErrMissingWAFExclusionNumber = errors.New("missing required field 'WAFExclusionNumber'")
+
+// ErrMissingWAFExclusion is an error that is returned when an input struct
+// requires a "WAFExclusion" key, but one was not set.
+var ErrMissingWAFExclusion = errors.New("missing required field 'WAFExclusion'")
+
 // ErrMissingOWASPID is an error that is returned was an input struct
 // requires a "OWASPID" key, but one was not set
 var ErrMissingOWASPID = errors.New("missing required field 'OWASPID'")

--- a/vendor/github.com/fastly/go-fastly/v2/fastly/waf_exclusion.go
+++ b/vendor/github.com/fastly/go-fastly/v2/fastly/waf_exclusion.go
@@ -1,0 +1,297 @@
+package fastly
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"reflect"
+	"strconv"
+	"time"
+
+	"github.com/google/jsonapi"
+)
+
+// WAFExclusionType is used for reflection because JSONAPI wants to know what it's
+// decoding into.
+var WAFExclusionType = reflect.TypeOf(new(WAFExclusion))
+
+const (
+	// WAFExclusionTypeRule is the type of WAF exclusions that excludes rules from the WAF based on certain conditions
+	WAFExclusionTypeRule = "rule"
+	// WAFExclusionTypeWAF is the type of WAF exclusions that excludes WAF based on certain conditions
+	WAFExclusionTypeWAF = "waf"
+)
+
+// WAFExclusion is the information about a WAF exclusion object.
+type WAFExclusion struct {
+	ID            string     `jsonapi:"primary,waf_exclusion"`
+	Name          *string    `jsonapi:"attr,name"`
+	ExclusionType *string    `jsonapi:"attr,exclusion_type"`
+	Condition     *string    `jsonapi:"attr,condition"`
+	Number        *int       `jsonapi:"attr,number"`
+	Rules         []*WAFRule `jsonapi:"relation,waf_rules,omitempty"`
+	CreatedAt     *time.Time `jsonapi:"attr,created_at,iso8601,omitempty"`
+	UpdatedAt     *time.Time `jsonapi:"attr,updated_at,iso8601,omitempty"`
+}
+
+// WAFExclusionResponse represents a list of exclusions - full response.
+type WAFExclusionResponse struct {
+	Items []*WAFExclusion
+	Info  infoResponse
+}
+
+// ListWAFExclusionsInput used as input for listing a WAF's exclusions.
+type ListWAFExclusionsInput struct {
+	// The Web Application Firewall's ID.
+	WAFID string
+	// The Web Application Firewall's version number.
+	WAFVersionNumber int
+	// Limit results to exclusions with the specified exclusions type.
+	FilterExclusionType *string
+	// Limit results to exclusions with the specified exclusion name.
+	FilterName *string
+	// Limit results to exclusions that represent the specified ModSecurity modsec_rule_id.
+	FilterModSedID *string
+	// Limit the number of returned pages.
+	PageSize *int
+	// Request a specific page of exclusions.
+	PageNumber *int
+	// Include relationships. Optional, comma-separated values. Permitted values: waf_rule_revision and waf_firewall_version.
+	Include *string
+}
+
+// ListAllWAFExclusionsInput used as input for listing all WAF exclusions.
+type ListAllWAFExclusionsInput struct {
+	// The Web Application Firewall's ID.
+	WAFID string
+	// The Web Application Firewall's version number.
+	WAFVersionNumber int
+	// Limit results to exclusions with the specified exclusions type.
+	FilterExclusionType *string
+	// Limit results to exclusions with the specified exclusion name.
+	FilterName *string
+	// Limit results to exclusions that represent the specified ModSecurity modsec_rule_id.
+	FilterModSedID *string
+	// Include relationships. Optional, comma-separated values. Permitted values: waf_rule_revision and waf_firewall_version.
+	Include *string
+}
+
+// CreateWAFExclusionInput used as input to create a WAF exclusion.
+type CreateWAFExclusionInput struct {
+	// The Web Application Firewall's ID.
+	WAFID string
+	// The Web Application Firewall's version number.
+	WAFVersionNumber int
+	// The Web Application Firewall's exclusion
+	WAFExclusion *WAFExclusion
+}
+
+// UpdateWAFExclusionInput is used for exclusions updates.
+type UpdateWAFExclusionInput struct {
+	// The Web Application Firewall's ID.
+	WAFID string
+	// The Web Application Firewall's version number.
+	WAFVersionNumber int
+	// The exclusion number.
+	Number int
+	// The WAF exclusion
+	WAFExclusion *WAFExclusion
+}
+
+// DeleteWAFExclusionInput used as input for removing WAF exclusions.
+type DeleteWAFExclusionInput struct {
+	// The Web Application Firewall's ID.
+	WAFID string
+	// The Web Application Firewall's version number.
+	WAFVersionNumber int
+	// The exclusion number.
+	Number int
+}
+
+func (i *ListWAFExclusionsInput) formatFilters() map[string]string {
+
+	result := map[string]string{}
+	pairings := map[string]interface{}{
+		"filter[exclusion_type]":           i.FilterExclusionType,
+		"filter[name]":                     i.FilterName,
+		"filter[waf_rules.modsec_rule_id]": i.FilterModSedID,
+		"page[size]":                       i.PageSize,
+		"page[number]":                     i.PageNumber,
+		"include":                          i.Include,
+	}
+
+	for key, value := range pairings {
+		switch value := value.(type) {
+		case *string:
+			if value != nil {
+				result[key] = *value
+			}
+		case *int:
+			if value != nil {
+				result[key] = strconv.Itoa(*value)
+			}
+		}
+	}
+	return result
+}
+
+// ListWAFExclusions returns the list of exclusions for a given WAF ID.
+func (c *Client) ListWAFExclusions(i *ListWAFExclusionsInput) (*WAFExclusionResponse, error) {
+
+	if i.WAFID == "" {
+		return nil, ErrMissingWAFID
+	}
+
+	if i.WAFVersionNumber == 0 {
+		return nil, ErrMissingWAFVersionNumber
+	}
+
+	path := fmt.Sprintf("/waf/firewalls/%s/versions/%d/exclusions", i.WAFID, i.WAFVersionNumber)
+	resp, err := c.Get(path, &RequestOptions{
+		Params: i.formatFilters(),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var buf bytes.Buffer
+	tee := io.TeeReader(resp.Body, &buf)
+
+	info, err := getResponseInfo(tee)
+	if err != nil {
+		return nil, err
+	}
+
+	data, err := jsonapi.UnmarshalManyPayload(bytes.NewReader(buf.Bytes()), WAFExclusionType)
+	if err != nil {
+		return nil, err
+	}
+
+	wafExclusions := make([]*WAFExclusion, len(data))
+	for i := range data {
+		typed, ok := data[i].(*WAFExclusion)
+		if !ok {
+			return nil, fmt.Errorf("got back a non-WAFExclusion response")
+		}
+		wafExclusions[i] = typed
+	}
+	return &WAFExclusionResponse{
+		Items: wafExclusions,
+		Info:  info,
+	}, nil
+}
+
+// ListAllWAFExclusions returns the complete list of WAF exclusions for a given WAF ID. It iterates through
+// all existing pages to ensure all WAF exclusions are returned at once.
+func (c *Client) ListAllWAFExclusions(i *ListAllWAFExclusionsInput) (*WAFExclusionResponse, error) {
+
+	if i.WAFID == "" {
+		return nil, ErrMissingWAFID
+	}
+
+	if i.WAFVersionNumber == 0 {
+		return nil, ErrMissingWAFVersionNumber
+	}
+
+	currentPage := 1
+	pageSize := WAFPaginationPageSize
+	result := &WAFExclusionResponse{Items: []*WAFExclusion{}}
+	for {
+		r, err := c.ListWAFExclusions(&ListWAFExclusionsInput{
+			WAFID:               i.WAFID,
+			WAFVersionNumber:    i.WAFVersionNumber,
+			PageNumber:          &currentPage,
+			PageSize:            &pageSize,
+			Include:             i.Include,
+			FilterName:          i.FilterName,
+			FilterModSedID:      i.FilterModSedID,
+			FilterExclusionType: i.FilterExclusionType,
+		})
+		if err != nil {
+			return r, err
+		}
+
+		currentPage++
+		result.Items = append(result.Items, r.Items...)
+
+		if r.Info.Links.Next == "" || len(r.Items) == 0 {
+			return result, nil
+		}
+	}
+}
+
+// CreateWAFExclusion used to create a particular WAF exclusion.
+func (c *Client) CreateWAFExclusion(i *CreateWAFExclusionInput) (*WAFExclusion, error) {
+
+	if i.WAFID == "" {
+		return nil, ErrMissingWAFID
+	}
+
+	if i.WAFVersionNumber == 0 {
+		return nil, ErrMissingWAFVersionNumber
+	}
+
+	if i.WAFExclusion == nil {
+		return nil, ErrMissingWAFExclusion
+	}
+
+	path := fmt.Sprintf("/waf/firewalls/%s/versions/%d/exclusions", i.WAFID, i.WAFVersionNumber)
+	resp, err := c.PostJSONAPI(path, i.WAFExclusion, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var wafExclusion WAFExclusion
+	if err := jsonapi.UnmarshalPayload(resp.Body, &wafExclusion); err != nil {
+		return nil, err
+	}
+	return &wafExclusion, nil
+}
+
+// UpdateWAFExclusion used to update a particular WAF exclusion.
+func (c *Client) UpdateWAFExclusion(i *UpdateWAFExclusionInput) (*WAFExclusion, error) {
+	if i.WAFID == "" {
+		return nil, ErrMissingWAFID
+	}
+
+	if i.WAFVersionNumber == 0 {
+		return nil, ErrMissingWAFVersionNumber
+	}
+
+	if i.Number == 0 {
+		return nil, ErrMissingWAFExclusionNumber
+	}
+
+	if i.WAFExclusion == nil {
+		return nil, ErrMissingWAFExclusion
+	}
+
+	path := fmt.Sprintf("/waf/firewalls/%s/versions/%d/exclusions/%d", i.WAFID, i.WAFVersionNumber, i.Number)
+	resp, err := c.PatchJSONAPI(path, i.WAFExclusion, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var exc *WAFExclusion
+	if err := decodeBodyMap(resp.Body, &exc); err != nil {
+		return nil, err
+	}
+	return exc, nil
+}
+
+// DeleteWAFExclusions removes rules from a particular WAF.
+func (c *Client) DeleteWAFExclusion(i *DeleteWAFExclusionInput) error {
+	if i.WAFID == "" {
+		return ErrMissingWAFID
+	}
+	if i.WAFVersionNumber == 0 {
+		return ErrMissingWAFVersionNumber
+	}
+	if i.Number == 0 {
+		return ErrMissingWAFExclusionNumber
+	}
+
+	path := fmt.Sprintf("/waf/firewalls/%s/versions/%d/exclusions/%d", i.WAFID, i.WAFVersionNumber, i.Number)
+	_, err := c.Delete(path, nil)
+	return err
+}

--- a/vendor/github.com/fastly/go-fastly/v2/fastly/waf_rule_exclusion.go
+++ b/vendor/github.com/fastly/go-fastly/v2/fastly/waf_rule_exclusion.go
@@ -11,19 +11,19 @@ import (
 	"github.com/google/jsonapi"
 )
 
-// WAFExclusionType is used for reflection because JSONAPI wants to know what it's
+// WAFRuleExclusionType is used for reflection because JSONAPI wants to know what it's
 // decoding into.
-var WAFExclusionType = reflect.TypeOf(new(WAFExclusion))
+var WAFRuleExclusionType = reflect.TypeOf(new(WAFRuleExclusion))
 
 const (
-	// WAFExclusionTypeRule is the type of WAF exclusions that excludes rules from the WAF based on certain conditions
-	WAFExclusionTypeRule = "rule"
-	// WAFExclusionTypeWAF is the type of WAF exclusions that excludes WAF based on certain conditions
-	WAFExclusionTypeWAF = "waf"
+	// WAFRuleExclusionTypeRule is the type of WAF rule exclusions that excludes rules from the WAF based on certain conditions.
+	WAFRuleExclusionTypeRule = "rule"
+	// WAFRuleExclusionTypeWAF is the type of WAF rule exclusions that excludes WAF based on certain conditions.
+	WAFRuleExclusionTypeWAF = "waf"
 )
 
-// WAFExclusion is the information about a WAF exclusion object.
-type WAFExclusion struct {
+// WAFRuleExclusion is the information about a WAF rule exclusion object.
+type WAFRuleExclusion struct {
 	ID            string     `jsonapi:"primary,waf_exclusion"`
 	Name          *string    `jsonapi:"attr,name"`
 	ExclusionType *string    `jsonapi:"attr,exclusion_type"`
@@ -34,14 +34,14 @@ type WAFExclusion struct {
 	UpdatedAt     *time.Time `jsonapi:"attr,updated_at,iso8601,omitempty"`
 }
 
-// WAFExclusionResponse represents a list of exclusions - full response.
-type WAFExclusionResponse struct {
-	Items []*WAFExclusion
+// WAFRuleExclusionResponse represents a list of rule exclusions - full response.
+type WAFRuleExclusionResponse struct {
+	Items []*WAFRuleExclusion
 	Info  infoResponse
 }
 
-// ListWAFExclusionsInput used as input for listing a WAF's exclusions.
-type ListWAFExclusionsInput struct {
+// ListWAFRuleExclusionsInput used as input for listing a WAF's rule exclusions.
+type ListWAFRuleExclusionsInput struct {
 	// The Web Application Firewall's ID.
 	WAFID string
 	// The Web Application Firewall's version number.
@@ -60,8 +60,8 @@ type ListWAFExclusionsInput struct {
 	Include *string
 }
 
-// ListAllWAFExclusionsInput used as input for listing all WAF exclusions.
-type ListAllWAFExclusionsInput struct {
+// ListAllWAFRuleExclusionsInput used as input for listing all WAF rule exclusions.
+type ListAllWAFRuleExclusionsInput struct {
 	// The Web Application Firewall's ID.
 	WAFID string
 	// The Web Application Firewall's version number.
@@ -76,39 +76,39 @@ type ListAllWAFExclusionsInput struct {
 	Include *string
 }
 
-// CreateWAFExclusionInput used as input to create a WAF exclusion.
-type CreateWAFExclusionInput struct {
+// CreateWAFRuleExclusionInput used as input to create a WAF rule exclusion.
+type CreateWAFRuleExclusionInput struct {
 	// The Web Application Firewall's ID.
 	WAFID string
 	// The Web Application Firewall's version number.
 	WAFVersionNumber int
 	// The Web Application Firewall's exclusion
-	WAFExclusion *WAFExclusion
+	WAFRuleExclusion *WAFRuleExclusion
 }
 
-// UpdateWAFExclusionInput is used for exclusions updates.
-type UpdateWAFExclusionInput struct {
+// UpdateWAFRuleExclusionInput is used for exclusions updates.
+type UpdateWAFRuleExclusionInput struct {
 	// The Web Application Firewall's ID.
 	WAFID string
 	// The Web Application Firewall's version number.
 	WAFVersionNumber int
 	// The exclusion number.
 	Number int
-	// The WAF exclusion
-	WAFExclusion *WAFExclusion
+	// The WAF rule exclusion
+	WAFRuleExclusion *WAFRuleExclusion
 }
 
-// DeleteWAFExclusionInput used as input for removing WAF exclusions.
-type DeleteWAFExclusionInput struct {
+// DeleteWAFRuleExclusionInput used as input for removing WAF rule exclusions.
+type DeleteWAFRuleExclusionInput struct {
 	// The Web Application Firewall's ID.
 	WAFID string
 	// The Web Application Firewall's version number.
 	WAFVersionNumber int
-	// The exclusion number.
+	// The rule exclusion number.
 	Number int
 }
 
-func (i *ListWAFExclusionsInput) formatFilters() map[string]string {
+func (i *ListWAFRuleExclusionsInput) formatFilters() map[string]string {
 
 	result := map[string]string{}
 	pairings := map[string]interface{}{
@@ -135,8 +135,8 @@ func (i *ListWAFExclusionsInput) formatFilters() map[string]string {
 	return result
 }
 
-// ListWAFExclusions returns the list of exclusions for a given WAF ID.
-func (c *Client) ListWAFExclusions(i *ListWAFExclusionsInput) (*WAFExclusionResponse, error) {
+// ListWAFRuleExclusions returns the list of exclusions for a given WAF ID.
+func (c *Client) ListWAFRuleExclusions(i *ListWAFRuleExclusionsInput) (*WAFRuleExclusionResponse, error) {
 
 	if i.WAFID == "" {
 		return nil, ErrMissingWAFID
@@ -162,28 +162,28 @@ func (c *Client) ListWAFExclusions(i *ListWAFExclusionsInput) (*WAFExclusionResp
 		return nil, err
 	}
 
-	data, err := jsonapi.UnmarshalManyPayload(bytes.NewReader(buf.Bytes()), WAFExclusionType)
+	data, err := jsonapi.UnmarshalManyPayload(bytes.NewReader(buf.Bytes()), WAFRuleExclusionType)
 	if err != nil {
 		return nil, err
 	}
 
-	wafExclusions := make([]*WAFExclusion, len(data))
+	wafExclusions := make([]*WAFRuleExclusion, len(data))
 	for i := range data {
-		typed, ok := data[i].(*WAFExclusion)
+		typed, ok := data[i].(*WAFRuleExclusion)
 		if !ok {
-			return nil, fmt.Errorf("got back a non-WAFExclusion response")
+			return nil, fmt.Errorf("got back a non-WAFRuleExclusion response")
 		}
 		wafExclusions[i] = typed
 	}
-	return &WAFExclusionResponse{
+	return &WAFRuleExclusionResponse{
 		Items: wafExclusions,
 		Info:  info,
 	}, nil
 }
 
-// ListAllWAFExclusions returns the complete list of WAF exclusions for a given WAF ID. It iterates through
-// all existing pages to ensure all WAF exclusions are returned at once.
-func (c *Client) ListAllWAFExclusions(i *ListAllWAFExclusionsInput) (*WAFExclusionResponse, error) {
+// ListAllWAFRuleExclusions returns the complete list of WAF rule exclusions for a given WAF ID. It iterates through
+// all existing pages to ensure all WAF rule exclusions are returned at once.
+func (c *Client) ListAllWAFRuleExclusions(i *ListAllWAFRuleExclusionsInput) (*WAFRuleExclusionResponse, error) {
 
 	if i.WAFID == "" {
 		return nil, ErrMissingWAFID
@@ -195,9 +195,9 @@ func (c *Client) ListAllWAFExclusions(i *ListAllWAFExclusionsInput) (*WAFExclusi
 
 	currentPage := 1
 	pageSize := WAFPaginationPageSize
-	result := &WAFExclusionResponse{Items: []*WAFExclusion{}}
+	result := &WAFRuleExclusionResponse{Items: []*WAFRuleExclusion{}}
 	for {
-		r, err := c.ListWAFExclusions(&ListWAFExclusionsInput{
+		r, err := c.ListWAFRuleExclusions(&ListWAFRuleExclusionsInput{
 			WAFID:               i.WAFID,
 			WAFVersionNumber:    i.WAFVersionNumber,
 			PageNumber:          &currentPage,
@@ -220,8 +220,8 @@ func (c *Client) ListAllWAFExclusions(i *ListAllWAFExclusionsInput) (*WAFExclusi
 	}
 }
 
-// CreateWAFExclusion used to create a particular WAF exclusion.
-func (c *Client) CreateWAFExclusion(i *CreateWAFExclusionInput) (*WAFExclusion, error) {
+// CreateWAFRuleExclusion used to create a particular WAF rule exclusion.
+func (c *Client) CreateWAFRuleExclusion(i *CreateWAFRuleExclusionInput) (*WAFRuleExclusion, error) {
 
 	if i.WAFID == "" {
 		return nil, ErrMissingWAFID
@@ -231,25 +231,25 @@ func (c *Client) CreateWAFExclusion(i *CreateWAFExclusionInput) (*WAFExclusion, 
 		return nil, ErrMissingWAFVersionNumber
 	}
 
-	if i.WAFExclusion == nil {
-		return nil, ErrMissingWAFExclusion
+	if i.WAFRuleExclusion == nil {
+		return nil, ErrMissingWAFRuleExclusion
 	}
 
 	path := fmt.Sprintf("/waf/firewalls/%s/versions/%d/exclusions", i.WAFID, i.WAFVersionNumber)
-	resp, err := c.PostJSONAPI(path, i.WAFExclusion, nil)
+	resp, err := c.PostJSONAPI(path, i.WAFRuleExclusion, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	var wafExclusion WAFExclusion
+	var wafExclusion WAFRuleExclusion
 	if err := jsonapi.UnmarshalPayload(resp.Body, &wafExclusion); err != nil {
 		return nil, err
 	}
 	return &wafExclusion, nil
 }
 
-// UpdateWAFExclusion used to update a particular WAF exclusion.
-func (c *Client) UpdateWAFExclusion(i *UpdateWAFExclusionInput) (*WAFExclusion, error) {
+// UpdateWAFRuleExclusion used to update a particular WAF rule exclusion.
+func (c *Client) UpdateWAFRuleExclusion(i *UpdateWAFRuleExclusionInput) (*WAFRuleExclusion, error) {
 	if i.WAFID == "" {
 		return nil, ErrMissingWAFID
 	}
@@ -259,20 +259,20 @@ func (c *Client) UpdateWAFExclusion(i *UpdateWAFExclusionInput) (*WAFExclusion, 
 	}
 
 	if i.Number == 0 {
-		return nil, ErrMissingWAFExclusionNumber
+		return nil, ErrMissingWAFRuleExclusionNumber
 	}
 
-	if i.WAFExclusion == nil {
-		return nil, ErrMissingWAFExclusion
+	if i.WAFRuleExclusion == nil {
+		return nil, ErrMissingWAFRuleExclusion
 	}
 
 	path := fmt.Sprintf("/waf/firewalls/%s/versions/%d/exclusions/%d", i.WAFID, i.WAFVersionNumber, i.Number)
-	resp, err := c.PatchJSONAPI(path, i.WAFExclusion, nil)
+	resp, err := c.PatchJSONAPI(path, i.WAFRuleExclusion, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	var exc *WAFExclusion
+	var exc *WAFRuleExclusion
 	if err := decodeBodyMap(resp.Body, &exc); err != nil {
 		return nil, err
 	}
@@ -280,7 +280,7 @@ func (c *Client) UpdateWAFExclusion(i *UpdateWAFExclusionInput) (*WAFExclusion, 
 }
 
 // DeleteWAFExclusions removes rules from a particular WAF.
-func (c *Client) DeleteWAFExclusion(i *DeleteWAFExclusionInput) error {
+func (c *Client) DeleteWAFRuleExclusion(i *DeleteWAFRuleExclusionInput) error {
 	if i.WAFID == "" {
 		return ErrMissingWAFID
 	}
@@ -288,7 +288,7 @@ func (c *Client) DeleteWAFExclusion(i *DeleteWAFExclusionInput) error {
 		return ErrMissingWAFVersionNumber
 	}
 	if i.Number == 0 {
-		return ErrMissingWAFExclusionNumber
+		return ErrMissingWAFRuleExclusionNumber
 	}
 
 	path := fmt.Sprintf("/waf/firewalls/%s/versions/%d/exclusions/%d", i.WAFID, i.WAFVersionNumber, i.Number)

--- a/vendor/github.com/fastly/go-fastly/v2/fastly/waf_rule_exclusion.go
+++ b/vendor/github.com/fastly/go-fastly/v2/fastly/waf_rule_exclusion.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"reflect"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/google/jsonapi"
@@ -56,8 +57,8 @@ type ListWAFRuleExclusionsInput struct {
 	PageSize *int
 	// Request a specific page of exclusions.
 	PageNumber *int
-	// Include relationships. Optional, comma-separated values. Permitted values: waf_rule_revision and waf_firewall_version.
-	Include *string
+	// Include relationships. Optional. Permitted values: waf_rules.
+	Include []string
 }
 
 // ListAllWAFRuleExclusionsInput used as input for listing all WAF rule exclusions.
@@ -72,8 +73,8 @@ type ListAllWAFRuleExclusionsInput struct {
 	FilterName *string
 	// Limit results to exclusions that represent the specified ModSecurity modsec_rule_id.
 	FilterModSedID *string
-	// Include relationships. Optional, comma-separated values. Permitted values: waf_rule_revision and waf_firewall_version.
-	Include *string
+	// Include relationships. Optional. Permitted values: waf_rules.
+	Include []string
 }
 
 // CreateWAFRuleExclusionInput used as input to create a WAF rule exclusion.
@@ -110,6 +111,8 @@ type DeleteWAFRuleExclusionInput struct {
 
 func (i *ListWAFRuleExclusionsInput) formatFilters() map[string]string {
 
+	include := strings.Join(i.Include, ",")
+
 	result := map[string]string{}
 	pairings := map[string]interface{}{
 		"filter[exclusion_type]":           i.FilterExclusionType,
@@ -117,11 +120,15 @@ func (i *ListWAFRuleExclusionsInput) formatFilters() map[string]string {
 		"filter[waf_rules.modsec_rule_id]": i.FilterModSedID,
 		"page[size]":                       i.PageSize,
 		"page[number]":                     i.PageNumber,
-		"include":                          i.Include,
+		"include":                          include,
 	}
 
 	for key, value := range pairings {
 		switch value := value.(type) {
+		case string:
+			if value != "" {
+				result[key] = value
+			}
 		case *string:
 			if value != nil {
 				result[key] = *value

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -59,7 +59,7 @@ github.com/bgentry/go-netrc/netrc
 github.com/bgentry/speakeasy
 # github.com/davecgh/go-spew v1.1.1
 github.com/davecgh/go-spew/spew
-# github.com/fastly/go-fastly/v2 v2.0.0-alpha.1
+# github.com/fastly/go-fastly/v2 v2.0.0-alpha.2
 ## explicit
 github.com/fastly/go-fastly/v2/fastly
 # github.com/fatih/color v1.7.0
@@ -366,4 +366,3 @@ google.golang.org/grpc/stats
 google.golang.org/grpc/status
 google.golang.org/grpc/tap
 google.golang.org/grpc/test/bufconn
-# github.com/fastly/go-fastly/v2

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -366,3 +366,4 @@ google.golang.org/grpc/stats
 google.golang.org/grpc/status
 google.golang.org/grpc/tap
 google.golang.org/grpc/test/bufconn
+# github.com/fastly/go-fastly/v2

--- a/website/docs/r/service_waf_configuration.html.markdown
+++ b/website/docs/r/service_waf_configuration.html.markdown
@@ -134,6 +134,74 @@ resource "fastly_service_waf_configuration" "waf" {
 }
 ```
 
+Usage with exclusions:
+
+```hcl
+resource "fastly_service_v1" "demo" {
+  name = "demofastly"
+
+  domain {
+    name    = "example.com"
+    comment = "demo"
+  }
+
+  backend {
+    address = "127.0.0.1"
+    name    = "origin1"
+    port    = 80
+  }
+
+  condition {
+    name      = "WAF_Prefetch"
+    type      = "PREFETCH"
+    statement = "req.backend.is_origin"
+  }
+
+  # This condition will always be false
+  # adding it to the response object created below
+  # prevents Fastly from returning a 403 on all of your traffic.
+  condition {
+    name      = "WAF_always_false"
+    statement = "false"
+    type      = "REQUEST"
+  }
+
+  response_object {
+    name              = "WAF_Response"
+    status            = "403"
+    response          = "Forbidden"
+    content_type      = "text/html"
+    content           = "<html><body>Forbidden</body></html>"
+    request_condition = "WAF_always_false"
+  }
+
+  waf {
+    prefetch_condition = "WAF_Prefetch"
+    response_object    = "WAF_Response"
+  }
+
+  force_destroy = true
+}
+
+resource "fastly_service_waf_configuration" "waf" {
+  waf_id                          = fastly_service_v1.demo.waf[0].waf_id
+  http_violation_score_threshold  = 100
+
+  rule {
+    modsec_rule_id = 2029718
+    revision       = 1
+    status         = "log"
+  }
+
+  exclusion {
+    name = "index page"
+    exclusion_type = "rule"
+    condition = "req.url.basename == \"index.html\""
+    modsec_rule_ids = [2029718]
+  }
+}
+```
+
 Usage with rules from data source:
 
 ```hcl
@@ -520,6 +588,7 @@ The following arguments are supported:
 * `warning_anomaly_score` - (Optional) Score value to add for warning anomalies.
 * `xss_score_threshold` - (Optional) XSS attack threshold.
 * `rule` - (Optional) The Web Application Firewall's active rules.
+* `exclusion` - (Optional) The Web Application Firewall's exclusions.
 
 
 The `rule` block supports:
@@ -528,6 +597,16 @@ The `rule` block supports:
 * `modsec_rule_id` - (Required) The Web Application Firewall rule's modsecurity ID.
 * `revision` - (Optional) The Web Application Firewall rule's revision. The latest revision will be used if this is not provided.
 
+The `exclusion` block supports:
+
+* `name` - (Required) The name of exclusion.
+* `exclusion_type` - (Required) The type of exclusion. Values are `rule` to exclude the specified rule(s), or `waf` to disable the Web Application Firewall.
+* `condition` - (Required) A conditional expression in VCL used to determine if the condition is met.
+* `modsec_rule_ids` - (Required) Set of modsecurity IDs to be excluded. No rules should be provided when `exclusion_type` is `waf`. The rules need to be configured on the Web Application Firewall to be excluded.
+
+The `exclusion` block exports:
+
+* `number` - The numeric ID assigned to the WAF Exclusion.
 
 ## Import
 

--- a/website/docs/r/service_waf_configuration.html.markdown
+++ b/website/docs/r/service_waf_configuration.html.markdown
@@ -134,7 +134,7 @@ resource "fastly_service_waf_configuration" "waf" {
 }
 ```
 
-Usage with exclusions:
+Usage with rule exclusions:
 
 ```hcl
 resource "fastly_service_v1" "demo" {
@@ -193,7 +193,7 @@ resource "fastly_service_waf_configuration" "waf" {
     status         = "log"
   }
 
-  exclusion {
+  rule_exclusion {
     name = "index page"
     exclusion_type = "rule"
     condition = "req.url.basename == \"index.html\""
@@ -588,7 +588,7 @@ The following arguments are supported:
 * `warning_anomaly_score` - (Optional) Score value to add for warning anomalies.
 * `xss_score_threshold` - (Optional) XSS attack threshold.
 * `rule` - (Optional) The Web Application Firewall's active rules.
-* `exclusion` - (Optional) The Web Application Firewall's exclusions.
+* `rule_exclusion` - (Optional) The Web Application Firewall's rule exclusions.
 
 
 The `rule` block supports:
@@ -597,16 +597,16 @@ The `rule` block supports:
 * `modsec_rule_id` - (Required) The Web Application Firewall rule's modsecurity ID.
 * `revision` - (Optional) The Web Application Firewall rule's revision. The latest revision will be used if this is not provided.
 
-The `exclusion` block supports:
+The `rule_exclusion` block supports:
 
-* `name` - (Required) The name of exclusion.
-* `exclusion_type` - (Required) The type of exclusion. Values are `rule` to exclude the specified rule(s), or `waf` to disable the Web Application Firewall.
+* `name` - (Required) The name of rule exclusion.
+* `exclusion_type` - (Required) The type of rule exclusion. Values are `rule` to exclude the specified rule(s), or `waf` to disable the Web Application Firewall.
 * `condition` - (Required) A conditional expression in VCL used to determine if the condition is met.
 * `modsec_rule_ids` - (Required) Set of modsecurity IDs to be excluded. No rules should be provided when `exclusion_type` is `waf`. The rules need to be configured on the Web Application Firewall to be excluded.
 
-The `exclusion` block exports:
+The `rule_exclusion` block exports:
 
-* `number` - The numeric ID assigned to the WAF Exclusion.
+* `number` - The numeric ID assigned to the WAF Rule Exclusion.
 
 ## Import
 

--- a/website_src/docs/r/service_waf_configuration.html.markdown.tmpl
+++ b/website_src/docs/r/service_waf_configuration.html.markdown.tmpl
@@ -134,6 +134,74 @@ resource "fastly_service_waf_configuration" "waf" {
 }
 ```
 
+Usage with exclusions:
+
+```hcl
+resource "fastly_service_v1" "demo" {
+  name = "demofastly"
+
+  domain {
+    name    = "example.com"
+    comment = "demo"
+  }
+
+  backend {
+    address = "127.0.0.1"
+    name    = "origin1"
+    port    = 80
+  }
+
+  condition {
+    name      = "WAF_Prefetch"
+    type      = "PREFETCH"
+    statement = "req.backend.is_origin"
+  }
+
+  # This condition will always be false
+  # adding it to the response object created below
+  # prevents Fastly from returning a 403 on all of your traffic.
+  condition {
+    name      = "WAF_always_false"
+    statement = "false"
+    type      = "REQUEST"
+  }
+
+  response_object {
+    name              = "WAF_Response"
+    status            = "403"
+    response          = "Forbidden"
+    content_type      = "text/html"
+    content           = "<html><body>Forbidden</body></html>"
+    request_condition = "WAF_always_false"
+  }
+
+  waf {
+    prefetch_condition = "WAF_Prefetch"
+    response_object    = "WAF_Response"
+  }
+
+  force_destroy = true
+}
+
+resource "fastly_service_waf_configuration" "waf" {
+  waf_id                          = fastly_service_v1.demo.waf[0].waf_id
+  http_violation_score_threshold  = 100
+
+  rule {
+    modsec_rule_id = 2029718
+    revision       = 1
+    status         = "log"
+  }
+
+  exclusion {
+    name = "index page"
+    exclusion_type = "rule"
+    condition = "req.url.basename == \"index.html\""
+    modsec_rule_ids = [2029718]
+  }
+}
+```
+
 Usage with rules from data source:
 
 ```hcl
@@ -520,6 +588,7 @@ The following arguments are supported:
 * `warning_anomaly_score` - (Optional) Score value to add for warning anomalies.
 * `xss_score_threshold` - (Optional) XSS attack threshold.
 * `rule` - (Optional) The Web Application Firewall's active rules.
+* `exclusion` - (Optional) The Web Application Firewall's exclusions.
 
 
 The `rule` block supports:
@@ -528,6 +597,16 @@ The `rule` block supports:
 * `modsec_rule_id` - (Required) The Web Application Firewall rule's modsecurity ID.
 * `revision` - (Optional) The Web Application Firewall rule's revision. The latest revision will be used if this is not provided.
 
+The `exclusion` block supports:
+
+* `name` - (Required) The name of exclusion.
+* `exclusion_type` - (Required) The type of exclusion. Values are `rule` to exclude the specified rule(s), or `waf` to disable the Web Application Firewall.
+* `condition` - (Required) A conditional expression in VCL used to determine if the condition is met.
+* `modsec_rule_ids` - (Required) Set of modsecurity IDs to be excluded. No rules should be provided when `exclusion_type` is `waf`. The rules need to be configured on the Web Application Firewall to be excluded.
+
+The `exclusion` block exports:
+
+* `number` - The numeric ID assigned to the WAF Exclusion.
 
 ## Import
 

--- a/website_src/docs/r/service_waf_configuration.html.markdown.tmpl
+++ b/website_src/docs/r/service_waf_configuration.html.markdown.tmpl
@@ -134,7 +134,7 @@ resource "fastly_service_waf_configuration" "waf" {
 }
 ```
 
-Usage with exclusions:
+Usage with rule exclusions:
 
 ```hcl
 resource "fastly_service_v1" "demo" {
@@ -193,7 +193,7 @@ resource "fastly_service_waf_configuration" "waf" {
     status         = "log"
   }
 
-  exclusion {
+  rule_exclusion {
     name = "index page"
     exclusion_type = "rule"
     condition = "req.url.basename == \"index.html\""
@@ -588,7 +588,7 @@ The following arguments are supported:
 * `warning_anomaly_score` - (Optional) Score value to add for warning anomalies.
 * `xss_score_threshold` - (Optional) XSS attack threshold.
 * `rule` - (Optional) The Web Application Firewall's active rules.
-* `exclusion` - (Optional) The Web Application Firewall's exclusions.
+* `rule_exclusion` - (Optional) The Web Application Firewall's rule exclusions.
 
 
 The `rule` block supports:
@@ -597,16 +597,16 @@ The `rule` block supports:
 * `modsec_rule_id` - (Required) The Web Application Firewall rule's modsecurity ID.
 * `revision` - (Optional) The Web Application Firewall rule's revision. The latest revision will be used if this is not provided.
 
-The `exclusion` block supports:
+The `rule_exclusion` block supports:
 
-* `name` - (Required) The name of exclusion.
-* `exclusion_type` - (Required) The type of exclusion. Values are `rule` to exclude the specified rule(s), or `waf` to disable the Web Application Firewall.
+* `name` - (Required) The name of rule exclusion.
+* `exclusion_type` - (Required) The type of rule exclusion. Values are `rule` to exclude the specified rule(s), or `waf` to disable the Web Application Firewall.
 * `condition` - (Required) A conditional expression in VCL used to determine if the condition is met.
 * `modsec_rule_ids` - (Required) Set of modsecurity IDs to be excluded. No rules should be provided when `exclusion_type` is `waf`. The rules need to be configured on the Web Application Firewall to be excluded.
 
-The `exclusion` block exports:
+The `rule_exclusion` block exports:
 
-* `number` - The numeric ID assigned to the WAF Exclusion.
+* `number` - The numeric ID assigned to the WAF Rule Exclusion.
 
 ## Import
 


### PR DESCRIPTION
During this implementation, I've refactored some of the WAF acceptance tests to reduce overlapping:
1. `TestAccFastlyServiceWAFVersionV1ImportWithRules` was merged into `TestAccFastlyServiceWAFVersionV1Import`. This tests was also enhanced to include WAF exclusions.

2. `TestAccFastlyServiceWAFVersionV1AddWithRules` and `TestAccFastlyServiceWAFVersionV1DeleteRules` was merged into `TestAccFastlyServiceWAFVersionV1UpdateRules`. The update tests was performing add, update and delete already. `TestAccFastlyServiceWAFVersionV1UpdateRules` was renamed to `TestAccFastlyServiceWAFVersionV1AddUpdateDeleteRules` to make it clearer

PS: When https://github.com/fastly/go-fastly/pull/223 is approved and merged, I'll need just update the `go.mod` and vendor folder with the latest tag.

<details>
  <summary>Acceptance Test Results</summary>

    === RUN   TestResourceFastlyFlattenAcl
    --- PASS: TestResourceFastlyFlattenAcl (0.00s)
    === RUN   TestResourceFastlyFlattenBigQuery
    --- PASS: TestResourceFastlyFlattenBigQuery (0.30s)
    === RUN   TestAccFastlyServiceV1_bigquerylogging_compute
    --- PASS: TestAccFastlyServiceV1_bigquerylogging_compute (57.35s)
    === RUN   TestResourceFastlyFlattenBlobStorage
    --- PASS: TestResourceFastlyFlattenBlobStorage (0.00s)
    === RUN   TestAccFastlyServiceV1_blobstoragelogging_basic_compute
    --- PASS: TestAccFastlyServiceV1_blobstoragelogging_basic_compute (58.80s)
    === RUN   TestAccFastlyServiceV1_blobstoragelogging_env
    --- PASS: TestAccFastlyServiceV1_blobstoragelogging_env (134.09s)
    === RUN   TestResourceFastlyFlattenCacheSettings
    --- PASS: TestResourceFastlyFlattenCacheSettings (0.00s)
    === RUN   TestAccFastlyServiceV1_bigquerylogging_env
    --- PASS: TestAccFastlyServiceV1_bigquerylogging_env (65.62s)
    === RUN   TestAccFastlyServiceV1_acl
    --- PASS: TestAccFastlyServiceV1_acl (65.01s)
    === RUN   TestAccFastlyServiceV1_bigquerylogging
    --- PASS: TestAccFastlyServiceV1_bigquerylogging (65.97s)
    === RUN   TestResourceFastlyFlattenConditions
    --- PASS: TestResourceFastlyFlattenConditions (0.00s)
    === RUN   TestAccFastlyServiceV1_conditional_basic
    --- PASS: TestAccFastlyServiceV1_conditional_basic (99.14s)
    === RUN   TestResourceFastlyFlattenDictionary
    --- PASS: TestResourceFastlyFlattenDictionary (0.00s)
    === RUN   TestAccFastlyServiceV1_blobstoragelogging_default
    --- PASS: TestAccFastlyServiceV1_blobstoragelogging_default (67.87s)
    === RUN   TestAccFastlyServiceV1_dictionary_update_name
    --- PASS: TestAccFastlyServiceV1_dictionary_update_name (172.97s)
    === RUN   TestResourceFastlyFlattenDirectors
    --- PASS: TestResourceFastlyFlattenDirectors (0.00s)
    === RUN   TestAccFastlyServiceV1_directors_basic
    --- PASS: TestAccFastlyServiceV1_directors_basic (191.11s)
    === RUN   TestResourceFastlyFlattenDynamicSnippets
    --- PASS: TestResourceFastlyFlattenDynamicSnippets (0.00s)
    === RUN   TestAccFastlyServiceV1_dictionary_write_only
    --- PASS: TestAccFastlyServiceV1_dictionary_write_only (117.28s)
    === RUN   TestAccFastlyServiceV1_blobstoragelogging_basic
    --- PASS: TestAccFastlyServiceV1_blobstoragelogging_basic (192.37s)
    === RUN   TestResourceFastlyFlattenGCS
    --- PASS: TestResourceFastlyFlattenGCS (2.06s)
    === RUN   TestAccFastlyServiceV1_dictionary
    --- PASS: TestAccFastlyServiceV1_dictionary (122.51s)
    === RUN   TestAccFastlyServiceV1_gcslogging_compute
    --- PASS: TestAccFastlyServiceV1_gcslogging_compute (112.06s)
    === RUN   TestResourceFastlyFlattenGzips
    --- PASS: TestResourceFastlyFlattenGzips (0.00s)
    === RUN   TestAccFastlyServiceV1_gcslogging
    --- PASS: TestAccFastlyServiceV1_gcslogging (119.54s)
    === RUN   TestAccFastlyServiceV1CacheSetting_basic
    --- PASS: TestAccFastlyServiceV1CacheSetting_basic (246.58s)
    === RUN   TestAccFastlyServiceV1_dictionary_update_write_only
    --- PASS: TestAccFastlyServiceV1_dictionary_update_write_only (242.43s)
    === RUN   TestAccFastlyServiceV1DynamicSnippet_basic
    --- PASS: TestAccFastlyServiceV1DynamicSnippet_basic (238.16s)
    === RUN   TestAccFastlyServiceV1_gcslogging_env
    --- PASS: TestAccFastlyServiceV1_gcslogging_env (118.18s)
    === RUN   TestResourceFastlyFlattenHeaders
    --- PASS: TestResourceFastlyFlattenHeaders (0.00s)
    === RUN   TestFastlyServiceV1_BuildHeaders
    --- PASS: TestFastlyServiceV1_BuildHeaders (0.00s)
    === RUN   TestResourceFastlyFlattenHealthChecks
    --- PASS: TestResourceFastlyFlattenHealthChecks (0.00s)
    === RUN   TestResourceFastlyFlattenHTTPS
    --- PASS: TestResourceFastlyFlattenHTTPS (0.00s)
    === RUN   TestResourceFastlyFlattenLogentries
    --- PASS: TestResourceFastlyFlattenLogentries (0.00s)
    === RUN   TestAccFastlyServiceV1_httpslogging_basic_compute
    --- PASS: TestAccFastlyServiceV1_httpslogging_basic_compute (102.78s)
    === RUN   TestAccFastlyServiceV1_logentries_basic_compute
    --- PASS: TestAccFastlyServiceV1_logentries_basic_compute (95.81s)
    === RUN   TestAccFastlyServiceV1_gzips_basic
    --- PASS: TestAccFastlyServiceV1_gzips_basic (228.41s)
    === RUN   TestResourceFastlyFlattenCloudfiles
    --- PASS: TestResourceFastlyFlattenCloudfiles (0.02s)
    === RUN   TestAccFastlyServiceV1_healthcheck_basic
    --- PASS: TestAccFastlyServiceV1_healthcheck_basic (227.12s)
    === RUN   TestAccFastlyServiceV1_headers_basic
    --- PASS: TestAccFastlyServiceV1_headers_basic (235.10s)
    === RUN   TestResourceFastlyFlattenDatadog
    --- PASS: TestResourceFastlyFlattenDatadog (0.00s)
    === RUN   TestAccFastlyServiceV1_httpslogging_basic
    --- PASS: TestAccFastlyServiceV1_httpslogging_basic (235.55s)
    === RUN   TestAccFastlyServiceV1_logentries_basic
    --- PASS: TestAccFastlyServiceV1_logentries_basic (234.82s)
    === RUN   TestResourceFastlyFlattenDigitalOcean
    --- PASS: TestResourceFastlyFlattenDigitalOcean (0.00s)
    === RUN   TestAccFastlyServiceV1_logentries_formatVersion
    --- PASS: TestAccFastlyServiceV1_logentries_formatVersion (110.53s)
    === RUN   TestAccFastlyServiceV1_logging_cloudfiles_basic_compute
    --- PASS: TestAccFastlyServiceV1_logging_cloudfiles_basic_compute (101.23s)
    === RUN   TestResourceFastlyFlattenElasticsearch
    --- PASS: TestResourceFastlyFlattenElasticsearch (0.00s)
    === RUN   TestAccFastlyServiceV1_logging_datadog_basic_compute
    --- PASS: TestAccFastlyServiceV1_logging_datadog_basic_compute (104.04s)
    === RUN   TestAccFastlyServiceV1_logging_elasticsearch_basic_compute
    --- PASS: TestAccFastlyServiceV1_logging_elasticsearch_basic_compute (82.19s)
    === RUN   TestResourceFastlyFlattenFTP
    --- PASS: TestResourceFastlyFlattenFTP (0.00s)
    === RUN   TestAccFastlyServiceV1_logging_digitalocean_basic_compute
    --- PASS: TestAccFastlyServiceV1_logging_digitalocean_basic_compute (65.80s)
    === RUN   TestAccFastlyServiceV1_logging_cloudfiles_basic
    --- PASS: TestAccFastlyServiceV1_logging_cloudfiles_basic (198.24s)
    === RUN   TestResourceFastlyFlattenGooglePubSub
    --- PASS: TestResourceFastlyFlattenGooglePubSub (0.00s)
    === RUN   TestAccFastlyServiceV1_logging_datadog_basic
    --- PASS: TestAccFastlyServiceV1_logging_datadog_basic (236.99s)
    === RUN   TestAccFastlyServiceV1_logging_digitalocean_basic
    --- PASS: TestAccFastlyServiceV1_logging_digitalocean_basic (238.70s)
    === RUN   TestResourceFastlyFlattenHeroku
    --- PASS: TestResourceFastlyFlattenHeroku (0.00s)
    === RUN   TestAccFastlyServiceV1_logging_ftp_basic_compute
    --- PASS: TestAccFastlyServiceV1_logging_ftp_basic_compute (107.64s)
    === RUN   TestAccFastlyServiceV1_logging_elasticsearch_basic
    --- PASS: TestAccFastlyServiceV1_logging_elasticsearch_basic (201.58s)
    === RUN   TestResourceFastlyFlattenHoneycomb
    --- PASS: TestResourceFastlyFlattenHoneycomb (0.00s)
    === RUN   TestAccFastlyServiceV1_googlepubsublogging_basic_compute
    --- PASS: TestAccFastlyServiceV1_googlepubsublogging_basic_compute (64.44s)
    === RUN   TestAccFastlyServiceV1_logging_ftp_basic
    --- PASS: TestAccFastlyServiceV1_logging_ftp_basic (199.56s)
    === RUN   TestResourceFastlyFlattenKafka
    --- PASS: TestResourceFastlyFlattenKafka (0.00s)
    === RUN   TestAccFastlyServiceV1_logging_heroku_basic_compute
    --- PASS: TestAccFastlyServiceV1_logging_heroku_basic_compute (111.46s)
    === RUN   TestAccFastlyServiceV1_logging_honeycomb_basic_compute
    --- PASS: TestAccFastlyServiceV1_logging_honeycomb_basic_compute (98.84s)
    === RUN   TestResourceFastlyFlattenLoggly
    --- PASS: TestResourceFastlyFlattenLoggly (0.00s)
    === RUN   TestAccFastlyServiceV1_googlepubsublogging_basic
    --- PASS: TestAccFastlyServiceV1_googlepubsublogging_basic (239.86s)
    === RUN   TestAccFastlyServiceV1_logging_heroku_basic
    --- PASS: TestAccFastlyServiceV1_logging_heroku_basic (189.60s)
    === RUN   TestResourceFastlyFlattenLogshuttle
    --- PASS: TestResourceFastlyFlattenLogshuttle (0.00s)
    === RUN   TestAccFastlyServiceV1_kafkalogging_basic_compute
    --- PASS: TestAccFastlyServiceV1_kafkalogging_basic_compute (79.99s)
    === RUN   TestAccFastlyServiceV1_logging_loggly_basic_compute
    --- PASS: TestAccFastlyServiceV1_logging_loggly_basic_compute (102.94s)
    === RUN   TestResourceFastlyFlattenNewRelic
    --- PASS: TestResourceFastlyFlattenNewRelic (0.00s)
    === RUN   TestAccFastlyServiceV1_logging_honeycomb_basic
    --- PASS: TestAccFastlyServiceV1_logging_honeycomb_basic (238.60s)
    === RUN   TestAccFastlyServiceV1_kafkalogging_basic
    --- PASS: TestAccFastlyServiceV1_kafkalogging_basic (241.00s)
    === RUN   TestAccFastlyServiceV1_logging_logshuttle_basic_compute
    --- PASS: TestAccFastlyServiceV1_logging_logshuttle_basic_compute (88.76s)
    === RUN   TestResourceFastlyFlattenOpenstack
    --- PASS: TestResourceFastlyFlattenOpenstack (0.00s)
    === RUN   TestAccFastlyServiceV1_logging_loggly_basic
    --- PASS: TestAccFastlyServiceV1_logging_loggly_basic (227.68s)
    === RUN   TestAccFastlyServiceV1_logging_newrelic_basic_compute
    --- PASS: TestAccFastlyServiceV1_logging_newrelic_basic_compute (100.21s)
    === RUN   TestResourceFastlyFlattenScalyr
    --- PASS: TestResourceFastlyFlattenScalyr (0.00s)
    === RUN   TestAccFastlyServiceV1_logging_openstack_basic_compute
    --- PASS: TestAccFastlyServiceV1_logging_openstack_basic_compute (100.33s)
    === RUN   TestResourceFastlyFlattenSFTP
    --- PASS: TestResourceFastlyFlattenSFTP (0.00s)
    === RUN   TestAccFastlyServiceV1_logging_logshuttle_basic
    --- PASS: TestAccFastlyServiceV1_logging_logshuttle_basic (232.26s)
    === RUN   TestAccFastlyServiceV1_scalyrlogging_basic_compute
    --- PASS: TestAccFastlyServiceV1_scalyrlogging_basic_compute (79.65s)
    === RUN   TestAccFastlyServiceV1_logging_sftp_password_secret_key
    --- PASS: TestAccFastlyServiceV1_logging_sftp_password_secret_key (11.41s)
    === RUN   TestAccFastlyServiceV1_logging_newrelic_basic
    --- PASS: TestAccFastlyServiceV1_logging_newrelic_basic (223.85s)
    === RUN   TestResourceFastlyFlattenPapertrail
    --- PASS: TestResourceFastlyFlattenPapertrail (0.00s)
    === RUN   TestAccFastlyServiceV1_logging_sftp_basic_compute
    --- PASS: TestAccFastlyServiceV1_logging_sftp_basic_compute (94.49s)
    === RUN   TestAccFastlyServiceV1_papertrail_basic_compute
    --- PASS: TestAccFastlyServiceV1_papertrail_basic_compute (63.12s)
    === RUN   TestResourceFastlyFlattenRequestSettings
    --- PASS: TestResourceFastlyFlattenRequestSettings (0.00s)
    === RUN   TestAccFastlyServiceV1_logging_openstack_basic
    --- PASS: TestAccFastlyServiceV1_logging_openstack_basic (230.79s)
    === RUN   TestResourceFastlyFlattenResponseObjects
    --- PASS: TestResourceFastlyFlattenResponseObjects (0.00s)
    === RUN   TestAccFastlyServiceV1RequestSetting_basic
    --- PASS: TestAccFastlyServiceV1RequestSetting_basic (61.28s)
    === RUN   TestResourceFastlyFlattenS3
    --- PASS: TestResourceFastlyFlattenS3 (0.00s)
    === RUN   TestAccFastlyServiceV1_s3logging_basic
    --- PASS: TestAccFastlyServiceV1_s3logging_basic (155.54s)
    === RUN   TestAccFastlyServiceV1_scalyrlogging_basic
    --- PASS: TestAccFastlyServiceV1_scalyrlogging_basic (209.20s)
    === RUN   TestAccFastlyServiceV1_logging_sftp_basic
    --- PASS: TestAccFastlyServiceV1_logging_sftp_basic (201.84s)
    === RUN   TestAccFastlyServiceV1_s3logging_s3_env
    --- PASS: TestAccFastlyServiceV1_s3logging_s3_env (78.21s)
    === RUN   TestAccFastlyServiceV1_s3logging_basic_compute
    --- PASS: TestAccFastlyServiceV1_s3logging_basic_compute (94.45s)
    === RUN   TestResourceFastlyFlattenSnippets
    --- PASS: TestResourceFastlyFlattenSnippets (0.00s)
    === RUN   TestAccFastlyServiceV1_papertrail_basic
    --- PASS: TestAccFastlyServiceV1_papertrail_basic (204.80s)
    === RUN   TestResourceFastlyFlattenSplunk
    --- PASS: TestResourceFastlyFlattenSplunk (0.10s)
    === RUN   TestAccFastlyServiceV1_s3logging_domain_default
    --- PASS: TestAccFastlyServiceV1_s3logging_domain_default (116.34s)
    === RUN   TestAccFastlyServiceV1_s3logging_formatVersion
    --- PASS: TestAccFastlyServiceV1_s3logging_formatVersion (112.26s)
    === RUN   TestAccFastlyServiceV1_package_basic
    --- PASS: TestAccFastlyServiceV1_package_basic (272.13s)
    === RUN   TestAccFastlyServiceV1_splunk_complete
    --- PASS: TestAccFastlyServiceV1_splunk_complete (161.49s)
    === RUN   TestAccFastlyServiceV1_response_object_basic
    --- PASS: TestAccFastlyServiceV1_response_object_basic (232.19s)
    === RUN   TestResourceFastlyFlattenSumologic
    --- PASS: TestResourceFastlyFlattenSumologic (0.00s)
    === RUN   TestAccFastlyServiceV1_splunk_basic_compute
    --- PASS: TestAccFastlyServiceV1_splunk_basic_compute (91.91s)
    === RUN   TestAccFastlyServiceV1_splunk_default
    --- PASS: TestAccFastlyServiceV1_splunk_default (107.86s)
    === RUN   TestResourceFastlyFlattenSyslog
    --- PASS: TestResourceFastlyFlattenSyslog (0.16s)
    === RUN   TestAccFastlyServiceV1_splunk_env
    --- PASS: TestAccFastlyServiceV1_splunk_env (103.43s)
    === RUN   TestAccFastlyServiceV1Snippet_basic
    --- PASS: TestAccFastlyServiceV1Snippet_basic (213.47s)
    === RUN   TestAccFastlyServiceV1_sumologic_compute
    --- PASS: TestAccFastlyServiceV1_sumologic_compute (102.51s)
    === RUN   TestAccFastlyServiceV1_splunk_basic
    --- PASS: TestAccFastlyServiceV1_splunk_basic (237.20s)
    === RUN   TestResourceFastlyFlattenVCLs
    --- PASS: TestResourceFastlyFlattenVCLs (0.00s)
    === RUN   TestAccFastlyServiceV1_syslog_basic_compute
    --- PASS: TestAccFastlyServiceV1_syslog_basic_compute (88.54s)
    === RUN   TestResourceFastlyFlattenWAF
    --- PASS: TestResourceFastlyFlattenWAF (0.00s)
    === RUN   TestAccFastlyServiceV1_sumologic
    --- PASS: TestAccFastlyServiceV1_sumologic (209.79s)
    === RUN   TestAccFastlyServiceV1_syslog_formatVersion
    --- PASS: TestAccFastlyServiceV1_syslog_formatVersion (109.37s)
    === RUN   TestAccFastlyServiceV1WAFUpdateResponse
    === PAUSE TestAccFastlyServiceV1WAFUpdateResponse
    === CONT  TestAccFastlyServiceV1WAFUpdateResponse
    --- PASS: TestAccFastlyServiceV1WAFUpdateResponse (169.16s)
    === RUN   TestAccFastlyServiceV1_syslog_useTls
    --- PASS: TestAccFastlyServiceV1_syslog_useTls (120.47s)
    === RUN   TestAccFastlyServiceWAFVersionV1FlattenWAFActiveRules
    --- PASS: TestAccFastlyServiceWAFVersionV1FlattenWAFActiveRules (0.00s)
    === RUN   TestAccFastlyServiceWAFVersionV1FlattenWAFDeleteByModSecID
    --- PASS: TestAccFastlyServiceWAFVersionV1FlattenWAFDeleteByModSecID (0.00s)
    === RUN   TestAccFastlyServiceV1_syslog_basic
    --- PASS: TestAccFastlyServiceV1_syslog_basic (236.01s)
    === RUN   TestAccFastlyServiceWAFVersionV1FlattenWAFExclusions
    --- PASS: TestAccFastlyServiceWAFVersionV1FlattenWAFExclusions (0.00s)
    === RUN   TestAccFastlyServiceV1WAFAdd
    === PAUSE TestAccFastlyServiceV1WAFAdd
    === CONT  TestAccFastlyServiceV1WAFAdd
    --- PASS: TestAccFastlyServiceV1WAFAdd (117.22s)
    === RUN   TestAccFastlyServiceWAFVersionV1Validation
    --- PASS: TestAccFastlyServiceWAFVersionV1Validation (0.23s)
    === RUN   TestUserAgentContainsProviderVersion
    --- PASS: TestUserAgentContainsProviderVersion (0.00s)
    === RUN   TestStringPtr
    --- PASS: TestStringPtr (0.00s)
    === RUN   TestIntPtr
    --- PASS: TestIntPtr (0.00s)
    === RUN   TestBoolPtr
    --- PASS: TestBoolPtr (0.00s)
    === RUN   TestDefaultUintToZero
    --- PASS: TestDefaultUintToZero (0.00s)
    === RUN   TestDefaultUint
    --- PASS: TestDefaultUint (0.00s)
    === RUN   TestAccFastlyIPRanges
    --- PASS: TestAccFastlyIPRanges (2.80s)
    === RUN   TestAccFastlyWAFRulesDetermineRevision
    --- PASS: TestAccFastlyWAFRulesDetermineRevision (0.00s)
    === RUN   TestAccFastlyWAFRulesFlattenWAFRules
    --- PASS: TestAccFastlyWAFRulesFlattenWAFRules (0.00s)
    === RUN   TestAccFastlyWAFRulesPublisherFilter
    --- PASS: TestAccFastlyWAFRulesPublisherFilter (18.74s)
    === RUN   TestAccFastlyWAFRulesExcludeFilter
    --- PASS: TestAccFastlyWAFRulesExcludeFilter (11.06s)
    === RUN   TestAccFastlyWAFRulesTagFilter
    --- PASS: TestAccFastlyWAFRulesTagFilter (8.52s)
    === RUN   TestSetDiff_Diff
    === RUN   TestSetDiff_Diff/should_return_the_correct_diff
    === RUN   TestSetDiff_Diff/should_diff_empty_element_lists
    === RUN   TestSetDiff_Diff/should_return_error_if_key_cannot_be_computed
    --- PASS: TestSetDiff_Diff (0.00s)
        --- PASS: TestSetDiff_Diff/should_return_the_correct_diff (0.00s)
        --- PASS: TestSetDiff_Diff/should_diff_empty_element_lists (0.00s)
        --- PASS: TestSetDiff_Diff/should_return_error_if_key_cannot_be_computed (0.00s)
    === RUN   TestEscapePercentSign
    === RUN   TestEscapePercentSign/string_no_percent_signs_should_change_nothing
    === RUN   TestEscapePercentSign/one_percent_sign_should_return_two_percent_signs
    === RUN   TestEscapePercentSign/one_percent_sign_mid-string_should_return_two_percent_signs_in_the_same_place
    === RUN   TestEscapePercentSign/one_percent_sign_before_left_curly_brace_should_return_four_percent_signs_then_curly_brace
    --- PASS: TestEscapePercentSign (0.00s)
        --- PASS: TestEscapePercentSign/string_no_percent_signs_should_change_nothing (0.00s)
        --- PASS: TestEscapePercentSign/one_percent_sign_should_return_two_percent_signs (0.00s)
        --- PASS: TestEscapePercentSign/one_percent_sign_mid-string_should_return_two_percent_signs_in_the_same_place (0.00s)
        --- PASS: TestEscapePercentSign/one_percent_sign_before_left_curly_brace_should_return_four_percent_signs_then_curly_brace (0.00s)
    === RUN   TestProvider
    --- PASS: TestProvider (0.01s)
    === RUN   TestProvider_impl
    --- PASS: TestProvider_impl (0.00s)
    === RUN   TestResourceFastlyFlattenAclEntries
    --- PASS: TestResourceFastlyFlattenAclEntries (0.00s)
    === RUN   TestAccFastlyServiceAclEntriesV1_create
    --- PASS: TestAccFastlyServiceAclEntriesV1_create (70.12s)
    === RUN   TestAccFastlyServiceV1_VCL_basic
    --- PASS: TestAccFastlyServiceV1_VCL_basic (219.89s)
    === RUN   TestAccFastlyServiceV1WAFUpdateCondition
    === PAUSE TestAccFastlyServiceV1WAFUpdateCondition
    === CONT  TestAccFastlyServiceV1WAFUpdateCondition
    --- PASS: TestAccFastlyServiceV1WAFUpdateCondition (223.04s)
    === RUN   TestAccFastlyServiceV1WAFAddAndRemove
    === PAUSE TestAccFastlyServiceV1WAFAddAndRemove
    === CONT  TestAccFastlyServiceV1WAFAddAndRemove
    --- PASS: TestAccFastlyServiceV1WAFAddAndRemove (341.10s)
    === RUN   TestAccFastlyServiceAclEntriesV1_update
    --- PASS: TestAccFastlyServiceAclEntriesV1_update (231.41s)
    === RUN   TestAccFastlyServiceWAFVersionV1AddUpdateDeleteExclusions
    === PAUSE TestAccFastlyServiceWAFVersionV1AddUpdateDeleteExclusions
    === CONT  TestAccFastlyServiceWAFVersionV1AddUpdateDeleteExclusions
    --- PASS: TestAccFastlyServiceWAFVersionV1AddUpdateDeleteExclusions (222.55s)
    === RUN   TestResourceFastlyFlattenBackendCompute
    --- PASS: TestResourceFastlyFlattenBackendCompute (0.00s)
    === RUN   TestAccFastlyServiceCompute_basic
    --- PASS: TestAccFastlyServiceCompute_basic (17.15s)
    === RUN   TestAccFastlyServiceWAFVersionV1AddUpdateDeleteRules
    === PAUSE TestAccFastlyServiceWAFVersionV1AddUpdateDeleteRules
    === CONT  TestAccFastlyServiceWAFVersionV1AddUpdateDeleteRules
    --- PASS: TestAccFastlyServiceWAFVersionV1AddUpdateDeleteRules (327.49s)
    === RUN   TestResourceFastlyFlattenDictionaryItems
    --- PASS: TestResourceFastlyFlattenDictionaryItems (0.00s)
    === RUN   TestAccFastlyServiceAclEntriesV1_update_additional_fields
    --- PASS: TestAccFastlyServiceAclEntriesV1_update_additional_fields (204.40s)
    === RUN   TestAccFastlyServiceCompute_import
    --- PASS: TestAccFastlyServiceCompute_import (47.24s)
    === RUN   TestAccFastlyServiceAclEntriesV1_import
    --- PASS: TestAccFastlyServiceAclEntriesV1_import (101.33s)
    === RUN   TestAccFastlyServiceAclEntriesV1_delete
    --- PASS: TestAccFastlyServiceAclEntriesV1_delete (220.14s)
    === RUN   TestAccFastlyServiceDictionaryItemV1_create
    --- PASS: TestAccFastlyServiceDictionaryItemV1_create (106.02s)
    === RUN   TestAccFastlyServiceAclEntriesV1_process_1001_entries
    --- PASS: TestAccFastlyServiceAclEntriesV1_process_1001_entries (149.49s)
    === RUN   TestAccFastlyServiceDictionaryItemV1_create_dynamic
    --- PASS: TestAccFastlyServiceDictionaryItemV1_create_dynamic (124.61s)
    === RUN   TestAccFastlyServiceDictionaryItemV1_import
    --- PASS: TestAccFastlyServiceDictionaryItemV1_import (122.83s)
    === RUN   TestAccFastlyServiceDictionaryItemV1_external_item_is_removed
    --- PASS: TestAccFastlyServiceDictionaryItemV1_external_item_is_removed (188.31s)
    === RUN   TestAccFastlyServiceDictionaryItemV1_batch_1001_items
    --- PASS: TestAccFastlyServiceDictionaryItemV1_batch_1001_items (140.44s)
    === RUN   TestAccFastlyServiceDynamicSnippetContentV1_create
    --- PASS: TestAccFastlyServiceDynamicSnippetContentV1_create (120.82s)
    === RUN   TestAccFastlyServiceDynamicSnippetContentV1_import
    --- PASS: TestAccFastlyServiceDynamicSnippetContentV1_import (78.76s)
    === RUN   TestResourceFastlyFlattenDomains
    --- PASS: TestResourceFastlyFlattenDomains (0.00s)
    === RUN   TestResourceFastlyFlattenBackend
    --- PASS: TestResourceFastlyFlattenBackend (0.00s)
    === RUN   TestAccFastlyServiceV1_updateDomain
    --- PASS: TestAccFastlyServiceV1_updateDomain (139.53s)
    === RUN   TestAccFastlyServiceV1_updateBackend
    --- PASS: TestAccFastlyServiceV1_updateBackend (138.79s)
    === RUN   TestAccFastlyServiceDictionaryItemV1_update
    --- PASS: TestAccFastlyServiceDictionaryItemV1_update (253.22s)
    === RUN   TestAccFastlyServiceDictionaryItemV1_external_item_deleted
    --- PASS: TestAccFastlyServiceDictionaryItemV1_external_item_deleted (238.24s)
    === RUN   TestAccFastlyServiceV1_disappears
    --- PASS: TestAccFastlyServiceV1_disappears (34.69s)
    === RUN   TestAccFastlyServiceV1_updateInvalidBackend
    --- PASS: TestAccFastlyServiceV1_updateInvalidBackend (119.37s)
    === RUN   TestAccFastlyServiceDynamicSnippetContentV1_update
    --- PASS: TestAccFastlyServiceDynamicSnippetContentV1_update (217.31s)
    === RUN   TestAccFastlyServiceDynamicSnippetContentV1_normal_snippet_is_not_removed
    --- PASS: TestAccFastlyServiceDynamicSnippetContentV1_normal_snippet_is_not_removed (249.02s)
    === RUN   TestAccFastlyServiceDynamicSnippetContentV1_external_snippet_is_removed
    --- PASS: TestAccFastlyServiceDynamicSnippetContentV1_external_snippet_is_removed (252.57s)
    === RUN   TestAccFastlyServiceV1_createDefaultTTL
    --- PASS: TestAccFastlyServiceV1_createDefaultTTL (119.13s)
    === RUN   TestAccFastlyServiceWAFVersionV1DetermineVersion
    --- PASS: TestAccFastlyServiceWAFVersionV1DetermineVersion (0.00s)
    === RUN   TestAccFastlyServiceV1_basic
    --- PASS: TestAccFastlyServiceV1_basic (210.38s)
    === RUN   TestAccFastlyServiceV1_createZeroDefaultTTL
    --- PASS: TestAccFastlyServiceV1_createZeroDefaultTTL (109.20s)
    === RUN   TestAccFastlyServiceV1_creation_with_versionless_resources
    --- PASS: TestAccFastlyServiceV1_creation_with_versionless_resources (125.94s)
    === RUN   TestAccFastlyServiceV1_import
    --- PASS: TestAccFastlyServiceV1_import (160.55s)
    === RUN   TestAccFastlyServiceV1_defaultTTL
    --- PASS: TestAccFastlyServiceV1_defaultTTL (328.86s)
    === RUN   TestAccFastlyUserV1_basic
    --- PASS: TestAccFastlyUserV1_basic (12.14s)
    === RUN   TestAccFastlyUserV1_updateLogin
    --- PASS: TestAccFastlyUserV1_updateLogin (12.28s)
    === RUN   TestAccFastlyServiceWAFVersionDeploymentStatus
    === RUN   TestAccFastlyServiceWAFVersionDeploymentStatus/Status_
    === RUN   TestAccFastlyServiceWAFVersionDeploymentStatus/Status_failed
    === RUN   TestAccFastlyServiceWAFVersionDeploymentStatus/Status_completed
    --- PASS: TestAccFastlyServiceWAFVersionDeploymentStatus (0.41s)
        --- PASS: TestAccFastlyServiceWAFVersionDeploymentStatus/Status_ (0.00s)
        --- PASS: TestAccFastlyServiceWAFVersionDeploymentStatus/Status_failed (0.00s)
        --- PASS: TestAccFastlyServiceWAFVersionDeploymentStatus/Status_completed (0.41s)
    === RUN   TestValidateLoggingFormatVersion
    === RUN   TestValidateLoggingFormatVersion/0
    === RUN   TestValidateLoggingFormatVersion/1
    === RUN   TestValidateLoggingFormatVersion/2
    === RUN   TestValidateLoggingFormatVersion/3
    === RUN   TestValidateLoggingFormatVersion/4
    === RUN   TestValidateLoggingFormatVersion/5
    --- PASS: TestValidateLoggingFormatVersion (0.00s)
        --- PASS: TestValidateLoggingFormatVersion/0 (0.00s)
        --- PASS: TestValidateLoggingFormatVersion/1 (0.00s)
        --- PASS: TestValidateLoggingFormatVersion/2 (0.00s)
        --- PASS: TestValidateLoggingFormatVersion/3 (0.00s)
        --- PASS: TestValidateLoggingFormatVersion/4 (0.00s)
        --- PASS: TestValidateLoggingFormatVersion/5 (0.00s)
    === RUN   TestValidateLoggingMessageType
    === RUN   TestValidateLoggingMessageType/classic
    === RUN   TestValidateLoggingMessageType/loggly
    === RUN   TestValidateLoggingMessageType/logplex
    === RUN   TestValidateLoggingMessageType/blank
    === RUN   TestValidateLoggingMessageType/CLASSIC
    === RUN   TestValidateLoggingMessageType/LOGGLY
    === RUN   TestValidateLoggingMessageType/LOGPLEX
    === RUN   TestValidateLoggingMessageType/BLANK
    --- PASS: TestValidateLoggingMessageType (0.00s)
        --- PASS: TestValidateLoggingMessageType/classic (0.00s)
        --- PASS: TestValidateLoggingMessageType/loggly (0.00s)
        --- PASS: TestValidateLoggingMessageType/logplex (0.00s)
        --- PASS: TestValidateLoggingMessageType/blank (0.00s)
        --- PASS: TestValidateLoggingMessageType/CLASSIC (0.00s)
        --- PASS: TestValidateLoggingMessageType/LOGGLY (0.00s)
        --- PASS: TestValidateLoggingMessageType/LOGPLEX (0.00s)
        --- PASS: TestValidateLoggingMessageType/BLANK (0.00s)
    === RUN   TestValidateLoggingPlacement
    === RUN   TestValidateLoggingPlacement/none
    === RUN   TestValidateLoggingPlacement/waf_debug
    === RUN   TestValidateLoggingPlacement/NONE
    === RUN   TestValidateLoggingPlacement/WAF_DEBUG
    --- PASS: TestValidateLoggingPlacement (0.00s)
        --- PASS: TestValidateLoggingPlacement/none (0.00s)
        --- PASS: TestValidateLoggingPlacement/waf_debug (0.00s)
        --- PASS: TestValidateLoggingPlacement/NONE (0.00s)
        --- PASS: TestValidateLoggingPlacement/WAF_DEBUG (0.00s)
    === RUN   TestValidateLoggingServerSideEncryption
    === RUN   TestValidateLoggingServerSideEncryption/AES256
    === RUN   TestValidateLoggingServerSideEncryption/aws:kms
    === RUN   TestValidateLoggingServerSideEncryption/aes256
    === RUN   TestValidateLoggingServerSideEncryption/AWS:KMS
    === RUN   TestValidateLoggingServerSideEncryption/aws:KMS
    === RUN   TestValidateLoggingServerSideEncryption/AWS:kms
    --- PASS: TestValidateLoggingServerSideEncryption (0.00s)
        --- PASS: TestValidateLoggingServerSideEncryption/AES256 (0.00s)
        --- PASS: TestValidateLoggingServerSideEncryption/aws:kms (0.00s)
        --- PASS: TestValidateLoggingServerSideEncryption/aes256 (0.00s)
        --- PASS: TestValidateLoggingServerSideEncryption/AWS:KMS (0.00s)
        --- PASS: TestValidateLoggingServerSideEncryption/aws:KMS (0.00s)
        --- PASS: TestValidateLoggingServerSideEncryption/AWS:kms (0.00s)
    === RUN   TestValidateDirectorQuorum
    === RUN   TestValidateDirectorQuorum/100
    === RUN   TestValidateDirectorQuorum/-1
    === RUN   TestValidateDirectorQuorum/101
    === RUN   TestValidateDirectorQuorum/150
    === RUN   TestValidateDirectorQuorum/0
    === RUN   TestValidateDirectorQuorum/55
    --- PASS: TestValidateDirectorQuorum (0.00s)
        --- PASS: TestValidateDirectorQuorum/100 (0.00s)
        --- PASS: TestValidateDirectorQuorum/-1 (0.00s)
        --- PASS: TestValidateDirectorQuorum/101 (0.00s)
        --- PASS: TestValidateDirectorQuorum/150 (0.00s)
        --- PASS: TestValidateDirectorQuorum/0 (0.00s)
        --- PASS: TestValidateDirectorQuorum/55 (0.00s)
    === RUN   TestValidateDirectorType
    === RUN   TestValidateDirectorType/3
    === RUN   TestValidateDirectorType/4
    === RUN   TestValidateDirectorType/5
    === RUN   TestValidateDirectorType/0
    === RUN   TestValidateDirectorType/1
    === RUN   TestValidateDirectorType/2
    --- PASS: TestValidateDirectorType (0.00s)
        --- PASS: TestValidateDirectorType/3 (0.00s)
        --- PASS: TestValidateDirectorType/4 (0.00s)
        --- PASS: TestValidateDirectorType/5 (0.00s)
        --- PASS: TestValidateDirectorType/0 (0.00s)
        --- PASS: TestValidateDirectorType/1 (0.00s)
        --- PASS: TestValidateDirectorType/2 (0.00s)
    === RUN   TestValidateConditionType
    === RUN   TestValidateConditionType/REQUEST
    === RUN   TestValidateConditionType/RESPONSE
    === RUN   TestValidateConditionType/CACHE
    === RUN   TestValidateConditionType/PREFETCH
    === RUN   TestValidateConditionType/request
    === RUN   TestValidateConditionType/response
    === RUN   TestValidateConditionType/cache
    === RUN   TestValidateConditionType/prefetch
    --- PASS: TestValidateConditionType (0.00s)
        --- PASS: TestValidateConditionType/REQUEST (0.00s)
        --- PASS: TestValidateConditionType/RESPONSE (0.00s)
        --- PASS: TestValidateConditionType/CACHE (0.00s)
        --- PASS: TestValidateConditionType/PREFETCH (0.00s)
        --- PASS: TestValidateConditionType/request (0.00s)
        --- PASS: TestValidateConditionType/response (0.00s)
        --- PASS: TestValidateConditionType/cache (0.00s)
        --- PASS: TestValidateConditionType/prefetch (0.00s)
    === RUN   TestValidateHeaderAction
    === RUN   TestValidateHeaderAction/set
    === RUN   TestValidateHeaderAction/append
    === RUN   TestValidateHeaderAction/delete
    === RUN   TestValidateHeaderAction/regex
    === RUN   TestValidateHeaderAction/regex_repeat
    === RUN   TestValidateHeaderAction/SET
    === RUN   TestValidateHeaderAction/APPEND
    === RUN   TestValidateHeaderAction/DELETE
    === RUN   TestValidateHeaderAction/REGEX
    === RUN   TestValidateHeaderAction/REGEX_REPEAT
    --- PASS: TestValidateHeaderAction (0.00s)
        --- PASS: TestValidateHeaderAction/set (0.00s)
        --- PASS: TestValidateHeaderAction/append (0.00s)
        --- PASS: TestValidateHeaderAction/delete (0.00s)
        --- PASS: TestValidateHeaderAction/regex (0.00s)
        --- PASS: TestValidateHeaderAction/regex_repeat (0.00s)
        --- PASS: TestValidateHeaderAction/SET (0.00s)
        --- PASS: TestValidateHeaderAction/APPEND (0.00s)
        --- PASS: TestValidateHeaderAction/DELETE (0.00s)
        --- PASS: TestValidateHeaderAction/REGEX (0.00s)
        --- PASS: TestValidateHeaderAction/REGEX_REPEAT (0.00s)
    === RUN   TestAccFastlyServiceWAFVersionV1Add
    === PAUSE TestAccFastlyServiceWAFVersionV1Add
    === CONT  TestAccFastlyServiceWAFVersionV1Add
    --- PASS: TestAccFastlyServiceWAFVersionV1Add (180.67s)
    === RUN   TestValidateHeaderType
    === RUN   TestValidateHeaderType/request
    === RUN   TestValidateHeaderType/fetch
    === RUN   TestValidateHeaderType/cache
    === RUN   TestValidateHeaderType/response
    === RUN   TestValidateHeaderType/REQUEST
    === RUN   TestValidateHeaderType/FETCH
    === RUN   TestValidateHeaderType/CACHE
    === RUN   TestValidateHeaderType/RESPONSE
    --- PASS: TestValidateHeaderType (0.00s)
        --- PASS: TestValidateHeaderType/request (0.00s)
        --- PASS: TestValidateHeaderType/fetch (0.00s)
        --- PASS: TestValidateHeaderType/cache (0.00s)
        --- PASS: TestValidateHeaderType/response (0.00s)
        --- PASS: TestValidateHeaderType/REQUEST (0.00s)
        --- PASS: TestValidateHeaderType/FETCH (0.00s)
        --- PASS: TestValidateHeaderType/CACHE (0.00s)
        --- PASS: TestValidateHeaderType/RESPONSE (0.00s)
    === RUN   TestValidateRuleStatusType
    === RUN   TestValidateRuleStatusType/log
    === RUN   TestValidateRuleStatusType/block
    === RUN   TestValidateRuleStatusType/score
    === RUN   TestValidateRuleStatusType/123
    === RUN   TestValidateRuleStatusType/any
    === RUN   TestValidateRuleStatusType/???
    --- PASS: TestValidateRuleStatusType (0.00s)
        --- PASS: TestValidateRuleStatusType/log (0.00s)
        --- PASS: TestValidateRuleStatusType/block (0.00s)
        --- PASS: TestValidateRuleStatusType/score (0.00s)
        --- PASS: TestValidateRuleStatusType/123 (0.00s)
        --- PASS: TestValidateRuleStatusType/any (0.00s)
        --- PASS: TestValidateRuleStatusType/??? (0.00s)
    === RUN   TestValidateSnippetType
    === RUN   TestValidateSnippetType/init
    === RUN   TestValidateSnippetType/recv
    === RUN   TestValidateSnippetType/hit
    === RUN   TestValidateSnippetType/miss
    === RUN   TestValidateSnippetType/pass
    === RUN   TestValidateSnippetType/hash
    === RUN   TestValidateSnippetType/fetch
    === RUN   TestValidateSnippetType/error
    === RUN   TestValidateSnippetType/deliver
    === RUN   TestValidateSnippetType/log
    === RUN   TestValidateSnippetType/none
    === RUN   TestValidateSnippetType/INIT
    === RUN   TestValidateSnippetType/RECV
    === RUN   TestValidateSnippetType/HIT
    === RUN   TestValidateSnippetType/MISS
    === RUN   TestValidateSnippetType/PASS
    === RUN   TestValidateSnippetType/FETCH
    === RUN   TestValidateSnippetType/HASH
    === RUN   TestValidateSnippetType/ERROR
    === RUN   TestValidateSnippetType/DELIVER
    === RUN   TestValidateSnippetType/LOG
    === RUN   TestValidateSnippetType/NONE
    --- PASS: TestValidateSnippetType (0.00s)
        --- PASS: TestValidateSnippetType/init (0.00s)
        --- PASS: TestValidateSnippetType/recv (0.00s)
        --- PASS: TestValidateSnippetType/hit (0.00s)
        --- PASS: TestValidateSnippetType/miss (0.00s)
        --- PASS: TestValidateSnippetType/pass (0.00s)
        --- PASS: TestValidateSnippetType/hash (0.00s)
        --- PASS: TestValidateSnippetType/fetch (0.00s)
        --- PASS: TestValidateSnippetType/error (0.00s)
        --- PASS: TestValidateSnippetType/deliver (0.00s)
        --- PASS: TestValidateSnippetType/log (0.00s)
        --- PASS: TestValidateSnippetType/none (0.00s)
        --- PASS: TestValidateSnippetType/INIT (0.00s)
        --- PASS: TestValidateSnippetType/RECV (0.00s)
        --- PASS: TestValidateSnippetType/HIT (0.00s)
        --- PASS: TestValidateSnippetType/MISS (0.00s)
        --- PASS: TestValidateSnippetType/PASS (0.00s)
        --- PASS: TestValidateSnippetType/FETCH (0.00s)
        --- PASS: TestValidateSnippetType/HASH (0.00s)
        --- PASS: TestValidateSnippetType/ERROR (0.00s)
        --- PASS: TestValidateSnippetType/DELIVER (0.00s)
        --- PASS: TestValidateSnippetType/LOG (0.00s)
        --- PASS: TestValidateSnippetType/NONE (0.00s)
    === RUN   TestValidateDictionaryItemMaxSize
    === RUN   TestValidateDictionaryItemMaxSize/Ten_hundred_dictionary_items
    === RUN   TestValidateDictionaryItemMaxSize/Ten_thousand_dictionary_items
    === RUN   TestValidateDictionaryItemMaxSize/Ten_thousand_and_one_dictionary_items
    --- PASS: TestValidateDictionaryItemMaxSize (0.02s)
        --- PASS: TestValidateDictionaryItemMaxSize/Ten_hundred_dictionary_items (0.00s)
        --- PASS: TestValidateDictionaryItemMaxSize/Ten_thousand_dictionary_items (0.00s)
        --- PASS: TestValidateDictionaryItemMaxSize/Ten_thousand_and_one_dictionary_items (0.00s)
    === RUN   TestValidateUserRole
    === RUN   TestValidateUserRole/user
    === RUN   TestValidateUserRole/billing
    === RUN   TestValidateUserRole/engineer
    === RUN   TestValidateUserRole/superuser
    === RUN   TestValidateUserRole/USER
    === RUN   TestValidateUserRole/BILLING
    === RUN   TestValidateUserRole/ENGINEER
    === RUN   TestValidateUserRole/SUPERUSER
    --- PASS: TestValidateUserRole (0.00s)
        --- PASS: TestValidateUserRole/user (0.00s)
        --- PASS: TestValidateUserRole/billing (0.00s)
        --- PASS: TestValidateUserRole/engineer (0.00s)
        --- PASS: TestValidateUserRole/superuser (0.00s)
        --- PASS: TestValidateUserRole/USER (0.00s)
        --- PASS: TestValidateUserRole/BILLING (0.00s)
        --- PASS: TestValidateUserRole/ENGINEER (0.00s)
        --- PASS: TestValidateUserRole/SUPERUSER (0.00s)
    === RUN   TestValidateHTTPSURL
    === RUN   TestValidateHTTPSURL/https://api.fastly.com
    === RUN   TestValidateHTTPSURL/http://example.com
    --- PASS: TestValidateHTTPSURL (0.00s)
        --- PASS: TestValidateHTTPSURL/https://api.fastly.com (0.00s)
        --- PASS: TestValidateHTTPSURL/http://example.com (0.00s)
    === RUN   TestAccFastlyServiceWAFVersionV1AddExistingService
    === PAUSE TestAccFastlyServiceWAFVersionV1AddExistingService
    === CONT  TestAccFastlyServiceWAFVersionV1AddExistingService
    --- PASS: TestAccFastlyServiceWAFVersionV1AddExistingService (252.23s)
    === RUN   TestAccFastlyServiceWAFVersionV1Delete
    === PAUSE TestAccFastlyServiceWAFVersionV1Delete
    === CONT  TestAccFastlyServiceWAFVersionV1Delete
    --- PASS: TestAccFastlyServiceWAFVersionV1Delete (174.47s)
    === RUN   TestAccFastlyServiceWAFVersionV1Import
    === PAUSE TestAccFastlyServiceWAFVersionV1Import
    === CONT  TestAccFastlyServiceWAFVersionV1Import
    --- PASS: TestAccFastlyServiceWAFVersionV1Import (166.27s)
    === RUN   TestAccFastlyServiceWAFVersionV1Update
    === PAUSE TestAccFastlyServiceWAFVersionV1Update
    === CONT  TestAccFastlyServiceWAFVersionV1Update
    --- PASS: TestAccFastlyServiceWAFVersionV1Update (259.11s)

</details>
