### PR TITLE
Add support for kafka endpoints with sasl options

### DIFF
--- a/fastly/block_fastly_service_v1_logging_kafka.go
+++ b/fastly/block_fastly_service_v1_logging_kafka.go
@@ -53,7 +53,7 @@ func (h *KafkaServiceAttributeHandler) Register(s *schema.Resource) error {
 		"required_acks": {
 			Type:     schema.TypeString,
 			Optional: true,
-			Description: "The Number of acknowledgements blockAttributes leader must receive before blockAttributes write is considered successful. One of: 1 (default) One server needs to respond. 0 No servers need to respond. -1	Wait for all in-sync replicas to respond.",
+			Description: "The Number of acknowledgements a leader must receive before a write is considered successful. One of: 1 (default) One server needs to respond. 0 No servers need to respond. -1	Wait for all in-sync replicas to respond.",
 		},
 
 		"use_tls": {
@@ -93,38 +93,38 @@ func (h *KafkaServiceAttributeHandler) Register(s *schema.Resource) error {
 		"tls_hostname": {
 			Type:        schema.TypeString,
 			Optional:    true,
-			Description: "The hostname used to verify the server's certificate. It can either be the Common Name or blockAttributes Subject Alternative Name (SAN).",
+			Description: "The hostname used to verify the server's certificate. It can either be the Common Name or a Subject Alternative Name (SAN).",
 		},
 
 		"parse_log_keyvals": {
 			Type:        schema.TypeBool,
 			Optional:    true,
 			Default:     false,
-			Description: "Parse key-value pairs within the log formatWhether to use TLS for secure logging.",
+			Description: "Enables parsing of key=value tuples from the beginning of a logline, turning them into record headers.",
 		},
 
-		"max_batch_size": {
+		"request_max_bytes": {
 			Type:        schema.TypeInt,
 			Optional:    true,
-			Description: "The maximum size of the log batch in bytes.",
+			Description: "Maximum size of log batch, if non-zero. Defaults to 0 for unbounded.",
 		},
 
 		"auth_method": {
 			Type:        schema.TypeString,
 			Optional:    true,
-			Description: "SASL authentication method. Valid values are: plain, scram-sha-256, scram-sha-512.",
+			Description: "SASL authentication method. One of: plain, scram-sha-256, scram-sha-512.",
 		},
 
 		"username": {
 			Type:        schema.TypeString,
 			Optional:    true,
-			Description: "SASL authentication username",
+			Description: "SASL User.",
 		},
 
 		"password": {
 			Type:        schema.TypeString,
 			Optional:    true,
-			Description: "SASL authentication password",
+			Description: "SASL Pass.",
 		},
 	}
 
@@ -283,7 +283,7 @@ func flattenKafka(kafkaList []*gofastly.Kafka) []map[string]interface{} {
 			"placement":          s.Placement,
 			"response_condition": s.ResponseCondition,
 			"parse_log_keyvals":  s.ParseLogKeyvals,
-			"max_batch_size":     s.RequestMaxBytes,
+			"request_max_bytes":  s.RequestMaxBytes,
 			"auth_method":        s.AuthMethod,
 			"username":           s.User,
 			"password":           s.Password,
@@ -324,7 +324,7 @@ func (h *KafkaServiceAttributeHandler) buildCreate(kafkaMap interface{}, service
 		Placement:         gofastly.NullString(vla.placement),
 		ResponseCondition: gofastly.NullString(vla.responseCondition),
 		ParseLogKeyvals:   fastly.CBool(df["parse_log_keyvals"].(bool)),
-		RequestMaxBytes:   fastly.Uint(uint(df["max_batch_size"].(int))),
+		RequestMaxBytes:   fastly.Uint(uint(df["request_max_bytes"].(int))),
 		AuthMethod:        fastly.NullString(df["auth_method"].(string)),
 		User:              fastly.NullString(df["username"].(string)),
 		Password:          fastly.NullString(df["password"].(string)),

--- a/fastly/block_fastly_service_v1_logging_kafka.go
+++ b/fastly/block_fastly_service_v1_logging_kafka.go
@@ -115,7 +115,7 @@ func (h *KafkaServiceAttributeHandler) Register(s *schema.Resource) error {
 			Description: "SASL authentication method. One of: plain, scram-sha-256, scram-sha-512.",
 		},
 
-		"username": {
+		"user": {
 			Type:        schema.TypeString,
 			Optional:    true,
 			Description: "SASL User.",
@@ -285,7 +285,7 @@ func flattenKafka(kafkaList []*gofastly.Kafka) []map[string]interface{} {
 			"parse_log_keyvals":  s.ParseLogKeyvals,
 			"request_max_bytes":  s.RequestMaxBytes,
 			"auth_method":        s.AuthMethod,
-			"username":           s.User,
+			"user":               s.User,
 			"password":           s.Password,
 		}
 
@@ -326,7 +326,7 @@ func (h *KafkaServiceAttributeHandler) buildCreate(kafkaMap interface{}, service
 		ParseLogKeyvals:   fastly.CBool(df["parse_log_keyvals"].(bool)),
 		RequestMaxBytes:   fastly.Uint(uint(df["request_max_bytes"].(int))),
 		AuthMethod:        fastly.NullString(df["auth_method"].(string)),
-		User:              fastly.NullString(df["username"].(string)),
+		User:              fastly.NullString(df["user"].(string)),
 		Password:          fastly.NullString(df["password"].(string)),
 	}
 }

--- a/fastly/block_fastly_service_v1_logging_kafka.go
+++ b/fastly/block_fastly_service_v1_logging_kafka.go
@@ -95,6 +95,37 @@ func (h *KafkaServiceAttributeHandler) Register(s *schema.Resource) error {
 			Optional:    true,
 			Description: "The hostname used to verify the server's certificate. It can either be the Common Name or blockAttributes Subject Alternative Name (SAN).",
 		},
+
+		"parse_log_keyvals": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Default:     false,
+			Description: "Parse key-value pairs within the log formatWhether to use TLS for secure logging.",
+		},
+
+		"max_batch_size": {
+			Type:        schema.TypeInt,
+			Optional:    true,
+			Description: "The maximum size of the log batch in bytes.",
+		},
+
+		"auth_method": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "SASL authentication method. Valid values are: plain, scram-sha-256, scram-sha-512.",
+		},
+
+		"username": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "SASL authentication username",
+		},
+
+		"password": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "SASL authentication password",
+		},
 	}
 
 	if h.GetServiceMetadata().serviceType == ServiceTypeVCL {
@@ -251,6 +282,11 @@ func flattenKafka(kafkaList []*gofastly.Kafka) []map[string]interface{} {
 			"format_version":     s.FormatVersion,
 			"placement":          s.Placement,
 			"response_condition": s.ResponseCondition,
+			"parse_log_keyvals":  s.ParseLogKeyvals,
+			"max_batch_size":     s.RequestMaxBytes,
+			"auth_method":        s.AuthMethod,
+			"username":           s.User,
+			"password":           s.Password,
 		}
 
 		// prune any empty values that come from the default string value in structs
@@ -287,6 +323,11 @@ func (h *KafkaServiceAttributeHandler) buildCreate(kafkaMap interface{}, service
 		FormatVersion:     vla.formatVersion,
 		Placement:         gofastly.NullString(vla.placement),
 		ResponseCondition: gofastly.NullString(vla.responseCondition),
+		ParseLogKeyvals:   fastly.CBool(df["parse_log_keyvals"].(bool)),
+		RequestMaxBytes:   fastly.Uint(uint(df["max_batch_size"].(int))),
+		AuthMethod:        fastly.NullString(df["auth_method"].(string)),
+		User:              fastly.NullString(df["username"].(string)),
+		Password:          fastly.NullString(df["password"].(string)),
 	}
 }
 

--- a/fastly/block_fastly_service_v1_logging_kafka_test.go
+++ b/fastly/block_fastly_service_v1_logging_kafka_test.go
@@ -59,7 +59,7 @@ func TestResourceFastlyFlattenKafka(t *testing.T) {
 					"placement":          "none",
 					"format_version":     uint(2),
 					"parse_log_keyvals":  true,
-					"max_batch_size":     uint(12345),
+					"request_max_bytes":  uint(12345),
 					"auth_method":        "scram-sha-512",
 					"username":           "user",
 					"password":           "password",
@@ -353,7 +353,7 @@ resource "fastly_service_v1" "foo" {
 		format_version     = 2
 		placement          = "none"
 		parse_log_keyvals  = true
-		max_batch_size     = 12345
+		request_max_bytes  = 12345
 		auth_method        = "plain"
 		username           = "user"
 		password           = "password"
@@ -402,7 +402,7 @@ resource "fastly_service_v1" "foo" {
 		format_version     = 2
 		placement          = "waf_debug"
 		parse_log_keyvals  = true
-		max_batch_size     = 12345
+		request_max_bytes  = 12345
 		auth_method        = "scram-sha-256"
 		username           = "user"
 		password           = "password"
@@ -424,7 +424,7 @@ resource "fastly_service_v1" "foo" {
 		format_version     = 2
 		placement          = "none"
 		parse_log_keyvals  = true
-		max_batch_size     = 12345
+		request_max_bytes  = 12345
 		auth_method        = "scram-sha-256"
 		username           = "user"
 		password           = "password"

--- a/fastly/block_fastly_service_v1_logging_kafka_test.go
+++ b/fastly/block_fastly_service_v1_logging_kafka_test.go
@@ -35,6 +35,11 @@ func TestResourceFastlyFlattenKafka(t *testing.T) {
 					Format:            `%a %l %u %t %m %U%q %H %>s %b %T`,
 					FormatVersion:     2,
 					Placement:         "none",
+					ParseLogKeyvals:   true,
+					RequestMaxBytes:   12345,
+					AuthMethod:        "scram-sha-512",
+					User:              "user",
+					Password:          "password",
 				},
 			},
 			local: []map[string]interface{}{
@@ -53,6 +58,11 @@ func TestResourceFastlyFlattenKafka(t *testing.T) {
 					"format":             `%a %l %u %t %m %U%q %H %>s %b %T`,
 					"placement":          "none",
 					"format_version":     uint(2),
+					"parse_log_keyvals":  true,
+					"max_batch_size":     uint(12345),
+					"auth_method":        "scram-sha-512",
+					"username":           "user",
+					"password":           "password",
 				},
 			},
 		},
@@ -87,6 +97,11 @@ func TestAccFastlyServiceV1_kafkalogging_basic(t *testing.T) {
 		Format:            `%a %l %u %t %m %U%q %H %>s %b %T`,
 		FormatVersion:     2,
 		Placement:         "none",
+		ParseLogKeyvals:   true,
+		RequestMaxBytes:   12345,
+		AuthMethod:        "plain",
+		User:              "user",
+		Password:          "password",
 	}
 
 	log1_after_update := gofastly.Kafka{
@@ -105,6 +120,11 @@ func TestAccFastlyServiceV1_kafkalogging_basic(t *testing.T) {
 		Format:            `%a %l %u %t %m %U%q %H %>s %b %T`,
 		FormatVersion:     2,
 		Placement:         "waf_debug",
+		ParseLogKeyvals:   true,
+		RequestMaxBytes:   12345,
+		AuthMethod:        "scram-sha-256",
+		User:              "user",
+		Password:          "password",
 	}
 
 	log2 := gofastly.Kafka{
@@ -123,6 +143,11 @@ func TestAccFastlyServiceV1_kafkalogging_basic(t *testing.T) {
 		Format:            `%a %l %u %t %m %U%q %H %>s %b %T`,
 		FormatVersion:     2,
 		Placement:         "none",
+		ParseLogKeyvals:   true,
+		RequestMaxBytes:   12345,
+		AuthMethod:        "scram-sha-256",
+		User:              "user",
+		Password:          "password",
 	}
 
 	resource.Test(t, resource.TestCase{
@@ -327,6 +352,11 @@ resource "fastly_service_v1" "foo" {
 		format             = "%%a %%l %%u %%t %%m %%U%%q %%H %%>s %%b %%T"
 		format_version     = 2
 		placement          = "none"
+		parse_log_keyvals  = true
+		max_batch_size     = 12345
+		auth_method        = "plain"
+		username           = "user"
+		password           = "password"
 	}
 
 	force_destroy = true
@@ -371,6 +401,11 @@ resource "fastly_service_v1" "foo" {
 		format             = "%%a %%l %%u %%t %%m %%U%%q %%H %%>s %%b %%T"
 		format_version     = 2
 		placement          = "waf_debug"
+		parse_log_keyvals  = true
+		max_batch_size     = 12345
+		auth_method        = "scram-sha-256"
+		username           = "user"
+		password           = "password"
 	}
 
 	logging_kafka {
@@ -388,6 +423,11 @@ resource "fastly_service_v1" "foo" {
 		format             = "%%a %%l %%u %%t %%m %%U%%q %%H %%>s %%b %%T"
 		format_version     = 2
 		placement          = "none"
+		parse_log_keyvals  = true
+		max_batch_size     = 12345
+		auth_method        = "scram-sha-256"
+		username           = "user"
+		password           = "password"
 	}
 
 	force_destroy = true

--- a/fastly/block_fastly_service_v1_logging_kafka_test.go
+++ b/fastly/block_fastly_service_v1_logging_kafka_test.go
@@ -61,7 +61,7 @@ func TestResourceFastlyFlattenKafka(t *testing.T) {
 					"parse_log_keyvals":  true,
 					"request_max_bytes":  uint(12345),
 					"auth_method":        "scram-sha-512",
-					"username":           "user",
+					"user":               "user",
 					"password":           "password",
 				},
 			},
@@ -355,7 +355,7 @@ resource "fastly_service_v1" "foo" {
 		parse_log_keyvals  = true
 		request_max_bytes  = 12345
 		auth_method        = "plain"
-		username           = "user"
+		user               = "user"
 		password           = "password"
 	}
 
@@ -404,7 +404,7 @@ resource "fastly_service_v1" "foo" {
 		parse_log_keyvals  = true
 		request_max_bytes  = 12345
 		auth_method        = "scram-sha-256"
-		username           = "user"
+		user               = "user"
 		password           = "password"
 	}
 
@@ -426,7 +426,7 @@ resource "fastly_service_v1" "foo" {
 		parse_log_keyvals  = true
 		request_max_bytes  = 12345
 		auth_method        = "scram-sha-256"
-		username           = "user"
+		user               = "user"
 		password           = "password"
 	}
 


### PR DESCRIPTION
Add support for the following fields in order to support SASL for Kafka logging endpoints:

- parse_log_keyvals
- auth_method
- request_max_bytes
- user
- password

## Testing

```
$ env TF_ACC=1 make testacc TESTARGS='-v -run=[Kk]afka'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -v -run=[Kk]afka -timeout 360m -ldflags="-X=github.com/fastly/terraform-provider-fastly/version.ProviderVersion=acc"
?   	github.com/fastly/terraform-provider-fastly	[no test files]
=== RUN   TestResourceFastlyFlattenKafka
--- PASS: TestResourceFastlyFlattenKafka (0.00s)
=== RUN   TestAccFastlyServiceV1_kafkalogging_basic
--- PASS: TestAccFastlyServiceV1_kafkalogging_basic (105.85s)
=== RUN   TestAccFastlyServiceV1_kafkalogging_basic_compute
--- PASS: TestAccFastlyServiceV1_kafkalogging_basic_compute (46.12s)
PASS
ok  	github.com/fastly/terraform-provider-fastly/fastly	151.993s
?   	github.com/fastly/terraform-provider-fastly/scripts/website	[no test files]
?   	github.com/fastly/terraform-provider-fastly/version	[no test files]
```