### PR TITLE
Guard WAF rule_exclusion read 

### DIFF
--- a/fastly/resource_fastly_service_waf_configuration.go
+++ b/fastly/resource_fastly_service_waf_configuration.go
@@ -299,8 +299,14 @@ func resourceServiceWAFConfigurationV1Read(d *schema.ResourceData, meta interfac
 		return err
 	}
 
-	if err := readWAFRuleExclusions(meta, d, latestVersion.Number); err != nil {
-		return err
+	// As the rule exclusion API is still behind a beta feature
+	// flag, ensure we only read if the Set is non-empty.
+	//
+	// TODO(phamann): Remove d.GetOk() guard once in limited availability.
+	if _, ok := d.GetOk("rule_exclusion"); ok {
+		if err := readWAFRuleExclusions(meta, d, latestVersion.Number); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/website/docs/r/service_waf_configuration.html.markdown
+++ b/website/docs/r/service_waf_configuration.html.markdown
@@ -136,6 +136,8 @@ resource "fastly_service_waf_configuration" "waf" {
 
 Usage with rule exclusions:
 
+~> **Warning:** Rule exclusions are part of a **beta release**, which may be subject to breaking changes and improvements over time. For more information, see our [product and feature lifecycle](https://docs.fastly.com/products/fastly-product-lifecycle#beta) descriptions.
+
 ```hcl
 resource "fastly_service_v1" "demo" {
   name = "demofastly"
@@ -599,13 +601,12 @@ The `rule` block supports:
 
 The `rule_exclusion` block supports:
 
+~> **Warning:** Rule exclusions are part of a **beta release**, which may be subject to breaking changes and improvements over time. For more information, see our [product and feature lifecycle](https://docs.fastly.com/products/fastly-product-lifecycle#beta) descriptions.
+
 * `name` - (Required) The name of rule exclusion.
 * `exclusion_type` - (Required) The type of rule exclusion. Values are `rule` to exclude the specified rule(s), or `waf` to disable the Web Application Firewall.
 * `condition` - (Required) A conditional expression in VCL used to determine if the condition is met.
 * `modsec_rule_ids` - (Required) Set of modsecurity IDs to be excluded. No rules should be provided when `exclusion_type` is `waf`. The rules need to be configured on the Web Application Firewall to be excluded.
-
-The `rule_exclusion` block exports:
-
 * `number` - The numeric ID assigned to the WAF Rule Exclusion.
 
 ## Import

--- a/website_src/docs/r/service_waf_configuration.html.markdown.tmpl
+++ b/website_src/docs/r/service_waf_configuration.html.markdown.tmpl
@@ -136,6 +136,8 @@ resource "fastly_service_waf_configuration" "waf" {
 
 Usage with rule exclusions:
 
+~> **Warning:** Rule exclusions are part of a **beta release**, which may be subject to breaking changes and improvements over time. For more information, see our [product and feature lifecycle](https://docs.fastly.com/products/fastly-product-lifecycle#beta) descriptions.
+
 ```hcl
 resource "fastly_service_v1" "demo" {
   name = "demofastly"
@@ -599,13 +601,12 @@ The `rule` block supports:
 
 The `rule_exclusion` block supports:
 
+~> **Warning:** Rule exclusions are part of a **beta release**, which may be subject to breaking changes and improvements over time. For more information, see our [product and feature lifecycle](https://docs.fastly.com/products/fastly-product-lifecycle#beta) descriptions.
+
 * `name` - (Required) The name of rule exclusion.
 * `exclusion_type` - (Required) The type of rule exclusion. Values are `rule` to exclude the specified rule(s), or `waf` to disable the Web Application Firewall.
 * `condition` - (Required) A conditional expression in VCL used to determine if the condition is met.
 * `modsec_rule_ids` - (Required) Set of modsecurity IDs to be excluded. No rules should be provided when `exclusion_type` is `waf`. The rules need to be configured on the Web Application Firewall to be excluded.
-
-The `rule_exclusion` block exports:
-
 * `number` - The numeric ID assigned to the WAF Rule Exclusion.
 
 ## Import


### PR DESCRIPTION
### TL;DR
As part of the [v0.21.0](https://github.com/fastly/terraform-provider-fastly/releases/tag/v0.21.0) release we introduced the new `rule_exclusion` block to the [`fastly_service_waf_configuration`](https://registry.terraform.io/providers/fastly/fastly/latest/docs/resources/service_waf_configuration) resource which is causing errors for existing users of the resource - this PR attempts to fix the error with a temporary guard.

### Why?
The Fastly API backing this feature is still in "beta" and therefore behind a feature flag, users without the flag enabled on their account will see a 403 error when trying to plan/apply their `fastly_service_waf_configuration` due to the read phase always calling the UI. Until the feature moves to "limited availability" we have decided to roll-forwards and guard the read with a `d.GetOK()` check to validate the configuration includes the block before attempting to read. We have also updated the documentation to note the feature is still in beta. 