### PR TITLE
Add TLSCLientCert and TLSClientKey options for splunk logging

### DIFF
--- a/docs/resources/service_compute.md
+++ b/docs/resources/service_compute.md
@@ -588,6 +588,8 @@ Required:
 Optional:
 
 - **tls_ca_cert** (String) A secure certificate to authenticate the server with. Must be in PEM format. You can provide this certificate via an environment variable, `FASTLY_SPLUNK_CA_CERT`
+- **tls_client_cert** (String) The client certificate used to make authenticated requests. Must be in PEM format.
+- **tls_client_key** (String, Sensitive) The client private key used to make authenticated requests. Must be in PEM format.
 - **tls_hostname** (String) The hostname used to verify the server's certificate. It can either be the Common Name or a Subject Alternative Name (SAN)
 - **token** (String, Sensitive) The Splunk token to be used for authentication
 

--- a/docs/resources/service_v1.md
+++ b/docs/resources/service_v1.md
@@ -1044,6 +1044,8 @@ Optional:
 - **placement** (String) Where in the generated VCL the logging call should be placed
 - **response_condition** (String) The name of the condition to apply
 - **tls_ca_cert** (String) A secure certificate to authenticate the server with. Must be in PEM format. You can provide this certificate via an environment variable, `FASTLY_SPLUNK_CA_CERT`
+- **tls_client_cert** (String) The client certificate used to make authenticated requests. Must be in PEM format.
+- **tls_client_key** (String, Sensitive) The client private key used to make authenticated requests. Must be in PEM format.
 - **tls_hostname** (String) The hostname used to verify the server's certificate. It can either be the Common Name or a Subject Alternative Name (SAN)
 - **token** (String, Sensitive) The Splunk token to be used for authentication
 

