### PR TITLE
Update CHANGELOG.md for v0.21.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## 0.22.0 (Unreleased)
 
+## 0.21.2 (December 16, 2020)
+
+BUG FIXES:
+
+* resource/fastly_service_*: Ensure we still refresh remote state when `activate` is set to `false` ([#345](https://github.com/fastly/terraform-provider-fastly/pull/345))
+
 ## 0.21.1 (October 15, 2020)
 
 BUG FIXES:


### PR DESCRIPTION
Includes:

- `resource/fastly_service_*`: Ensure we still refresh remote state when `activate` is set to `false` ([#345](https://github.com/fastly/terraform-provider-fastly/pull/345))