### PR TITLE
Ensure we still read/refresh remote state when activate is set to false.

### DIFF
--- a/fastly/base_fastly_service_v1.go
+++ b/fastly/base_fastly_service_v1.go
@@ -450,7 +450,12 @@ func resourceServiceRead(d *schema.ResourceData, meta interface{}, serviceDef Se
 	d.Set("version_comment", s.Version.Comment)
 	d.Set("active_version", s.ActiveVersion.Number)
 
-	if s.ActiveVersion.Number == 0 && isImport {
+	// If we are importing or `activate` is set to false, temporarily set the
+	// service.ActiveVersion number to the latest version supplied via the get
+	// service version details call. This is to ensure we still read all of the
+	// state below.
+	isInactive := d.Get("activate").(bool) == false
+	if s.ActiveVersion.Number == 0 && isImport || isInactive {
 		s.ActiveVersion.Number = s.Version.Number
 	}
 


### PR DESCRIPTION
### TL;DR
Fixes an edge case in the `fastly_service_*` resources, in which we don't refresh remote state if the `activate` field is set to `false`. This was introduced in https://github.com/fastly/terraform-provider-fastly/pull/269, when we refactored the service resources to the "block" model and introduced the base service definition interface.

### What?
After a couple of bug reports related to `activate = false` via Fastly support, we investigated further and found that if a configuration has the `activate` field set to false AND it has no previous active version the state wasn't being read. This manifested itself as  a runtime error in certain situations, such as another resource referencing the state in its configuration. 

It turns out we were assuming that the service will always have an active version number greater than 0 within the  `Read` method and gating the read on that condition. 

Fixes: https://github.com/hashicorp/terraform/issues/27258

### Note:
I've ran the tests I introduced in this PR to confirm this fixes the  issue. However still ned to run the full suite before merging, which I'll try and do in the coming days.