--- a/fastly/block_fastly_service_v1_splunk.go
+++ b/fastly/block_fastly_service_v1_splunk.go
@@ -83,6 +83,8 @@ func (h *SplunkServiceAttributeHandler) Process(d *schema.ResourceData, latestVe
 			Token:             sf["token"].(string),
 			TLSHostname:       sf["tls_hostname"].(string),
 			TLSCACert:         sf["tls_ca_cert"].(string),
+			TLSClientCert:     sf["tls_client_cert"].(string),
+			TLSClientKey:      sf["tls_client_key"].(string),
 			Format:            vla.format,
 			FormatVersion:     uintOrDefault(vla.formatVersion),
 			ResponseCondition: vla.responseCondition,
@@ -149,6 +151,19 @@ func (h *SplunkServiceAttributeHandler) Register(s *schema.Resource) error {
 			DefaultFunc: schema.EnvDefaultFunc("FASTLY_SPLUNK_CA_CERT", ""),
 			Description: "A secure certificate to authenticate the server with. Must be in PEM format. You can provide this certificate via an environment variable, `FASTLY_SPLUNK_CA_CERT`",
 		},
+		"tls_client_cert": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			DefaultFunc: schema.EnvDefaultFunc("FASTLY_SPLUNK_CLIENT_CERT", ""),
+			Description: "The client certificate used to make authenticated requests. Must be in PEM format.",
+		},
+		"tls_client_key": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			DefaultFunc: schema.EnvDefaultFunc("FASTLY_SPLUNK_CLIENT_KEY", ""),
+			Description: "The client private key used to make authenticated requests. Must be in PEM format.",
+			Sensitive:   true,
+		},
 	}
 
 	if h.GetServiceMetadata().serviceType == ServiceTypeVCL {
@@ -202,6 +217,8 @@ func flattenSplunks(splunkList []*gofastly.Splunk) []map[string]interface{} {
 			"token":              s.Token,
 			"tls_hostname":       s.TLSHostname,
 			"tls_ca_cert":        s.TLSCACert,
+			"tls_client_cert":    s.TLSClientCert,
+			"tls_client_key":     s.TLSClientKey,
 		}
 
 		// prune any empty values that come from the default string value in structs

--- a/fastly/block_fastly_service_v1_splunk_test.go
+++ b/fastly/block_fastly_service_v1_splunk_test.go
@@ -576,7 +576,7 @@ func testAccServiceV1SplunkConfig_updateUseTLS(serviceName, cert, key string) st
 	format := "%h %l %u %%{now}V %%{req.method}V %%{req.url}V %>s %%{resp.http.Content-Length}V"
 
 	// The same certificate is used here for tls_ca_cert and tls_client_cert,
-	// but this is stricly for testing. In practice the same value should
+	// but this is strictly for testing. In practice the same value should
 	// not be used for these two fields.
 	return fmt.Sprintf(`
 resource "fastly_service_v1" "foo" {

--- a/fastly/block_fastly_service_v1_splunk_test.go
+++ b/fastly/block_fastly_service_v1_splunk_test.go
@@ -260,7 +260,7 @@ func TestAccFastlyServiceV1_splunk_complete(t *testing.T) {
 		TLSHostname:       "example.com",
 		// The same certificate is used here for
 		// TLSCACert and TLSClientCert, but this
-		// is stricly for testing. In practice
+		// is strictly for testing. In practice
 		// the same value should not be used for
 		// these two fields.
 		TLSCACert:     cert,

--- a/fastly/block_fastly_service_v1_splunk_test.go
+++ b/fastly/block_fastly_service_v1_splunk_test.go
@@ -222,7 +222,7 @@ func TestAccFastlyServiceV1_splunk_complete(t *testing.T) {
 		TLSHostname:       "example.com",
 		// The same certificate is used here for
 		// TLSCACert and TLSClientCert, but this
-		// is stricly for testing. In practice
+		// is strictly for testing. In practice
 		// the same value should not be used for
 		// these two fields.
 		TLSCACert:     cert,

--- a/fastly/block_fastly_service_v1_splunk_test.go
+++ b/fastly/block_fastly_service_v1_splunk_test.go
@@ -34,7 +34,7 @@ func TestResourceFastlyFlattenSplunk(t *testing.T) {
 					Token:             "test-token",
 					// The same certificate is used here for
 					// TLSCACert and TLSClientCert, but this
-					// is stricly for testing. In practice
+					// is strictly for testing. In practice
 					// the same value should not be used for
 					// these two fields.
 					TLSCACert:     cert,

--- a/fastly/block_fastly_service_v1_splunk_test.go
+++ b/fastly/block_fastly_service_v1_splunk_test.go
@@ -474,7 +474,7 @@ func testAccServiceV1SplunkConfig_useTLS(serviceName, cert, key string) string {
 	format := "%h %l %u %t \"%r\" %>s %b"
 
 	// The same certificate is used here for tls_ca_cert and tls_client_cert,
-	// but this is stricly for testing. In practice the same value should
+	// but this is strictly for testing. In practice the same value should
 	// not be used for these two fields.
 	return fmt.Sprintf(`
 resource "fastly_service_v1" "foo" {

--- a/fastly/block_fastly_service_v1_splunk_test.go
+++ b/fastly/block_fastly_service_v1_splunk_test.go
@@ -241,7 +241,7 @@ func TestAccFastlyServiceV1_splunk_complete(t *testing.T) {
 		TLSHostname:       "example.com",
 		// The same certificate is used here for
 		// TLSCACert and TLSClientCert, but this
-		// is stricly for testing. In practice
+		// is strictly for testing. In practice
 		// the same value should not be used for
 		// these two fields.
 		TLSCACert:     cert,

--- a/fastly/block_fastly_service_v1_splunk_test.go
+++ b/fastly/block_fastly_service_v1_splunk_test.go
@@ -32,10 +32,15 @@ func TestResourceFastlyFlattenSplunk(t *testing.T) {
 					ResponseCondition: "error_response",
 					Placement:         "waf_debug",
 					Token:             "test-token",
-					TLSCACert:         cert,
-					TLSHostname:       "example.com",
-					TLSClientCert:     cert,
-					TLSClientKey:      key,
+					// The same certificate is used here for
+					// TLSCACert and TLSClientCert, but this
+					// is stricly for testing. In practice
+					// the same value should not be used for
+					// these two fields.
+					TLSCACert:     cert,
+					TLSHostname:   "example.com",
+					TLSClientCert: cert,
+					TLSClientKey:  key,
 				},
 			},
 			local: []map[string]interface{}{
@@ -48,9 +53,14 @@ func TestResourceFastlyFlattenSplunk(t *testing.T) {
 					"placement":          "waf_debug",
 					"token":              "test-token",
 					"tls_hostname":       "example.com",
-					"tls_ca_cert":        cert,
-					"tls_client_cert":    cert,
-					"tls_client_key":     key,
+					// The same certificate is used here for
+					// TLSCACert and TLSClientCert, but this
+					// is stricly for testing. In practice
+					// the same value should not be used for
+					// these two fields.
+					"tls_ca_cert":     cert,
+					"tls_client_cert": cert,
+					"tls_client_key":  key,
 				},
 			},
 		},
@@ -210,9 +220,14 @@ func TestAccFastlyServiceV1_splunk_complete(t *testing.T) {
 		Placement:         "waf_debug",
 		ResponseCondition: "error_response_5XX",
 		TLSHostname:       "example.com",
-		TLSCACert:         cert,
-		TLSClientCert:     cert,
-		TLSClientKey:      key,
+		// The same certificate is used here for
+		// TLSCACert and TLSClientCert, but this
+		// is stricly for testing. In practice
+		// the same value should not be used for
+		// these two fields.
+		TLSCACert:     cert,
+		TLSClientCert: cert,
+		TLSClientKey:  key,
 	}
 
 	splunkLogOneUpdated := gofastly.Splunk{
@@ -224,9 +239,14 @@ func TestAccFastlyServiceV1_splunk_complete(t *testing.T) {
 		Placement:         "waf_debug",
 		ResponseCondition: "error_response_5XX",
 		TLSHostname:       "example.com",
-		TLSCACert:         cert,
-		TLSClientCert:     cert,
-		TLSClientKey:      key,
+		// The same certificate is used here for
+		// TLSCACert and TLSClientCert, but this
+		// is stricly for testing. In practice
+		// the same value should not be used for
+		// these two fields.
+		TLSCACert:     cert,
+		TLSClientCert: cert,
+		TLSClientKey:  key,
 	}
 
 	splunkLogTwo := gofastly.Splunk{
@@ -238,9 +258,14 @@ func TestAccFastlyServiceV1_splunk_complete(t *testing.T) {
 		Placement:         "waf_debug",
 		ResponseCondition: "ok_response_2XX",
 		TLSHostname:       "example.com",
-		TLSCACert:         cert,
-		TLSClientCert:     cert,
-		TLSClientKey:      key,
+		// The same certificate is used here for
+		// TLSCACert and TLSClientCert, but this
+		// is stricly for testing. In practice
+		// the same value should not be used for
+		// these two fields.
+		TLSCACert:     cert,
+		TLSClientCert: cert,
+		TLSClientKey:  key,
 	}
 
 	resource.Test(t, resource.TestCase{
@@ -448,6 +473,9 @@ func testAccServiceV1SplunkConfig_useTLS(serviceName, cert, key string) string {
 
 	format := "%h %l %u %t \"%r\" %>s %b"
 
+	// The same certificate is used here for tls_ca_cert and tls_client_cert,
+	// but this is stricly for testing. In practice the same value should
+	// not be used for these two fields.
 	return fmt.Sprintf(`
 resource "fastly_service_v1" "foo" {
   name = %q
@@ -547,6 +575,9 @@ func testAccServiceV1SplunkConfig_updateUseTLS(serviceName, cert, key string) st
 	domainName := fmt.Sprintf("fastly-test.tf-%s.com", acctest.RandString(10))
 	format := "%h %l %u %%{now}V %%{req.method}V %%{req.url}V %>s %%{resp.http.Content-Length}V"
 
+	// The same certificate is used here for tls_ca_cert and tls_client_cert,
+	// but this is stricly for testing. In practice the same value should
+	// not be used for these two fields.
 	return fmt.Sprintf(`
 resource "fastly_service_v1" "foo" {
   name = %q

--- a/fastly/block_fastly_service_v1_splunk_test.go
+++ b/fastly/block_fastly_service_v1_splunk_test.go
@@ -55,7 +55,7 @@ func TestResourceFastlyFlattenSplunk(t *testing.T) {
 					"tls_hostname":       "example.com",
 					// The same certificate is used here for
 					// TLSCACert and TLSClientCert, but this
-					// is stricly for testing. In practice
+					// is strictly for testing. In practice
 					// the same value should not be used for
 					// these two fields.
 					"tls_ca_cert":     cert,


### PR DESCRIPTION
Add support for the `TLSClientCert` and `TLSClientKey` options.

Follows from [this](https://github.com/fastly/go-fastly/pull/236) `go-fastly` PR.

### Testing
I ran the splunk tests to verify the change and I will defer the full suite run until after code review.

```
13:55:02:terraform-provider-fastly(splunk-tls-options) $ env TF_ACC=1 make testacc TESTARGS='-v -run=[Ss]plunk'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -v -run=[Ss]plunk -timeout 360m -ldflags="-X=github.com/fastly/terraform-provider-fastly/version.ProviderVersion=acc"
?   	github.com/fastly/terraform-provider-fastly	[no test files]
=== RUN   TestResourceFastlyFlattenSplunk
--- PASS: TestResourceFastlyFlattenSplunk (0.14s)
=== RUN   TestAccFastlyServiceV1_splunk_basic
--- PASS: TestAccFastlyServiceV1_splunk_basic (88.55s)
=== RUN   TestAccFastlyServiceV1_splunk_basic_compute
--- PASS: TestAccFastlyServiceV1_splunk_basic_compute (41.56s)
=== RUN   TestAccFastlyServiceV1_splunk_default
--- PASS: TestAccFastlyServiceV1_splunk_default (42.82s)
=== RUN   TestAccFastlyServiceV1_splunk_complete
--- PASS: TestAccFastlyServiceV1_splunk_complete (87.56s)
=== RUN   TestAccFastlyServiceV1_splunk_env
--- PASS: TestAccFastlyServiceV1_splunk_env (42.17s)
PASS
ok  	github.com/fastly/terraform-provider-fastly/fastly	302.819s
?   	github.com/fastly/terraform-provider-fastly/scripts/website	[no test files]
?   	github.com/fastly/terraform-provider-fastly/version	[no test files]
```