### PR TITLE
Update CHANGELOG.md for v0.21.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## 0.22.0 (Unreleased)
 
+## 0.21.1 (October 15, 2020)
+
+BUG FIXES:
+
+* resource/fastly_service_waf_configuration: Guard `rule_exclusion` read to ensure API is only called if used. ([#330](https://github.com/fastly/terraform-provider-fastly/pull/330))
+
 ## 0.21.0 (October 14, 2020)
 
 ENHANCEMENTS:


### PR DESCRIPTION
### TL;DR
Updates the CHANGELOG.md for the v0.21.1 release. Which includes:

- #330 Guard WAF rule_extension read.