### PR TITLE
Correct IP range example

### DIFF
--- a/website/docs/d/ip_ranges.html.markdown
+++ b/website/docs/d/ip_ranges.html.markdown
@@ -22,8 +22,8 @@ resource "aws_security_group" "from_fastly" {
     from_port         = "443"
     to_port           = "443"
     protocol          = "tcp"
-    cidr_blocks       = ["${data.fastly_ip_ranges.fastly.cidr_blocks}"]
-    ipv6_cidr_blocks  = ["${data.fastly_ip_ranges.fastly.ipv6_cidr_blocks}"]
+    cidr_blocks       = data.fastly_ip_ranges.fastly.cidr_blocks
+    ipv6_cidr_blocks  = data.fastly_ip_ranges.fastly.ipv6_cidr_blocks
   }
 }
 ```


### PR DESCRIPTION
Correct the example for `fastly_ip_ranges` datasource. `cidr_blocks` is expecting a list of strings but the example passes a list of a list of strings and that leads to this error:

`Inappropriate value for attribute "cidr_blocks": element 0: string required`

It works once I removed the extra list.