### PR TITLE
Fix link rendering on documentation index

### DIFF
--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -16,8 +16,8 @@ Pricing and signup information can be found at https://www.fastly.com/signup
 
 Use the navigation to the left to read about the available resources.
 
-The Fastly provider prior to version v0.13.0 requires using [--parallelism=1]
-(/docs/commands/apply.html#parallelism-n) for `apply` operations.
+The Fastly provider prior to version v0.13.0 requires using
+[--parallelism=1](/docs/commands/apply.html#parallelism-n) for `apply` operations.
 
 ## Example Usage
 


### PR DESCRIPTION
- cannot have a line break within Markdown link code; it will prevent rendering:
![image](https://user-images.githubusercontent.com/119839/98395441-1bed4700-2011-11eb-8a60-42a90482ce21.png)

- tested correction using https://registry.terraform.io/tools/doc-preview 
![image](https://user-images.githubusercontent.com/119839/98395470-26a7dc00-2011-11eb-8623-45228dcffb0a.png)
