### PR TITLE
Ensure schema.Set uses custom SetDiff algorithm

### DIFF
--- a/docs/resources/service_compute.md
+++ b/docs/resources/service_compute.md
@@ -121,7 +121,7 @@ $ terraform import fastly_service_compute.demo xxxxxxxxxxxxxxxxxxxx
 
 Required:
 
-- **name** (String) The domain that this Service will respond to
+- **name** (String) The domain that this Service will respond to. It is important to note that changing this attribute will delete and recreate the domain.
 
 Optional:
 

--- a/docs/resources/service_compute.md
+++ b/docs/resources/service_compute.md
@@ -216,11 +216,11 @@ Optional:
 
 Required:
 
-- **name** (String) A unique name to identify this dictionary
+- **name** (String) A unique name to identify this dictionary. It is important to note that changing this attribute will delete and recreate the dictionary, and discard the current items in the dictionary
 
 Optional:
 
-- **write_only** (Boolean) If `true`, the dictionary is a private dictionary, and items are not readable in the UI or via API. Default is `false`. It is important to note that changing this attribute will delete and recreate the dictionary, discard the current items in the dictionary. Using a write-only/private dictionary should only be done if the items are managed outside of Terraform
+- **write_only** (Boolean) If `true`, the dictionary is a private dictionary, and items are not readable in the UI or via API. Default is `false`. It is important to note that changing this attribute will delete and recreate the dictionary, and discard the current items in the dictionary. Using a write-only/private dictionary should only be done if the items are managed outside of Terraform
 
 Read-Only:
 

--- a/docs/resources/service_compute.md
+++ b/docs/resources/service_compute.md
@@ -121,7 +121,7 @@ $ terraform import fastly_service_compute.demo xxxxxxxxxxxxxxxxxxxx
 
 Required:
 
-- **name** (String) The domain that this Service will respond to. It is important to note that changing this attribute will delete and recreate the domain.
+- **name** (String) The domain that this Service will respond to. It is important to note that changing this attribute will delete and recreate the resource.
 
 Optional:
 
@@ -146,7 +146,7 @@ Optional:
 Required:
 
 - **address** (String) An IPv4, hostname, or IPv6 address for the Backend
-- **name** (String) Name for this Backend. Must be unique to this Service
+- **name** (String) Name for this Backend. Must be unique to this Service. It is important to note that changing this attribute will delete and recreate the resource
 
 Optional:
 
@@ -180,7 +180,7 @@ Optional:
 Required:
 
 - **dataset** (String) The ID of your BigQuery dataset
-- **name** (String) A unique name to identify this BigQuery logging endpoint
+- **name** (String) A unique name to identify this BigQuery logging endpoint. It is important to note that changing this attribute will delete and recreate the resource
 - **project_id** (String) The ID of your GCP project
 - **table** (String) The ID of your BigQuery table
 
@@ -198,7 +198,7 @@ Required:
 
 - **account_name** (String) The unique Azure Blob Storage namespace in which your data objects are stored
 - **container** (String) The name of the Azure Blob Storage container in which to store logs
-- **name** (String) A unique name to identify the Azure Blob Storage endpoint
+- **name** (String) A unique name to identify the Azure Blob Storage endpoint. It is important to note that changing this attribute will delete and recreate the resource
 
 Optional:
 
@@ -233,7 +233,7 @@ Read-Only:
 Required:
 
 - **bucket_name** (String) The name of the bucket in which to store the logs
-- **name** (String) A unique name to identify this GCS endpoint
+- **name** (String) A unique name to identify this GCS endpoint. It is important to note that changing this attribute will delete and recreate the resource
 
 Optional:
 
@@ -252,7 +252,7 @@ Optional:
 Required:
 
 - **host** (String) The Host header to send for this Healthcheck
-- **name** (String) A unique name to identify this Healthcheck
+- **name** (String) A unique name to identify this Healthcheck. It is important to note that changing this attribute will delete and recreate the resource
 - **path** (String) The path to check
 
 Optional:
@@ -272,7 +272,7 @@ Optional:
 
 Required:
 
-- **name** (String) The unique name of the HTTPS logging endpoint
+- **name** (String) The unique name of the HTTPS logging endpoint. It is important to note that changing this attribute will delete and recreate the resource
 - **url** (String) URL that log data will be sent to. Must use the https protocol
 
 Optional:
@@ -296,7 +296,7 @@ Optional:
 
 Required:
 
-- **name** (String) The unique name of the Logentries logging endpoint
+- **name** (String) The unique name of the Logentries logging endpoint. It is important to note that changing this attribute will delete and recreate the resource
 - **token** (String) Use token based authentication (https://logentries.com/doc/input-token/)
 
 Optional:
@@ -312,7 +312,7 @@ Required:
 
 - **access_key** (String, Sensitive) Your Cloud File account access key
 - **bucket_name** (String) The name of your Cloud Files container
-- **name** (String) The unique name of the Rackspace Cloud Files logging endpoint
+- **name** (String) The unique name of the Rackspace Cloud Files logging endpoint. It is important to note that changing this attribute will delete and recreate the resource
 - **user** (String) The username for your Cloud Files account
 
 Optional:
@@ -331,7 +331,7 @@ Optional:
 
 Required:
 
-- **name** (String) The unique name of the Datadog logging endpoint
+- **name** (String) The unique name of the Datadog logging endpoint. It is important to note that changing this attribute will delete and recreate the resource
 - **token** (String, Sensitive) The API key from your Datadog account
 
 Optional:
@@ -346,7 +346,7 @@ Required:
 
 - **access_key** (String, Sensitive) Your DigitalOcean Spaces account access key
 - **bucket_name** (String) The name of the DigitalOcean Space
-- **name** (String) The unique name of the DigitalOcean Spaces logging endpoint
+- **name** (String) The unique name of the DigitalOcean Spaces logging endpoint. It is important to note that changing this attribute will delete and recreate the resource
 - **secret_key** (String, Sensitive) Your DigitalOcean Spaces account secret key
 
 Optional:
@@ -366,7 +366,7 @@ Optional:
 Required:
 
 - **index** (String) The name of the Elasticsearch index to send documents (logs) to
-- **name** (String) The unique name of the Elasticsearch logging endpoint
+- **name** (String) The unique name of the Elasticsearch logging endpoint. It is important to note that changing this attribute will delete and recreate the resource
 - **url** (String) The Elasticsearch URL to stream logs to
 
 Optional:
@@ -388,7 +388,7 @@ Optional:
 Required:
 
 - **address** (String) The FTP address to stream logs to
-- **name** (String) The unique name of the FTP logging endpoint
+- **name** (String) The unique name of the FTP logging endpoint. It is important to note that changing this attribute will delete and recreate the resource
 - **password** (String, Sensitive) The password for the server (for anonymous use an email address)
 - **path** (String) The path to upload log files to. If the path ends in `/` then it is treated as a directory
 - **user** (String) The username for the server (can be `anonymous`)
@@ -408,7 +408,7 @@ Optional:
 
 Required:
 
-- **name** (String) The unique name of the Google Cloud Pub/Sub logging endpoint
+- **name** (String) The unique name of the Google Cloud Pub/Sub logging endpoint. It is important to note that changing this attribute will delete and recreate the resource
 - **project_id** (String) The ID of your Google Cloud Platform project
 - **secret_key** (String) Your Google Cloud Platform account secret key. The `private_key` field in your service account authentication JSON
 - **topic** (String) The Google Cloud Pub/Sub topic to which logs will be published
@@ -420,7 +420,7 @@ Required:
 
 Required:
 
-- **name** (String) The unique name of the Heroku logging endpoint
+- **name** (String) The unique name of the Heroku logging endpoint. It is important to note that changing this attribute will delete and recreate the resource
 - **token** (String, Sensitive) The token to use for authentication (https://www.heroku.com/docs/customer-token-authentication-token/)
 - **url** (String) The URL to stream logs to
 
@@ -431,7 +431,7 @@ Required:
 Required:
 
 - **dataset** (String) The Honeycomb Dataset you want to log to
-- **name** (String) The unique name of the Honeycomb logging endpoint
+- **name** (String) The unique name of the Honeycomb logging endpoint. It is important to note that changing this attribute will delete and recreate the resource
 - **token** (String, Sensitive) The Write Key from the Account page of your Honeycomb account
 
 
@@ -441,7 +441,7 @@ Required:
 Required:
 
 - **brokers** (String) A comma-separated list of IP addresses or hostnames of Kafka brokers
-- **name** (String) The unique name of the Kafka logging endpoint
+- **name** (String) The unique name of the Kafka logging endpoint. It is important to note that changing this attribute will delete and recreate the resource
 - **topic** (String) The Kafka topic to send logs to
 
 Optional:
@@ -466,7 +466,7 @@ Optional:
 Required:
 
 - **access_key** (String, Sensitive) The AWS access key to be used to write to the stream
-- **name** (String) The unique name of the Kinesis logging endpoint
+- **name** (String) The unique name of the Kinesis logging endpoint. It is important to note that changing this attribute will delete and recreate the resource
 - **secret_key** (String, Sensitive) The AWS secret access key to authenticate with
 - **topic** (String) The Kinesis stream name
 
@@ -480,7 +480,7 @@ Optional:
 
 Required:
 
-- **name** (String) The unique name of the Loggly logging endpoint
+- **name** (String) The unique name of the Loggly logging endpoint. It is important to note that changing this attribute will delete and recreate the resource
 - **token** (String, Sensitive) The token to use for authentication (https://www.loggly.com/docs/customer-token-authentication-token/).
 
 
@@ -489,7 +489,7 @@ Required:
 
 Required:
 
-- **name** (String) The unique name of the Log Shuttle logging endpoint
+- **name** (String) The unique name of the Log Shuttle logging endpoint. It is important to note that changing this attribute will delete and recreate the resource
 - **token** (String, Sensitive) The data authentication token associated with this endpoint
 - **url** (String) Your Log Shuttle endpoint URL
 
@@ -499,7 +499,7 @@ Required:
 
 Required:
 
-- **name** (String) The unique name of the New Relic logging endpoint
+- **name** (String) The unique name of the New Relic logging endpoint. It is important to note that changing this attribute will delete and recreate the resource
 - **token** (String, Sensitive) The Insert API key from the Account page of your New Relic account
 
 
@@ -510,7 +510,7 @@ Required:
 
 - **access_key** (String, Sensitive) Your OpenStack account access key
 - **bucket_name** (String) The name of your OpenStack container
-- **name** (String) The unique name of the OpenStack logging endpoint
+- **name** (String) The unique name of the OpenStack logging endpoint. It is important to note that changing this attribute will delete and recreate the resource
 - **url** (String) Your OpenStack auth url
 - **user** (String) The username for your OpenStack account
 
@@ -529,7 +529,7 @@ Optional:
 
 Required:
 
-- **name** (String) The unique name of the Scalyr logging endpoint
+- **name** (String) The unique name of the Scalyr logging endpoint. It is important to note that changing this attribute will delete and recreate the resource
 - **token** (String, Sensitive) The token to use for authentication (https://www.scalyr.com/keys)
 
 Optional:
@@ -543,7 +543,7 @@ Optional:
 Required:
 
 - **address** (String) The SFTP address to stream logs to
-- **name** (String) The unique name of the SFTP logging endpoint
+- **name** (String) The unique name of the SFTP logging endpoint. It is important to note that changing this attribute will delete and recreate the resource
 - **path** (String) The path to upload log files to. If the path ends in `/` then it is treated as a directory
 - **ssh_known_hosts** (String) A list of host keys for all hosts we can connect to over SFTP
 - **user** (String) The username for the server
@@ -566,7 +566,7 @@ Optional:
 Required:
 
 - **address** (String) The address of the Papertrail endpoint
-- **name** (String) A unique name to identify this Papertrail endpoint
+- **name** (String) A unique name to identify this Papertrail endpoint. It is important to note that changing this attribute will delete and recreate the resource
 - **port** (Number) The port associated with the address where the Papertrail endpoint can be accessed
 
 
@@ -576,7 +576,7 @@ Required:
 Required:
 
 - **bucket_name** (String) The name of the bucket in which to store the logs
-- **name** (String) The unique name of the S3 logging endpoint
+- **name** (String) The unique name of the S3 logging endpoint. It is important to note that changing this attribute will delete and recreate the resource
 
 Optional:
 
@@ -599,7 +599,7 @@ Optional:
 
 Required:
 
-- **name** (String) A unique name to identify the Splunk endpoint
+- **name** (String) A unique name to identify the Splunk endpoint. It is important to note that changing this attribute will delete and recreate the resource
 - **url** (String) The Splunk URL to stream logs to
 
 Optional:
@@ -616,7 +616,7 @@ Optional:
 
 Required:
 
-- **name** (String) A unique name to identify this Sumologic endpoint
+- **name** (String) A unique name to identify this Sumologic endpoint. It is important to note that changing this attribute will delete and recreate the resource
 - **url** (String) The URL to Sumologic collector endpoint
 
 Optional:
@@ -630,7 +630,7 @@ Optional:
 Required:
 
 - **address** (String) A hostname or IPv4 address of the Syslog endpoint
-- **name** (String) A unique name to identify this Syslog endpoint
+- **name** (String) A unique name to identify this Syslog endpoint. It is important to note that changing this attribute will delete and recreate the resource
 
 Optional:
 

--- a/docs/resources/service_compute.md
+++ b/docs/resources/service_compute.md
@@ -296,7 +296,7 @@ Optional:
 
 Required:
 
-- **name** (String) Unique name to refer to this logging setup
+- **name** (String) The unique name of the Logentries logging endpoint
 - **token** (String) Use token based authentication (https://logentries.com/doc/input-token/)
 
 Optional:

--- a/docs/resources/service_v1.md
+++ b/docs/resources/service_v1.md
@@ -292,7 +292,7 @@ $ terraform import fastly_service_v1.demo xxxxxxxxxxxxxxxxxxxx
 
 Required:
 
-- **name** (String) The domain that this Service will respond to
+- **name** (String) The domain that this Service will respond to. It is important to note that changing this attribute will delete and recreate the domain.
 
 Optional:
 

--- a/docs/resources/service_v1.md
+++ b/docs/resources/service_v1.md
@@ -292,7 +292,7 @@ $ terraform import fastly_service_v1.demo xxxxxxxxxxxxxxxxxxxx
 
 Required:
 
-- **name** (String) The domain that this Service will respond to. It is important to note that changing this attribute will delete and recreate the domain.
+- **name** (String) The domain that this Service will respond to. It is important to note that changing this attribute will delete and recreate the resource.
 
 Optional:
 
@@ -317,7 +317,7 @@ Read-Only:
 Required:
 
 - **address** (String) An IPv4, hostname, or IPv6 address for the Backend
-- **name** (String) Name for this Backend. Must be unique to this Service
+- **name** (String) Name for this Backend. Must be unique to this Service. It is important to note that changing this attribute will delete and recreate the resource
 
 Optional:
 
@@ -352,7 +352,7 @@ Optional:
 Required:
 
 - **dataset** (String) The ID of your BigQuery dataset
-- **name** (String) A unique name to identify this BigQuery logging endpoint
+- **name** (String) A unique name to identify this BigQuery logging endpoint. It is important to note that changing this attribute will delete and recreate the resource
 - **project_id** (String) The ID of your GCP project
 - **table** (String) The ID of your BigQuery table
 
@@ -373,7 +373,7 @@ Required:
 
 - **account_name** (String) The unique Azure Blob Storage namespace in which your data objects are stored
 - **container** (String) The name of the Azure Blob Storage container in which to store logs
-- **name** (String) A unique name to identify the Azure Blob Storage endpoint
+- **name** (String) A unique name to identify the Azure Blob Storage endpoint. It is important to note that changing this attribute will delete and recreate the resource
 
 Optional:
 
@@ -395,7 +395,7 @@ Optional:
 
 Required:
 
-- **name** (String) Unique name for this Cache Setting
+- **name** (String) Unique name for this Cache Setting. It is important to note that changing this attribute will delete and recreate the resource
 
 Optional:
 
@@ -410,7 +410,7 @@ Optional:
 
 Required:
 
-- **name** (String) The unique name for the condition
+- **name** (String) The unique name for the condition. It is important to note that changing this attribute will delete and recreate the resource
 - **statement** (String) The statement used to determine if the condition is met
 - **type** (String) Type of condition, either `REQUEST` (req), `RESPONSE` (req, resp), or `CACHE` (req, beresp)
 
@@ -441,7 +441,7 @@ Read-Only:
 Required:
 
 - **backends** (Set of String) Names of defined backends to map the director to. Example: `[ "origin1", "origin2" ]`
-- **name** (String) Unique name for this Director
+- **name** (String) Unique name for this Director. It is important to note that changing this attribute will delete and recreate the resource
 
 Optional:
 
@@ -458,7 +458,7 @@ Optional:
 
 Required:
 
-- **name** (String) A name that is unique across "regular" and "dynamic" VCL Snippet configuration blocks
+- **name** (String) A name that is unique across "regular" and "dynamic" VCL Snippet configuration blocks. It is important to note that changing this attribute will delete and recreate the resource
 - **type** (String) The location in generated VCL where the snippet should be placed (can be one of `init`, `recv`, `hit`, `miss`, `pass`, `fetch`, `error`, `deliver`, `log` or `none`)
 
 Optional:
@@ -476,7 +476,7 @@ Read-Only:
 Required:
 
 - **bucket_name** (String) The name of the bucket in which to store the logs
-- **name** (String) A unique name to identify this GCS endpoint
+- **name** (String) A unique name to identify this GCS endpoint. It is important to note that changing this attribute will delete and recreate the resource
 
 Optional:
 
@@ -497,7 +497,7 @@ Optional:
 
 Required:
 
-- **name** (String) A name to refer to this gzip condition
+- **name** (String) A name to refer to this gzip condition. It is important to note that changing this attribute will delete and recreate the resource
 
 Optional:
 
@@ -513,7 +513,7 @@ Required:
 
 - **action** (String) The Header manipulation action to take; must be one of `set`, `append`, `delete`, `regex`, or `regex_repeat`
 - **destination** (String) The name of the header that is going to be affected by the Action
-- **name** (String) Unique name for this header attribute
+- **name** (String) Unique name for this header attribute. It is important to note that changing this attribute will delete and recreate the resource
 - **type** (String) The Request type on which to apply the selected Action; must be one of `request`, `fetch`, `cache` or `response`
 
 Optional:
@@ -534,7 +534,7 @@ Optional:
 Required:
 
 - **host** (String) The Host header to send for this Healthcheck
-- **name** (String) A unique name to identify this Healthcheck
+- **name** (String) A unique name to identify this Healthcheck. It is important to note that changing this attribute will delete and recreate the resource
 - **path** (String) The path to check
 
 Optional:
@@ -554,7 +554,7 @@ Optional:
 
 Required:
 
-- **name** (String) The unique name of the HTTPS logging endpoint
+- **name** (String) The unique name of the HTTPS logging endpoint. It is important to note that changing this attribute will delete and recreate the resource
 - **url** (String) URL that log data will be sent to. Must use the https protocol
 
 Optional:
@@ -582,7 +582,7 @@ Optional:
 
 Required:
 
-- **name** (String) The unique name of the Logentries logging endpoint
+- **name** (String) The unique name of the Logentries logging endpoint. It is important to note that changing this attribute will delete and recreate the resource
 - **token** (String) Use token based authentication (https://logentries.com/doc/input-token/)
 
 Optional:
@@ -602,7 +602,7 @@ Required:
 
 - **access_key** (String, Sensitive) Your Cloud File account access key
 - **bucket_name** (String) The name of your Cloud Files container
-- **name** (String) The unique name of the Rackspace Cloud Files logging endpoint
+- **name** (String) The unique name of the Rackspace Cloud Files logging endpoint. It is important to note that changing this attribute will delete and recreate the resource
 - **user** (String) The username for your Cloud Files account
 
 Optional:
@@ -625,7 +625,7 @@ Optional:
 
 Required:
 
-- **name** (String) The unique name of the Datadog logging endpoint
+- **name** (String) The unique name of the Datadog logging endpoint. It is important to note that changing this attribute will delete and recreate the resource
 - **token** (String, Sensitive) The API key from your Datadog account
 
 Optional:
@@ -644,7 +644,7 @@ Required:
 
 - **access_key** (String, Sensitive) Your DigitalOcean Spaces account access key
 - **bucket_name** (String) The name of the DigitalOcean Space
-- **name** (String) The unique name of the DigitalOcean Spaces logging endpoint
+- **name** (String) The unique name of the DigitalOcean Spaces logging endpoint. It is important to note that changing this attribute will delete and recreate the resource
 - **secret_key** (String, Sensitive) Your DigitalOcean Spaces account secret key
 
 Optional:
@@ -668,7 +668,7 @@ Optional:
 Required:
 
 - **index** (String) The name of the Elasticsearch index to send documents (logs) to
-- **name** (String) The unique name of the Elasticsearch logging endpoint
+- **name** (String) The unique name of the Elasticsearch logging endpoint. It is important to note that changing this attribute will delete and recreate the resource
 - **url** (String) The Elasticsearch URL to stream logs to
 
 Optional:
@@ -694,7 +694,7 @@ Optional:
 Required:
 
 - **address** (String) The FTP address to stream logs to
-- **name** (String) The unique name of the FTP logging endpoint
+- **name** (String) The unique name of the FTP logging endpoint. It is important to note that changing this attribute will delete and recreate the resource
 - **password** (String, Sensitive) The password for the server (for anonymous use an email address)
 - **path** (String) The path to upload log files to. If the path ends in `/` then it is treated as a directory
 - **user** (String) The username for the server (can be `anonymous`)
@@ -718,7 +718,7 @@ Optional:
 
 Required:
 
-- **name** (String) The unique name of the Google Cloud Pub/Sub logging endpoint
+- **name** (String) The unique name of the Google Cloud Pub/Sub logging endpoint. It is important to note that changing this attribute will delete and recreate the resource
 - **project_id** (String) The ID of your Google Cloud Platform project
 - **secret_key** (String) Your Google Cloud Platform account secret key. The `private_key` field in your service account authentication JSON
 - **topic** (String) The Google Cloud Pub/Sub topic to which logs will be published
@@ -737,7 +737,7 @@ Optional:
 
 Required:
 
-- **name** (String) The unique name of the Heroku logging endpoint
+- **name** (String) The unique name of the Heroku logging endpoint. It is important to note that changing this attribute will delete and recreate the resource
 - **token** (String, Sensitive) The token to use for authentication (https://www.heroku.com/docs/customer-token-authentication-token/)
 - **url** (String) The URL to stream logs to
 
@@ -755,7 +755,7 @@ Optional:
 Required:
 
 - **dataset** (String) The Honeycomb Dataset you want to log to
-- **name** (String) The unique name of the Honeycomb logging endpoint
+- **name** (String) The unique name of the Honeycomb logging endpoint. It is important to note that changing this attribute will delete and recreate the resource
 - **token** (String, Sensitive) The Write Key from the Account page of your Honeycomb account
 
 Optional:
@@ -772,7 +772,7 @@ Optional:
 Required:
 
 - **brokers** (String) A comma-separated list of IP addresses or hostnames of Kafka brokers
-- **name** (String) The unique name of the Kafka logging endpoint
+- **name** (String) The unique name of the Kafka logging endpoint. It is important to note that changing this attribute will delete and recreate the resource
 - **topic** (String) The Kafka topic to send logs to
 
 Optional:
@@ -801,7 +801,7 @@ Optional:
 Required:
 
 - **access_key** (String, Sensitive) The AWS access key to be used to write to the stream
-- **name** (String) The unique name of the Kinesis logging endpoint
+- **name** (String) The unique name of the Kinesis logging endpoint. It is important to note that changing this attribute will delete and recreate the resource
 - **secret_key** (String, Sensitive) The AWS secret access key to authenticate with
 - **topic** (String) The Kinesis stream name
 
@@ -819,7 +819,7 @@ Optional:
 
 Required:
 
-- **name** (String) The unique name of the Loggly logging endpoint
+- **name** (String) The unique name of the Loggly logging endpoint. It is important to note that changing this attribute will delete and recreate the resource
 - **token** (String, Sensitive) The token to use for authentication (https://www.loggly.com/docs/customer-token-authentication-token/).
 
 Optional:
@@ -835,7 +835,7 @@ Optional:
 
 Required:
 
-- **name** (String) The unique name of the Log Shuttle logging endpoint
+- **name** (String) The unique name of the Log Shuttle logging endpoint. It is important to note that changing this attribute will delete and recreate the resource
 - **token** (String, Sensitive) The data authentication token associated with this endpoint
 - **url** (String) Your Log Shuttle endpoint URL
 
@@ -852,7 +852,7 @@ Optional:
 
 Required:
 
-- **name** (String) The unique name of the New Relic logging endpoint
+- **name** (String) The unique name of the New Relic logging endpoint. It is important to note that changing this attribute will delete and recreate the resource
 - **token** (String, Sensitive) The Insert API key from the Account page of your New Relic account
 
 Optional:
@@ -870,7 +870,7 @@ Required:
 
 - **access_key** (String, Sensitive) Your OpenStack account access key
 - **bucket_name** (String) The name of your OpenStack container
-- **name** (String) The unique name of the OpenStack logging endpoint
+- **name** (String) The unique name of the OpenStack logging endpoint. It is important to note that changing this attribute will delete and recreate the resource
 - **url** (String) Your OpenStack auth url
 - **user** (String) The username for your OpenStack account
 
@@ -893,7 +893,7 @@ Optional:
 
 Required:
 
-- **name** (String) The unique name of the Scalyr logging endpoint
+- **name** (String) The unique name of the Scalyr logging endpoint. It is important to note that changing this attribute will delete and recreate the resource
 - **token** (String, Sensitive) The token to use for authentication (https://www.scalyr.com/keys)
 
 Optional:
@@ -911,7 +911,7 @@ Optional:
 Required:
 
 - **address** (String) The SFTP address to stream logs to
-- **name** (String) The unique name of the SFTP logging endpoint
+- **name** (String) The unique name of the SFTP logging endpoint. It is important to note that changing this attribute will delete and recreate the resource
 - **path** (String) The path to upload log files to. If the path ends in `/` then it is treated as a directory
 - **ssh_known_hosts** (String) A list of host keys for all hosts we can connect to over SFTP
 - **user** (String) The username for the server
@@ -938,7 +938,7 @@ Optional:
 Required:
 
 - **address** (String) The address of the Papertrail endpoint
-- **name** (String) A unique name to identify this Papertrail endpoint
+- **name** (String) A unique name to identify this Papertrail endpoint. It is important to note that changing this attribute will delete and recreate the resource
 - **port** (Number) The port associated with the address where the Papertrail endpoint can be accessed
 
 Optional:
@@ -954,7 +954,7 @@ Optional:
 
 Required:
 
-- **name** (String) Unique name to refer to this Request Setting
+- **name** (String) Unique name to refer to this Request Setting. It is important to note that changing this attribute will delete and recreate the resource
 
 Optional:
 
@@ -976,7 +976,7 @@ Optional:
 
 Required:
 
-- **name** (String) A unique name to identify this Response Object
+- **name** (String) A unique name to identify this Response Object. It is important to note that changing this attribute will delete and recreate the resource
 
 Optional:
 
@@ -994,7 +994,7 @@ Optional:
 Required:
 
 - **bucket_name** (String) The name of the bucket in which to store the logs
-- **name** (String) The unique name of the S3 logging endpoint
+- **name** (String) The unique name of the S3 logging endpoint. It is important to note that changing this attribute will delete and recreate the resource
 
 Optional:
 
@@ -1022,7 +1022,7 @@ Optional:
 Required:
 
 - **content** (String) The VCL code that specifies exactly what the snippet does
-- **name** (String) A name that is unique across "regular" and "dynamic" VCL Snippet configuration blocks
+- **name** (String) A name that is unique across "regular" and "dynamic" VCL Snippet configuration blocks. It is important to note that changing this attribute will delete and recreate the resource
 - **type** (String) The location in generated VCL where the snippet should be placed (can be one of `init`, `recv`, `hit`, `miss`, `pass`, `fetch`, `error`, `deliver`, `log` or `none`)
 
 Optional:
@@ -1035,7 +1035,7 @@ Optional:
 
 Required:
 
-- **name** (String) A unique name to identify the Splunk endpoint
+- **name** (String) A unique name to identify the Splunk endpoint. It is important to note that changing this attribute will delete and recreate the resource
 - **url** (String) The Splunk URL to stream logs to
 
 Optional:
@@ -1056,7 +1056,7 @@ Optional:
 
 Required:
 
-- **name** (String) A unique name to identify this Sumologic endpoint
+- **name** (String) A unique name to identify this Sumologic endpoint. It is important to note that changing this attribute will delete and recreate the resource
 - **url** (String) The URL to Sumologic collector endpoint
 
 Optional:
@@ -1074,7 +1074,7 @@ Optional:
 Required:
 
 - **address** (String) A hostname or IPv4 address of the Syslog endpoint
-- **name** (String) A unique name to identify this Syslog endpoint
+- **name** (String) A unique name to identify this Syslog endpoint. It is important to note that changing this attribute will delete and recreate the resource
 
 Optional:
 
@@ -1098,7 +1098,7 @@ Optional:
 Required:
 
 - **content** (String) The custom VCL code to upload
-- **name** (String) A unique name for this configuration block
+- **name** (String) A unique name for this configuration block. It is important to note that changing this attribute will delete and recreate the resource
 
 Optional:
 

--- a/docs/resources/service_v1.md
+++ b/docs/resources/service_v1.md
@@ -943,9 +943,10 @@ Required:
 
 Optional:
 
-- **format** (String) Apache-style string or VCL variables to use for log formatting
-- **placement** (String) Where in the generated VCL the logging call should be placed
-- **response_condition** (String) Name of blockAttributes condition to apply this logging
+- **format** (String) A Fastly [log format string](https://docs.fastly.com/en/guides/custom-log-formats)
+- **format_version** (Number) The version of the custom logging format used for the configured endpoint. The logging call gets placed by default in `vcl_log` if `format_version` is set to `2` and in `vcl_deliver` if `format_version` is set to `1`
+- **placement** (String) Where in the generated VCL the logging call should be placed. If not set, endpoints with `format_version` of 2 are placed in `vcl_log` and those with `format_version` of 1 are placed in `vcl_deliver`
+- **response_condition** (String) The name of an existing condition in the configured endpoint, or leave blank to always execute
 
 
 <a id="nestedblock--request_setting"></a>

--- a/docs/resources/service_v1.md
+++ b/docs/resources/service_v1.md
@@ -304,7 +304,7 @@ Optional:
 
 Required:
 
-- **name** (String) A unique name to identify this ACL
+- **name** (String) A unique name to identify this ACL. It is important to note that changing this attribute will delete and recreate the ACL, and discard the current items in the ACL
 
 Read-Only:
 
@@ -424,11 +424,11 @@ Optional:
 
 Required:
 
-- **name** (String) A unique name to identify this dictionary
+- **name** (String) A unique name to identify this dictionary. It is important to note that changing this attribute will delete and recreate the dictionary, and discard the current items in the dictionary
 
 Optional:
 
-- **write_only** (Boolean) If `true`, the dictionary is a private dictionary, and items are not readable in the UI or via API. Default is `false`. It is important to note that changing this attribute will delete and recreate the dictionary, discard the current items in the dictionary. Using a write-only/private dictionary should only be done if the items are managed outside of Terraform
+- **write_only** (Boolean) If `true`, the dictionary is a private dictionary, and items are not readable in the UI or via API. Default is `false`. It is important to note that changing this attribute will delete and recreate the dictionary, and discard the current items in the dictionary. Using a write-only/private dictionary should only be done if the items are managed outside of Terraform
 
 Read-Only:
 

--- a/docs/resources/service_v1.md
+++ b/docs/resources/service_v1.md
@@ -582,7 +582,7 @@ Optional:
 
 Required:
 
-- **name** (String) Unique name to refer to this logging setup
+- **name** (String) The unique name of the Logentries logging endpoint
 - **token** (String) Use token based authentication (https://logentries.com/doc/input-token/)
 
 Optional:

--- a/fastly/block_fastly_service_v1_acl.go
+++ b/fastly/block_fastly_service_v1_acl.go
@@ -83,33 +83,14 @@ func (h *ACLServiceAttributeHandler) Process(d *schema.ResourceData, latestVersi
 		}
 	}
 
-	// UPDATE modified resources
+	// UPDATE modified resources (NOT IMPLEMENTED)
 	//
-	// NOTE: although the go-fastly API client enables updating of a resource by
+	// Although the go-fastly API client enables updating of a resource by
 	// its 'name' attribute, this isn't possible within terraform due to
 	// constraints in the data model/schema of the resources not having a uid.
-	for _, resource := range diffResult.Modified {
-		resource := resource.(map[string]interface{})
-
-		opts := gofastly.UpdateACLInput{
-			ServiceID:      d.Id(),
-			ServiceVersion: latestVersion,
-			Name:           resource["name"].(string),
-		}
-
-		// only attempt to update attributes that have changed
-		modified := setDiff.Filter(resource, oldSet)
-
-		if v, ok := modified["name"]; ok {
-			opts.NewName = v.(string)
-		}
-
-		log.Printf("[DEBUG] Update ACL Opts: %#v", opts)
-		_, err := conn.UpdateACL(&opts)
-		if err != nil {
-			return err
-		}
-	}
+	//
+	// Because of this we do not implement any logic for updating the dictionary
+	// resource, only CREATE and DELETE functionality.
 
 	return nil
 }

--- a/fastly/block_fastly_service_v1_acl.go
+++ b/fastly/block_fastly_service_v1_acl.go
@@ -168,20 +168,20 @@ func (h *ACLServiceAttributeHandler) Register(s *schema.Resource) error {
 func flattenACLs(aclList []*gofastly.ACL) []map[string]interface{} {
 	var al []map[string]interface{}
 	for _, acl := range aclList {
-		// Convert VCLs to a map for saving to state.
-		vclMap := map[string]interface{}{
+		// Convert ACLs to a map for saving to state.
+		aclMap := map[string]interface{}{
 			"acl_id": acl.ID,
 			"name":   acl.Name,
 		}
 
 		// prune any empty values that come from the default string value in structs
-		for k, v := range vclMap {
+		for k, v := range aclMap {
 			if v == "" {
-				delete(vclMap, k)
+				delete(aclMap, k)
 			}
 		}
 
-		al = append(al, vclMap)
+		al = append(al, aclMap)
 	}
 
 	return al

--- a/fastly/block_fastly_service_v1_acl.go
+++ b/fastly/block_fastly_service_v1_acl.go
@@ -30,15 +30,15 @@ func (h *ACLServiceAttributeHandler) Process(d *schema.ResourceData, latestVersi
 		newACLVal = new(schema.Set)
 	}
 
-	oldACLSet := oldACLVal.(*schema.Set)
-	newACLSet := newACLVal.(*schema.Set)
+	oldSet := oldACLVal.(*schema.Set)
+	newSet := newACLVal.(*schema.Set)
 
-	setDiff := NewSetDiff(func(acl interface{}) (interface{}, error) {
-		// Use the acl name as the key
-		return acl.(map[string]interface{})["name"], nil
+	setDiff := NewSetDiff(func(resource interface{}) (interface{}, error) {
+		// Use the resource name as the key
+		return resource.(map[string]interface{})["name"], nil
 	})
 
-	diffResult, err := setDiff.Diff(oldACLSet, newACLSet)
+	diffResult, err := setDiff.Diff(oldSet, newSet)
 	if err != nil {
 		return err
 	}

--- a/fastly/block_fastly_service_v1_acl.go
+++ b/fastly/block_fastly_service_v1_acl.go
@@ -151,7 +151,7 @@ func (h *ACLServiceAttributeHandler) Register(s *schema.Resource) error {
 				"name": {
 					Type:        schema.TypeString,
 					Required:    true,
-					Description: "A unique name to identify this ACL",
+					Description: "A unique name to identify this ACL. It is important to note that changing this attribute will delete and recreate the ACL, and discard the current items in the ACL",
 				},
 				// Optional fields
 				"acl_id": {

--- a/fastly/block_fastly_service_v1_acl.go
+++ b/fastly/block_fastly_service_v1_acl.go
@@ -89,7 +89,7 @@ func (h *ACLServiceAttributeHandler) Process(d *schema.ResourceData, latestVersi
 	// its 'name' attribute, this isn't possible within terraform due to
 	// constraints in the data model/schema of the resources not having a uid.
 	//
-	// Because of this we do not implement any logic for updating the dictionary
+	// Because of this we do not implement any logic for updating the ACL
 	// resource, only CREATE and DELETE functionality.
 
 	return nil

--- a/fastly/block_fastly_service_v1_acl.go
+++ b/fastly/block_fastly_service_v1_acl.go
@@ -46,13 +46,6 @@ func (h *ACLServiceAttributeHandler) Process(d *schema.ResourceData, latestVersi
 		return err
 	}
 
-	// TODO: URGENT/CRITICAL:
-	// The SetDiff.Diff causes the ACL resource to be deleted and created.
-	//
-	// This is fine for making the tests pass, but the impact of doing this is
-	// that a client will lose data as the resource is version-less and mean any
-	// content they dynamically add to the resource will be lost!
-
 	// DELETE removed resources
 	for _, resource := range diffResult.Deleted {
 		resource := resource.(map[string]interface{})

--- a/fastly/block_fastly_service_v1_acl.go
+++ b/fastly/block_fastly_service_v1_acl.go
@@ -67,7 +67,7 @@ func (h *ACLServiceAttributeHandler) Process(d *schema.ResourceData, latestVersi
 		}
 	}
 
-	// ADD new resources
+	// CREATE new resources
 	for _, resource := range diffResult.Added {
 		resource := resource.(map[string]interface{})
 		opts := gofastly.CreateACLInput{

--- a/fastly/block_fastly_service_v1_acl_test.go
+++ b/fastly/block_fastly_service_v1_acl_test.go
@@ -43,7 +43,8 @@ func TestResourceFastlyFlattenAcl(t *testing.T) {
 func TestAccFastlyServiceV1_acl(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
-	aclName := fmt.Sprintf("acl %s", acctest.RandString(10))
+	aclName := fmt.Sprintf("acl_%s", acctest.RandString(10))
+	aclNameUpdated := fmt.Sprintf("acl_updated_%s", acctest.RandString(10))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -54,7 +55,16 @@ func TestAccFastlyServiceV1_acl(t *testing.T) {
 				Config: testAccServiceV1Config_acl(name, aclName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
-					testAccCheckFastlyServiceV1Attributes_acl(&service, name, aclName),
+					testAccCheckFastlyServiceV1Attributes_acl(&service, name, "a_"+aclName),
+					testAccCheckFastlyServiceV1Attributes_acl(&service, name, "b_"+aclName),
+				),
+			},
+			{
+				Config: testAccServiceV1Config_acl(name, aclNameUpdated),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
+					testAccCheckFastlyServiceV1Attributes_acl(&service, name, "a_"+aclNameUpdated),
+					testAccCheckFastlyServiceV1Attributes_acl(&service, name, "b_"+aclNameUpdated),
 				),
 			},
 		},
@@ -106,9 +116,13 @@ resource "fastly_service_v1" "foo" {
   }
 
   acl {
-	name       = "%s"
+		name       = "a_%s"
+  }
+
+  acl {
+		name       = "b_%s"
   }
 
   force_destroy = true
-}`, name, domainName, backendName, aclName)
+}`, name, domainName, backendName, aclName, aclName)
 }

--- a/fastly/block_fastly_service_v1_backend.go
+++ b/fastly/block_fastly_service_v1_backend.go
@@ -31,15 +31,15 @@ func (h *BackendServiceAttributeHandler) Process(d *schema.ResourceData, latestV
 		nb = new(schema.Set)
 	}
 
-	obs := ob.(*schema.Set)
-	nbs := nb.(*schema.Set)
+	oldSet := ob.(*schema.Set)
+	newSet := nb.(*schema.Set)
 
-	setDiff := NewSetDiff(func(backend interface{}) (interface{}, error) {
-		// Use the backend name as key
-		return backend.(map[string]interface{})["name"], nil
+	setDiff := NewSetDiff(func(resource interface{}) (interface{}, error) {
+		// Use the resource name as key
+		return resource.(map[string]interface{})["name"], nil
 	})
 
-	diffResult, err := setDiff.Diff(obs, nbs)
+	diffResult, err := setDiff.Diff(oldSet, newSet)
 	if err != nil {
 		return err
 	}
@@ -81,7 +81,7 @@ func (h *BackendServiceAttributeHandler) Process(d *schema.ResourceData, latestV
 		// filter out any unmodified nested fields by comparing them against the
 		// original backend set data structure using .Filter.
 		//
-		modified := setDiff.Filter(backend, obs)
+		modified := setDiff.Filter(backend, oldSet)
 		opts := h.buildUpdateBackendInput(d.Id(), latestVersion, backend, modified)
 
 		log.Printf("[DEBUG] Update Backend Opts: %#v", opts)

--- a/fastly/block_fastly_service_v1_backend.go
+++ b/fastly/block_fastly_service_v1_backend.go
@@ -353,7 +353,7 @@ func (h *BackendServiceAttributeHandler) Register(s *schema.Resource) error {
 		"name": {
 			Type:        schema.TypeString,
 			Required:    true,
-			Description: "Name for this Backend. Must be unique to this Service",
+			Description: "Name for this Backend. Must be unique to this Service. It is important to note that changing this attribute will delete and recreate the resource",
 		},
 		"address": {
 			Type:        schema.TypeString,

--- a/fastly/block_fastly_service_v1_backend.go
+++ b/fastly/block_fastly_service_v1_backend.go
@@ -63,7 +63,7 @@ func (h *BackendServiceAttributeHandler) Process(d *schema.ResourceData, latestV
 		}
 	}
 
-	// ADD new resources
+	// CREATE new resources
 	for _, resource := range diffResult.Added {
 		resource := resource.(map[string]interface{})
 		opts := h.buildCreateBackendInput(d.Id(), latestVersion, resource)

--- a/fastly/block_fastly_service_v1_bigquerylogging.go
+++ b/fastly/block_fastly_service_v1_bigquerylogging.go
@@ -198,7 +198,7 @@ func (h *BigQueryLoggingServiceAttributeHandler) Register(s *schema.Resource) er
 		"name": {
 			Type:        schema.TypeString,
 			Required:    true,
-			Description: "A unique name to identify this BigQuery logging endpoint",
+			Description: "A unique name to identify this BigQuery logging endpoint. It is important to note that changing this attribute will delete and recreate the resource",
 		},
 		"project_id": {
 			Type:        schema.TypeString,

--- a/fastly/block_fastly_service_v1_bigquerylogging.go
+++ b/fastly/block_fastly_service_v1_bigquerylogging.go
@@ -66,7 +66,7 @@ func (h *BigQueryLoggingServiceAttributeHandler) Process(d *schema.ResourceData,
 		}
 	}
 
-	// ADD new resources
+	// CREATE new resources
 	for _, resource := range diffResult.Added {
 		resource := resource.(map[string]interface{})
 

--- a/fastly/block_fastly_service_v1_bigquerylogging.go
+++ b/fastly/block_fastly_service_v1_bigquerylogging.go
@@ -30,15 +30,15 @@ func (h *BigQueryLoggingServiceAttributeHandler) Process(d *schema.ResourceData,
 		ns = new(schema.Set)
 	}
 
-	oss := os.(*schema.Set)
-	nss := ns.(*schema.Set)
+	oldSet := os.(*schema.Set)
+	newSet := ns.(*schema.Set)
 
-	setDiff := NewSetDiff(func(logging interface{}) (interface{}, error) {
-		// Use the logging endpoint name as the key
-		return logging.(map[string]interface{})["name"], nil
+	setDiff := NewSetDiff(func(resource interface{}) (interface{}, error) {
+		// Use the resource endpoint name as the key
+		return resource.(map[string]interface{})["name"], nil
 	})
 
-	diffResult, err := setDiff.Diff(oss, nss)
+	diffResult, err := setDiff.Diff(oldSet, newSet)
 	if err != nil {
 		return err
 	}

--- a/fastly/block_fastly_service_v1_blobstoragelogging.go
+++ b/fastly/block_fastly_service_v1_blobstoragelogging.go
@@ -66,7 +66,7 @@ func (h *BlobStorageLoggingServiceAttributeHandler) Process(d *schema.ResourceDa
 		}
 	}
 
-	// ADD new resources
+	// CREATE new resources
 	for _, resource := range diffResult.Added {
 		resource := resource.(map[string]interface{})
 

--- a/fastly/block_fastly_service_v1_blobstoragelogging.go
+++ b/fastly/block_fastly_service_v1_blobstoragelogging.go
@@ -34,8 +34,11 @@ func (h *BlobStorageLoggingServiceAttributeHandler) Process(d *schema.ResourceDa
 	newSet := nbsl.(*schema.Set)
 
 	setDiff := NewSetDiff(func(resource interface{}) (interface{}, error) {
-		// Use the resource endpoint name as the key
-		return resource.(map[string]interface{})["name"], nil
+		t, ok := resource.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("resource failed to be type asserted: %+v", resource)
+		}
+		return t["name"], nil
 	})
 
 	diffResult, err := setDiff.Diff(oldSet, newSet)
@@ -43,13 +46,13 @@ func (h *BlobStorageLoggingServiceAttributeHandler) Process(d *schema.ResourceDa
 		return err
 	}
 
-	// DELETE old Blob Storage logging configurations
-	for _, bslRaw := range diffResult.Deleted {
-		bslf := bslRaw.(map[string]interface{})
+	// DELETE removed resources
+	for _, resource := range diffResult.Deleted {
+		resource := resource.(map[string]interface{})
 		opts := gofastly.DeleteBlobStorageInput{
 			ServiceID:      d.Id(),
 			ServiceVersion: latestVersion,
-			Name:           bslf["name"].(string),
+			Name:           resource["name"].(string),
 		}
 
 		log.Printf("[DEBUG] Blob Storage logging removal opts: %#v", opts)
@@ -63,9 +66,9 @@ func (h *BlobStorageLoggingServiceAttributeHandler) Process(d *schema.ResourceDa
 		}
 	}
 
-	// POST new/updated Blob Storage logging configurations
-	for _, bslRaw := range diffResult.Added {
-		bslf := bslRaw.(map[string]interface{})
+	// ADD new resources
+	for _, resource := range diffResult.Added {
+		resource := resource.(map[string]interface{})
 
 		// @HACK for a TF SDK Issue.
 		//
@@ -77,24 +80,24 @@ func (h *BlobStorageLoggingServiceAttributeHandler) Process(d *schema.ResourceDa
 		// This is caused by using a StateFunc in a nested TypeSet. While the StateFunc
 		// properly handles setting state with the StateFunc, it returns extra entries
 		// during state Gets, specifically `GetChange("blobstoragelogging")` in this case.
-		if v, ok := bslf["name"]; !ok || v.(string) == "" {
+		if v, ok := resource["name"]; !ok || v.(string) == "" {
 			continue
 		}
 
-		var vla = h.getVCLLoggingAttributes(bslf)
+		var vla = h.getVCLLoggingAttributes(resource)
 		opts := gofastly.CreateBlobStorageInput{
 			ServiceID:         d.Id(),
 			ServiceVersion:    latestVersion,
-			Name:              bslf["name"].(string),
-			Path:              bslf["path"].(string),
-			AccountName:       bslf["account_name"].(string),
-			Container:         bslf["container"].(string),
-			SASToken:          bslf["sas_token"].(string),
-			Period:            uint(bslf["period"].(int)),
-			TimestampFormat:   bslf["timestamp_format"].(string),
-			GzipLevel:         uint(bslf["gzip_level"].(int)),
-			PublicKey:         bslf["public_key"].(string),
-			MessageType:       bslf["message_type"].(string),
+			Name:              resource["name"].(string),
+			Path:              resource["path"].(string),
+			AccountName:       resource["account_name"].(string),
+			Container:         resource["container"].(string),
+			SASToken:          resource["sas_token"].(string),
+			Period:            uint(resource["period"].(int)),
+			TimestampFormat:   resource["timestamp_format"].(string),
+			GzipLevel:         uint(resource["gzip_level"].(int)),
+			PublicKey:         resource["public_key"].(string),
+			MessageType:       resource["message_type"].(string),
 			Format:            vla.format,
 			FormatVersion:     uintOrDefault(vla.formatVersion),
 			Placement:         vla.placement,
@@ -107,6 +110,79 @@ func (h *BlobStorageLoggingServiceAttributeHandler) Process(d *schema.ResourceDa
 			return err
 		}
 	}
+
+	// UPDATE modified resources
+	//
+	// NOTE: although the go-fastly API client enables updating of a resource by
+	// its 'name' attribute, this isn't possible within terraform due to
+	// constraints in the data model/schema of the resources not having a uid.
+	for _, resource := range diffResult.Modified {
+		resource := resource.(map[string]interface{})
+
+		opts := gofastly.UpdateBlobStorageInput{
+			ServiceID:      d.Id(),
+			ServiceVersion: latestVersion,
+			Name:           resource["name"].(string),
+		}
+
+		// only attempt to update attributes that have changed
+		modified := setDiff.Filter(resource, oldSet)
+
+		// NOTE: where we transition between interface{} we lose the ability to
+		// infer the underlying type being either a uint vs an int. This
+		// materializes as a panic (yay) and so it's only at runtime we discover
+		// this and so we've updated the below code to convert the type asserted
+		// int into a uint before passing the value to gofastly.Uint().
+		if v, ok := modified["path"]; ok {
+			opts.Path = gofastly.String(v.(string))
+		}
+		if v, ok := modified["account_name"]; ok {
+			opts.AccountName = gofastly.String(v.(string))
+		}
+		if v, ok := modified["container"]; ok {
+			opts.Container = gofastly.String(v.(string))
+		}
+		if v, ok := modified["sas_token"]; ok {
+			opts.SASToken = gofastly.String(v.(string))
+		}
+		if v, ok := modified["period"]; ok {
+			opts.Period = gofastly.Uint(uint(v.(int)))
+		}
+		if v, ok := modified["timestamp_format"]; ok {
+			opts.TimestampFormat = gofastly.String(v.(string))
+		}
+		if v, ok := modified["compression_codec"]; ok {
+			opts.CompressionCodec = gofastly.String(v.(string))
+		}
+		if v, ok := modified["gzip_level"]; ok {
+			opts.GzipLevel = gofastly.Uint(uint(v.(int)))
+		}
+		if v, ok := modified["public_key"]; ok {
+			opts.PublicKey = gofastly.String(v.(string))
+		}
+		if v, ok := modified["format"]; ok {
+			opts.Format = gofastly.String(v.(string))
+		}
+		if v, ok := modified["format_version"]; ok {
+			opts.FormatVersion = gofastly.Uint(uint(v.(int)))
+		}
+		if v, ok := modified["message_type"]; ok {
+			opts.MessageType = gofastly.String(v.(string))
+		}
+		if v, ok := modified["placement"]; ok {
+			opts.Placement = gofastly.String(v.(string))
+		}
+		if v, ok := modified["response_condition"]; ok {
+			opts.ResponseCondition = gofastly.String(v.(string))
+		}
+
+		log.Printf("[DEBUG] Update Blob Storage Opts: %#v", opts)
+		_, err := conn.UpdateBlobStorage(&opts)
+		if err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 

--- a/fastly/block_fastly_service_v1_blobstoragelogging.go
+++ b/fastly/block_fastly_service_v1_blobstoragelogging.go
@@ -211,7 +211,7 @@ func (h *BlobStorageLoggingServiceAttributeHandler) Register(s *schema.Resource)
 		"name": {
 			Type:        schema.TypeString,
 			Required:    true,
-			Description: "A unique name to identify the Azure Blob Storage endpoint",
+			Description: "A unique name to identify the Azure Blob Storage endpoint. It is important to note that changing this attribute will delete and recreate the resource",
 		},
 		"account_name": {
 			Type:        schema.TypeString,

--- a/fastly/block_fastly_service_v1_blobstoragelogging.go
+++ b/fastly/block_fastly_service_v1_blobstoragelogging.go
@@ -30,15 +30,15 @@ func (h *BlobStorageLoggingServiceAttributeHandler) Process(d *schema.ResourceDa
 		nbsl = new(schema.Set)
 	}
 
-	obsls := obsl.(*schema.Set)
-	nbsls := nbsl.(*schema.Set)
+	oldSet := obsl.(*schema.Set)
+	newSet := nbsl.(*schema.Set)
 
-	setDiff := NewSetDiff(func(logging interface{}) (interface{}, error) {
-		// Use the logging endpoint name as the key
-		return logging.(map[string]interface{})["name"], nil
+	setDiff := NewSetDiff(func(resource interface{}) (interface{}, error) {
+		// Use the resource endpoint name as the key
+		return resource.(map[string]interface{})["name"], nil
 	})
 
-	diffResult, err := setDiff.Diff(obsls, nbsls)
+	diffResult, err := setDiff.Diff(oldSet, newSet)
 	if err != nil {
 		return err
 	}

--- a/fastly/block_fastly_service_v1_cachesetting.go
+++ b/fastly/block_fastly_service_v1_cachesetting.go
@@ -157,7 +157,7 @@ func (h *CacheSettingServiceAttributeHandler) Register(s *schema.Resource) error
 				"name": {
 					Type:        schema.TypeString,
 					Required:    true,
-					Description: "Unique name for this Cache Setting",
+					Description: "Unique name for this Cache Setting. It is important to note that changing this attribute will delete and recreate the resource",
 				},
 				"action": {
 					Type:        schema.TypeString,

--- a/fastly/block_fastly_service_v1_cachesetting.go
+++ b/fastly/block_fastly_service_v1_cachesetting.go
@@ -67,7 +67,7 @@ func (h *CacheSettingServiceAttributeHandler) Process(d *schema.ResourceData, la
 		}
 	}
 
-	// ADD new resources
+	// CREATE new resources
 	for _, resource := range diffResult.Added {
 		opts, err := buildCacheSetting(resource.(map[string]interface{}))
 		if err != nil {

--- a/fastly/block_fastly_service_v1_cachesetting.go
+++ b/fastly/block_fastly_service_v1_cachesetting.go
@@ -35,8 +35,11 @@ func (h *CacheSettingServiceAttributeHandler) Process(d *schema.ResourceData, la
 	newSet := nc.(*schema.Set)
 
 	setDiff := NewSetDiff(func(resource interface{}) (interface{}, error) {
-		// Use the resource name as the key
-		return resource.(map[string]interface{})["name"], nil
+		t, ok := resource.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("resource failed to be type asserted: %+v", resource)
+		}
+		return t["name"], nil
 	})
 
 	diffResult, err := setDiff.Diff(oldSet, newSet)
@@ -44,13 +47,13 @@ func (h *CacheSettingServiceAttributeHandler) Process(d *schema.ResourceData, la
 		return err
 	}
 
-	// Delete removed Cache Settings
-	for _, dRaw := range diffResult.Deleted {
-		df := dRaw.(map[string]interface{})
+	// DELETE removed resources
+	for _, resource := range diffResult.Deleted {
+		resource := resource.(map[string]interface{})
 		opts := gofastly.DeleteCacheSettingInput{
 			ServiceID:      d.Id(),
 			ServiceVersion: latestVersion,
-			Name:           df["name"].(string),
+			Name:           resource["name"].(string),
 		}
 
 		log.Printf("[DEBUG] Fastly Cache Settings removal opts: %#v", opts)
@@ -64,9 +67,9 @@ func (h *CacheSettingServiceAttributeHandler) Process(d *schema.ResourceData, la
 		}
 	}
 
-	// POST new Cache Settings
-	for _, dRaw := range diffResult.Added {
-		opts, err := buildCacheSetting(dRaw.(map[string]interface{}))
+	// ADD new resources
+	for _, resource := range diffResult.Added {
+		opts, err := buildCacheSetting(resource.(map[string]interface{}))
 		if err != nil {
 			log.Printf("[DEBUG] Error building Cache Setting: %s", err)
 			return err
@@ -80,6 +83,49 @@ func (h *CacheSettingServiceAttributeHandler) Process(d *schema.ResourceData, la
 			return err
 		}
 	}
+
+	// UPDATE modified resources
+	//
+	// NOTE: although the go-fastly API client enables updating of a resource by
+	// its 'name' attribute, this isn't possible within terraform due to
+	// constraints in the data model/schema of the resources not having a uid.
+	for _, resource := range diffResult.Modified {
+		resource := resource.(map[string]interface{})
+
+		opts := gofastly.UpdateCacheSettingInput{
+			ServiceID:      d.Id(),
+			ServiceVersion: latestVersion,
+			Name:           resource["name"].(string),
+		}
+
+		// only attempt to update attributes that have changed
+		modified := setDiff.Filter(resource, oldSet)
+
+		// NOTE: where we transition between interface{} we lose the ability to
+		// infer the underlying type being either a uint vs an int. This
+		// materializes as a panic (yay) and so it's only at runtime we discover
+		// this and so we've updated the below code to convert the type asserted
+		// int into a uint before passing the value to gofastly.Uint().
+		if v, ok := modified["action"]; ok {
+			opts.Action = gofastly.CacheSettingAction(v.(string))
+		}
+		if v, ok := modified["ttl"]; ok {
+			opts.TTL = gofastly.Uint(uint(v.(int)))
+		}
+		if v, ok := modified["stale_ttl"]; ok {
+			opts.StaleTTL = gofastly.Uint(uint(v.(int)))
+		}
+		if v, ok := modified["cache_condition"]; ok {
+			opts.CacheCondition = gofastly.String(v.(string))
+		}
+
+		log.Printf("[DEBUG] Update Cache Setting Opts: %#v", opts)
+		_, err := conn.UpdateCacheSetting(&opts)
+		if err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 

--- a/fastly/block_fastly_service_v1_cachesetting.go
+++ b/fastly/block_fastly_service_v1_cachesetting.go
@@ -31,15 +31,15 @@ func (h *CacheSettingServiceAttributeHandler) Process(d *schema.ResourceData, la
 		nc = new(schema.Set)
 	}
 
-	ocs := oc.(*schema.Set)
-	ncs := nc.(*schema.Set)
+	oldSet := oc.(*schema.Set)
+	newSet := nc.(*schema.Set)
 
-	setDiff := NewSetDiff(func(cachesettings interface{}) (interface{}, error) {
-		// Use the cache settings name as the key
-		return cachesettings.(map[string]interface{})["name"], nil
+	setDiff := NewSetDiff(func(resource interface{}) (interface{}, error) {
+		// Use the resource name as the key
+		return resource.(map[string]interface{})["name"], nil
 	})
 
-	diffResult, err := setDiff.Diff(ocs, ncs)
+	diffResult, err := setDiff.Diff(oldSet, newSet)
 	if err != nil {
 		return err
 	}

--- a/fastly/block_fastly_service_v1_condition.go
+++ b/fastly/block_fastly_service_v1_condition.go
@@ -167,7 +167,7 @@ func (h *ConditionServiceAttributeHandler) Register(s *schema.Resource) error {
 				"name": {
 					Type:        schema.TypeString,
 					Required:    true,
-					Description: "The unique name for the condition",
+					Description: "The unique name for the condition. It is important to note that changing this attribute will delete and recreate the resource",
 				},
 				"statement": {
 					Type:        schema.TypeString,

--- a/fastly/block_fastly_service_v1_condition.go
+++ b/fastly/block_fastly_service_v1_condition.go
@@ -37,15 +37,15 @@ func (h *ConditionServiceAttributeHandler) Process(d *schema.ResourceData, lates
 		nc = new(schema.Set)
 	}
 
-	ocs := oc.(*schema.Set)
-	ncs := nc.(*schema.Set)
+	oldSet := oc.(*schema.Set)
+	newSet := nc.(*schema.Set)
 
-	setDiff := NewSetDiff(func(cond interface{}) (interface{}, error) {
-		// Use the condition name as the key
-		return cond.(map[string]interface{})["name"], nil
+	setDiff := NewSetDiff(func(resource interface{}) (interface{}, error) {
+		// Use the resource name as the key
+		return resource.(map[string]interface{})["name"], nil
 	})
 
-	diffResult, err := setDiff.Diff(ocs, ncs)
+	diffResult, err := setDiff.Diff(oldSet, newSet)
 	if err != nil {
 		return err
 	}

--- a/fastly/block_fastly_service_v1_condition.go
+++ b/fastly/block_fastly_service_v1_condition.go
@@ -73,7 +73,7 @@ func (h *ConditionServiceAttributeHandler) Process(d *schema.ResourceData, lates
 		}
 	}
 
-	// ADD new resources
+	// CREATE new resources
 	for _, resource := range diffResult.Added {
 		resource := resource.(map[string]interface{})
 		opts := gofastly.CreateConditionInput{

--- a/fastly/block_fastly_service_v1_dictionary.go
+++ b/fastly/block_fastly_service_v1_dictionary.go
@@ -31,15 +31,15 @@ func (h *DictionaryServiceAttributeHandler) Process(d *schema.ResourceData, late
 		newDictVal = new(schema.Set)
 	}
 
-	oldDictSet := oldDictVal.(*schema.Set)
-	newDictSet := newDictVal.(*schema.Set)
+	oldSet := oldDictVal.(*schema.Set)
+	newSet := newDictVal.(*schema.Set)
 
-	setDiff := NewSetDiff(func(dictionary interface{}) (interface{}, error) {
-		// Use the dictionary name as the key
-		return dictionary.(map[string]interface{})["name"], nil
+	setDiff := NewSetDiff(func(resource interface{}) (interface{}, error) {
+		// Use the resource name as the key
+		return resource.(map[string]interface{})["name"], nil
 	})
 
-	diffResult, err := setDiff.Diff(oldDictSet, newDictSet)
+	diffResult, err := setDiff.Diff(oldSet, newSet)
 	if err != nil {
 		return err
 	}

--- a/fastly/block_fastly_service_v1_dictionary.go
+++ b/fastly/block_fastly_service_v1_dictionary.go
@@ -67,7 +67,7 @@ func (h *DictionaryServiceAttributeHandler) Process(d *schema.ResourceData, late
 		}
 	}
 
-	// ADD new resources
+	// CREATE new resources
 	for _, resource := range diffResult.Added {
 		opts, err := buildDictionary(resource.(map[string]interface{}))
 		if err != nil {

--- a/fastly/block_fastly_service_v1_dictionary.go
+++ b/fastly/block_fastly_service_v1_dictionary.go
@@ -128,7 +128,7 @@ func (h *DictionaryServiceAttributeHandler) Register(s *schema.Resource) error {
 				"name": {
 					Type:        schema.TypeString,
 					Required:    true,
-					Description: "A unique name to identify this dictionary",
+					Description: "A unique name to identify this dictionary. It is important to note that changing this attribute will delete and recreate the dictionary, and discard the current items in the dictionary",
 				},
 				// Optional fields
 				"dictionary_id": {
@@ -140,7 +140,7 @@ func (h *DictionaryServiceAttributeHandler) Register(s *schema.Resource) error {
 					Type:        schema.TypeBool,
 					Optional:    true,
 					Default:     false,
-					Description: "If `true`, the dictionary is a private dictionary, and items are not readable in the UI or via API. Default is `false`. It is important to note that changing this attribute will delete and recreate the dictionary, discard the current items in the dictionary. Using a write-only/private dictionary should only be done if the items are managed outside of Terraform",
+					Description: "If `true`, the dictionary is a private dictionary, and items are not readable in the UI or via API. Default is `false`. It is important to note that changing this attribute will delete and recreate the dictionary, and discard the current items in the dictionary. Using a write-only/private dictionary should only be done if the items are managed outside of Terraform",
 				},
 			},
 		},

--- a/fastly/block_fastly_service_v1_dictionary_test.go
+++ b/fastly/block_fastly_service_v1_dictionary_test.go
@@ -78,7 +78,7 @@ func TestAccFastlyServiceV1_dictionary_write_only(t *testing.T) {
 		CheckDestroy: testAccCheckServiceV1Destroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccServiceV1Config_dictionary_write_only(name, dictName, backendName, domainName, true),
+				Config: testAccServiceV1Config_dictionary_write_only(name, dictName, backendName, domainName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
 					testAccCheckFastlyServiceV1Attributes_dictionary(&service, name, dictName, true),
@@ -114,36 +114,6 @@ func TestAccFastlyServiceV1_dictionary_update_name(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
 					testAccCheckFastlyServiceV1Attributes_dictionary(&service, name, updatedDictName, false),
-				),
-			},
-		},
-	})
-}
-
-func TestAccFastlyServiceV1_dictionary_update_write_only(t *testing.T) {
-	var service gofastly.ServiceDetail
-	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
-	dictName := fmt.Sprintf("dict %s", acctest.RandString(10))
-	backendName := fmt.Sprintf("%s.aws.amazon.com", acctest.RandString(3))
-	domainName := fmt.Sprintf("fastly-test.tf-%s.com", acctest.RandString(10))
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckServiceV1Destroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccServiceV1Config_dictionary(name, dictName, backendName, domainName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
-					testAccCheckFastlyServiceV1Attributes_dictionary(&service, name, dictName, false),
-				),
-			},
-			{
-				Config: testAccServiceV1Config_dictionary_write_only(name, dictName, backendName, domainName, true),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
-					testAccCheckFastlyServiceV1Attributes_dictionary(&service, name, dictName, true),
 				),
 			},
 		},
@@ -203,7 +173,7 @@ resource "fastly_service_v1" "foo" {
 }`, name, domainName, backendName, dictName)
 }
 
-func testAccServiceV1Config_dictionary_write_only(name, dictName, backendName, domainName string, writeOnly bool) string {
+func testAccServiceV1Config_dictionary_write_only(name, dictName, backendName, domainName string) string {
 	return fmt.Sprintf(`
 resource "fastly_service_v1" "foo" {
   name = "%s"
@@ -220,9 +190,9 @@ resource "fastly_service_v1" "foo" {
 
   dictionary {
     name       = "%s"
-    write_only = %v
+    write_only = true
   }
 
   force_destroy = true
-}`, name, domainName, backendName, dictName, writeOnly)
+}`, name, domainName, backendName, dictName)
 }

--- a/fastly/block_fastly_service_v1_director.go
+++ b/fastly/block_fastly_service_v1_director.go
@@ -254,7 +254,7 @@ func (h *DirectorServiceAttributeHandler) Register(s *schema.Resource) error {
 				"name": {
 					Type:        schema.TypeString,
 					Required:    true,
-					Description: "Unique name for this Director",
+					Description: "Unique name for this Director. It is important to note that changing this attribute will delete and recreate the resource",
 				},
 				"backends": {
 					Type:        schema.TypeSet,

--- a/fastly/block_fastly_service_v1_director.go
+++ b/fastly/block_fastly_service_v1_director.go
@@ -30,15 +30,15 @@ func (h *DirectorServiceAttributeHandler) Process(d *schema.ResourceData, latest
 		nd = new(schema.Set)
 	}
 
-	ods := od.(*schema.Set)
-	nds := nd.(*schema.Set)
+	oldSet := od.(*schema.Set)
+	newSet := nd.(*schema.Set)
 
-	setDiff := NewSetDiff(func(director interface{}) (interface{}, error) {
-		// Use the director name as the key
-		return director.(map[string]interface{})["name"], nil
+	setDiff := NewSetDiff(func(resource interface{}) (interface{}, error) {
+		// Use the resource name as the key
+		return resource.(map[string]interface{})["name"], nil
 	})
 
-	diffResult, err := setDiff.Diff(ods, nds)
+	diffResult, err := setDiff.Diff(oldSet, newSet)
 	if err != nil {
 		return err
 	}

--- a/fastly/block_fastly_service_v1_director.go
+++ b/fastly/block_fastly_service_v1_director.go
@@ -66,7 +66,7 @@ func (h *DirectorServiceAttributeHandler) Process(d *schema.ResourceData, latest
 		}
 	}
 
-	// ADD new resources
+	// CREATE new resources
 	for _, resource := range diffResult.Added {
 		resource := resource.(map[string]interface{})
 		opts := gofastly.CreateDirectorInput{

--- a/fastly/block_fastly_service_v1_director_test.go
+++ b/fastly/block_fastly_service_v1_director_test.go
@@ -121,64 +121,64 @@ func TestAccFastlyServiceV1_directors_basic(t *testing.T) {
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	domainName1 := fmt.Sprintf("fastly-test.tf-%s.com", acctest.RandString(10))
 
-	createdDir1 := gofastly.Director{
+	// Director + Backend 1
+	directorDeveloper := gofastly.Director{
 		ServiceVersion: 1,
-		Name:           "mydirector",
+		Name:           "director_developer",
 		Type:           3,
 		Quorum:         75,
 		Capacity:       100,
 		Retries:        5,
 	}
-	createdDb1 := gofastly.DirectorBackend{
-		Director: "mydirector",
-		Backend:  "origin old",
+	directorBackendDeveloper := gofastly.DirectorBackend{
+		Director: "director_developer",
+		Backend:  "developer",
 	}
 
-	updatedDir1 := gofastly.Director{
+	// Director + Backend 2
+	directorDeveloperUpdated := gofastly.Director{
 		ServiceVersion: 1,
-		Name:           "mydirector",
+		Name:           "director_developer",
 		Type:           4,
 		Quorum:         30,
 		Capacity:       25,
 		Retries:        10,
 	}
-	updatedDb1 := gofastly.DirectorBackend{
-		Director: "mydirector",
-		Backend:  "origin new",
+	directorBackendDeveloperUpdated := gofastly.DirectorBackend{
+		Director: "director_developer",
+		Backend:  "developer_updated",
 	}
 
-	createdDir2 := gofastly.Director{
+	// Director + Backend 3
+	directorApps := gofastly.Director{
 		ServiceVersion: 1,
-		Name:           "unchangeddirector",
+		Name:           "director_apps",
 		Type:           3,
 		Quorum:         75,
 		Capacity:       100,
 		Retries:        5,
 	}
-	createdDb2 := gofastly.DirectorBackend{
-		Director: "unchangeddirector",
-		Backend:  "origin apps",
+	directorBackendApps := gofastly.DirectorBackend{
+		Director: "director_apps",
+		Backend:  "apps",
 	}
 
-	// Updated director should be the same as the created ones
-	updatedDir2 := createdDir2
-	updatedDb2 := createdDb2
-
-	updatedDir3 := gofastly.Director{
+	// Director + Backend 4
+	directorWWWDemo := gofastly.Director{
 		ServiceVersion: 1,
-		Name:           "myotherdirector",
+		Name:           "director_www_demo",
 		Type:           3,
 		Quorum:         75,
 		Capacity:       100,
 		Retries:        5,
 	}
-	updatedDb3x := gofastly.DirectorBackend{
-		Director: "myotherdirector",
-		Backend:  "origin x",
+	directorBackendWWW := gofastly.DirectorBackend{
+		Director: "director_www_demo",
+		Backend:  "www",
 	}
-	updatedDb3y := gofastly.DirectorBackend{
-		Director: "myotherdirector",
-		Backend:  "origin y",
+	directorBackendDemo := gofastly.DirectorBackend{
+		Director: "director_www_demo",
+		Backend:  "demo",
 	}
 
 	resource.Test(t, resource.TestCase{
@@ -192,12 +192,10 @@ func TestAccFastlyServiceV1_directors_basic(t *testing.T) {
 					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
 					testAccCheckFastlyServiceV1DirectorsAttributes(
 						&service,
-						[]*gofastly.Director{&createdDir1, &createdDir2},
-						[]*gofastly.DirectorBackend{&createdDb1, &createdDb2}),
-					resource.TestCheckResourceAttr(
-						"fastly_service_v1.foo", "name", name),
-					resource.TestCheckResourceAttr(
-						"fastly_service_v1.foo", "director.#", "2"),
+						[]*gofastly.Director{&directorDeveloper, &directorApps},
+						[]*gofastly.DirectorBackend{&directorBackendDeveloper, &directorBackendApps}),
+					resource.TestCheckResourceAttr("fastly_service_v1.foo", "name", name),
+					resource.TestCheckResourceAttr("fastly_service_v1.foo", "director.#", "2"),
 				),
 			},
 
@@ -207,12 +205,10 @@ func TestAccFastlyServiceV1_directors_basic(t *testing.T) {
 					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
 					testAccCheckFastlyServiceV1DirectorsAttributes(
 						&service,
-						[]*gofastly.Director{&updatedDir1, &updatedDir2, &updatedDir3},
-						[]*gofastly.DirectorBackend{&updatedDb1, &updatedDb2, &updatedDb3x, &updatedDb3y}),
-					resource.TestCheckResourceAttr(
-						"fastly_service_v1.foo", "name", name),
-					resource.TestCheckResourceAttr(
-						"fastly_service_v1.foo", "director.#", "3"),
+						[]*gofastly.Director{&directorDeveloperUpdated, &directorApps, &directorWWWDemo},
+						[]*gofastly.DirectorBackend{&directorBackendDeveloperUpdated, &directorBackendApps, &directorBackendWWW, &directorBackendDemo}),
+					resource.TestCheckResourceAttr("fastly_service_v1.foo", "name", name),
+					resource.TestCheckResourceAttr("fastly_service_v1.foo", "director.#", "3"),
 				),
 			},
 		},
@@ -272,25 +268,25 @@ resource "fastly_service_v1" "foo" {
 
   backend {
     address = "developer.fastly.com"
-    name    = "origin old"
+    name    = "developer"
   }
 
   backend {
     address = "apps.fastly.com"
-    name    = "origin apps"
+    name    = "apps"
     weight  = 1
   }
 
   director {
-    name = "mydirector"
+    name = "director_developer"
     type = 3
-    backends = [ "origin old" ]
+    backends = [ "developer" ]
   }
 
   director {
-    name = "unchangeddirector"
+    name = "director_apps"
     type = 3
-    backends = [ "origin apps" ]
+    backends = [ "apps" ]
   }
 
   force_destroy = true
@@ -309,44 +305,44 @@ resource "fastly_service_v1" "foo" {
 
   backend {
     address = "developer.fastly.com"
-    name    = "origin new"
+    name    = "developer_updated"
   }
 
   backend {
     address = "apps.fastly.com"
-    name    = "origin apps"
+    name    = "apps"
     weight  = 9
   }
 
   backend {
     address = "www.fastly.com"
-    name    = "origin x"
+    name    = "www"
   }
 
   backend {
     address = "www.fastlydemo.net"
-    name    = "origin y"
+    name    = "demo"
   }
 
   director {
-    name = "mydirector"
+    name = "director_developer"
     type = 4
     quorum = 30
     retries = 10
     capacity = 25
-    backends = [ "origin new" ]
+    backends = [ "developer_updated" ]
   }
 
   director {
-    name = "unchangeddirector"
+    name = "director_apps"
     type = 3
-    backends = [ "origin apps" ]
+    backends = [ "apps" ]
   }
 
   director {
-    name = "myotherdirector"
+    name = "director_www_demo"
     type = 3
-    backends = [ "origin x", "origin y" ]
+    backends = [ "www", "demo" ]
   }
 
   force_destroy = true

--- a/fastly/block_fastly_service_v1_domain.go
+++ b/fastly/block_fastly_service_v1_domain.go
@@ -47,12 +47,12 @@ func (h *DomainServiceAttributeHandler) Process(d *schema.ResourceData, latestVe
 	}
 
 	// DELETE removed resources
-	for _, domain := range diffResult.Deleted {
-		domain := domain.(map[string]interface{})
+	for _, resource := range diffResult.Deleted {
+		resource := resource.(map[string]interface{})
 		opts := gofastly.DeleteDomainInput{
 			ServiceID:      d.Id(),
 			ServiceVersion: latestVersion,
-			Name:           domain["name"].(string),
+			Name:           resource["name"].(string),
 		}
 
 		log.Printf("[DEBUG] Fastly Domain removal opts: %#v", opts)
@@ -88,12 +88,9 @@ func (h *DomainServiceAttributeHandler) Process(d *schema.ResourceData, latestVe
 
 	// UPDATE modified resources
 	//
-	// NOTE: although the go-fastly API client enables updating of a domain by
+	// NOTE: although the go-fastly API client enables updating of a resource by
 	// its 'name' attribute, this isn't possible within terraform due to
 	// constraints in the data model/schema of the resources not having a uid.
-	// Although we do allow for updating a domain whose 'comment' attribute has
-	// been updated (thus avoiding the expense associated with a DELETE/CREATE
-	// by enabling just the UPDATE operation).
 	for _, resource := range diffResult.Modified {
 		resource := resource.(map[string]interface{})
 

--- a/fastly/block_fastly_service_v1_domain.go
+++ b/fastly/block_fastly_service_v1_domain.go
@@ -46,7 +46,7 @@ func (h *DomainServiceAttributeHandler) Process(d *schema.ResourceData, latestVe
 		return err
 	}
 
-	// DELETE removed domains
+	// DELETE removed resources
 	for _, domain := range diffResult.Deleted {
 		domain := domain.(map[string]interface{})
 		opts := gofastly.DeleteDomainInput{
@@ -66,16 +66,16 @@ func (h *DomainServiceAttributeHandler) Process(d *schema.ResourceData, latestVe
 		}
 	}
 
-	// ADD new domains
-	for _, domain := range diffResult.Added {
-		domain := domain.(map[string]interface{})
+	// ADD new resources
+	for _, resource := range diffResult.Added {
+		resource := resource.(map[string]interface{})
 		opts := gofastly.CreateDomainInput{
 			ServiceID:      d.Id(),
 			ServiceVersion: latestVersion,
-			Name:           domain["name"].(string),
+			Name:           resource["name"].(string),
 		}
 
-		if v, ok := domain["comment"]; ok {
+		if v, ok := resource["comment"]; ok {
 			opts.Comment = v.(string)
 		}
 
@@ -86,7 +86,7 @@ func (h *DomainServiceAttributeHandler) Process(d *schema.ResourceData, latestVe
 		}
 	}
 
-	// UPDATE modified domains
+	// UPDATE modified resources
 	//
 	// NOTE: although the go-fastly API client enables updating of a domain by
 	// its 'name' attribute, this isn't possible within terraform due to
@@ -94,17 +94,17 @@ func (h *DomainServiceAttributeHandler) Process(d *schema.ResourceData, latestVe
 	// Although we do allow for updating a domain whose 'comment' attribute has
 	// been updated (thus avoiding the expense associated with a DELETE/CREATE
 	// by enabling just the UPDATE operation).
-	for _, domain := range diffResult.Modified {
-		domain := domain.(map[string]interface{})
+	for _, resource := range diffResult.Modified {
+		resource := resource.(map[string]interface{})
 
 		opts := gofastly.UpdateDomainInput{
 			ServiceID:      d.Id(),
 			ServiceVersion: latestVersion,
-			Name:           domain["name"].(string),
+			Name:           resource["name"].(string),
 		}
 
 		// only attempt to update attributes that have changed
-		modified := setDiff.Filter(domain, oldSet)
+		modified := setDiff.Filter(resource, oldSet)
 
 		if v, ok := modified["comment"]; ok {
 			opts.Comment = gofastly.String(v.(string))

--- a/fastly/block_fastly_service_v1_domain.go
+++ b/fastly/block_fastly_service_v1_domain.go
@@ -30,15 +30,15 @@ func (h *DomainServiceAttributeHandler) Process(d *schema.ResourceData, latestVe
 		nd = new(schema.Set)
 	}
 
-	ods := od.(*schema.Set)
-	nds := nd.(*schema.Set)
+	oldSet := od.(*schema.Set)
+	newSet := nd.(*schema.Set)
 
-	setDiff := NewSetDiff(func(domain interface{}) (interface{}, error) {
-		// Use the domain name as the key
-		return domain.(map[string]interface{})["name"], nil
+	setDiff := NewSetDiff(func(resource interface{}) (interface{}, error) {
+		// Use the resource name as the key
+		return resource.(map[string]interface{})["name"], nil
 	})
 
-	diffResult, err := setDiff.Diff(ods, nds)
+	diffResult, err := setDiff.Diff(oldSet, newSet)
 	if err != nil {
 		return err
 	}

--- a/fastly/block_fastly_service_v1_domain.go
+++ b/fastly/block_fastly_service_v1_domain.go
@@ -150,7 +150,7 @@ func (h *DomainServiceAttributeHandler) Register(s *schema.Resource) error {
 				"name": {
 					Type:        schema.TypeString,
 					Required:    true,
-					Description: "The domain that this Service will respond to",
+					Description: "The domain that this Service will respond to. It is important to note that changing this attribute will delete and recreate the domain.",
 				},
 
 				"comment": {

--- a/fastly/block_fastly_service_v1_domain.go
+++ b/fastly/block_fastly_service_v1_domain.go
@@ -150,7 +150,7 @@ func (h *DomainServiceAttributeHandler) Register(s *schema.Resource) error {
 				"name": {
 					Type:        schema.TypeString,
 					Required:    true,
-					Description: "The domain that this Service will respond to. It is important to note that changing this attribute will delete and recreate the domain.",
+					Description: "The domain that this Service will respond to. It is important to note that changing this attribute will delete and recreate the resource.",
 				},
 
 				"comment": {

--- a/fastly/block_fastly_service_v1_domain.go
+++ b/fastly/block_fastly_service_v1_domain.go
@@ -66,7 +66,7 @@ func (h *DomainServiceAttributeHandler) Process(d *schema.ResourceData, latestVe
 		}
 	}
 
-	// ADD new resources
+	// CREATE new resources
 	for _, resource := range diffResult.Added {
 		resource := resource.(map[string]interface{})
 		opts := gofastly.CreateDomainInput{

--- a/fastly/block_fastly_service_v1_domain.go
+++ b/fastly/block_fastly_service_v1_domain.go
@@ -103,7 +103,10 @@ func (h *DomainServiceAttributeHandler) Process(d *schema.ResourceData, latestVe
 			Name:           domain["name"].(string),
 		}
 
-		if v, ok := domain["comment"]; ok {
+		// only attempt to update attributes that have changed
+		modified := setDiff.Filter(domain, oldSet)
+
+		if v, ok := modified["comment"]; ok {
 			opts.Comment = gofastly.String(v.(string))
 		}
 

--- a/fastly/block_fastly_service_v1_dynamicsnippet.go
+++ b/fastly/block_fastly_service_v1_dynamicsnippet.go
@@ -158,7 +158,7 @@ func (h *DynamicSnippetServiceAttributeHandler) Register(s *schema.Resource) err
 				"name": {
 					Type:        schema.TypeString,
 					Required:    true,
-					Description: `A name that is unique across "regular" and "dynamic" VCL Snippet configuration blocks`,
+					Description: `A name that is unique across "regular" and "dynamic" VCL Snippet configuration blocks. It is important to note that changing this attribute will delete and recreate the resource`,
 				},
 				"type": {
 					Type:         schema.TypeString,

--- a/fastly/block_fastly_service_v1_dynamicsnippet.go
+++ b/fastly/block_fastly_service_v1_dynamicsnippet.go
@@ -33,15 +33,15 @@ func (h *DynamicSnippetServiceAttributeHandler) Process(d *schema.ResourceData, 
 		newDynamicSnippetVal = new(schema.Set)
 	}
 
-	oldDynamicSnippetSet := oldDynamicSnippetVal.(*schema.Set)
-	newDynamicSnippetSet := newDynamicSnippetVal.(*schema.Set)
+	oldSet := oldDynamicSnippetVal.(*schema.Set)
+	newSet := newDynamicSnippetVal.(*schema.Set)
 
-	setDiff := NewSetDiff(func(dynsnippet interface{}) (interface{}, error) {
-		// Use the dynamic snippet name as the key
-		return dynsnippet.(map[string]interface{})["name"], nil
+	setDiff := NewSetDiff(func(resource interface{}) (interface{}, error) {
+		// Use the resource name as the key
+		return resource.(map[string]interface{})["name"], nil
 	})
 
-	diffResult, err := setDiff.Diff(oldDynamicSnippetSet, newDynamicSnippetSet)
+	diffResult, err := setDiff.Diff(oldSet, newSet)
 	if err != nil {
 		return err
 	}

--- a/fastly/block_fastly_service_v1_dynamicsnippet.go
+++ b/fastly/block_fastly_service_v1_dynamicsnippet.go
@@ -69,7 +69,7 @@ func (h *DynamicSnippetServiceAttributeHandler) Process(d *schema.ResourceData, 
 		}
 	}
 
-	// ADD new resources
+	// CREATE new resources
 	for _, resource := range diffResult.Added {
 		opts, err := buildDynamicSnippet(resource.(map[string]interface{}))
 		if err != nil {

--- a/fastly/block_fastly_service_v1_gcslogging.go
+++ b/fastly/block_fastly_service_v1_gcslogging.go
@@ -66,7 +66,7 @@ func (h *GCSLoggingServiceAttributeHandler) Process(d *schema.ResourceData, late
 		}
 	}
 
-	// ADD new resources
+	// CREATE new resources
 	for _, resource := range diffResult.Added {
 		resource := resource.(map[string]interface{})
 		var vla = h.getVCLLoggingAttributes(resource)

--- a/fastly/block_fastly_service_v1_gcslogging.go
+++ b/fastly/block_fastly_service_v1_gcslogging.go
@@ -30,15 +30,15 @@ func (h *GCSLoggingServiceAttributeHandler) Process(d *schema.ResourceData, late
 		ns = new(schema.Set)
 	}
 
-	oss := os.(*schema.Set)
-	nss := ns.(*schema.Set)
+	oldSet := os.(*schema.Set)
+	newSet := ns.(*schema.Set)
 
-	setDiff := NewSetDiff(func(logging interface{}) (interface{}, error) {
-		// Use the logging endpoint name as the key
-		return logging.(map[string]interface{})["name"], nil
+	setDiff := NewSetDiff(func(resource interface{}) (interface{}, error) {
+		// Use the resource endpoint name as the key
+		return resource.(map[string]interface{})["name"], nil
 	})
 
-	diffResult, err := setDiff.Diff(oss, nss)
+	diffResult, err := setDiff.Diff(oldSet, newSet)
 	if err != nil {
 		return err
 	}

--- a/fastly/block_fastly_service_v1_gcslogging.go
+++ b/fastly/block_fastly_service_v1_gcslogging.go
@@ -191,7 +191,7 @@ func (h *GCSLoggingServiceAttributeHandler) Register(s *schema.Resource) error {
 		"name": {
 			Type:        schema.TypeString,
 			Required:    true,
-			Description: "A unique name to identify this GCS endpoint",
+			Description: "A unique name to identify this GCS endpoint. It is important to note that changing this attribute will delete and recreate the resource",
 		},
 		"email": {
 			Type:        schema.TypeString,

--- a/fastly/block_fastly_service_v1_gzip.go
+++ b/fastly/block_fastly_service_v1_gzip.go
@@ -31,15 +31,15 @@ func (h *GzipServiceAttributeHandler) Process(d *schema.ResourceData, latestVers
 		ng = new(schema.Set)
 	}
 
-	ogs := og.(*schema.Set)
-	ngs := ng.(*schema.Set)
+	oldSet := og.(*schema.Set)
+	newSet := ng.(*schema.Set)
 
-	setDiff := NewSetDiff(func(gzip interface{}) (interface{}, error) {
-		// Use the gzip name as the key
-		return gzip.(map[string]interface{})["name"], nil
+	setDiff := NewSetDiff(func(resource interface{}) (interface{}, error) {
+		// Use the resource name as the key
+		return resource.(map[string]interface{})["name"], nil
 	})
 
-	diffResult, err := setDiff.Diff(ogs, ngs)
+	diffResult, err := setDiff.Diff(oldSet, newSet)
 	if err != nil {
 		return err
 	}

--- a/fastly/block_fastly_service_v1_gzip.go
+++ b/fastly/block_fastly_service_v1_gzip.go
@@ -67,7 +67,7 @@ func (h *GzipServiceAttributeHandler) Process(d *schema.ResourceData, latestVers
 		}
 	}
 
-	// ADD new resources
+	// CREATE new resources
 	for _, resource := range diffResult.Added {
 		resource := resource.(map[string]interface{})
 		opts := gofastly.CreateGzipInput{

--- a/fastly/block_fastly_service_v1_gzip.go
+++ b/fastly/block_fastly_service_v1_gzip.go
@@ -176,7 +176,7 @@ func (h *GzipServiceAttributeHandler) Register(s *schema.Resource) error {
 				"name": {
 					Type:        schema.TypeString,
 					Required:    true,
-					Description: "A name to refer to this gzip condition",
+					Description: "A name to refer to this gzip condition. It is important to note that changing this attribute will delete and recreate the resource",
 				},
 				// optional fields
 				"content_types": {

--- a/fastly/block_fastly_service_v1_header.go
+++ b/fastly/block_fastly_service_v1_header.go
@@ -180,7 +180,7 @@ func (h *HeaderServiceAttributeHandler) Register(s *schema.Resource) error {
 				"name": {
 					Type:        schema.TypeString,
 					Required:    true,
-					Description: "Unique name for this header attribute",
+					Description: "Unique name for this header attribute. It is important to note that changing this attribute will delete and recreate the resource",
 				},
 				"action": {
 					Type:         schema.TypeString,

--- a/fastly/block_fastly_service_v1_header.go
+++ b/fastly/block_fastly_service_v1_header.go
@@ -67,7 +67,7 @@ func (h *HeaderServiceAttributeHandler) Process(d *schema.ResourceData, latestVe
 		}
 	}
 
-	// ADD new resources
+	// CREATE new resources
 	for _, resource := range diffResult.Added {
 		opts, err := buildHeader(resource.(map[string]interface{}))
 		if err != nil {

--- a/fastly/block_fastly_service_v1_header.go
+++ b/fastly/block_fastly_service_v1_header.go
@@ -31,15 +31,15 @@ func (h *HeaderServiceAttributeHandler) Process(d *schema.ResourceData, latestVe
 		nh = new(schema.Set)
 	}
 
-	ohs := oh.(*schema.Set)
-	nhs := nh.(*schema.Set)
+	oldSet := oh.(*schema.Set)
+	newSet := nh.(*schema.Set)
 
-	setDiff := NewSetDiff(func(domain interface{}) (interface{}, error) {
-		// Use the header name as the key
-		return domain.(map[string]interface{})["name"], nil
+	setDiff := NewSetDiff(func(resource interface{}) (interface{}, error) {
+		// Use the resource name as the key
+		return resource.(map[string]interface{})["name"], nil
 	})
 
-	diffResult, err := setDiff.Diff(ohs, nhs)
+	diffResult, err := setDiff.Diff(oldSet, newSet)
 	if err != nil {
 		return err
 	}

--- a/fastly/block_fastly_service_v1_healthcheck.go
+++ b/fastly/block_fastly_service_v1_healthcheck.go
@@ -189,7 +189,7 @@ func (h *HealthCheckServiceAttributeHandler) Register(s *schema.Resource) error 
 				"name": {
 					Type:        schema.TypeString,
 					Required:    true,
-					Description: "A unique name to identify this Healthcheck",
+					Description: "A unique name to identify this Healthcheck. It is important to note that changing this attribute will delete and recreate the resource",
 				},
 				"host": {
 					Type:        schema.TypeString,

--- a/fastly/block_fastly_service_v1_healthcheck.go
+++ b/fastly/block_fastly_service_v1_healthcheck.go
@@ -66,7 +66,7 @@ func (h *HealthCheckServiceAttributeHandler) Process(d *schema.ResourceData, lat
 		}
 	}
 
-	// ADD new resources
+	// CREATE new resources
 	for _, resource := range diffResult.Added {
 		resource := resource.(map[string]interface{})
 

--- a/fastly/block_fastly_service_v1_healthcheck.go
+++ b/fastly/block_fastly_service_v1_healthcheck.go
@@ -30,15 +30,15 @@ func (h *HealthCheckServiceAttributeHandler) Process(d *schema.ResourceData, lat
 		nh = new(schema.Set)
 	}
 
-	ohs := oh.(*schema.Set)
-	nhs := nh.(*schema.Set)
+	oldSet := oh.(*schema.Set)
+	newSet := nh.(*schema.Set)
 
-	setDiff := NewSetDiff(func(healthcheck interface{}) (interface{}, error) {
-		// Use the health check name as the key
-		return healthcheck.(map[string]interface{})["name"], nil
+	setDiff := NewSetDiff(func(resource interface{}) (interface{}, error) {
+		// Use the resource name as the key
+		return resource.(map[string]interface{})["name"], nil
 	})
 
-	diffResult, err := setDiff.Diff(ohs, nhs)
+	diffResult, err := setDiff.Diff(oldSet, newSet)
 	if err != nil {
 		return err
 	}

--- a/fastly/block_fastly_service_v1_httpslogging.go
+++ b/fastly/block_fastly_service_v1_httpslogging.go
@@ -61,7 +61,7 @@ func (h *HTTPSLoggingServiceAttributeHandler) Process(d *schema.ResourceData, la
 		}
 	}
 
-	// ADD new resources
+	// CREATE new resources
 	for _, nRaw := range diffResult.Added {
 		hf := nRaw.(map[string]interface{})
 		opts := h.buildCreate(hf, serviceID, latestVersion)

--- a/fastly/block_fastly_service_v1_httpslogging.go
+++ b/fastly/block_fastly_service_v1_httpslogging.go
@@ -184,7 +184,7 @@ func (h *HTTPSLoggingServiceAttributeHandler) Register(s *schema.Resource) error
 		"name": {
 			Type:        schema.TypeString,
 			Required:    true,
-			Description: "The unique name of the HTTPS logging endpoint",
+			Description: "The unique name of the HTTPS logging endpoint. It is important to note that changing this attribute will delete and recreate the resource",
 		},
 		"url": {
 			Type:         schema.TypeString,

--- a/fastly/block_fastly_service_v1_httpslogging.go
+++ b/fastly/block_fastly_service_v1_httpslogging.go
@@ -33,15 +33,15 @@ func (h *HTTPSLoggingServiceAttributeHandler) Process(d *schema.ResourceData, la
 		nh = new(schema.Set)
 	}
 
-	ohs := oh.(*schema.Set)
-	nhs := nh.(*schema.Set)
+	oldSet := oh.(*schema.Set)
+	newSet := nh.(*schema.Set)
 
-	setDiff := NewSetDiff(func(logging interface{}) (interface{}, error) {
-		// Use the logging endpoint name as the key
-		return logging.(map[string]interface{})["name"], nil
+	setDiff := NewSetDiff(func(resource interface{}) (interface{}, error) {
+		// Use the resource endpoint name as the key
+		return resource.(map[string]interface{})["name"], nil
 	})
 
-	diffResult, err := setDiff.Diff(ohs, nhs)
+	diffResult, err := setDiff.Diff(oldSet, newSet)
 	if err != nil {
 		return err
 	}

--- a/fastly/block_fastly_service_v1_logentries.go
+++ b/fastly/block_fastly_service_v1_logentries.go
@@ -117,7 +117,7 @@ func (h *LogentriesServiceAttributeHandler) Register(s *schema.Resource) error {
 		"name": {
 			Type:        schema.TypeString,
 			Required:    true,
-			Description: "Unique name to refer to this logging setup",
+			Description: "The unique name of the Logentries logging endpoint",
 		},
 		"token": {
 			Type:        schema.TypeString,

--- a/fastly/block_fastly_service_v1_logentries.go
+++ b/fastly/block_fastly_service_v1_logentries.go
@@ -174,7 +174,7 @@ func (h *LogentriesServiceAttributeHandler) Register(s *schema.Resource) error {
 		"name": {
 			Type:        schema.TypeString,
 			Required:    true,
-			Description: "The unique name of the Logentries logging endpoint",
+			Description: "The unique name of the Logentries logging endpoint. It is important to note that changing this attribute will delete and recreate the resource",
 		},
 		"token": {
 			Type:        schema.TypeString,

--- a/fastly/block_fastly_service_v1_logentries.go
+++ b/fastly/block_fastly_service_v1_logentries.go
@@ -34,8 +34,11 @@ func (h *LogentriesServiceAttributeHandler) Process(d *schema.ResourceData, late
 	newSet := ns.(*schema.Set)
 
 	setDiff := NewSetDiff(func(resource interface{}) (interface{}, error) {
-		// Use the resource endpoint name as the key
-		return resource.(map[string]interface{})["name"], nil
+		t, ok := resource.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("resource failed to be type asserted: %+v", resource)
+		}
+		return t["name"], nil
 	})
 
 	diffResult, err := setDiff.Diff(oldSet, newSet)
@@ -43,13 +46,13 @@ func (h *LogentriesServiceAttributeHandler) Process(d *schema.ResourceData, late
 		return err
 	}
 
-	// DELETE old logentries configurations
-	for _, pRaw := range diffResult.Deleted {
-		slf := pRaw.(map[string]interface{})
+	// DELETE removed resources
+	for _, resource := range diffResult.Deleted {
+		resource := resource.(map[string]interface{})
 		opts := gofastly.DeleteLogentriesInput{
 			ServiceID:      d.Id(),
 			ServiceVersion: latestVersion,
-			Name:           slf["name"].(string),
+			Name:           resource["name"].(string),
 		}
 
 		log.Printf("[DEBUG] Fastly Logentries removal opts: %#v", opts)
@@ -63,18 +66,18 @@ func (h *LogentriesServiceAttributeHandler) Process(d *schema.ResourceData, late
 		}
 	}
 
-	// POST new/updated Logentries
-	for _, pRaw := range diffResult.Added {
-		slf := pRaw.(map[string]interface{})
+	// ADD new resources
+	for _, resource := range diffResult.Added {
+		resource := resource.(map[string]interface{})
 
-		var vla = h.getVCLLoggingAttributes(slf)
+		var vla = h.getVCLLoggingAttributes(resource)
 		opts := gofastly.CreateLogentriesInput{
 			ServiceID:         d.Id(),
 			ServiceVersion:    latestVersion,
-			Name:              slf["name"].(string),
-			Port:              uint(slf["port"].(int)),
-			UseTLS:            gofastly.Compatibool(slf["use_tls"].(bool)),
-			Token:             slf["token"].(string),
+			Name:              resource["name"].(string),
+			Port:              uint(resource["port"].(int)),
+			UseTLS:            gofastly.Compatibool(resource["use_tls"].(bool)),
+			Token:             resource["token"].(string),
 			Format:            vla.format,
 			FormatVersion:     uintOrDefault(vla.formatVersion),
 			Placement:         vla.placement,
@@ -83,6 +86,60 @@ func (h *LogentriesServiceAttributeHandler) Process(d *schema.ResourceData, late
 
 		log.Printf("[DEBUG] Create Logentries Opts: %#v", opts)
 		_, err := conn.CreateLogentries(&opts)
+		if err != nil {
+			return err
+		}
+	}
+
+	// UPDATE modified resources
+	//
+	// NOTE: although the go-fastly API client enables updating of a resource by
+	// its 'name' attribute, this isn't possible within terraform due to
+	// constraints in the data model/schema of the resources not having a uid.
+	for _, resource := range diffResult.Modified {
+		resource := resource.(map[string]interface{})
+
+		opts := gofastly.UpdateLogentriesInput{
+			ServiceID:      d.Id(),
+			ServiceVersion: latestVersion,
+			Name:           resource["name"].(string),
+		}
+
+		// only attempt to update attributes that have changed
+		modified := setDiff.Filter(resource, oldSet)
+
+		// NOTE: where we transition between interface{} we lose the ability to
+		// infer the underlying type being either a uint vs an int. This
+		// materializes as a panic (yay) and so it's only at runtime we discover
+		// this and so we've updated the below code to convert the type asserted
+		// int into a uint before passing the value to gofastly.Uint().
+		if v, ok := modified["port"]; ok {
+			opts.Port = gofastly.Uint(uint(v.(int)))
+		}
+		if v, ok := modified["use_tls"]; ok {
+			opts.UseTLS = gofastly.CBool(v.(bool))
+		}
+		if v, ok := modified["token"]; ok {
+			opts.Token = gofastly.String(v.(string))
+		}
+		if v, ok := modified["format"]; ok {
+			opts.Format = gofastly.String(v.(string))
+		}
+		if v, ok := modified["format_version"]; ok {
+			opts.FormatVersion = gofastly.Uint(uint(v.(int)))
+		}
+		if v, ok := modified["response_condition"]; ok {
+			opts.ResponseCondition = gofastly.String(v.(string))
+		}
+		if v, ok := modified["region"]; ok {
+			opts.Region = gofastly.String(v.(string))
+		}
+		if v, ok := modified["placement"]; ok {
+			opts.Placement = gofastly.String(v.(string))
+		}
+
+		log.Printf("[DEBUG] Update Logentries Opts: %#v", opts)
+		_, err := conn.UpdateLogentries(&opts)
 		if err != nil {
 			return err
 		}

--- a/fastly/block_fastly_service_v1_logentries.go
+++ b/fastly/block_fastly_service_v1_logentries.go
@@ -66,7 +66,7 @@ func (h *LogentriesServiceAttributeHandler) Process(d *schema.ResourceData, late
 		}
 	}
 
-	// ADD new resources
+	// CREATE new resources
 	for _, resource := range diffResult.Added {
 		resource := resource.(map[string]interface{})
 

--- a/fastly/block_fastly_service_v1_logentries.go
+++ b/fastly/block_fastly_service_v1_logentries.go
@@ -30,15 +30,15 @@ func (h *LogentriesServiceAttributeHandler) Process(d *schema.ResourceData, late
 		ns = new(schema.Set)
 	}
 
-	oss := os.(*schema.Set)
-	nss := ns.(*schema.Set)
+	oldSet := os.(*schema.Set)
+	newSet := ns.(*schema.Set)
 
-	setDiff := NewSetDiff(func(logging interface{}) (interface{}, error) {
-		// Use the logging endpoint name as the key
-		return logging.(map[string]interface{})["name"], nil
+	setDiff := NewSetDiff(func(resource interface{}) (interface{}, error) {
+		// Use the resource endpoint name as the key
+		return resource.(map[string]interface{})["name"], nil
 	})
 
-	diffResult, err := setDiff.Diff(oss, nss)
+	diffResult, err := setDiff.Diff(oldSet, newSet)
 	if err != nil {
 		return err
 	}

--- a/fastly/block_fastly_service_v1_logging_cloudfiles.go
+++ b/fastly/block_fastly_service_v1_logging_cloudfiles.go
@@ -32,15 +32,15 @@ func (h *CloudfilesServiceAttributeHandler) Process(d *schema.ResourceData, late
 		nl = new(schema.Set)
 	}
 
-	ols := ol.(*schema.Set)
-	nls := nl.(*schema.Set)
+	oldSet := ol.(*schema.Set)
+	newSet := nl.(*schema.Set)
 
-	setDiff := NewSetDiff(func(logging interface{}) (interface{}, error) {
-		// Use the logging endpoint name as the key
-		return logging.(map[string]interface{})["name"], nil
+	setDiff := NewSetDiff(func(resource interface{}) (interface{}, error) {
+		// Use the resource endpoint name as the key
+		return resource.(map[string]interface{})["name"], nil
 	})
 
-	diffResult, err := setDiff.Diff(ols, nls)
+	diffResult, err := setDiff.Diff(oldSet, newSet)
 	if err != nil {
 		return err
 	}

--- a/fastly/block_fastly_service_v1_logging_cloudfiles.go
+++ b/fastly/block_fastly_service_v1_logging_cloudfiles.go
@@ -35,11 +35,18 @@ func (h *CloudfilesServiceAttributeHandler) Process(d *schema.ResourceData, late
 	ols := ol.(*schema.Set)
 	nls := nl.(*schema.Set)
 
-	removeCloudfilesLogging := ols.Difference(nls).List()
-	addCloudfilesLogging := nls.Difference(ols).List()
+	setDiff := NewSetDiff(func(logging interface{}) (interface{}, error) {
+		// Use the logging endpoint name as the key
+		return logging.(map[string]interface{})["name"], nil
+	})
+
+	diffResult, err := setDiff.Diff(ols, nls)
+	if err != nil {
+		return err
+	}
 
 	// DELETE old Cloud Files logging endpoints.
-	for _, oRaw := range removeCloudfilesLogging {
+	for _, oRaw := range diffResult.Deleted {
 		of := oRaw.(map[string]interface{})
 		opts := h.buildDelete(of, serviceID, latestVersion)
 
@@ -51,7 +58,7 @@ func (h *CloudfilesServiceAttributeHandler) Process(d *schema.ResourceData, late
 	}
 
 	// POST new/updated Cloud Files logging endpoints.
-	for _, nRaw := range addCloudfilesLogging {
+	for _, nRaw := range diffResult.Added {
 		lf := nRaw.(map[string]interface{})
 
 		// @HACK for a TF SDK Issue.

--- a/fastly/block_fastly_service_v1_logging_cloudfiles.go
+++ b/fastly/block_fastly_service_v1_logging_cloudfiles.go
@@ -36,8 +36,11 @@ func (h *CloudfilesServiceAttributeHandler) Process(d *schema.ResourceData, late
 	newSet := nl.(*schema.Set)
 
 	setDiff := NewSetDiff(func(resource interface{}) (interface{}, error) {
-		// Use the resource endpoint name as the key
-		return resource.(map[string]interface{})["name"], nil
+		t, ok := resource.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("resource failed to be type asserted: %+v", resource)
+		}
+		return t["name"], nil
 	})
 
 	diffResult, err := setDiff.Diff(oldSet, newSet)
@@ -45,10 +48,10 @@ func (h *CloudfilesServiceAttributeHandler) Process(d *schema.ResourceData, late
 		return err
 	}
 
-	// DELETE old Cloud Files logging endpoints.
-	for _, oRaw := range diffResult.Deleted {
-		of := oRaw.(map[string]interface{})
-		opts := h.buildDelete(of, serviceID, latestVersion)
+	// DELETE removed resources
+	for _, resource := range diffResult.Deleted {
+		resource := resource.(map[string]interface{})
+		opts := h.buildDelete(resource, serviceID, latestVersion)
 
 		log.Printf("[DEBUG] Fastly Cloud Files logging endpoint removal opts: %#v", opts)
 
@@ -57,9 +60,9 @@ func (h *CloudfilesServiceAttributeHandler) Process(d *schema.ResourceData, late
 		}
 	}
 
-	// POST new/updated Cloud Files logging endpoints.
-	for _, nRaw := range diffResult.Added {
-		lf := nRaw.(map[string]interface{})
+	// ADD new resources
+	for _, resource := range diffResult.Added {
+		resource := resource.(map[string]interface{})
 
 		// @HACK for a TF SDK Issue.
 		//
@@ -71,14 +74,86 @@ func (h *CloudfilesServiceAttributeHandler) Process(d *schema.ResourceData, late
 		// This is caused by using a StateFunc in a nested TypeSet. While the StateFunc
 		// properly handles setting state with the StateFunc, it returns extra entries
 		// during state Gets, specifically `GetChange("logging_cloudfiles")` in this case.
-		if v, ok := lf["name"]; !ok || v.(string) == "" {
+		if v, ok := resource["name"]; !ok || v.(string) == "" {
 			continue
 		}
-		opts := h.buildCreate(lf, serviceID, latestVersion)
+		opts := h.buildCreate(resource, serviceID, latestVersion)
 
 		log.Printf("[DEBUG] Fastly Cloud Files logging addition opts: %#v", opts)
 
 		if err := createCloudfiles(conn, opts); err != nil {
+			return err
+		}
+	}
+
+	// UPDATE modified resources
+	//
+	// NOTE: although the go-fastly API client enables updating of a resource by
+	// its 'name' attribute, this isn't possible within terraform due to
+	// constraints in the data model/schema of the resources not having a uid.
+	for _, resource := range diffResult.Modified {
+		resource := resource.(map[string]interface{})
+
+		opts := gofastly.UpdateCloudfilesInput{
+			ServiceID:      d.Id(),
+			ServiceVersion: latestVersion,
+			Name:           resource["name"].(string),
+		}
+
+		// only attempt to update attributes that have changed
+		modified := setDiff.Filter(resource, oldSet)
+
+		// NOTE: where we transition between interface{} we lose the ability to
+		// infer the underlying type being either a uint vs an int. This
+		// materializes as a panic (yay) and so it's only at runtime we discover
+		// this and so we've updated the below code to convert the type asserted
+		// int into a uint before passing the value to gofastly.Uint().
+		if v, ok := modified["user"]; ok {
+			opts.User = gofastly.String(v.(string))
+		}
+		if v, ok := modified["access_key"]; ok {
+			opts.AccessKey = gofastly.String(v.(string))
+		}
+		if v, ok := modified["bucket_name"]; ok {
+			opts.BucketName = gofastly.String(v.(string))
+		}
+		if v, ok := modified["path"]; ok {
+			opts.Path = gofastly.String(v.(string))
+		}
+		if v, ok := modified["region"]; ok {
+			opts.Region = gofastly.String(v.(string))
+		}
+		if v, ok := modified["placement"]; ok {
+			opts.Placement = gofastly.String(v.(string))
+		}
+		if v, ok := modified["period"]; ok {
+			opts.Period = gofastly.Uint(uint(v.(int)))
+		}
+		if v, ok := modified["gzip_level"]; ok {
+			opts.GzipLevel = gofastly.Uint(uint(v.(int)))
+		}
+		if v, ok := modified["format"]; ok {
+			opts.Format = gofastly.String(v.(string))
+		}
+		if v, ok := modified["format_version"]; ok {
+			opts.FormatVersion = gofastly.Uint(uint(v.(int)))
+		}
+		if v, ok := modified["response_condition"]; ok {
+			opts.ResponseCondition = gofastly.String(v.(string))
+		}
+		if v, ok := modified["message_type"]; ok {
+			opts.MessageType = gofastly.String(v.(string))
+		}
+		if v, ok := modified["timestamp_format"]; ok {
+			opts.TimestampFormat = gofastly.String(v.(string))
+		}
+		if v, ok := modified["public_key"]; ok {
+			opts.PublicKey = gofastly.String(v.(string))
+		}
+
+		log.Printf("[DEBUG] Update Cloud Files Opts: %#v", opts)
+		_, err := conn.UpdateCloudfiles(&opts)
+		if err != nil {
 			return err
 		}
 	}

--- a/fastly/block_fastly_service_v1_logging_cloudfiles.go
+++ b/fastly/block_fastly_service_v1_logging_cloudfiles.go
@@ -280,7 +280,7 @@ func (h *CloudfilesServiceAttributeHandler) Register(s *schema.Resource) error {
 		"name": {
 			Type:        schema.TypeString,
 			Required:    true,
-			Description: "The unique name of the Rackspace Cloud Files logging endpoint",
+			Description: "The unique name of the Rackspace Cloud Files logging endpoint. It is important to note that changing this attribute will delete and recreate the resource",
 		},
 
 		"bucket_name": {

--- a/fastly/block_fastly_service_v1_logging_cloudfiles.go
+++ b/fastly/block_fastly_service_v1_logging_cloudfiles.go
@@ -60,7 +60,7 @@ func (h *CloudfilesServiceAttributeHandler) Process(d *schema.ResourceData, late
 		}
 	}
 
-	// ADD new resources
+	// CREATE new resources
 	for _, resource := range diffResult.Added {
 		resource := resource.(map[string]interface{})
 

--- a/fastly/block_fastly_service_v1_logging_datadog.go
+++ b/fastly/block_fastly_service_v1_logging_datadog.go
@@ -36,8 +36,11 @@ func (h *DatadogServiceAttributeHandler) Process(d *schema.ResourceData, latestV
 	newSet := nd.(*schema.Set)
 
 	setDiff := NewSetDiff(func(resource interface{}) (interface{}, error) {
-		// Use the resource endpoint name as the key
-		return resource.(map[string]interface{})["name"], nil
+		t, ok := resource.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("resource failed to be type asserted: %+v", resource)
+		}
+		return t["name"], nil
 	})
 
 	diffResult, err := setDiff.Diff(oldSet, newSet)
@@ -45,10 +48,10 @@ func (h *DatadogServiceAttributeHandler) Process(d *schema.ResourceData, latestV
 		return err
 	}
 
-	// DELETE old Datadog logging endpoints.
-	for _, oRaw := range diffResult.Deleted {
-		of := oRaw.(map[string]interface{})
-		opts := h.buildDelete(of, serviceID, latestVersion)
+	// DELETE removed resources
+	for _, resource := range diffResult.Deleted {
+		resource := resource.(map[string]interface{})
+		opts := h.buildDelete(resource, serviceID, latestVersion)
 
 		log.Printf("[DEBUG] Fastly Datadog logging endpoint removal opts: %#v", opts)
 
@@ -57,14 +60,62 @@ func (h *DatadogServiceAttributeHandler) Process(d *schema.ResourceData, latestV
 		}
 	}
 
-	// POST new/updated Datadog logging endpoints.
-	for _, nRaw := range diffResult.Added {
-		df := nRaw.(map[string]interface{})
-		opts := h.buildCreate(df, serviceID, latestVersion)
+	// ADD new resources
+	for _, resource := range diffResult.Added {
+		resource := resource.(map[string]interface{})
+		opts := h.buildCreate(resource, serviceID, latestVersion)
 
 		log.Printf("[DEBUG] Fastly Datadog logging addition opts: %#v", opts)
 
 		if err := createDatadog(conn, opts); err != nil {
+			return err
+		}
+	}
+
+	// UPDATE modified resources
+	//
+	// NOTE: although the go-fastly API client enables updating of a resource by
+	// its 'name' attribute, this isn't possible within terraform due to
+	// constraints in the data model/schema of the resources not having a uid.
+	for _, resource := range diffResult.Modified {
+		resource := resource.(map[string]interface{})
+
+		opts := gofastly.UpdateDatadogInput{
+			ServiceID:      d.Id(),
+			ServiceVersion: latestVersion,
+			Name:           resource["name"].(string),
+		}
+
+		// only attempt to update attributes that have changed
+		modified := setDiff.Filter(resource, oldSet)
+
+		// NOTE: where we transition between interface{} we lose the ability to
+		// infer the underlying type being either a uint vs an int. This
+		// materializes as a panic (yay) and so it's only at runtime we discover
+		// this and so we've updated the below code to convert the type asserted
+		// int into a uint before passing the value to gofastly.Uint().
+		if v, ok := modified["token"]; ok {
+			opts.Token = gofastly.String(v.(string))
+		}
+		if v, ok := modified["region"]; ok {
+			opts.Region = gofastly.String(v.(string))
+		}
+		if v, ok := modified["format"]; ok {
+			opts.Format = gofastly.String(v.(string))
+		}
+		if v, ok := modified["format_version"]; ok {
+			opts.FormatVersion = gofastly.Uint(uint(v.(int)))
+		}
+		if v, ok := modified["response_condition"]; ok {
+			opts.ResponseCondition = gofastly.String(v.(string))
+		}
+		if v, ok := modified["placement"]; ok {
+			opts.Placement = gofastly.String(v.(string))
+		}
+
+		log.Printf("[DEBUG] Update Datadog Opts: %#v", opts)
+		_, err := conn.UpdateDatadog(&opts)
+		if err != nil {
 			return err
 		}
 	}

--- a/fastly/block_fastly_service_v1_logging_datadog.go
+++ b/fastly/block_fastly_service_v1_logging_datadog.go
@@ -32,15 +32,15 @@ func (h *DatadogServiceAttributeHandler) Process(d *schema.ResourceData, latestV
 		nd = new(schema.Set)
 	}
 
-	ods := od.(*schema.Set)
-	nds := nd.(*schema.Set)
+	oldSet := od.(*schema.Set)
+	newSet := nd.(*schema.Set)
 
-	setDiff := NewSetDiff(func(logging interface{}) (interface{}, error) {
-		// Use the logging endpoint name as the key
-		return logging.(map[string]interface{})["name"], nil
+	setDiff := NewSetDiff(func(resource interface{}) (interface{}, error) {
+		// Use the resource endpoint name as the key
+		return resource.(map[string]interface{})["name"], nil
 	})
 
-	diffResult, err := setDiff.Diff(ods, nds)
+	diffResult, err := setDiff.Diff(oldSet, newSet)
 	if err != nil {
 		return err
 	}

--- a/fastly/block_fastly_service_v1_logging_datadog.go
+++ b/fastly/block_fastly_service_v1_logging_datadog.go
@@ -172,7 +172,7 @@ func (h *DatadogServiceAttributeHandler) Register(s *schema.Resource) error {
 		"name": {
 			Type:        schema.TypeString,
 			Required:    true,
-			Description: "The unique name of the Datadog logging endpoint",
+			Description: "The unique name of the Datadog logging endpoint. It is important to note that changing this attribute will delete and recreate the resource",
 		},
 
 		"token": {

--- a/fastly/block_fastly_service_v1_logging_datadog.go
+++ b/fastly/block_fastly_service_v1_logging_datadog.go
@@ -60,7 +60,7 @@ func (h *DatadogServiceAttributeHandler) Process(d *schema.ResourceData, latestV
 		}
 	}
 
-	// ADD new resources
+	// CREATE new resources
 	for _, resource := range diffResult.Added {
 		resource := resource.(map[string]interface{})
 		opts := h.buildCreate(resource, serviceID, latestVersion)

--- a/fastly/block_fastly_service_v1_logging_digitalocean.go
+++ b/fastly/block_fastly_service_v1_logging_digitalocean.go
@@ -36,8 +36,11 @@ func (h *DigitalOceanServiceAttributeHandler) Process(d *schema.ResourceData, la
 	newSet := nl.(*schema.Set)
 
 	setDiff := NewSetDiff(func(resource interface{}) (interface{}, error) {
-		// Use the resource endpoint name as the key
-		return resource.(map[string]interface{})["name"], nil
+		t, ok := resource.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("resource failed to be type asserted: %+v", resource)
+		}
+		return t["name"], nil
 	})
 
 	diffResult, err := setDiff.Diff(oldSet, newSet)
@@ -45,10 +48,10 @@ func (h *DigitalOceanServiceAttributeHandler) Process(d *schema.ResourceData, la
 		return err
 	}
 
-	// DELETE old DigitalOcean Spaces logging endpoints.
-	for _, oRaw := range diffResult.Deleted {
-		of := oRaw.(map[string]interface{})
-		opts := h.buildDelete(of, serviceID, latestVersion)
+	// DELETE removed resources
+	for _, resource := range diffResult.Deleted {
+		resource := resource.(map[string]interface{})
+		opts := h.buildDelete(resource, serviceID, latestVersion)
 
 		log.Printf("[DEBUG] Fastly DigitalOcean Spaces logging endpoint removal opts: %#v", opts)
 
@@ -57,9 +60,9 @@ func (h *DigitalOceanServiceAttributeHandler) Process(d *schema.ResourceData, la
 		}
 	}
 
-	// POST new/updated DigitalOcean Spaces logging endpoints.
-	for _, nRaw := range diffResult.Added {
-		lf := nRaw.(map[string]interface{})
+	// ADD new resources
+	for _, resource := range diffResult.Added {
+		resource := resource.(map[string]interface{})
 
 		// @HACK for a TF SDK Issue.
 		//
@@ -71,15 +74,87 @@ func (h *DigitalOceanServiceAttributeHandler) Process(d *schema.ResourceData, la
 		// This is caused by using a StateFunc in a nested TypeSet. While the StateFunc
 		// properly handles setting state with the StateFunc, it returns extra entries
 		// during state Gets, specifically `GetChange("logging_digitalocean")` in this case.
-		if v, ok := lf["name"]; !ok || v.(string) == "" {
+		if v, ok := resource["name"]; !ok || v.(string) == "" {
 			continue
 		}
 
-		opts := h.buildCreate(lf, serviceID, latestVersion)
+		opts := h.buildCreate(resource, serviceID, latestVersion)
 
 		log.Printf("[DEBUG] Fastly DigitalOcean Spaces logging addition opts: %#v", opts)
 
 		if err := createDigitalOcean(conn, opts); err != nil {
+			return err
+		}
+	}
+
+	// UPDATE modified resources
+	//
+	// NOTE: although the go-fastly API client enables updating of a resource by
+	// its 'name' attribute, this isn't possible within terraform due to
+	// constraints in the data model/schema of the resources not having a uid.
+	for _, resource := range diffResult.Modified {
+		resource := resource.(map[string]interface{})
+
+		opts := gofastly.UpdateDigitalOceanInput{
+			ServiceID:      d.Id(),
+			ServiceVersion: latestVersion,
+			Name:           resource["name"].(string),
+		}
+
+		// only attempt to update attributes that have changed
+		modified := setDiff.Filter(resource, oldSet)
+
+		// NOTE: where we transition between interface{} we lose the ability to
+		// infer the underlying type being either a uint vs an int. This
+		// materializes as a panic (yay) and so it's only at runtime we discover
+		// this and so we've updated the below code to convert the type asserted
+		// int into a uint before passing the value to gofastly.Uint().
+		if v, ok := modified["bucket_name"]; ok {
+			opts.BucketName = gofastly.String(v.(string))
+		}
+		if v, ok := modified["domain"]; ok {
+			opts.Domain = gofastly.String(v.(string))
+		}
+		if v, ok := modified["access_key"]; ok {
+			opts.AccessKey = gofastly.String(v.(string))
+		}
+		if v, ok := modified["secret_key"]; ok {
+			opts.SecretKey = gofastly.String(v.(string))
+		}
+		if v, ok := modified["path"]; ok {
+			opts.Path = gofastly.String(v.(string))
+		}
+		if v, ok := modified["period"]; ok {
+			opts.Period = gofastly.Uint(uint(v.(int)))
+		}
+		if v, ok := modified["gzip_level"]; ok {
+			opts.GzipLevel = gofastly.Uint(uint(v.(int)))
+		}
+		if v, ok := modified["format"]; ok {
+			opts.Format = gofastly.String(v.(string))
+		}
+		if v, ok := modified["format_version"]; ok {
+			opts.FormatVersion = gofastly.Uint(uint(v.(int)))
+		}
+		if v, ok := modified["response_condition"]; ok {
+			opts.ResponseCondition = gofastly.String(v.(string))
+		}
+		if v, ok := modified["message_type"]; ok {
+			opts.MessageType = gofastly.String(v.(string))
+		}
+		if v, ok := modified["timestamp_format"]; ok {
+			opts.TimestampFormat = gofastly.String(v.(string))
+		}
+		if v, ok := modified["placement"]; ok {
+			opts.Placement = gofastly.String(v.(string))
+		}
+		if v, ok := modified["public_key"]; ok {
+			opts.PublicKey = gofastly.String(v.(string))
+		}
+
+		log.Printf("[DEBUG] Update DigitalOcean Opts: %#v", opts)
+		_, err := conn.UpdateDigitalOcean(&opts)
+		if err != nil {
 			return err
 		}
 	}

--- a/fastly/block_fastly_service_v1_logging_digitalocean.go
+++ b/fastly/block_fastly_service_v1_logging_digitalocean.go
@@ -60,7 +60,7 @@ func (h *DigitalOceanServiceAttributeHandler) Process(d *schema.ResourceData, la
 		}
 	}
 
-	// ADD new resources
+	// CREATE new resources
 	for _, resource := range diffResult.Added {
 		resource := resource.(map[string]interface{})
 

--- a/fastly/block_fastly_service_v1_logging_digitalocean.go
+++ b/fastly/block_fastly_service_v1_logging_digitalocean.go
@@ -32,15 +32,15 @@ func (h *DigitalOceanServiceAttributeHandler) Process(d *schema.ResourceData, la
 		nl = new(schema.Set)
 	}
 
-	ols := ol.(*schema.Set)
-	nls := nl.(*schema.Set)
+	oldSet := ol.(*schema.Set)
+	newSet := nl.(*schema.Set)
 
-	setDiff := NewSetDiff(func(logging interface{}) (interface{}, error) {
-		// Use the logging endpoint name as the key
-		return logging.(map[string]interface{})["name"], nil
+	setDiff := NewSetDiff(func(resource interface{}) (interface{}, error) {
+		// Use the resource endpoint name as the key
+		return resource.(map[string]interface{})["name"], nil
 	})
 
-	diffResult, err := setDiff.Diff(ols, nls)
+	diffResult, err := setDiff.Diff(oldSet, newSet)
 	if err != nil {
 		return err
 	}

--- a/fastly/block_fastly_service_v1_logging_digitalocean.go
+++ b/fastly/block_fastly_service_v1_logging_digitalocean.go
@@ -281,7 +281,7 @@ func (h *DigitalOceanServiceAttributeHandler) Register(s *schema.Resource) error
 		"name": {
 			Type:        schema.TypeString,
 			Required:    true,
-			Description: "The unique name of the DigitalOcean Spaces logging endpoint",
+			Description: "The unique name of the DigitalOcean Spaces logging endpoint. It is important to note that changing this attribute will delete and recreate the resource",
 		},
 
 		"bucket_name": {

--- a/fastly/block_fastly_service_v1_logging_elasticsearch.go
+++ b/fastly/block_fastly_service_v1_logging_elasticsearch.go
@@ -35,11 +35,18 @@ func (h *ElasticSearchServiceAttributeHandler) Process(d *schema.ResourceData, l
 	oes := oe.(*schema.Set)
 	nes := ne.(*schema.Set)
 
-	removeElasticsearchLogging := oes.Difference(nes).List()
-	addElasticsearchLogging := nes.Difference(oes).List()
+	setDiff := NewSetDiff(func(logging interface{}) (interface{}, error) {
+		// Use the logging endpoint name as the key
+		return logging.(map[string]interface{})["name"], nil
+	})
+
+	diffResult, err := setDiff.Diff(oes, nes)
+	if err != nil {
+		return err
+	}
 
 	// DELETE old Elasticsearch logging endpoints.
-	for _, oRaw := range removeElasticsearchLogging {
+	for _, oRaw := range diffResult.Deleted {
 		of := oRaw.(map[string]interface{})
 		opts := h.buildDelete(of, serviceID, latestVersion)
 
@@ -51,7 +58,7 @@ func (h *ElasticSearchServiceAttributeHandler) Process(d *schema.ResourceData, l
 	}
 
 	// POST new/updated Elasticsearch logging endpoints.
-	for _, nRaw := range addElasticsearchLogging {
+	for _, nRaw := range diffResult.Added {
 		ef := nRaw.(map[string]interface{})
 		opts := h.buildCreate(ef, serviceID, latestVersion)
 

--- a/fastly/block_fastly_service_v1_logging_elasticsearch.go
+++ b/fastly/block_fastly_service_v1_logging_elasticsearch.go
@@ -32,15 +32,15 @@ func (h *ElasticSearchServiceAttributeHandler) Process(d *schema.ResourceData, l
 		ne = new(schema.Set)
 	}
 
-	oes := oe.(*schema.Set)
-	nes := ne.(*schema.Set)
+	oldSet := oe.(*schema.Set)
+	newSet := ne.(*schema.Set)
 
-	setDiff := NewSetDiff(func(logging interface{}) (interface{}, error) {
-		// Use the logging endpoint name as the key
-		return logging.(map[string]interface{})["name"], nil
+	setDiff := NewSetDiff(func(resource interface{}) (interface{}, error) {
+		// Use the resource endpoint name as the key
+		return resource.(map[string]interface{})["name"], nil
 	})
 
-	diffResult, err := setDiff.Diff(oes, nes)
+	diffResult, err := setDiff.Diff(oldSet, newSet)
 	if err != nil {
 		return err
 	}

--- a/fastly/block_fastly_service_v1_logging_elasticsearch.go
+++ b/fastly/block_fastly_service_v1_logging_elasticsearch.go
@@ -176,7 +176,7 @@ func (h *ElasticSearchServiceAttributeHandler) Register(s *schema.Resource) erro
 		"name": {
 			Type:        schema.TypeString,
 			Required:    true,
-			Description: "The unique name of the Elasticsearch logging endpoint",
+			Description: "The unique name of the Elasticsearch logging endpoint. It is important to note that changing this attribute will delete and recreate the resource",
 		},
 
 		"url": {

--- a/fastly/block_fastly_service_v1_logging_elasticsearch.go
+++ b/fastly/block_fastly_service_v1_logging_elasticsearch.go
@@ -36,8 +36,11 @@ func (h *ElasticSearchServiceAttributeHandler) Process(d *schema.ResourceData, l
 	newSet := ne.(*schema.Set)
 
 	setDiff := NewSetDiff(func(resource interface{}) (interface{}, error) {
-		// Use the resource endpoint name as the key
-		return resource.(map[string]interface{})["name"], nil
+		t, ok := resource.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("resource failed to be type asserted: %+v", resource)
+		}
+		return t["name"], nil
 	})
 
 	diffResult, err := setDiff.Diff(oldSet, newSet)
@@ -45,10 +48,10 @@ func (h *ElasticSearchServiceAttributeHandler) Process(d *schema.ResourceData, l
 		return err
 	}
 
-	// DELETE old Elasticsearch logging endpoints.
-	for _, oRaw := range diffResult.Deleted {
-		of := oRaw.(map[string]interface{})
-		opts := h.buildDelete(of, serviceID, latestVersion)
+	// DELETE removed resources
+	for _, resource := range diffResult.Deleted {
+		resource := resource.(map[string]interface{})
+		opts := h.buildDelete(resource, serviceID, latestVersion)
 
 		log.Printf("[DEBUG] Fastly Elasticsearch logging endpoint removal opts: %#v", opts)
 
@@ -57,14 +60,89 @@ func (h *ElasticSearchServiceAttributeHandler) Process(d *schema.ResourceData, l
 		}
 	}
 
-	// POST new/updated Elasticsearch logging endpoints.
-	for _, nRaw := range diffResult.Added {
-		ef := nRaw.(map[string]interface{})
-		opts := h.buildCreate(ef, serviceID, latestVersion)
+	// ADD new resources
+	for _, resource := range diffResult.Added {
+		resource := resource.(map[string]interface{})
+		opts := h.buildCreate(resource, serviceID, latestVersion)
 
 		log.Printf("[DEBUG] Fastly Elasticsearch logging addition opts: %#v", opts)
 
 		if err := createElasticsearch(conn, opts); err != nil {
+			return err
+		}
+	}
+
+	// UPDATE modified resources
+	//
+	// NOTE: although the go-fastly API client enables updating of a resource by
+	// its 'name' attribute, this isn't possible within terraform due to
+	// constraints in the data model/schema of the resources not having a uid.
+	for _, resource := range diffResult.Modified {
+		resource := resource.(map[string]interface{})
+
+		opts := gofastly.UpdateElasticsearchInput{
+			ServiceID:      d.Id(),
+			ServiceVersion: latestVersion,
+			Name:           resource["name"].(string),
+		}
+
+		// only attempt to update attributes that have changed
+		modified := setDiff.Filter(resource, oldSet)
+
+		// NOTE: where we transition between interface{} we lose the ability to
+		// infer the underlying type being either a uint vs an int. This
+		// materializes as a panic (yay) and so it's only at runtime we discover
+		// this and so we've updated the below code to convert the type asserted
+		// int into a uint before passing the value to gofastly.Uint().
+		if v, ok := modified["response_condition"]; ok {
+			opts.ResponseCondition = gofastly.String(v.(string))
+		}
+		if v, ok := modified["format"]; ok {
+			opts.Format = gofastly.String(v.(string))
+		}
+		if v, ok := modified["index"]; ok {
+			opts.Index = gofastly.String(v.(string))
+		}
+		if v, ok := modified["url"]; ok {
+			opts.URL = gofastly.String(v.(string))
+		}
+		if v, ok := modified["pipeline"]; ok {
+			opts.Pipeline = gofastly.String(v.(string))
+		}
+		if v, ok := modified["user"]; ok {
+			opts.User = gofastly.String(v.(string))
+		}
+		if v, ok := modified["password"]; ok {
+			opts.Password = gofastly.String(v.(string))
+		}
+		if v, ok := modified["request_max_entries"]; ok {
+			opts.RequestMaxEntries = gofastly.Uint(uint(v.(int)))
+		}
+		if v, ok := modified["request_max_bytes"]; ok {
+			opts.RequestMaxBytes = gofastly.Uint(uint(v.(int)))
+		}
+		if v, ok := modified["placement"]; ok {
+			opts.Placement = gofastly.String(v.(string))
+		}
+		if v, ok := modified["tls_ca_cert"]; ok {
+			opts.TLSCACert = gofastly.String(v.(string))
+		}
+		if v, ok := modified["tls_client_cert"]; ok {
+			opts.TLSClientCert = gofastly.String(v.(string))
+		}
+		if v, ok := modified["tls_client_key"]; ok {
+			opts.TLSClientKey = gofastly.String(v.(string))
+		}
+		if v, ok := modified["tls_hostname"]; ok {
+			opts.TLSHostname = gofastly.String(v.(string))
+		}
+		if v, ok := modified["format_version"]; ok {
+			opts.FormatVersion = gofastly.Uint(uint(v.(int)))
+		}
+
+		log.Printf("[DEBUG] Update Elasticsearch Opts: %#v", opts)
+		_, err := conn.UpdateElasticsearch(&opts)
+		if err != nil {
 			return err
 		}
 	}

--- a/fastly/block_fastly_service_v1_logging_elasticsearch.go
+++ b/fastly/block_fastly_service_v1_logging_elasticsearch.go
@@ -60,7 +60,7 @@ func (h *ElasticSearchServiceAttributeHandler) Process(d *schema.ResourceData, l
 		}
 	}
 
-	// ADD new resources
+	// CREATE new resources
 	for _, resource := range diffResult.Added {
 		resource := resource.(map[string]interface{})
 		opts := h.buildCreate(resource, serviceID, latestVersion)

--- a/fastly/block_fastly_service_v1_logging_ftp.go
+++ b/fastly/block_fastly_service_v1_logging_ftp.go
@@ -191,7 +191,7 @@ func (h *FTPServiceAttributeHandler) Register(s *schema.Resource) error {
 		"name": {
 			Type:        schema.TypeString,
 			Required:    true,
-			Description: "The unique name of the FTP logging endpoint",
+			Description: "The unique name of the FTP logging endpoint. It is important to note that changing this attribute will delete and recreate the resource",
 		},
 
 		"address": {

--- a/fastly/block_fastly_service_v1_logging_ftp.go
+++ b/fastly/block_fastly_service_v1_logging_ftp.go
@@ -32,15 +32,15 @@ func (h *FTPServiceAttributeHandler) Process(d *schema.ResourceData, latestVersi
 		nf = new(schema.Set)
 	}
 
-	ofs := of.(*schema.Set)
-	nfs := nf.(*schema.Set)
+	oldSet := of.(*schema.Set)
+	newSet := nf.(*schema.Set)
 
-	setDiff := NewSetDiff(func(logging interface{}) (interface{}, error) {
-		// Use the logging endpoint name as the key
-		return logging.(map[string]interface{})["name"], nil
+	setDiff := NewSetDiff(func(resource interface{}) (interface{}, error) {
+		// Use the resource endpoint name as the key
+		return resource.(map[string]interface{})["name"], nil
 	})
 
-	diffResult, err := setDiff.Diff(ofs, nfs)
+	diffResult, err := setDiff.Diff(oldSet, newSet)
 	if err != nil {
 		return err
 	}

--- a/fastly/block_fastly_service_v1_logging_ftp.go
+++ b/fastly/block_fastly_service_v1_logging_ftp.go
@@ -60,7 +60,7 @@ func (h *FTPServiceAttributeHandler) Process(d *schema.ResourceData, latestVersi
 		}
 	}
 
-	// ADD new resources
+	// CREATE new resources
 	for _, resource := range diffResult.Added {
 		resource := resource.(map[string]interface{})
 

--- a/fastly/block_fastly_service_v1_logging_ftp.go
+++ b/fastly/block_fastly_service_v1_logging_ftp.go
@@ -36,8 +36,11 @@ func (h *FTPServiceAttributeHandler) Process(d *schema.ResourceData, latestVersi
 	newSet := nf.(*schema.Set)
 
 	setDiff := NewSetDiff(func(resource interface{}) (interface{}, error) {
-		// Use the resource endpoint name as the key
-		return resource.(map[string]interface{})["name"], nil
+		t, ok := resource.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("resource failed to be type asserted: %+v", resource)
+		}
+		return t["name"], nil
 	})
 
 	diffResult, err := setDiff.Diff(oldSet, newSet)
@@ -45,10 +48,10 @@ func (h *FTPServiceAttributeHandler) Process(d *schema.ResourceData, latestVersi
 		return err
 	}
 
-	// DELETE old FTP logging endpoints.
-	for _, oRaw := range diffResult.Deleted {
-		of := oRaw.(map[string]interface{})
-		opts := h.buildDelete(of, serviceID, latestVersion)
+	// DELETE removed resources
+	for _, resource := range diffResult.Deleted {
+		resource := resource.(map[string]interface{})
+		opts := h.buildDelete(resource, serviceID, latestVersion)
 
 		log.Printf("[DEBUG] Fastly FTP logging endpoint removal opts: %#v", opts)
 
@@ -57,9 +60,9 @@ func (h *FTPServiceAttributeHandler) Process(d *schema.ResourceData, latestVersi
 		}
 	}
 
-	// POST new/updated FTP logging endpoints.
-	for _, nRaw := range diffResult.Added {
-		ef := nRaw.(map[string]interface{})
+	// ADD new resources
+	for _, resource := range diffResult.Added {
+		resource := resource.(map[string]interface{})
 
 		// @HACK for a TF SDK Issue.
 		//
@@ -71,15 +74,90 @@ func (h *FTPServiceAttributeHandler) Process(d *schema.ResourceData, latestVersi
 		// This is caused by using a StateFunc in a nested TypeSet. While the StateFunc
 		// properly handles setting state with the StateFunc, it returns extra entries
 		// during state Gets, specifically `GetChange("logging_ftp")` in this case.
-		if v, ok := ef["name"]; !ok || v.(string) == "" {
+		if v, ok := resource["name"]; !ok || v.(string) == "" {
 			continue
 		}
 
-		opts := h.buildCreate(ef, serviceID, latestVersion)
+		opts := h.buildCreate(resource, serviceID, latestVersion)
 
 		log.Printf("[DEBUG] Fastly FTP logging addition opts: %#v", opts)
 
 		if err := createFTP(conn, opts); err != nil {
+			return err
+		}
+	}
+
+	// UPDATE modified resources
+	//
+	// NOTE: although the go-fastly API client enables updating of a resource by
+	// its 'name' attribute, this isn't possible within terraform due to
+	// constraints in the data model/schema of the resources not having a uid.
+	for _, resource := range diffResult.Modified {
+		resource := resource.(map[string]interface{})
+
+		opts := gofastly.UpdateFTPInput{
+			ServiceID:      d.Id(),
+			ServiceVersion: latestVersion,
+			Name:           resource["name"].(string),
+		}
+
+		// only attempt to update attributes that have changed
+		modified := setDiff.Filter(resource, oldSet)
+
+		// NOTE: where we transition between interface{} we lose the ability to
+		// infer the underlying type being either a uint vs an int. This
+		// materializes as a panic (yay) and so it's only at runtime we discover
+		// this and so we've updated the below code to convert the type asserted
+		// int into a uint before passing the value to gofastly.Uint().
+		if v, ok := modified["address"]; ok {
+			opts.Address = gofastly.String(v.(string))
+		}
+		if v, ok := modified["port"]; ok {
+			opts.Port = gofastly.Uint(uint(v.(int)))
+		}
+		if v, ok := modified["public_key"]; ok {
+			opts.PublicKey = gofastly.String(v.(string))
+		}
+		if v, ok := modified["user"]; ok {
+			opts.Username = gofastly.String(v.(string))
+		}
+		if v, ok := modified["password"]; ok {
+			opts.Password = gofastly.String(v.(string))
+		}
+		if v, ok := modified["path"]; ok {
+			opts.Path = gofastly.String(v.(string))
+		}
+		if v, ok := modified["period"]; ok {
+			opts.Period = gofastly.Uint(uint(v.(int)))
+		}
+		if v, ok := modified["format"]; ok {
+			opts.Format = gofastly.String(v.(string))
+		}
+		if v, ok := modified["format_version"]; ok {
+			opts.FormatVersion = gofastly.Uint(uint(v.(int)))
+		}
+		if v, ok := modified["response_condition"]; ok {
+			opts.ResponseCondition = gofastly.String(v.(string))
+		}
+		if v, ok := modified["placement"]; ok {
+			opts.Placement = gofastly.String(v.(string))
+		}
+		if v, ok := modified["gzip_level"]; ok {
+			opts.GzipLevel = gofastly.Uint8(uint8(v.(int)))
+		}
+		if v, ok := modified["compression_codec"]; ok {
+			opts.CompressionCodec = gofastly.String(v.(string))
+		}
+		if v, ok := modified["message_type"]; ok {
+			opts.MessageType = gofastly.String(v.(string))
+		}
+		if v, ok := modified["timestamp_format"]; ok {
+			opts.TimestampFormat = gofastly.String(v.(string))
+		}
+
+		log.Printf("[DEBUG] Update FTP Opts: %#v", opts)
+		_, err := conn.UpdateFTP(&opts)
+		if err != nil {
 			return err
 		}
 	}

--- a/fastly/block_fastly_service_v1_logging_googlepubsub.go
+++ b/fastly/block_fastly_service_v1_logging_googlepubsub.go
@@ -106,8 +106,11 @@ func (h *GooglePubSubServiceAttributeHandler) Process(d *schema.ResourceData, la
 	newSet := newLogCfg.(*schema.Set)
 
 	setDiff := NewSetDiff(func(resource interface{}) (interface{}, error) {
-		// Use the resource endpoint name as the key
-		return resource.(map[string]interface{})["name"], nil
+		t, ok := resource.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("resource failed to be type asserted: %+v", resource)
+		}
+		return t["name"], nil
 	})
 
 	diffResult, err := setDiff.Diff(oldSet, newSet)
@@ -115,10 +118,10 @@ func (h *GooglePubSubServiceAttributeHandler) Process(d *schema.ResourceData, la
 		return err
 	}
 
-	// DELETE old Google Cloud Pub/Sub logging endpoints.
-	for _, oRaw := range diffResult.Deleted {
-		of := oRaw.(map[string]interface{})
-		opts := h.buildDelete(of, serviceID, latestVersion)
+	// DELETE removed resources
+	for _, resource := range diffResult.Deleted {
+		resource := resource.(map[string]interface{})
+		opts := h.buildDelete(resource, serviceID, latestVersion)
 
 		log.Printf("[DEBUG] Fastly Google Cloud Pub/Sub logging endpoint removal opts: %#v", opts)
 
@@ -127,14 +130,68 @@ func (h *GooglePubSubServiceAttributeHandler) Process(d *schema.ResourceData, la
 		}
 	}
 
-	// POST new/updated Google Cloud Pub/Sub logging endponts.
-	for _, nRaw := range diffResult.Added {
-		cfg := nRaw.(map[string]interface{})
-		opts := h.buildCreate(cfg, serviceID, latestVersion)
+	// ADD new resources
+	for _, resource := range diffResult.Added {
+		resource := resource.(map[string]interface{})
+		opts := h.buildCreate(resource, serviceID, latestVersion)
 
 		log.Printf("[DEBUG] Fastly Google Cloud Pub/Sub logging addition opts: %#v", opts)
 
 		if err := createGooglePubSub(conn, opts); err != nil {
+			return err
+		}
+	}
+
+	// UPDATE modified resources
+	//
+	// NOTE: although the go-fastly API client enables updating of a resource by
+	// its 'name' attribute, this isn't possible within terraform due to
+	// constraints in the data model/schema of the resources not having a uid.
+	for _, resource := range diffResult.Modified {
+		resource := resource.(map[string]interface{})
+
+		opts := gofastly.UpdatePubsubInput{
+			ServiceID:      d.Id(),
+			ServiceVersion: latestVersion,
+			Name:           resource["name"].(string),
+		}
+
+		// only attempt to update attributes that have changed
+		modified := setDiff.Filter(resource, oldSet)
+
+		// NOTE: where we transition between interface{} we lose the ability to
+		// infer the underlying type being either a uint vs an int. This
+		// materializes as a panic (yay) and so it's only at runtime we discover
+		// this and so we've updated the below code to convert the type asserted
+		// int into a uint before passing the value to gofastly.Uint().
+		if v, ok := modified["topic"]; ok {
+			opts.Topic = gofastly.String(v.(string))
+		}
+		if v, ok := modified["user"]; ok {
+			opts.User = gofastly.String(v.(string))
+		}
+		if v, ok := modified["secret_key"]; ok {
+			opts.SecretKey = gofastly.String(v.(string))
+		}
+		if v, ok := modified["project_id"]; ok {
+			opts.ProjectID = gofastly.String(v.(string))
+		}
+		if v, ok := modified["format_version"]; ok {
+			opts.FormatVersion = gofastly.Uint(uint(v.(int)))
+		}
+		if v, ok := modified["format"]; ok {
+			opts.Format = gofastly.String(v.(string))
+		}
+		if v, ok := modified["response_condition"]; ok {
+			opts.ResponseCondition = gofastly.String(v.(string))
+		}
+		if v, ok := modified["placement"]; ok {
+			opts.Placement = gofastly.String(v.(string))
+		}
+
+		log.Printf("[DEBUG] Update Google Cloud Pub/Sub Opts: %#v", opts)
+		_, err := conn.UpdatePubsub(&opts)
+		if err != nil {
 			return err
 		}
 	}

--- a/fastly/block_fastly_service_v1_logging_googlepubsub.go
+++ b/fastly/block_fastly_service_v1_logging_googlepubsub.go
@@ -27,7 +27,7 @@ func (h *GooglePubSubServiceAttributeHandler) Register(s *schema.Resource) error
 		"name": {
 			Type:        schema.TypeString,
 			Required:    true,
-			Description: "The unique name of the Google Cloud Pub/Sub logging endpoint",
+			Description: "The unique name of the Google Cloud Pub/Sub logging endpoint. It is important to note that changing this attribute will delete and recreate the resource",
 		},
 
 		"user": {

--- a/fastly/block_fastly_service_v1_logging_googlepubsub.go
+++ b/fastly/block_fastly_service_v1_logging_googlepubsub.go
@@ -130,7 +130,7 @@ func (h *GooglePubSubServiceAttributeHandler) Process(d *schema.ResourceData, la
 		}
 	}
 
-	// ADD new resources
+	// CREATE new resources
 	for _, resource := range diffResult.Added {
 		resource := resource.(map[string]interface{})
 		opts := h.buildCreate(resource, serviceID, latestVersion)

--- a/fastly/block_fastly_service_v1_logging_googlepubsub.go
+++ b/fastly/block_fastly_service_v1_logging_googlepubsub.go
@@ -102,15 +102,15 @@ func (h *GooglePubSubServiceAttributeHandler) Process(d *schema.ResourceData, la
 		newLogCfg = new(schema.Set)
 	}
 
-	oldLogSet := oldLogCfg.(*schema.Set)
-	newLogSet := newLogCfg.(*schema.Set)
+	oldSet := oldLogCfg.(*schema.Set)
+	newSet := newLogCfg.(*schema.Set)
 
-	setDiff := NewSetDiff(func(logging interface{}) (interface{}, error) {
-		// Use the logging endpoint name as the key
-		return logging.(map[string]interface{})["name"], nil
+	setDiff := NewSetDiff(func(resource interface{}) (interface{}, error) {
+		// Use the resource endpoint name as the key
+		return resource.(map[string]interface{})["name"], nil
 	})
 
-	diffResult, err := setDiff.Diff(oldLogSet, newLogSet)
+	diffResult, err := setDiff.Diff(oldSet, newSet)
 	if err != nil {
 		return err
 	}

--- a/fastly/block_fastly_service_v1_logging_heroku.go
+++ b/fastly/block_fastly_service_v1_logging_heroku.go
@@ -36,8 +36,11 @@ func (h *HerokuServiceAttributeHandler) Process(d *schema.ResourceData, latestVe
 	newSet := nl.(*schema.Set)
 
 	setDiff := NewSetDiff(func(resource interface{}) (interface{}, error) {
-		// Use the resource endpoint name as the key
-		return resource.(map[string]interface{})["name"], nil
+		t, ok := resource.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("resource failed to be type asserted: %+v", resource)
+		}
+		return t["name"], nil
 	})
 
 	diffResult, err := setDiff.Diff(oldSet, newSet)
@@ -45,10 +48,10 @@ func (h *HerokuServiceAttributeHandler) Process(d *schema.ResourceData, latestVe
 		return err
 	}
 
-	// DELETE old Heroku logging endpoints.
-	for _, oRaw := range diffResult.Deleted {
-		of := oRaw.(map[string]interface{})
-		opts := h.buildDelete(of, serviceID, latestVersion)
+	// DELETE removed resources
+	for _, resource := range diffResult.Deleted {
+		resource := resource.(map[string]interface{})
+		opts := h.buildDelete(resource, serviceID, latestVersion)
 
 		log.Printf("[DEBUG] Fastly Heroku logging endpoint removal opts: %#v", opts)
 
@@ -57,14 +60,62 @@ func (h *HerokuServiceAttributeHandler) Process(d *schema.ResourceData, latestVe
 		}
 	}
 
-	// POST new/updated Heroku logging endpoints.
-	for _, nRaw := range diffResult.Added {
-		lf := nRaw.(map[string]interface{})
-		opts := h.buildCreate(lf, serviceID, latestVersion)
+	// ADD new resources
+	for _, resource := range diffResult.Added {
+		resource := resource.(map[string]interface{})
+		opts := h.buildCreate(resource, serviceID, latestVersion)
 
 		log.Printf("[DEBUG] Fastly Heroku logging addition opts: %#v", opts)
 
 		if err := createHeroku(conn, opts); err != nil {
+			return err
+		}
+	}
+
+	// UPDATE modified resources
+	//
+	// NOTE: although the go-fastly API client enables updating of a resource by
+	// its 'name' attribute, this isn't possible within terraform due to
+	// constraints in the data model/schema of the resources not having a uid.
+	for _, resource := range diffResult.Modified {
+		resource := resource.(map[string]interface{})
+
+		opts := gofastly.UpdateHerokuInput{
+			ServiceID:      d.Id(),
+			ServiceVersion: latestVersion,
+			Name:           resource["name"].(string),
+		}
+
+		// only attempt to update attributes that have changed
+		modified := setDiff.Filter(resource, oldSet)
+
+		// NOTE: where we transition between interface{} we lose the ability to
+		// infer the underlying type being either a uint vs an int. This
+		// materializes as a panic (yay) and so it's only at runtime we discover
+		// this and so we've updated the below code to convert the type asserted
+		// int into a uint before passing the value to gofastly.Uint().
+		if v, ok := modified["format"]; ok {
+			opts.Format = gofastly.String(v.(string))
+		}
+		if v, ok := modified["format_version"]; ok {
+			opts.FormatVersion = gofastly.Uint(uint(v.(int)))
+		}
+		if v, ok := modified["url"]; ok {
+			opts.URL = gofastly.String(v.(string))
+		}
+		if v, ok := modified["token"]; ok {
+			opts.Token = gofastly.String(v.(string))
+		}
+		if v, ok := modified["response_condition"]; ok {
+			opts.ResponseCondition = gofastly.String(v.(string))
+		}
+		if v, ok := modified["placement"]; ok {
+			opts.Placement = gofastly.String(v.(string))
+		}
+
+		log.Printf("[DEBUG] Update Heroku Opts: %#v", opts)
+		_, err := conn.UpdateHeroku(&opts)
+		if err != nil {
 			return err
 		}
 	}

--- a/fastly/block_fastly_service_v1_logging_heroku.go
+++ b/fastly/block_fastly_service_v1_logging_heroku.go
@@ -226,7 +226,7 @@ func (h *HerokuServiceAttributeHandler) Register(s *schema.Resource) error {
 		"name": {
 			Type:        schema.TypeString,
 			Required:    true,
-			Description: "The unique name of the Heroku logging endpoint",
+			Description: "The unique name of the Heroku logging endpoint. It is important to note that changing this attribute will delete and recreate the resource",
 		},
 
 		"token": {

--- a/fastly/block_fastly_service_v1_logging_heroku.go
+++ b/fastly/block_fastly_service_v1_logging_heroku.go
@@ -60,7 +60,7 @@ func (h *HerokuServiceAttributeHandler) Process(d *schema.ResourceData, latestVe
 		}
 	}
 
-	// ADD new resources
+	// CREATE new resources
 	for _, resource := range diffResult.Added {
 		resource := resource.(map[string]interface{})
 		opts := h.buildCreate(resource, serviceID, latestVersion)

--- a/fastly/block_fastly_service_v1_logging_heroku.go
+++ b/fastly/block_fastly_service_v1_logging_heroku.go
@@ -32,15 +32,15 @@ func (h *HerokuServiceAttributeHandler) Process(d *schema.ResourceData, latestVe
 		nl = new(schema.Set)
 	}
 
-	ols := ol.(*schema.Set)
-	nls := nl.(*schema.Set)
+	oldSet := ol.(*schema.Set)
+	newSet := nl.(*schema.Set)
 
-	setDiff := NewSetDiff(func(logging interface{}) (interface{}, error) {
-		// Use the logging endpoint name as the key
-		return logging.(map[string]interface{})["name"], nil
+	setDiff := NewSetDiff(func(resource interface{}) (interface{}, error) {
+		// Use the resource endpoint name as the key
+		return resource.(map[string]interface{})["name"], nil
 	})
 
-	diffResult, err := setDiff.Diff(ols, nls)
+	diffResult, err := setDiff.Diff(oldSet, newSet)
 	if err != nil {
 		return err
 	}

--- a/fastly/block_fastly_service_v1_logging_honeycomb.go
+++ b/fastly/block_fastly_service_v1_logging_honeycomb.go
@@ -36,8 +36,11 @@ func (h *HoneycombServiceAttributeHandler) Process(d *schema.ResourceData, lates
 	newSet := nl.(*schema.Set)
 
 	setDiff := NewSetDiff(func(resource interface{}) (interface{}, error) {
-		// Use the resource endpoint name as the key
-		return resource.(map[string]interface{})["name"], nil
+		t, ok := resource.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("resource failed to be type asserted: %+v", resource)
+		}
+		return t["name"], nil
 	})
 
 	diffResult, err := setDiff.Diff(oldSet, newSet)
@@ -45,10 +48,10 @@ func (h *HoneycombServiceAttributeHandler) Process(d *schema.ResourceData, lates
 		return err
 	}
 
-	// DELETE old Honeycomb logging endpoints.
-	for _, oRaw := range diffResult.Deleted {
-		of := oRaw.(map[string]interface{})
-		opts := h.buildDelete(of, serviceID, latestVersion)
+	// DELETE removed resources
+	for _, resource := range diffResult.Deleted {
+		resource := resource.(map[string]interface{})
+		opts := h.buildDelete(resource, serviceID, latestVersion)
 
 		log.Printf("[DEBUG] Fastly Honeycomb logging endpoint removal opts: %#v", opts)
 
@@ -57,14 +60,62 @@ func (h *HoneycombServiceAttributeHandler) Process(d *schema.ResourceData, lates
 		}
 	}
 
-	// POST new/updated Honeycomb logging endpoints.
-	for _, nRaw := range diffResult.Added {
-		lf := nRaw.(map[string]interface{})
-		opts := h.buildCreate(lf, serviceID, latestVersion)
+	// ADD new resources
+	for _, resource := range diffResult.Added {
+		resource := resource.(map[string]interface{})
+		opts := h.buildCreate(resource, serviceID, latestVersion)
 
 		log.Printf("[DEBUG] Fastly Honeycomb logging addition opts: %#v", opts)
 
 		if err := createHoneycomb(conn, opts); err != nil {
+			return err
+		}
+	}
+
+	// UPDATE modified resources
+	//
+	// NOTE: although the go-fastly API client enables updating of a resource by
+	// its 'name' attribute, this isn't possible within terraform due to
+	// constraints in the data model/schema of the resources not having a uid.
+	for _, resource := range diffResult.Modified {
+		resource := resource.(map[string]interface{})
+
+		opts := gofastly.UpdateHoneycombInput{
+			ServiceID:      d.Id(),
+			ServiceVersion: latestVersion,
+			Name:           resource["name"].(string),
+		}
+
+		// only attempt to update attributes that have changed
+		modified := setDiff.Filter(resource, oldSet)
+
+		// NOTE: where we transition between interface{} we lose the ability to
+		// infer the underlying type being either a uint vs an int. This
+		// materializes as a panic (yay) and so it's only at runtime we discover
+		// this and so we've updated the below code to convert the type asserted
+		// int into a uint before passing the value to gofastly.Uint().
+		if v, ok := modified["format"]; ok {
+			opts.Format = gofastly.String(v.(string))
+		}
+		if v, ok := modified["format_version"]; ok {
+			opts.FormatVersion = gofastly.Uint(uint(v.(int)))
+		}
+		if v, ok := modified["dataset"]; ok {
+			opts.Dataset = gofastly.String(v.(string))
+		}
+		if v, ok := modified["token"]; ok {
+			opts.Token = gofastly.String(v.(string))
+		}
+		if v, ok := modified["response_condition"]; ok {
+			opts.ResponseCondition = gofastly.String(v.(string))
+		}
+		if v, ok := modified["placement"]; ok {
+			opts.Placement = gofastly.String(v.(string))
+		}
+
+		log.Printf("[DEBUG] Update Honeycomb Opts: %#v", opts)
+		_, err := conn.UpdateHoneycomb(&opts)
+		if err != nil {
 			return err
 		}
 	}

--- a/fastly/block_fastly_service_v1_logging_honeycomb.go
+++ b/fastly/block_fastly_service_v1_logging_honeycomb.go
@@ -60,7 +60,7 @@ func (h *HoneycombServiceAttributeHandler) Process(d *schema.ResourceData, lates
 		}
 	}
 
-	// ADD new resources
+	// CREATE new resources
 	for _, resource := range diffResult.Added {
 		resource := resource.(map[string]interface{})
 		opts := h.buildCreate(resource, serviceID, latestVersion)

--- a/fastly/block_fastly_service_v1_logging_honeycomb.go
+++ b/fastly/block_fastly_service_v1_logging_honeycomb.go
@@ -35,11 +35,18 @@ func (h *HoneycombServiceAttributeHandler) Process(d *schema.ResourceData, lates
 	ols := ol.(*schema.Set)
 	nls := nl.(*schema.Set)
 
-	removeHoneycombLogging := ols.Difference(nls).List()
-	addHoneycombLogging := nls.Difference(ols).List()
+	setDiff := NewSetDiff(func(logging interface{}) (interface{}, error) {
+		// Use the logging endpoint name as the key
+		return logging.(map[string]interface{})["name"], nil
+	})
+
+	diffResult, err := setDiff.Diff(ols, nls)
+	if err != nil {
+		return err
+	}
 
 	// DELETE old Honeycomb logging endpoints.
-	for _, oRaw := range removeHoneycombLogging {
+	for _, oRaw := range diffResult.Deleted {
 		of := oRaw.(map[string]interface{})
 		opts := h.buildDelete(of, serviceID, latestVersion)
 
@@ -51,7 +58,7 @@ func (h *HoneycombServiceAttributeHandler) Process(d *schema.ResourceData, lates
 	}
 
 	// POST new/updated Honeycomb logging endpoints.
-	for _, nRaw := range addHoneycombLogging {
+	for _, nRaw := range diffResult.Added {
 		lf := nRaw.(map[string]interface{})
 		opts := h.buildCreate(lf, serviceID, latestVersion)
 

--- a/fastly/block_fastly_service_v1_logging_honeycomb.go
+++ b/fastly/block_fastly_service_v1_logging_honeycomb.go
@@ -32,15 +32,15 @@ func (h *HoneycombServiceAttributeHandler) Process(d *schema.ResourceData, lates
 		nl = new(schema.Set)
 	}
 
-	ols := ol.(*schema.Set)
-	nls := nl.(*schema.Set)
+	oldSet := ol.(*schema.Set)
+	newSet := nl.(*schema.Set)
 
-	setDiff := NewSetDiff(func(logging interface{}) (interface{}, error) {
-		// Use the logging endpoint name as the key
-		return logging.(map[string]interface{})["name"], nil
+	setDiff := NewSetDiff(func(resource interface{}) (interface{}, error) {
+		// Use the resource endpoint name as the key
+		return resource.(map[string]interface{})["name"], nil
 	})
 
-	diffResult, err := setDiff.Diff(ols, nls)
+	diffResult, err := setDiff.Diff(oldSet, newSet)
 	if err != nil {
 		return err
 	}

--- a/fastly/block_fastly_service_v1_logging_honeycomb.go
+++ b/fastly/block_fastly_service_v1_logging_honeycomb.go
@@ -226,7 +226,7 @@ func (h *HoneycombServiceAttributeHandler) Register(s *schema.Resource) error {
 		"name": {
 			Type:        schema.TypeString,
 			Required:    true,
-			Description: "The unique name of the Honeycomb logging endpoint",
+			Description: "The unique name of the Honeycomb logging endpoint. It is important to note that changing this attribute will delete and recreate the resource",
 		},
 
 		"token": {

--- a/fastly/block_fastly_service_v1_logging_kafka.go
+++ b/fastly/block_fastly_service_v1_logging_kafka.go
@@ -202,7 +202,7 @@ func (h *KafkaServiceAttributeHandler) Process(d *schema.ResourceData, latestVer
 		}
 	}
 
-	// ADD new resources
+	// CREATE new resources
 	for _, resource := range diffResult.Added {
 		resource := resource.(map[string]interface{})
 

--- a/fastly/block_fastly_service_v1_logging_kafka.go
+++ b/fastly/block_fastly_service_v1_logging_kafka.go
@@ -178,8 +178,11 @@ func (h *KafkaServiceAttributeHandler) Process(d *schema.ResourceData, latestVer
 	newSet := newLogCfg.(*schema.Set)
 
 	setDiff := NewSetDiff(func(resource interface{}) (interface{}, error) {
-		// Use the resource endpoint name as the key
-		return resource.(map[string]interface{})["name"], nil
+		t, ok := resource.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("resource failed to be type asserted: %+v", resource)
+		}
+		return t["name"], nil
 	})
 
 	diffResult, err := setDiff.Diff(oldSet, newSet)
@@ -187,10 +190,10 @@ func (h *KafkaServiceAttributeHandler) Process(d *schema.ResourceData, latestVer
 		return err
 	}
 
-	// DELETE old Kafka logging endpoints
-	for _, oRaw := range diffResult.Deleted {
-		of := oRaw.(map[string]interface{})
-		opts := h.buildDelete(of, serviceID, latestVersion)
+	// DELETE removed resources
+	for _, resource := range diffResult.Deleted {
+		resource := resource.(map[string]interface{})
+		opts := h.buildDelete(resource, serviceID, latestVersion)
 
 		log.Printf("[DEBUG] Fastly Kafka logging endpoint removal opts: %#v", opts)
 
@@ -199,9 +202,9 @@ func (h *KafkaServiceAttributeHandler) Process(d *schema.ResourceData, latestVer
 		}
 	}
 
-	// POST new/updated Kafka logging endponts
-	for _, nRaw := range diffResult.Added {
-		cfg := nRaw.(map[string]interface{})
+	// ADD new resources
+	for _, resource := range diffResult.Added {
+		resource := resource.(map[string]interface{})
 
 		// @HACK for a TF SDK Issue.
 		//
@@ -213,15 +216,99 @@ func (h *KafkaServiceAttributeHandler) Process(d *schema.ResourceData, latestVer
 		// This is caused by using a StateFunc in a nested TypeSet. While the StateFunc
 		// properly handles setting state with the StateFunc, it returns extra entries
 		// during state Gets, specifically `GetChange("logging_kafka")` in this case.
-		if v, ok := cfg["name"]; !ok || v.(string) == "" {
+		if v, ok := resource["name"]; !ok || v.(string) == "" {
 			continue
 		}
 
-		opts := h.buildCreate(cfg, serviceID, latestVersion)
+		opts := h.buildCreate(resource, serviceID, latestVersion)
 
 		log.Printf("[DEBUG] Fastly Kafka logging addition opts: %#v", opts)
 
 		if err := createKafka(conn, opts); err != nil {
+			return err
+		}
+	}
+
+	// UPDATE modified resources
+	//
+	// NOTE: although the go-fastly API client enables updating of a resource by
+	// its 'name' attribute, this isn't possible within terraform due to
+	// constraints in the data model/schema of the resources not having a uid.
+	for _, resource := range diffResult.Modified {
+		resource := resource.(map[string]interface{})
+
+		opts := gofastly.UpdateKafkaInput{
+			ServiceID:      d.Id(),
+			ServiceVersion: latestVersion,
+			Name:           resource["name"].(string),
+		}
+
+		// only attempt to update attributes that have changed
+		modified := setDiff.Filter(resource, oldSet)
+
+		// NOTE: where we transition between interface{} we lose the ability to
+		// infer the underlying type being either a uint vs an int. This
+		// materializes as a panic (yay) and so it's only at runtime we discover
+		// this and so we've updated the below code to convert the type asserted
+		// int into a uint before passing the value to gofastly.Uint().
+		if v, ok := modified["brokers"]; ok {
+			opts.Brokers = gofastly.String(v.(string))
+		}
+		if v, ok := modified["topic"]; ok {
+			opts.Topic = gofastly.String(v.(string))
+		}
+		if v, ok := modified["required_acks"]; ok {
+			opts.RequiredACKs = gofastly.String(v.(string))
+		}
+		if v, ok := modified["use_tls"]; ok {
+			opts.UseTLS = gofastly.CBool(v.(bool))
+		}
+		if v, ok := modified["compression_codec"]; ok {
+			opts.CompressionCodec = gofastly.String(v.(string))
+		}
+		if v, ok := modified["format"]; ok {
+			opts.Format = gofastly.String(v.(string))
+		}
+		if v, ok := modified["format_version"]; ok {
+			opts.FormatVersion = gofastly.Uint(uint(v.(int)))
+		}
+		if v, ok := modified["response_condition"]; ok {
+			opts.ResponseCondition = gofastly.String(v.(string))
+		}
+		if v, ok := modified["placement"]; ok {
+			opts.Placement = gofastly.String(v.(string))
+		}
+		if v, ok := modified["tls_ca_cert"]; ok {
+			opts.TLSCACert = gofastly.String(v.(string))
+		}
+		if v, ok := modified["tls_hostname"]; ok {
+			opts.TLSHostname = gofastly.String(v.(string))
+		}
+		if v, ok := modified["tls_client_cert"]; ok {
+			opts.TLSClientCert = gofastly.String(v.(string))
+		}
+		if v, ok := modified["tls_client_key"]; ok {
+			opts.TLSClientKey = gofastly.String(v.(string))
+		}
+		if v, ok := modified["parse_log_keyvals"]; ok {
+			opts.ParseLogKeyvals = gofastly.CBool(v.(bool))
+		}
+		if v, ok := modified["request_max_bytes"]; ok {
+			opts.RequestMaxBytes = gofastly.Uint(uint(v.(int)))
+		}
+		if v, ok := modified["auth_method"]; ok {
+			opts.AuthMethod = gofastly.String(v.(string))
+		}
+		if v, ok := modified["user"]; ok {
+			opts.User = gofastly.String(v.(string))
+		}
+		if v, ok := modified["password"]; ok {
+			opts.Password = gofastly.String(v.(string))
+		}
+
+		log.Printf("[DEBUG] Update Kafka Opts: %#v", opts)
+		_, err := conn.UpdateKafka(&opts)
+		if err != nil {
 			return err
 		}
 	}

--- a/fastly/block_fastly_service_v1_logging_kafka.go
+++ b/fastly/block_fastly_service_v1_logging_kafka.go
@@ -174,15 +174,15 @@ func (h *KafkaServiceAttributeHandler) Process(d *schema.ResourceData, latestVer
 		newLogCfg = new(schema.Set)
 	}
 
-	oldLogSet := oldLogCfg.(*schema.Set)
-	newLogSet := newLogCfg.(*schema.Set)
+	oldSet := oldLogCfg.(*schema.Set)
+	newSet := newLogCfg.(*schema.Set)
 
-	setDiff := NewSetDiff(func(logging interface{}) (interface{}, error) {
-		// Use the logging endpoint name as the key
-		return logging.(map[string]interface{})["name"], nil
+	setDiff := NewSetDiff(func(resource interface{}) (interface{}, error) {
+		// Use the resource endpoint name as the key
+		return resource.(map[string]interface{})["name"], nil
 	})
 
-	diffResult, err := setDiff.Diff(oldLogSet, newLogSet)
+	diffResult, err := setDiff.Diff(oldSet, newSet)
 	if err != nil {
 		return err
 	}

--- a/fastly/block_fastly_service_v1_logging_kafka.go
+++ b/fastly/block_fastly_service_v1_logging_kafka.go
@@ -27,7 +27,7 @@ func (h *KafkaServiceAttributeHandler) Register(s *schema.Resource) error {
 		"name": {
 			Type:        schema.TypeString,
 			Required:    true,
-			Description: "The unique name of the Kafka logging endpoint",
+			Description: "The unique name of the Kafka logging endpoint. It is important to note that changing this attribute will delete and recreate the resource",
 		},
 
 		"topic": {

--- a/fastly/block_fastly_service_v1_logging_kinesis.go
+++ b/fastly/block_fastly_service_v1_logging_kinesis.go
@@ -236,7 +236,7 @@ func (h *KinesisServiceAttributeHandler) Register(s *schema.Resource) error {
 		"name": {
 			Type:        schema.TypeString,
 			Required:    true,
-			Description: "The unique name of the Kinesis logging endpoint",
+			Description: "The unique name of the Kinesis logging endpoint. It is important to note that changing this attribute will delete and recreate the resource",
 		},
 
 		"topic": {

--- a/fastly/block_fastly_service_v1_logging_kinesis.go
+++ b/fastly/block_fastly_service_v1_logging_kinesis.go
@@ -60,7 +60,7 @@ func (h *KinesisServiceAttributeHandler) Process(d *schema.ResourceData, latestV
 		}
 	}
 
-	// ADD new resources
+	// CREATE new resources
 	for _, resource := range diffResult.Added {
 		resource := resource.(map[string]interface{})
 		opts := h.buildCreate(resource, serviceID, latestVersion)

--- a/fastly/block_fastly_service_v1_logging_kinesis.go
+++ b/fastly/block_fastly_service_v1_logging_kinesis.go
@@ -36,8 +36,11 @@ func (h *KinesisServiceAttributeHandler) Process(d *schema.ResourceData, latestV
 	newSet := nl.(*schema.Set)
 
 	setDiff := NewSetDiff(func(resource interface{}) (interface{}, error) {
-		// Use the resource endpoint name as the key
-		return resource.(map[string]interface{})["name"], nil
+		t, ok := resource.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("resource failed to be type asserted: %+v", resource)
+		}
+		return t["name"], nil
 	})
 
 	diffResult, err := setDiff.Diff(oldSet, newSet)
@@ -45,10 +48,10 @@ func (h *KinesisServiceAttributeHandler) Process(d *schema.ResourceData, latestV
 		return err
 	}
 
-	// DELETE old Kinesis logging endpoints.
-	for _, oRaw := range diffResult.Deleted {
-		of := oRaw.(map[string]interface{})
-		opts := h.buildDelete(of, serviceID, latestVersion)
+	// DELETE removed resources
+	for _, resource := range diffResult.Deleted {
+		resource := resource.(map[string]interface{})
+		opts := h.buildDelete(resource, serviceID, latestVersion)
 
 		log.Printf("[DEBUG] Fastly Kinesis logging endpoint removal opts: %#v", opts)
 
@@ -57,14 +60,68 @@ func (h *KinesisServiceAttributeHandler) Process(d *schema.ResourceData, latestV
 		}
 	}
 
-	// POST new/updated Kinesis logging endpoints.
-	for _, nRaw := range diffResult.Added {
-		lf := nRaw.(map[string]interface{})
-		opts := h.buildCreate(lf, serviceID, latestVersion)
+	// ADD new resources
+	for _, resource := range diffResult.Added {
+		resource := resource.(map[string]interface{})
+		opts := h.buildCreate(resource, serviceID, latestVersion)
 
 		log.Printf("[DEBUG] Fastly Kinesis logging addition opts: %#v", opts)
 
 		if err := createKinesis(conn, opts); err != nil {
+			return err
+		}
+	}
+
+	// UPDATE modified resources
+	//
+	// NOTE: although the go-fastly API client enables updating of a resource by
+	// its 'name' attribute, this isn't possible within terraform due to
+	// constraints in the data model/schema of the resources not having a uid.
+	for _, resource := range diffResult.Modified {
+		resource := resource.(map[string]interface{})
+
+		opts := gofastly.UpdateKinesisInput{
+			ServiceID:      d.Id(),
+			ServiceVersion: latestVersion,
+			Name:           resource["name"].(string),
+		}
+
+		// only attempt to update attributes that have changed
+		modified := setDiff.Filter(resource, oldSet)
+
+		// NOTE: where we transition between interface{} we lose the ability to
+		// infer the underlying type being either a uint vs an int. This
+		// materializes as a panic (yay) and so it's only at runtime we discover
+		// this and so we've updated the below code to convert the type asserted
+		// int into a uint before passing the value to gofastly.Uint().
+		if v, ok := modified["topic"]; ok {
+			opts.StreamName = gofastly.String(v.(string))
+		}
+		if v, ok := modified["region"]; ok {
+			opts.Region = gofastly.String(v.(string))
+		}
+		if v, ok := modified["access_key"]; ok {
+			opts.AccessKey = gofastly.String(v.(string))
+		}
+		if v, ok := modified["secret_key"]; ok {
+			opts.SecretKey = gofastly.String(v.(string))
+		}
+		if v, ok := modified["format"]; ok {
+			opts.Format = gofastly.String(v.(string))
+		}
+		if v, ok := modified["format_version"]; ok {
+			opts.FormatVersion = gofastly.Uint(uint(v.(int)))
+		}
+		if v, ok := modified["response_condition"]; ok {
+			opts.ResponseCondition = gofastly.String(v.(string))
+		}
+		if v, ok := modified["placement"]; ok {
+			opts.Placement = gofastly.String(v.(string))
+		}
+
+		log.Printf("[DEBUG] Update Kinesis Opts: %#v", opts)
+		_, err := conn.UpdateKinesis(&opts)
+		if err != nil {
 			return err
 		}
 	}

--- a/fastly/block_fastly_service_v1_logging_kinesis.go
+++ b/fastly/block_fastly_service_v1_logging_kinesis.go
@@ -35,11 +35,18 @@ func (h *KinesisServiceAttributeHandler) Process(d *schema.ResourceData, latestV
 	ols := ol.(*schema.Set)
 	nls := nl.(*schema.Set)
 
-	removeKinesisLogging := ols.Difference(nls).List()
-	addKinesisLogging := nls.Difference(ols).List()
+	setDiff := NewSetDiff(func(logging interface{}) (interface{}, error) {
+		// Use the logging endpoint name as the key
+		return logging.(map[string]interface{})["name"], nil
+	})
+
+	diffResult, err := setDiff.Diff(ols, nls)
+	if err != nil {
+		return err
+	}
 
 	// DELETE old Kinesis logging endpoints.
-	for _, oRaw := range removeKinesisLogging {
+	for _, oRaw := range diffResult.Deleted {
 		of := oRaw.(map[string]interface{})
 		opts := h.buildDelete(of, serviceID, latestVersion)
 
@@ -51,7 +58,7 @@ func (h *KinesisServiceAttributeHandler) Process(d *schema.ResourceData, latestV
 	}
 
 	// POST new/updated Kinesis logging endpoints.
-	for _, nRaw := range addKinesisLogging {
+	for _, nRaw := range diffResult.Added {
 		lf := nRaw.(map[string]interface{})
 		opts := h.buildCreate(lf, serviceID, latestVersion)
 

--- a/fastly/block_fastly_service_v1_logging_kinesis.go
+++ b/fastly/block_fastly_service_v1_logging_kinesis.go
@@ -32,15 +32,15 @@ func (h *KinesisServiceAttributeHandler) Process(d *schema.ResourceData, latestV
 		nl = new(schema.Set)
 	}
 
-	ols := ol.(*schema.Set)
-	nls := nl.(*schema.Set)
+	oldSet := ol.(*schema.Set)
+	newSet := nl.(*schema.Set)
 
-	setDiff := NewSetDiff(func(logging interface{}) (interface{}, error) {
-		// Use the logging endpoint name as the key
-		return logging.(map[string]interface{})["name"], nil
+	setDiff := NewSetDiff(func(resource interface{}) (interface{}, error) {
+		// Use the resource endpoint name as the key
+		return resource.(map[string]interface{})["name"], nil
 	})
 
-	diffResult, err := setDiff.Diff(ols, nls)
+	diffResult, err := setDiff.Diff(oldSet, newSet)
 	if err != nil {
 		return err
 	}

--- a/fastly/block_fastly_service_v1_logging_loggly.go
+++ b/fastly/block_fastly_service_v1_logging_loggly.go
@@ -35,11 +35,18 @@ func (h *LogglyServiceAttributeHandler) Process(d *schema.ResourceData, latestVe
 	ols := ol.(*schema.Set)
 	nls := nl.(*schema.Set)
 
-	removeLogglyLogging := ols.Difference(nls).List()
-	addLogglyLogging := nls.Difference(ols).List()
+	setDiff := NewSetDiff(func(logging interface{}) (interface{}, error) {
+		// Use the logging endpoint name as the key
+		return logging.(map[string]interface{})["name"], nil
+	})
+
+	diffResult, err := setDiff.Diff(ols, nls)
+	if err != nil {
+		return err
+	}
 
 	// DELETE old Loggly logging endpoints.
-	for _, oRaw := range removeLogglyLogging {
+	for _, oRaw := range diffResult.Deleted {
 		of := oRaw.(map[string]interface{})
 		opts := h.buildDelete(of, serviceID, latestVersion)
 
@@ -51,7 +58,7 @@ func (h *LogglyServiceAttributeHandler) Process(d *schema.ResourceData, latestVe
 	}
 
 	// POST new/updated Loggly logging endpoints.
-	for _, nRaw := range addLogglyLogging {
+	for _, nRaw := range diffResult.Added {
 		lf := nRaw.(map[string]interface{})
 		opts := h.buildCreate(lf, serviceID, latestVersion)
 

--- a/fastly/block_fastly_service_v1_logging_loggly.go
+++ b/fastly/block_fastly_service_v1_logging_loggly.go
@@ -36,8 +36,11 @@ func (h *LogglyServiceAttributeHandler) Process(d *schema.ResourceData, latestVe
 	newSet := nl.(*schema.Set)
 
 	setDiff := NewSetDiff(func(resource interface{}) (interface{}, error) {
-		// Use the resource endpoint name as the key
-		return resource.(map[string]interface{})["name"], nil
+		t, ok := resource.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("resource failed to be type asserted: %+v", resource)
+		}
+		return t["name"], nil
 	})
 
 	diffResult, err := setDiff.Diff(oldSet, newSet)
@@ -45,10 +48,10 @@ func (h *LogglyServiceAttributeHandler) Process(d *schema.ResourceData, latestVe
 		return err
 	}
 
-	// DELETE old Loggly logging endpoints.
-	for _, oRaw := range diffResult.Deleted {
-		of := oRaw.(map[string]interface{})
-		opts := h.buildDelete(of, serviceID, latestVersion)
+	// DELETE removed resources
+	for _, resource := range diffResult.Deleted {
+		resource := resource.(map[string]interface{})
+		opts := h.buildDelete(resource, serviceID, latestVersion)
 
 		log.Printf("[DEBUG] Fastly Loggly logging endpoint removal opts: %#v", opts)
 
@@ -57,14 +60,59 @@ func (h *LogglyServiceAttributeHandler) Process(d *schema.ResourceData, latestVe
 		}
 	}
 
-	// POST new/updated Loggly logging endpoints.
-	for _, nRaw := range diffResult.Added {
-		lf := nRaw.(map[string]interface{})
-		opts := h.buildCreate(lf, serviceID, latestVersion)
+	// ADD new resources
+	for _, resource := range diffResult.Added {
+		resource := resource.(map[string]interface{})
+		opts := h.buildCreate(resource, serviceID, latestVersion)
 
 		log.Printf("[DEBUG] Fastly Loggly logging addition opts: %#v", opts)
 
 		if err := createLoggly(conn, opts); err != nil {
+			return err
+		}
+	}
+
+	// UPDATE modified resources
+	//
+	// NOTE: although the go-fastly API client enables updating of a resource by
+	// its 'name' attribute, this isn't possible within terraform due to
+	// constraints in the data model/schema of the resources not having a uid.
+	for _, resource := range diffResult.Modified {
+		resource := resource.(map[string]interface{})
+
+		opts := gofastly.UpdateLogglyInput{
+			ServiceID:      d.Id(),
+			ServiceVersion: latestVersion,
+			Name:           resource["name"].(string),
+		}
+
+		// only attempt to update attributes that have changed
+		modified := setDiff.Filter(resource, oldSet)
+
+		// NOTE: where we transition between interface{} we lose the ability to
+		// infer the underlying type being either a uint vs an int. This
+		// materializes as a panic (yay) and so it's only at runtime we discover
+		// this and so we've updated the below code to convert the type asserted
+		// int into a uint before passing the value to gofastly.Uint().
+		if v, ok := modified["token"]; ok {
+			opts.Token = gofastly.String(v.(string))
+		}
+		if v, ok := modified["format"]; ok {
+			opts.Format = gofastly.String(v.(string))
+		}
+		if v, ok := modified["format_version"]; ok {
+			opts.FormatVersion = gofastly.Uint(uint(v.(int)))
+		}
+		if v, ok := modified["response_condition"]; ok {
+			opts.ResponseCondition = gofastly.String(v.(string))
+		}
+		if v, ok := modified["placement"]; ok {
+			opts.Placement = gofastly.String(v.(string))
+		}
+
+		log.Printf("[DEBUG] Update Loggly Opts: %#v", opts)
+		_, err := conn.UpdateLoggly(&opts)
+		if err != nil {
 			return err
 		}
 	}

--- a/fastly/block_fastly_service_v1_logging_loggly.go
+++ b/fastly/block_fastly_service_v1_logging_loggly.go
@@ -32,15 +32,15 @@ func (h *LogglyServiceAttributeHandler) Process(d *schema.ResourceData, latestVe
 		nl = new(schema.Set)
 	}
 
-	ols := ol.(*schema.Set)
-	nls := nl.(*schema.Set)
+	oldSet := ol.(*schema.Set)
+	newSet := nl.(*schema.Set)
 
-	setDiff := NewSetDiff(func(logging interface{}) (interface{}, error) {
-		// Use the logging endpoint name as the key
-		return logging.(map[string]interface{})["name"], nil
+	setDiff := NewSetDiff(func(resource interface{}) (interface{}, error) {
+		// Use the resource endpoint name as the key
+		return resource.(map[string]interface{})["name"], nil
 	})
 
-	diffResult, err := setDiff.Diff(ols, nls)
+	diffResult, err := setDiff.Diff(oldSet, newSet)
 	if err != nil {
 		return err
 	}

--- a/fastly/block_fastly_service_v1_logging_loggly.go
+++ b/fastly/block_fastly_service_v1_logging_loggly.go
@@ -221,7 +221,7 @@ func (h *LogglyServiceAttributeHandler) Register(s *schema.Resource) error {
 		"name": {
 			Type:        schema.TypeString,
 			Required:    true,
-			Description: "The unique name of the Loggly logging endpoint",
+			Description: "The unique name of the Loggly logging endpoint. It is important to note that changing this attribute will delete and recreate the resource",
 		},
 
 		"token": {

--- a/fastly/block_fastly_service_v1_logging_loggly.go
+++ b/fastly/block_fastly_service_v1_logging_loggly.go
@@ -60,7 +60,7 @@ func (h *LogglyServiceAttributeHandler) Process(d *schema.ResourceData, latestVe
 		}
 	}
 
-	// ADD new resources
+	// CREATE new resources
 	for _, resource := range diffResult.Added {
 		resource := resource.(map[string]interface{})
 		opts := h.buildCreate(resource, serviceID, latestVersion)

--- a/fastly/block_fastly_service_v1_logging_logshuttle.go
+++ b/fastly/block_fastly_service_v1_logging_logshuttle.go
@@ -60,7 +60,7 @@ func (h *LogshuttleServiceAttributeHandler) Process(d *schema.ResourceData, late
 		}
 	}
 
-	// ADD new resources
+	// CREATE new resources
 	for _, resource := range diffResult.Added {
 		resource := resource.(map[string]interface{})
 		opts := h.buildCreate(resource, serviceID, latestVersion)

--- a/fastly/block_fastly_service_v1_logging_logshuttle.go
+++ b/fastly/block_fastly_service_v1_logging_logshuttle.go
@@ -226,7 +226,7 @@ func (h *LogshuttleServiceAttributeHandler) Register(s *schema.Resource) error {
 		"name": {
 			Type:        schema.TypeString,
 			Required:    true,
-			Description: "The unique name of the Log Shuttle logging endpoint",
+			Description: "The unique name of the Log Shuttle logging endpoint. It is important to note that changing this attribute will delete and recreate the resource",
 		},
 
 		"token": {

--- a/fastly/block_fastly_service_v1_logging_logshuttle.go
+++ b/fastly/block_fastly_service_v1_logging_logshuttle.go
@@ -32,15 +32,15 @@ func (h *LogshuttleServiceAttributeHandler) Process(d *schema.ResourceData, late
 		nl = new(schema.Set)
 	}
 
-	ols := ol.(*schema.Set)
-	nls := nl.(*schema.Set)
+	oldSet := ol.(*schema.Set)
+	newSet := nl.(*schema.Set)
 
-	setDiff := NewSetDiff(func(logging interface{}) (interface{}, error) {
-		// Use the logging endpoint name as the key
-		return logging.(map[string]interface{})["name"], nil
+	setDiff := NewSetDiff(func(resource interface{}) (interface{}, error) {
+		// Use the resource endpoint name as the key
+		return resource.(map[string]interface{})["name"], nil
 	})
 
-	diffResult, err := setDiff.Diff(ols, nls)
+	diffResult, err := setDiff.Diff(oldSet, newSet)
 	if err != nil {
 		return err
 	}

--- a/fastly/block_fastly_service_v1_logging_logshuttle.go
+++ b/fastly/block_fastly_service_v1_logging_logshuttle.go
@@ -36,8 +36,11 @@ func (h *LogshuttleServiceAttributeHandler) Process(d *schema.ResourceData, late
 	newSet := nl.(*schema.Set)
 
 	setDiff := NewSetDiff(func(resource interface{}) (interface{}, error) {
-		// Use the resource endpoint name as the key
-		return resource.(map[string]interface{})["name"], nil
+		t, ok := resource.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("resource failed to be type asserted: %+v", resource)
+		}
+		return t["name"], nil
 	})
 
 	diffResult, err := setDiff.Diff(oldSet, newSet)
@@ -45,10 +48,10 @@ func (h *LogshuttleServiceAttributeHandler) Process(d *schema.ResourceData, late
 		return err
 	}
 
-	// DELETE old Log Shuttle logging endpoints.
-	for _, oRaw := range diffResult.Deleted {
-		of := oRaw.(map[string]interface{})
-		opts := h.buildDelete(of, serviceID, latestVersion)
+	// DELETE removed resources
+	for _, resource := range diffResult.Deleted {
+		resource := resource.(map[string]interface{})
+		opts := h.buildDelete(resource, serviceID, latestVersion)
 
 		log.Printf("[DEBUG] Fastly Log Shuttle logging endpoint removal opts: %#v", opts)
 
@@ -57,14 +60,62 @@ func (h *LogshuttleServiceAttributeHandler) Process(d *schema.ResourceData, late
 		}
 	}
 
-	// POST new/updated Log Shuttle logging endpoints.
-	for _, nRaw := range diffResult.Added {
-		lf := nRaw.(map[string]interface{})
-		opts := h.buildCreate(lf, serviceID, latestVersion)
+	// ADD new resources
+	for _, resource := range diffResult.Added {
+		resource := resource.(map[string]interface{})
+		opts := h.buildCreate(resource, serviceID, latestVersion)
 
 		log.Printf("[DEBUG] Fastly Log Shuttle logging addition opts: %#v", opts)
 
 		if err := createLogshuttle(conn, opts); err != nil {
+			return err
+		}
+	}
+
+	// UPDATE modified resources
+	//
+	// NOTE: although the go-fastly API client enables updating of a resource by
+	// its 'name' attribute, this isn't possible within terraform due to
+	// constraints in the data model/schema of the resources not having a uid.
+	for _, resource := range diffResult.Modified {
+		resource := resource.(map[string]interface{})
+
+		opts := gofastly.UpdateLogshuttleInput{
+			ServiceID:      d.Id(),
+			ServiceVersion: latestVersion,
+			Name:           resource["name"].(string),
+		}
+
+		// only attempt to update attributes that have changed
+		modified := setDiff.Filter(resource, oldSet)
+
+		// NOTE: where we transition between interface{} we lose the ability to
+		// infer the underlying type being either a uint vs an int. This
+		// materializes as a panic (yay) and so it's only at runtime we discover
+		// this and so we've updated the below code to convert the type asserted
+		// int into a uint before passing the value to gofastly.Uint().
+		if v, ok := modified["format"]; ok {
+			opts.Format = gofastly.String(v.(string))
+		}
+		if v, ok := modified["format_version"]; ok {
+			opts.FormatVersion = gofastly.Uint(uint(v.(int)))
+		}
+		if v, ok := modified["url"]; ok {
+			opts.URL = gofastly.String(v.(string))
+		}
+		if v, ok := modified["token"]; ok {
+			opts.Token = gofastly.String(v.(string))
+		}
+		if v, ok := modified["response_condition"]; ok {
+			opts.ResponseCondition = gofastly.String(v.(string))
+		}
+		if v, ok := modified["placement"]; ok {
+			opts.Placement = gofastly.String(v.(string))
+		}
+
+		log.Printf("[DEBUG] Update Log Shuttle Opts: %#v", opts)
+		_, err := conn.UpdateLogshuttle(&opts)
+		if err != nil {
 			return err
 		}
 	}

--- a/fastly/block_fastly_service_v1_logging_newrelic.go
+++ b/fastly/block_fastly_service_v1_logging_newrelic.go
@@ -219,7 +219,7 @@ func (h *NewRelicServiceAttributeHandler) Register(s *schema.Resource) error {
 		"name": {
 			Type:        schema.TypeString,
 			Required:    true,
-			Description: "The unique name of the New Relic logging endpoint",
+			Description: "The unique name of the New Relic logging endpoint. It is important to note that changing this attribute will delete and recreate the resource",
 		},
 
 		"token": {

--- a/fastly/block_fastly_service_v1_logging_newrelic.go
+++ b/fastly/block_fastly_service_v1_logging_newrelic.go
@@ -36,8 +36,11 @@ func (h *NewRelicServiceAttributeHandler) Process(d *schema.ResourceData, latest
 	newSet := nd.(*schema.Set)
 
 	setDiff := NewSetDiff(func(resource interface{}) (interface{}, error) {
-		// Use the resource endpoint name as the key
-		return resource.(map[string]interface{})["name"], nil
+		t, ok := resource.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("resource failed to be type asserted: %+v", resource)
+		}
+		return t["name"], nil
 	})
 
 	diffResult, err := setDiff.Diff(oldSet, newSet)
@@ -45,10 +48,10 @@ func (h *NewRelicServiceAttributeHandler) Process(d *schema.ResourceData, latest
 		return err
 	}
 
-	// DELETE old NewRelic logging endpoints.
-	for _, oRaw := range diffResult.Deleted {
-		of := oRaw.(map[string]interface{})
-		opts := h.buildDelete(of, serviceID, latestVersion)
+	// DELETE removed resources
+	for _, resource := range diffResult.Deleted {
+		resource := resource.(map[string]interface{})
+		opts := h.buildDelete(resource, serviceID, latestVersion)
 
 		log.Printf("[DEBUG] Fastly New Relic logging endpoint removal opts: %#v", opts)
 
@@ -57,14 +60,59 @@ func (h *NewRelicServiceAttributeHandler) Process(d *schema.ResourceData, latest
 		}
 	}
 
-	// POST new/updated NewRelic logging endpoints.
-	for _, nRaw := range diffResult.Added {
-		df := nRaw.(map[string]interface{})
-		opts := h.buildCreate(df, serviceID, latestVersion)
+	// ADD new resources
+	for _, resource := range diffResult.Added {
+		resource := resource.(map[string]interface{})
+		opts := h.buildCreate(resource, serviceID, latestVersion)
 
 		log.Printf("[DEBUG] Fastly New Relic logging addition opts: %#v", opts)
 
 		if err := createNewRelic(conn, opts); err != nil {
+			return err
+		}
+	}
+
+	// UPDATE modified resources
+	//
+	// NOTE: although the go-fastly API client enables updating of a resource by
+	// its 'name' attribute, this isn't possible within terraform due to
+	// constraints in the data model/schema of the resources not having a uid.
+	for _, resource := range diffResult.Modified {
+		resource := resource.(map[string]interface{})
+
+		opts := gofastly.UpdateNewRelicInput{
+			ServiceID:      d.Id(),
+			ServiceVersion: latestVersion,
+			Name:           resource["name"].(string),
+		}
+
+		// only attempt to update attributes that have changed
+		modified := setDiff.Filter(resource, oldSet)
+
+		// NOTE: where we transition between interface{} we lose the ability to
+		// infer the underlying type being either a uint vs an int. This
+		// materializes as a panic (yay) and so it's only at runtime we discover
+		// this and so we've updated the below code to convert the type asserted
+		// int into a uint before passing the value to gofastly.Uint().
+		if v, ok := modified["token"]; ok {
+			opts.Token = gofastly.String(v.(string))
+		}
+		if v, ok := modified["format"]; ok {
+			opts.Format = gofastly.String(v.(string))
+		}
+		if v, ok := modified["format_version"]; ok {
+			opts.FormatVersion = gofastly.Uint(uint(v.(int)))
+		}
+		if v, ok := modified["response_condition"]; ok {
+			opts.ResponseCondition = gofastly.String(v.(string))
+		}
+		if v, ok := modified["placement"]; ok {
+			opts.Placement = gofastly.String(v.(string))
+		}
+
+		log.Printf("[DEBUG] Update New Relic Opts: %#v", opts)
+		_, err := conn.UpdateNewRelic(&opts)
+		if err != nil {
 			return err
 		}
 	}

--- a/fastly/block_fastly_service_v1_logging_newrelic.go
+++ b/fastly/block_fastly_service_v1_logging_newrelic.go
@@ -60,7 +60,7 @@ func (h *NewRelicServiceAttributeHandler) Process(d *schema.ResourceData, latest
 		}
 	}
 
-	// ADD new resources
+	// CREATE new resources
 	for _, resource := range diffResult.Added {
 		resource := resource.(map[string]interface{})
 		opts := h.buildCreate(resource, serviceID, latestVersion)

--- a/fastly/block_fastly_service_v1_logging_newrelic.go
+++ b/fastly/block_fastly_service_v1_logging_newrelic.go
@@ -32,15 +32,15 @@ func (h *NewRelicServiceAttributeHandler) Process(d *schema.ResourceData, latest
 		nd = new(schema.Set)
 	}
 
-	ods := od.(*schema.Set)
-	nds := nd.(*schema.Set)
+	oldSet := od.(*schema.Set)
+	newSet := nd.(*schema.Set)
 
-	setDiff := NewSetDiff(func(logging interface{}) (interface{}, error) {
-		// Use the logging endpoint name as the key
-		return logging.(map[string]interface{})["name"], nil
+	setDiff := NewSetDiff(func(resource interface{}) (interface{}, error) {
+		// Use the resource endpoint name as the key
+		return resource.(map[string]interface{})["name"], nil
 	})
 
-	diffResult, err := setDiff.Diff(ods, nds)
+	diffResult, err := setDiff.Diff(oldSet, newSet)
 	if err != nil {
 		return err
 	}

--- a/fastly/block_fastly_service_v1_logging_openstack.go
+++ b/fastly/block_fastly_service_v1_logging_openstack.go
@@ -60,7 +60,7 @@ func (h *OpenstackServiceAttributeHandler) Process(d *schema.ResourceData, lates
 		}
 	}
 
-	// ADD new resources
+	// CREATE new resources
 	for _, resource := range diffResult.Added {
 		resource := resource.(map[string]interface{})
 

--- a/fastly/block_fastly_service_v1_logging_openstack.go
+++ b/fastly/block_fastly_service_v1_logging_openstack.go
@@ -36,8 +36,11 @@ func (h *OpenstackServiceAttributeHandler) Process(d *schema.ResourceData, lates
 	newSet := nl.(*schema.Set)
 
 	setDiff := NewSetDiff(func(resource interface{}) (interface{}, error) {
-		// Use the resource endpoint name as the key
-		return resource.(map[string]interface{})["name"], nil
+		t, ok := resource.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("resource failed to be type asserted: %+v", resource)
+		}
+		return t["name"], nil
 	})
 
 	diffResult, err := setDiff.Diff(oldSet, newSet)
@@ -45,10 +48,10 @@ func (h *OpenstackServiceAttributeHandler) Process(d *schema.ResourceData, lates
 		return err
 	}
 
-	// DELETE old OpenStack logging endpoints.
-	for _, oRaw := range diffResult.Deleted {
-		of := oRaw.(map[string]interface{})
-		opts := h.buildDelete(of, serviceID, latestVersion)
+	// DELETE removed resources
+	for _, resource := range diffResult.Deleted {
+		resource := resource.(map[string]interface{})
+		opts := h.buildDelete(resource, serviceID, latestVersion)
 
 		log.Printf("[DEBUG] Fastly OpenStack logging endpoint removal opts: %#v", opts)
 
@@ -57,9 +60,9 @@ func (h *OpenstackServiceAttributeHandler) Process(d *schema.ResourceData, lates
 		}
 	}
 
-	// POST new/updated OpenStack logging endpoints.
-	for _, nRaw := range diffResult.Added {
-		lf := nRaw.(map[string]interface{})
+	// ADD new resources
+	for _, resource := range diffResult.Added {
+		resource := resource.(map[string]interface{})
 
 		// @HACK for a TF SDK Issue.
 		//
@@ -71,15 +74,90 @@ func (h *OpenstackServiceAttributeHandler) Process(d *schema.ResourceData, lates
 		// This is caused by using a StateFunc in a nested TypeSet. While the StateFunc
 		// properly handles setting state with the StateFunc, it returns extra entries
 		// during state Gets, specifically `GetChange("logging_openstack")` in this case.
-		if v, ok := lf["name"]; !ok || v.(string) == "" {
+		if v, ok := resource["name"]; !ok || v.(string) == "" {
 			continue
 		}
 
-		opts := h.buildCreate(lf, serviceID, latestVersion)
+		opts := h.buildCreate(resource, serviceID, latestVersion)
 
 		log.Printf("[DEBUG] Fastly OpenStack logging addition opts: %#v", opts)
 
 		if err := createOpenstack(conn, opts); err != nil {
+			return err
+		}
+	}
+
+	// UPDATE modified resources
+	//
+	// NOTE: although the go-fastly API client enables updating of a resource by
+	// its 'name' attribute, this isn't possible within terraform due to
+	// constraints in the data model/schema of the resources not having a uid.
+	for _, resource := range diffResult.Modified {
+		resource := resource.(map[string]interface{})
+
+		opts := gofastly.UpdateOpenstackInput{
+			ServiceID:      d.Id(),
+			ServiceVersion: latestVersion,
+			Name:           resource["name"].(string),
+		}
+
+		// only attempt to update attributes that have changed
+		modified := setDiff.Filter(resource, oldSet)
+
+		// NOTE: where we transition between interface{} we lose the ability to
+		// infer the underlying type being either a uint vs an int. This
+		// materializes as a panic (yay) and so it's only at runtime we discover
+		// this and so we've updated the below code to convert the type asserted
+		// int into a uint before passing the value to gofastly.Uint().
+		if v, ok := modified["access_key"]; ok {
+			opts.AccessKey = gofastly.String(v.(string))
+		}
+		if v, ok := modified["bucket_name"]; ok {
+			opts.BucketName = gofastly.String(v.(string))
+		}
+		if v, ok := modified["url"]; ok {
+			opts.URL = gofastly.String(v.(string))
+		}
+		if v, ok := modified["user"]; ok {
+			opts.User = gofastly.String(v.(string))
+		}
+		if v, ok := modified["path"]; ok {
+			opts.Path = gofastly.String(v.(string))
+		}
+		if v, ok := modified["placement"]; ok {
+			opts.Placement = gofastly.String(v.(string))
+		}
+		if v, ok := modified["period"]; ok {
+			opts.Period = gofastly.Uint(uint(v.(int)))
+		}
+		if v, ok := modified["compression_codec"]; ok {
+			opts.CompressionCodec = gofastly.String(v.(string))
+		}
+		if v, ok := modified["gzip_level"]; ok {
+			opts.GzipLevel = gofastly.Uint(uint(v.(int)))
+		}
+		if v, ok := modified["format"]; ok {
+			opts.Format = gofastly.String(v.(string))
+		}
+		if v, ok := modified["format_version"]; ok {
+			opts.FormatVersion = gofastly.Uint(uint(v.(int)))
+		}
+		if v, ok := modified["response_condition"]; ok {
+			opts.ResponseCondition = gofastly.String(v.(string))
+		}
+		if v, ok := modified["message_type"]; ok {
+			opts.MessageType = gofastly.String(v.(string))
+		}
+		if v, ok := modified["timestamp_format"]; ok {
+			opts.TimestampFormat = gofastly.String(v.(string))
+		}
+		if v, ok := modified["public_key"]; ok {
+			opts.PublicKey = gofastly.String(v.(string))
+		}
+
+		log.Printf("[DEBUG] Update OpenStack Opts: %#v", opts)
+		_, err := conn.UpdateOpenstack(&opts)
+		if err != nil {
 			return err
 		}
 	}

--- a/fastly/block_fastly_service_v1_logging_openstack.go
+++ b/fastly/block_fastly_service_v1_logging_openstack.go
@@ -35,11 +35,18 @@ func (h *OpenstackServiceAttributeHandler) Process(d *schema.ResourceData, lates
 	ols := ol.(*schema.Set)
 	nls := nl.(*schema.Set)
 
-	removeOpenstackLogging := ols.Difference(nls).List()
-	addOpenstackLogging := nls.Difference(ols).List()
+	setDiff := NewSetDiff(func(logging interface{}) (interface{}, error) {
+		// Use the logging endpoint name as the key
+		return logging.(map[string]interface{})["name"], nil
+	})
+
+	diffResult, err := setDiff.Diff(ols, nls)
+	if err != nil {
+		return err
+	}
 
 	// DELETE old OpenStack logging endpoints.
-	for _, oRaw := range removeOpenstackLogging {
+	for _, oRaw := range diffResult.Deleted {
 		of := oRaw.(map[string]interface{})
 		opts := h.buildDelete(of, serviceID, latestVersion)
 
@@ -51,7 +58,7 @@ func (h *OpenstackServiceAttributeHandler) Process(d *schema.ResourceData, lates
 	}
 
 	// POST new/updated OpenStack logging endpoints.
-	for _, nRaw := range addOpenstackLogging {
+	for _, nRaw := range diffResult.Added {
 		lf := nRaw.(map[string]interface{})
 
 		// @HACK for a TF SDK Issue.

--- a/fastly/block_fastly_service_v1_logging_openstack.go
+++ b/fastly/block_fastly_service_v1_logging_openstack.go
@@ -32,15 +32,15 @@ func (h *OpenstackServiceAttributeHandler) Process(d *schema.ResourceData, lates
 		nl = new(schema.Set)
 	}
 
-	ols := ol.(*schema.Set)
-	nls := nl.(*schema.Set)
+	oldSet := ol.(*schema.Set)
+	newSet := nl.(*schema.Set)
 
-	setDiff := NewSetDiff(func(logging interface{}) (interface{}, error) {
-		// Use the logging endpoint name as the key
-		return logging.(map[string]interface{})["name"], nil
+	setDiff := NewSetDiff(func(resource interface{}) (interface{}, error) {
+		// Use the resource endpoint name as the key
+		return resource.(map[string]interface{})["name"], nil
 	})
 
-	diffResult, err := setDiff.Diff(ols, nls)
+	diffResult, err := setDiff.Diff(oldSet, newSet)
 	if err != nil {
 		return err
 	}

--- a/fastly/block_fastly_service_v1_logging_openstack.go
+++ b/fastly/block_fastly_service_v1_logging_openstack.go
@@ -284,7 +284,7 @@ func (h *OpenstackServiceAttributeHandler) Register(s *schema.Resource) error {
 		"name": {
 			Type:        schema.TypeString,
 			Required:    true,
-			Description: "The unique name of the OpenStack logging endpoint",
+			Description: "The unique name of the OpenStack logging endpoint. It is important to note that changing this attribute will delete and recreate the resource",
 		},
 
 		"url": {

--- a/fastly/block_fastly_service_v1_logging_scalyr.go
+++ b/fastly/block_fastly_service_v1_logging_scalyr.go
@@ -96,11 +96,18 @@ func (h *ScalyrServiceAttributeHandler) Process(d *schema.ResourceData, latestVe
 	oldLogSet := oldLogCfg.(*schema.Set)
 	newLogSet := newLogCfg.(*schema.Set)
 
-	removeScalyrLogging := oldLogSet.Difference(newLogSet).List()
-	addScalyrLogging := newLogSet.Difference(oldLogSet).List()
+	setDiff := NewSetDiff(func(logging interface{}) (interface{}, error) {
+		// Use the logging endpoint name as the key
+		return logging.(map[string]interface{})["name"], nil
+	})
+
+	diffResult, err := setDiff.Diff(oldLogSet, newLogSet)
+	if err != nil {
+		return err
+	}
 
 	// DELETE old Scalyr logging endpoints.
-	for _, oRaw := range removeScalyrLogging {
+	for _, oRaw := range diffResult.Deleted {
 		of := oRaw.(map[string]interface{})
 		opts := h.buildDelete(of, serviceID, latestVersion)
 
@@ -112,7 +119,7 @@ func (h *ScalyrServiceAttributeHandler) Process(d *schema.ResourceData, latestVe
 	}
 
 	// POST new/updated Scalyr logging endponts.
-	for _, nRaw := range addScalyrLogging {
+	for _, nRaw := range diffResult.Added {
 		cfg := nRaw.(map[string]interface{})
 		opts := h.buildCreate(cfg, serviceID, latestVersion)
 

--- a/fastly/block_fastly_service_v1_logging_scalyr.go
+++ b/fastly/block_fastly_service_v1_logging_scalyr.go
@@ -97,8 +97,11 @@ func (h *ScalyrServiceAttributeHandler) Process(d *schema.ResourceData, latestVe
 	newSet := newLogCfg.(*schema.Set)
 
 	setDiff := NewSetDiff(func(resource interface{}) (interface{}, error) {
-		// Use the resource endpoint name as the key
-		return resource.(map[string]interface{})["name"], nil
+		t, ok := resource.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("resource failed to be type asserted: %+v", resource)
+		}
+		return t["name"], nil
 	})
 
 	diffResult, err := setDiff.Diff(oldSet, newSet)
@@ -106,10 +109,10 @@ func (h *ScalyrServiceAttributeHandler) Process(d *schema.ResourceData, latestVe
 		return err
 	}
 
-	// DELETE old Scalyr logging endpoints.
-	for _, oRaw := range diffResult.Deleted {
-		of := oRaw.(map[string]interface{})
-		opts := h.buildDelete(of, serviceID, latestVersion)
+	// DELETE removed resources
+	for _, resource := range diffResult.Deleted {
+		resource := resource.(map[string]interface{})
+		opts := h.buildDelete(resource, serviceID, latestVersion)
 
 		log.Printf("[DEBUG] Fastly Scalyr logging endpoint removal opts: %#v", opts)
 
@@ -118,14 +121,62 @@ func (h *ScalyrServiceAttributeHandler) Process(d *schema.ResourceData, latestVe
 		}
 	}
 
-	// POST new/updated Scalyr logging endponts.
-	for _, nRaw := range diffResult.Added {
-		cfg := nRaw.(map[string]interface{})
-		opts := h.buildCreate(cfg, serviceID, latestVersion)
+	// ADD new resources
+	for _, resource := range diffResult.Added {
+		resource := resource.(map[string]interface{})
+		opts := h.buildCreate(resource, serviceID, latestVersion)
 
 		log.Printf("[DEBUG] Fastly Scalyr logging addition opts: %#v", opts)
 
 		if err := createScalyr(conn, opts); err != nil {
+			return err
+		}
+	}
+
+	// UPDATE modified resources
+	//
+	// NOTE: although the go-fastly API client enables updating of a resource by
+	// its 'name' attribute, this isn't possible within terraform due to
+	// constraints in the data model/schema of the resources not having a uid.
+	for _, resource := range diffResult.Modified {
+		resource := resource.(map[string]interface{})
+
+		opts := gofastly.UpdateScalyrInput{
+			ServiceID:      d.Id(),
+			ServiceVersion: latestVersion,
+			Name:           resource["name"].(string),
+		}
+
+		// only attempt to update attributes that have changed
+		modified := setDiff.Filter(resource, oldSet)
+
+		// NOTE: where we transition between interface{} we lose the ability to
+		// infer the underlying type being either a uint vs an int. This
+		// materializes as a panic (yay) and so it's only at runtime we discover
+		// this and so we've updated the below code to convert the type asserted
+		// int into a uint before passing the value to gofastly.Uint().
+		if v, ok := modified["format"]; ok {
+			opts.Format = gofastly.String(v.(string))
+		}
+		if v, ok := modified["format_version"]; ok {
+			opts.FormatVersion = gofastly.Uint(uint(v.(int)))
+		}
+		if v, ok := modified["token"]; ok {
+			opts.Token = gofastly.String(v.(string))
+		}
+		if v, ok := modified["region"]; ok {
+			opts.Region = gofastly.String(v.(string))
+		}
+		if v, ok := modified["response_condition"]; ok {
+			opts.ResponseCondition = gofastly.String(v.(string))
+		}
+		if v, ok := modified["placement"]; ok {
+			opts.Placement = gofastly.String(v.(string))
+		}
+
+		log.Printf("[DEBUG] Update Scalyr Opts: %#v", opts)
+		_, err := conn.UpdateScalyr(&opts)
+		if err != nil {
 			return err
 		}
 	}

--- a/fastly/block_fastly_service_v1_logging_scalyr.go
+++ b/fastly/block_fastly_service_v1_logging_scalyr.go
@@ -27,7 +27,7 @@ func (h *ScalyrServiceAttributeHandler) Register(s *schema.Resource) error {
 		"name": {
 			Type:        schema.TypeString,
 			Required:    true,
-			Description: "The unique name of the Scalyr logging endpoint",
+			Description: "The unique name of the Scalyr logging endpoint. It is important to note that changing this attribute will delete and recreate the resource",
 		},
 
 		"token": {

--- a/fastly/block_fastly_service_v1_logging_scalyr.go
+++ b/fastly/block_fastly_service_v1_logging_scalyr.go
@@ -93,15 +93,15 @@ func (h *ScalyrServiceAttributeHandler) Process(d *schema.ResourceData, latestVe
 		newLogCfg = new(schema.Set)
 	}
 
-	oldLogSet := oldLogCfg.(*schema.Set)
-	newLogSet := newLogCfg.(*schema.Set)
+	oldSet := oldLogCfg.(*schema.Set)
+	newSet := newLogCfg.(*schema.Set)
 
-	setDiff := NewSetDiff(func(logging interface{}) (interface{}, error) {
-		// Use the logging endpoint name as the key
-		return logging.(map[string]interface{})["name"], nil
+	setDiff := NewSetDiff(func(resource interface{}) (interface{}, error) {
+		// Use the resource endpoint name as the key
+		return resource.(map[string]interface{})["name"], nil
 	})
 
-	diffResult, err := setDiff.Diff(oldLogSet, newLogSet)
+	diffResult, err := setDiff.Diff(oldSet, newSet)
 	if err != nil {
 		return err
 	}

--- a/fastly/block_fastly_service_v1_logging_scalyr.go
+++ b/fastly/block_fastly_service_v1_logging_scalyr.go
@@ -121,7 +121,7 @@ func (h *ScalyrServiceAttributeHandler) Process(d *schema.ResourceData, latestVe
 		}
 	}
 
-	// ADD new resources
+	// CREATE new resources
 	for _, resource := range diffResult.Added {
 		resource := resource.(map[string]interface{})
 		opts := h.buildCreate(resource, serviceID, latestVersion)

--- a/fastly/block_fastly_service_v1_logging_sftp.go
+++ b/fastly/block_fastly_service_v1_logging_sftp.go
@@ -168,8 +168,11 @@ func (h *SFTPServiceAttributeHandler) Process(d *schema.ResourceData, latestVers
 	newSet := ns.(*schema.Set)
 
 	setDiff := NewSetDiff(func(resource interface{}) (interface{}, error) {
-		// Use the resource endpoint name as the key
-		return resource.(map[string]interface{})["name"], nil
+		t, ok := resource.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("resource failed to be type asserted: %+v", resource)
+		}
+		return t["name"], nil
 	})
 
 	diffResult, err := setDiff.Diff(oldSet, newSet)
@@ -177,10 +180,10 @@ func (h *SFTPServiceAttributeHandler) Process(d *schema.ResourceData, latestVers
 		return err
 	}
 
-	// DELETE old SFTP logging endpoints.
-	for _, oRaw := range diffResult.Deleted {
-		of := oRaw.(map[string]interface{})
-		opts := h.buildDelete(of, serviceID, latestVersion)
+	// DELETE removed resources
+	for _, resource := range diffResult.Deleted {
+		resource := resource.(map[string]interface{})
+		opts := h.buildDelete(resource, serviceID, latestVersion)
 
 		log.Printf("[DEBUG] Fastly SFTP logging endpoint removal opts: %#v", opts)
 
@@ -189,9 +192,9 @@ func (h *SFTPServiceAttributeHandler) Process(d *schema.ResourceData, latestVers
 		}
 	}
 
-	// POST new/updated SFTP logging endpoints.
-	for _, nRaw := range diffResult.Added {
-		sf := nRaw.(map[string]interface{})
+	// ADD new resources
+	for _, resource := range diffResult.Added {
+		resource := resource.(map[string]interface{})
 
 		// @HACK for a TF SDK Issue.
 		//
@@ -203,11 +206,11 @@ func (h *SFTPServiceAttributeHandler) Process(d *schema.ResourceData, latestVers
 		// This is caused by using a StateFunc in a nested TypeSet. While the StateFunc
 		// properly handles setting state with the StateFunc, it returns extra entries
 		// during state Gets, specifically `GetChange("logging_sftp")` in this case.
-		if v, ok := sf["name"]; !ok || v.(string) == "" {
+		if v, ok := resource["name"]; !ok || v.(string) == "" {
 			continue
 		}
 
-		opts := h.buildCreate(sf, serviceID, latestVersion)
+		opts := h.buildCreate(resource, serviceID, latestVersion)
 
 		if opts.Password == "" && opts.SecretKey == "" {
 			return fmt.Errorf("[ERR] Either password or secret_key must be set")
@@ -216,6 +219,87 @@ func (h *SFTPServiceAttributeHandler) Process(d *schema.ResourceData, latestVers
 		log.Printf("[DEBUG] Fastly SFTP logging addition opts: %#v", opts)
 
 		if err := createSFTP(conn, opts); err != nil {
+			return err
+		}
+	}
+
+	// UPDATE modified resources
+	//
+	// NOTE: although the go-fastly API client enables updating of a resource by
+	// its 'name' attribute, this isn't possible within terraform due to
+	// constraints in the data model/schema of the resources not having a uid.
+	for _, resource := range diffResult.Modified {
+		resource := resource.(map[string]interface{})
+
+		opts := gofastly.UpdateSFTPInput{
+			ServiceID:      d.Id(),
+			ServiceVersion: latestVersion,
+			Name:           resource["name"].(string),
+		}
+
+		// only attempt to update attributes that have changed
+		modified := setDiff.Filter(resource, oldSet)
+
+		// NOTE: where we transition between interface{} we lose the ability to
+		// infer the underlying type being either a uint vs an int. This
+		// materializes as a panic (yay) and so it's only at runtime we discover
+		// this and so we've updated the below code to convert the type asserted
+		// int into a uint before passing the value to gofastly.Uint().
+		if v, ok := modified["address"]; ok {
+			opts.Address = gofastly.String(v.(string))
+		}
+		if v, ok := modified["port"]; ok {
+			opts.Port = gofastly.Uint(uint(v.(int)))
+		}
+		if v, ok := modified["public_key"]; ok {
+			opts.PublicKey = gofastly.String(v.(string))
+		}
+		if v, ok := modified["secret_key"]; ok {
+			opts.SecretKey = gofastly.String(v.(string))
+		}
+		if v, ok := modified["ssh_known_hosts"]; ok {
+			opts.SSHKnownHosts = gofastly.String(v.(string))
+		}
+		if v, ok := modified["user"]; ok {
+			opts.User = gofastly.String(v.(string))
+		}
+		if v, ok := modified["password"]; ok {
+			opts.Password = gofastly.String(v.(string))
+		}
+		if v, ok := modified["path"]; ok {
+			opts.Path = gofastly.String(v.(string))
+		}
+		if v, ok := modified["period"]; ok {
+			opts.Period = gofastly.Uint(uint(v.(int)))
+		}
+		if v, ok := modified["format_version"]; ok {
+			opts.FormatVersion = gofastly.Uint(uint(v.(int)))
+		}
+		if v, ok := modified["compression_codec"]; ok {
+			opts.CompressionCodec = gofastly.String(v.(string))
+		}
+		if v, ok := modified["gzip_level"]; ok {
+			opts.GzipLevel = gofastly.Uint(uint(v.(int)))
+		}
+		if v, ok := modified["format"]; ok {
+			opts.Format = gofastly.String(v.(string))
+		}
+		if v, ok := modified["response_condition"]; ok {
+			opts.ResponseCondition = gofastly.String(v.(string))
+		}
+		if v, ok := modified["timestamp_format"]; ok {
+			opts.TimestampFormat = gofastly.String(v.(string))
+		}
+		if v, ok := modified["message_type"]; ok {
+			opts.MessageType = gofastly.String(v.(string))
+		}
+		if v, ok := modified["placement"]; ok {
+			opts.Placement = gofastly.String(v.(string))
+		}
+
+		log.Printf("[DEBUG] Update SFTP Opts: %#v", opts)
+		_, err := conn.UpdateSFTP(&opts)
+		if err != nil {
 			return err
 		}
 	}

--- a/fastly/block_fastly_service_v1_logging_sftp.go
+++ b/fastly/block_fastly_service_v1_logging_sftp.go
@@ -192,7 +192,7 @@ func (h *SFTPServiceAttributeHandler) Process(d *schema.ResourceData, latestVers
 		}
 	}
 
-	// ADD new resources
+	// CREATE new resources
 	for _, resource := range diffResult.Added {
 		resource := resource.(map[string]interface{})
 

--- a/fastly/block_fastly_service_v1_logging_sftp.go
+++ b/fastly/block_fastly_service_v1_logging_sftp.go
@@ -164,15 +164,15 @@ func (h *SFTPServiceAttributeHandler) Process(d *schema.ResourceData, latestVers
 		ns = new(schema.Set)
 	}
 
-	oss := os.(*schema.Set)
-	nss := ns.(*schema.Set)
+	oldSet := os.(*schema.Set)
+	newSet := ns.(*schema.Set)
 
-	setDiff := NewSetDiff(func(logging interface{}) (interface{}, error) {
-		// Use the logging endpoint name as the key
-		return logging.(map[string]interface{})["name"], nil
+	setDiff := NewSetDiff(func(resource interface{}) (interface{}, error) {
+		// Use the resource endpoint name as the key
+		return resource.(map[string]interface{})["name"], nil
 	})
 
-	diffResult, err := setDiff.Diff(oss, nss)
+	diffResult, err := setDiff.Diff(oldSet, newSet)
 	if err != nil {
 		return err
 	}

--- a/fastly/block_fastly_service_v1_logging_sftp.go
+++ b/fastly/block_fastly_service_v1_logging_sftp.go
@@ -27,7 +27,7 @@ func (h *SFTPServiceAttributeHandler) Register(s *schema.Resource) error {
 		"name": {
 			Type:        schema.TypeString,
 			Required:    true,
-			Description: "The unique name of the SFTP logging endpoint",
+			Description: "The unique name of the SFTP logging endpoint. It is important to note that changing this attribute will delete and recreate the resource",
 		},
 
 		"address": {

--- a/fastly/block_fastly_service_v1_papertrail.go
+++ b/fastly/block_fastly_service_v1_papertrail.go
@@ -30,15 +30,15 @@ func (h *PaperTrailServiceAttributeHandler) Process(d *schema.ResourceData, late
 		ns = new(schema.Set)
 	}
 
-	oss := os.(*schema.Set)
-	nss := ns.(*schema.Set)
+	oldSet := os.(*schema.Set)
+	newSet := ns.(*schema.Set)
 
-	setDiff := NewSetDiff(func(logging interface{}) (interface{}, error) {
-		// Use the logging endpoint name as the key
-		return logging.(map[string]interface{})["name"], nil
+	setDiff := NewSetDiff(func(resource interface{}) (interface{}, error) {
+		// Use the resource endpoint name as the key
+		return resource.(map[string]interface{})["name"], nil
 	})
 
-	diffResult, err := setDiff.Diff(oss, nss)
+	diffResult, err := setDiff.Diff(oldSet, newSet)
 	if err != nil {
 		return err
 	}

--- a/fastly/block_fastly_service_v1_papertrail.go
+++ b/fastly/block_fastly_service_v1_papertrail.go
@@ -66,7 +66,7 @@ func (h *PaperTrailServiceAttributeHandler) Process(d *schema.ResourceData, late
 		}
 	}
 
-	// ADD new resources
+	// CREATE new resources
 	for _, resource := range diffResult.Added {
 		resource := resource.(map[string]interface{})
 

--- a/fastly/block_fastly_service_v1_papertrail.go
+++ b/fastly/block_fastly_service_v1_papertrail.go
@@ -168,7 +168,7 @@ func (h *PaperTrailServiceAttributeHandler) Register(s *schema.Resource) error {
 		"name": {
 			Type:        schema.TypeString,
 			Required:    true,
-			Description: "A unique name to identify this Papertrail endpoint",
+			Description: "A unique name to identify this Papertrail endpoint. It is important to note that changing this attribute will delete and recreate the resource",
 		},
 		"address": {
 			Type:        schema.TypeString,

--- a/fastly/block_fastly_service_v1_papertrail.go
+++ b/fastly/block_fastly_service_v1_papertrail.go
@@ -34,8 +34,11 @@ func (h *PaperTrailServiceAttributeHandler) Process(d *schema.ResourceData, late
 	newSet := ns.(*schema.Set)
 
 	setDiff := NewSetDiff(func(resource interface{}) (interface{}, error) {
-		// Use the resource endpoint name as the key
-		return resource.(map[string]interface{})["name"], nil
+		t, ok := resource.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("resource failed to be type asserted: %+v", resource)
+		}
+		return t["name"], nil
 	})
 
 	diffResult, err := setDiff.Diff(oldSet, newSet)
@@ -43,13 +46,13 @@ func (h *PaperTrailServiceAttributeHandler) Process(d *schema.ResourceData, late
 		return err
 	}
 
-	// DELETE old papertrail configurations
-	for _, pRaw := range diffResult.Deleted {
-		pf := pRaw.(map[string]interface{})
+	// DELETE removed resources
+	for _, resource := range diffResult.Deleted {
+		resource := resource.(map[string]interface{})
 		opts := gofastly.DeletePapertrailInput{
 			ServiceID:      d.Id(),
 			ServiceVersion: latestVersion,
-			Name:           pf["name"].(string),
+			Name:           resource["name"].(string),
 		}
 
 		log.Printf("[DEBUG] Fastly Papertrail removal opts: %#v", opts)
@@ -63,24 +66,74 @@ func (h *PaperTrailServiceAttributeHandler) Process(d *schema.ResourceData, late
 		}
 	}
 
-	// POST new/updated Papertrail
-	for _, pRaw := range diffResult.Added {
-		pf := pRaw.(map[string]interface{})
+	// ADD new resources
+	for _, resource := range diffResult.Added {
+		resource := resource.(map[string]interface{})
 
-		var vla = h.getVCLLoggingAttributes(pf)
+		var vla = h.getVCLLoggingAttributes(resource)
+
 		opts := gofastly.CreatePapertrailInput{
 			ServiceID:         d.Id(),
 			ServiceVersion:    latestVersion,
-			Name:              pf["name"].(string),
-			Address:           pf["address"].(string),
-			Port:              uint(pf["port"].(int)),
+			Name:              resource["name"].(string),
+			Address:           resource["address"].(string),
+			Port:              uint(resource["port"].(int)),
 			Format:            vla.format,
+			FormatVersion:     uintOrDefault(vla.formatVersion),
 			ResponseCondition: vla.responseCondition,
 			Placement:         vla.placement,
 		}
 
 		log.Printf("[DEBUG] Create Papertrail Opts: %#v", opts)
 		_, err := conn.CreatePapertrail(&opts)
+		if err != nil {
+			return err
+		}
+	}
+
+	// UPDATE modified resources
+	//
+	// NOTE: although the go-fastly API client enables updating of a resource by
+	// its 'name' attribute, this isn't possible within terraform due to
+	// constraints in the data model/schema of the resources not having a uid.
+	for _, resource := range diffResult.Modified {
+		resource := resource.(map[string]interface{})
+
+		opts := gofastly.UpdatePapertrailInput{
+			ServiceID:      d.Id(),
+			ServiceVersion: latestVersion,
+			Name:           resource["name"].(string),
+		}
+
+		// only attempt to update attributes that have changed
+		modified := setDiff.Filter(resource, oldSet)
+
+		// NOTE: where we transition between interface{} we lose the ability to
+		// infer the underlying type being either a uint vs an int. This
+		// materializes as a panic (yay) and so it's only at runtime we discover
+		// this and so we've updated the below code to convert the type asserted
+		// int into a uint before passing the value to gofastly.Uint().
+		if v, ok := modified["address"]; ok {
+			opts.Address = gofastly.String(v.(string))
+		}
+		if v, ok := modified["port"]; ok {
+			opts.Port = gofastly.Uint(uint(v.(int)))
+		}
+		if v, ok := modified["format_version"]; ok {
+			opts.FormatVersion = gofastly.Uint(uint(v.(int)))
+		}
+		if v, ok := modified["format"]; ok {
+			opts.Format = gofastly.String(v.(string))
+		}
+		if v, ok := modified["response_condition"]; ok {
+			opts.ResponseCondition = gofastly.String(v.(string))
+		}
+		if v, ok := modified["placement"]; ok {
+			opts.Placement = gofastly.String(v.(string))
+		}
+
+		log.Printf("[DEBUG] Update Papertrail Opts: %#v", opts)
+		_, err := conn.UpdatePapertrail(&opts)
 		if err != nil {
 			return err
 		}
@@ -134,18 +187,25 @@ func (h *PaperTrailServiceAttributeHandler) Register(s *schema.Resource) error {
 			Type:        schema.TypeString,
 			Optional:    true,
 			Default:     "%h %l %u %t %r %>s",
-			Description: "Apache-style string or VCL variables to use for log formatting",
+			Description: "A Fastly [log format string](https://docs.fastly.com/en/guides/custom-log-formats)",
+		}
+		blockAttributes["format_version"] = &schema.Schema{
+			Type:         schema.TypeInt,
+			Optional:     true,
+			Default:      2,
+			Description:  "The version of the custom logging format used for the configured endpoint. The logging call gets placed by default in `vcl_log` if `format_version` is set to `2` and in `vcl_deliver` if `format_version` is set to `1`",
+			ValidateFunc: validateLoggingFormatVersion(),
 		}
 		blockAttributes["response_condition"] = &schema.Schema{
 			Type:        schema.TypeString,
 			Optional:    true,
 			Default:     "",
-			Description: "Name of blockAttributes condition to apply this logging",
+			Description: "The name of an existing condition in the configured endpoint, or leave blank to always execute",
 		}
 		blockAttributes["placement"] = &schema.Schema{
 			Type:         schema.TypeString,
 			Optional:     true,
-			Description:  "Where in the generated VCL the logging call should be placed",
+			Description:  "Where in the generated VCL the logging call should be placed. If not set, endpoints with `format_version` of 2 are placed in `vcl_log` and those with `format_version` of 1 are placed in `vcl_deliver`",
 			ValidateFunc: validateLoggingPlacement(),
 		}
 	}
@@ -169,6 +229,7 @@ func flattenPapertrails(papertrailList []*gofastly.Papertrail) []map[string]inte
 			"address":            p.Address,
 			"port":               p.Port,
 			"format":             p.Format,
+			"format_version":     p.FormatVersion,
 			"response_condition": p.ResponseCondition,
 			"placement":          p.Placement,
 		}

--- a/fastly/block_fastly_service_v1_papertrail_test.go
+++ b/fastly/block_fastly_service_v1_papertrail_test.go
@@ -25,6 +25,7 @@ func TestResourceFastlyFlattenPapertrail(t *testing.T) {
 					Address:           "test1.papertrailapp.com",
 					Port:              3600,
 					Format:            "%h %l %u %t %r %>s",
+					FormatVersion:     2,
 					ResponseCondition: "test_response_condition",
 				},
 			},
@@ -34,6 +35,7 @@ func TestResourceFastlyFlattenPapertrail(t *testing.T) {
 					"address":            "test1.papertrailapp.com",
 					"port":               uint(3600),
 					"format":             "%h %l %u %t %r %>s",
+					"format_version":     uint(2),
 					"response_condition": "test_response_condition",
 				},
 			},
@@ -60,6 +62,7 @@ func TestAccFastlyServiceV1_papertrail_basic(t *testing.T) {
 		Address:           "test1.papertrailapp.com",
 		Port:              uint(3600),
 		Format:            "%h %l %u %t %r %>s",
+		FormatVersion:     uint(2),
 		ResponseCondition: "test_response_condition",
 	}
 
@@ -69,6 +72,7 @@ func TestAccFastlyServiceV1_papertrail_basic(t *testing.T) {
 		Address:        "test2.papertrailapp.com",
 		Port:           uint(8080),
 		Format:         "%h %l %u %t %r %>s",
+		FormatVersion:  uint(2),
 	}
 
 	resource.Test(t, resource.TestCase{
@@ -160,8 +164,6 @@ func testAccCheckFastlyServiceV1PapertrailAttributes(service *gofastly.ServiceDe
 					// we don't know these things ahead of time, so populate them now
 					p.ServiceID = service.ID
 					p.ServiceVersion = service.ActiveVersion.Number
-					// we don't support the format_version field, so set it to the zero value
-					lp.FormatVersion = 0
 					// We don't track these, so clear them out because we also wont know
 					// these ahead of time
 					lp.CreatedAt = nil
@@ -169,6 +171,7 @@ func testAccCheckFastlyServiceV1PapertrailAttributes(service *gofastly.ServiceDe
 
 					// Ignore VCL attributes for Compute and set to whatever is returned from the API.
 					if serviceType == ServiceTypeCompute {
+						lp.FormatVersion = p.FormatVersion
 						lp.Format = p.Format
 						lp.ResponseCondition = p.ResponseCondition
 						lp.Placement = p.Placement

--- a/fastly/block_fastly_service_v1_requestsetting.go
+++ b/fastly/block_fastly_service_v1_requestsetting.go
@@ -67,7 +67,7 @@ func (h *RequestSettingServiceAttributeHandler) Process(d *schema.ResourceData, 
 		}
 	}
 
-	// ADD new resources
+	// CREATE new resources
 	for _, resource := range diffResult.Added {
 		opts, err := buildRequestSetting(resource.(map[string]interface{}))
 		if err != nil {

--- a/fastly/block_fastly_service_v1_requestsetting.go
+++ b/fastly/block_fastly_service_v1_requestsetting.go
@@ -31,15 +31,15 @@ func (h *RequestSettingServiceAttributeHandler) Process(d *schema.ResourceData, 
 		ns = new(schema.Set)
 	}
 
-	ors := os.(*schema.Set)
-	nrs := ns.(*schema.Set)
+	oldSet := os.(*schema.Set)
+	newSet := ns.(*schema.Set)
 
-	setDiff := NewSetDiff(func(reqsettings interface{}) (interface{}, error) {
-		// Use the request settings name as the key
-		return reqsettings.(map[string]interface{})["name"], nil
+	setDiff := NewSetDiff(func(resource interface{}) (interface{}, error) {
+		// Use the resource settings name as the key
+		return resource.(map[string]interface{})["name"], nil
 	})
 
-	diffResult, err := setDiff.Diff(ors, nrs)
+	diffResult, err := setDiff.Diff(oldSet, newSet)
 	if err != nil {
 		return err
 	}

--- a/fastly/block_fastly_service_v1_requestsetting.go
+++ b/fastly/block_fastly_service_v1_requestsetting.go
@@ -86,12 +86,9 @@ func (h *RequestSettingServiceAttributeHandler) Process(d *schema.ResourceData, 
 
 	// UPDATE modified resources
 	//
-	// NOTE: although the go-fastly API client enables updating of a domain by
+	// NOTE: although the go-fastly API client enables updating of a resource by
 	// its 'name' attribute, this isn't possible within terraform due to
 	// constraints in the data model/schema of the resources not having a uid.
-	// Although we do allow for updating a domain whose 'comment' attribute has
-	// been updated (thus avoiding the expense associated with a DELETE/CREATE
-	// by enabling just the UPDATE operation).
 	for _, resource := range diffResult.Modified {
 		resource := resource.(map[string]interface{})
 
@@ -154,7 +151,7 @@ func (h *RequestSettingServiceAttributeHandler) Process(d *schema.ResourceData, 
 			opts.RequestCondition = gofastly.String(v.(string))
 		}
 
-		log.Printf("[DEBUG] Update Domain Opts: %#v", opts)
+		log.Printf("[DEBUG] Update Request Settings Opts: %#v", opts)
 		_, err := conn.UpdateRequestSetting(&opts)
 		if err != nil {
 			return err

--- a/fastly/block_fastly_service_v1_requestsetting.go
+++ b/fastly/block_fastly_service_v1_requestsetting.go
@@ -35,8 +35,11 @@ func (h *RequestSettingServiceAttributeHandler) Process(d *schema.ResourceData, 
 	newSet := ns.(*schema.Set)
 
 	setDiff := NewSetDiff(func(resource interface{}) (interface{}, error) {
-		// Use the resource settings name as the key
-		return resource.(map[string]interface{})["name"], nil
+		t, ok := resource.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("resource failed to be type asserted: %+v", resource)
+		}
+		return t["name"], nil
 	})
 
 	diffResult, err := setDiff.Diff(oldSet, newSet)
@@ -44,13 +47,13 @@ func (h *RequestSettingServiceAttributeHandler) Process(d *schema.ResourceData, 
 		return err
 	}
 
-	// DELETE old Request Settings configurations
-	for _, sRaw := range diffResult.Deleted {
-		sf := sRaw.(map[string]interface{})
+	// DELETE removed resources
+	for _, resource := range diffResult.Deleted {
+		resource := resource.(map[string]interface{})
 		opts := gofastly.DeleteRequestSettingInput{
 			ServiceID:      d.Id(),
 			ServiceVersion: latestVersion,
-			Name:           sf["name"].(string),
+			Name:           resource["name"].(string),
 		}
 
 		log.Printf("[DEBUG] Fastly Request Setting removal opts: %#v", opts)
@@ -64,11 +67,11 @@ func (h *RequestSettingServiceAttributeHandler) Process(d *schema.ResourceData, 
 		}
 	}
 
-	// POST new/updated Request Setting
-	for _, sRaw := range diffResult.Added {
-		opts, err := buildRequestSetting(sRaw.(map[string]interface{}))
+	// ADD new resources
+	for _, resource := range diffResult.Added {
+		opts, err := buildRequestSetting(resource.(map[string]interface{}))
 		if err != nil {
-			log.Printf("[DEBUG] Error building Requset Setting: %s", err)
+			log.Printf("[DEBUG] Error building Request Setting: %s", err)
 			return err
 		}
 		opts.ServiceID = d.Id()
@@ -76,6 +79,83 @@ func (h *RequestSettingServiceAttributeHandler) Process(d *schema.ResourceData, 
 
 		log.Printf("[DEBUG] Create Request Setting Opts: %#v", opts)
 		_, err = conn.CreateRequestSetting(opts)
+		if err != nil {
+			return err
+		}
+	}
+
+	// UPDATE modified resources
+	//
+	// NOTE: although the go-fastly API client enables updating of a domain by
+	// its 'name' attribute, this isn't possible within terraform due to
+	// constraints in the data model/schema of the resources not having a uid.
+	// Although we do allow for updating a domain whose 'comment' attribute has
+	// been updated (thus avoiding the expense associated with a DELETE/CREATE
+	// by enabling just the UPDATE operation).
+	for _, resource := range diffResult.Modified {
+		resource := resource.(map[string]interface{})
+
+		opts := gofastly.UpdateRequestSettingInput{
+			ServiceID:      d.Id(),
+			ServiceVersion: latestVersion,
+			Name:           resource["name"].(string),
+		}
+
+		// only attempt to update attributes that have changed
+		modified := setDiff.Filter(resource, oldSet)
+
+		if v, ok := modified["force_miss"]; ok {
+			opts.ForceMiss = gofastly.CBool(v.(bool))
+		}
+		if v, ok := modified["force_ssl"]; ok {
+			opts.ForceSSL = gofastly.CBool(v.(bool))
+		}
+		if v, ok := modified["action"]; ok {
+			switch strings.ToLower(v.(string)) {
+			case "lookup":
+				opts.Action = gofastly.RequestSettingActionLookup
+			case "pass":
+				opts.Action = gofastly.RequestSettingActionPass
+			}
+		}
+		if v, ok := modified["bypass_busy_wait"]; ok {
+			opts.BypassBusyWait = gofastly.CBool(v.(bool))
+		}
+		if v, ok := modified["max_stale_age"]; ok {
+			opts.MaxStaleAge = gofastly.Uint(v.(uint))
+		}
+		if v, ok := modified["hash_keys"]; ok {
+			opts.HashKeys = gofastly.String(v.(string))
+		}
+		if v, ok := modified["xff"]; ok {
+			switch strings.ToLower(v.(string)) {
+			case "clear":
+				opts.XForwardedFor = gofastly.RequestSettingXFFClear
+			case "leave":
+				opts.XForwardedFor = gofastly.RequestSettingXFFLeave
+			case "append":
+				opts.XForwardedFor = gofastly.RequestSettingXFFAppend
+			case "append_all":
+				opts.XForwardedFor = gofastly.RequestSettingXFFAppendAll
+			case "overwrite":
+				opts.XForwardedFor = gofastly.RequestSettingXFFOverwrite
+			}
+		}
+		if v, ok := modified["timer_support"]; ok {
+			opts.TimerSupport = gofastly.CBool(v.(bool))
+		}
+		if v, ok := modified["geo_headers"]; ok {
+			opts.GeoHeaders = gofastly.CBool(v.(bool))
+		}
+		if v, ok := modified["default_host"]; ok {
+			opts.DefaultHost = gofastly.String(v.(string))
+		}
+		if v, ok := modified["request_condition"]; ok {
+			opts.RequestCondition = gofastly.String(v.(string))
+		}
+
+		log.Printf("[DEBUG] Update Domain Opts: %#v", opts)
+		_, err := conn.UpdateRequestSetting(&opts)
 		if err != nil {
 			return err
 		}
@@ -212,21 +292,21 @@ func flattenRequestSettings(rsList []*gofastly.RequestSetting) []map[string]inte
 }
 
 func buildRequestSetting(requestSettingMap interface{}) (*gofastly.CreateRequestSettingInput, error) {
-	df := requestSettingMap.(map[string]interface{})
+	resource := requestSettingMap.(map[string]interface{})
 	opts := gofastly.CreateRequestSettingInput{
-		Name:             df["name"].(string),
-		MaxStaleAge:      uint(df["max_stale_age"].(int)),
-		ForceMiss:        gofastly.Compatibool(df["force_miss"].(bool)),
-		ForceSSL:         gofastly.Compatibool(df["force_ssl"].(bool)),
-		BypassBusyWait:   gofastly.Compatibool(df["bypass_busy_wait"].(bool)),
-		HashKeys:         df["hash_keys"].(string),
-		TimerSupport:     gofastly.Compatibool(df["timer_support"].(bool)),
-		GeoHeaders:       gofastly.Compatibool(df["geo_headers"].(bool)),
-		DefaultHost:      df["default_host"].(string),
-		RequestCondition: df["request_condition"].(string),
+		Name:             resource["name"].(string),
+		MaxStaleAge:      uint(resource["max_stale_age"].(int)),
+		ForceMiss:        gofastly.Compatibool(resource["force_miss"].(bool)),
+		ForceSSL:         gofastly.Compatibool(resource["force_ssl"].(bool)),
+		BypassBusyWait:   gofastly.Compatibool(resource["bypass_busy_wait"].(bool)),
+		HashKeys:         resource["hash_keys"].(string),
+		TimerSupport:     gofastly.Compatibool(resource["timer_support"].(bool)),
+		GeoHeaders:       gofastly.Compatibool(resource["geo_headers"].(bool)),
+		DefaultHost:      resource["default_host"].(string),
+		RequestCondition: resource["request_condition"].(string),
 	}
 
-	act := strings.ToLower(df["action"].(string))
+	act := strings.ToLower(resource["action"].(string))
 	switch act {
 	case "lookup":
 		opts.Action = gofastly.RequestSettingActionLookup
@@ -234,7 +314,7 @@ func buildRequestSetting(requestSettingMap interface{}) (*gofastly.CreateRequest
 		opts.Action = gofastly.RequestSettingActionPass
 	}
 
-	xff := strings.ToLower(df["xff"].(string))
+	xff := strings.ToLower(resource["xff"].(string))
 	switch xff {
 	case "clear":
 		opts.XForwardedFor = gofastly.RequestSettingXFFClear

--- a/fastly/block_fastly_service_v1_requestsetting.go
+++ b/fastly/block_fastly_service_v1_requestsetting.go
@@ -190,7 +190,7 @@ func (h *RequestSettingServiceAttributeHandler) Register(s *schema.Resource) err
 				"name": {
 					Type:        schema.TypeString,
 					Required:    true,
-					Description: "Unique name to refer to this Request Setting",
+					Description: "Unique name to refer to this Request Setting. It is important to note that changing this attribute will delete and recreate the resource",
 				},
 				// Optional fields
 				"request_condition": {

--- a/fastly/block_fastly_service_v1_responseobject.go
+++ b/fastly/block_fastly_service_v1_responseobject.go
@@ -169,7 +169,7 @@ func (h *ResponseObjectServiceAttributeHandler) Register(s *schema.Resource) err
 				"name": {
 					Type:        schema.TypeString,
 					Required:    true,
-					Description: "A unique name to identify this Response Object",
+					Description: "A unique name to identify this Response Object. It is important to note that changing this attribute will delete and recreate the resource",
 				},
 				// Optional fields
 				"status": {

--- a/fastly/block_fastly_service_v1_responseobject.go
+++ b/fastly/block_fastly_service_v1_responseobject.go
@@ -66,7 +66,7 @@ func (h *ResponseObjectServiceAttributeHandler) Process(d *schema.ResourceData, 
 		}
 	}
 
-	// ADD new resources
+	// CREATE new resources
 	for _, resource := range diffResult.Added {
 		resource := resource.(map[string]interface{})
 

--- a/fastly/block_fastly_service_v1_responseobject.go
+++ b/fastly/block_fastly_service_v1_responseobject.go
@@ -34,8 +34,11 @@ func (h *ResponseObjectServiceAttributeHandler) Process(d *schema.ResourceData, 
 	newSet := nr.(*schema.Set)
 
 	setDiff := NewSetDiff(func(resource interface{}) (interface{}, error) {
-		// Use the resource name as the key
-		return resource.(map[string]interface{})["name"], nil
+		t, ok := resource.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("resource failed to be type asserted: %+v", resource)
+		}
+		return t["name"], nil
 	})
 
 	diffResult, err := setDiff.Diff(oldSet, newSet)
@@ -43,13 +46,13 @@ func (h *ResponseObjectServiceAttributeHandler) Process(d *schema.ResourceData, 
 		return err
 	}
 
-	// DELETE old response object configurations
-	for _, rRaw := range diffResult.Deleted {
-		rf := rRaw.(map[string]interface{})
+	// DELETE removed resources
+	for _, resource := range diffResult.Deleted {
+		resource := resource.(map[string]interface{})
 		opts := gofastly.DeleteResponseObjectInput{
 			ServiceID:      d.Id(),
 			ServiceVersion: latestVersion,
-			Name:           rf["name"].(string),
+			Name:           resource["name"].(string),
 		}
 
 		log.Printf("[DEBUG] Fastly Response Object removal opts: %#v", opts)
@@ -63,20 +66,20 @@ func (h *ResponseObjectServiceAttributeHandler) Process(d *schema.ResourceData, 
 		}
 	}
 
-	// POST new/updated Response Object
-	for _, rRaw := range diffResult.Added {
-		rf := rRaw.(map[string]interface{})
+	// ADD new resources
+	for _, resource := range diffResult.Added {
+		resource := resource.(map[string]interface{})
 
 		opts := gofastly.CreateResponseObjectInput{
 			ServiceID:        d.Id(),
 			ServiceVersion:   latestVersion,
-			Name:             rf["name"].(string),
-			Status:           uint(rf["status"].(int)),
-			Response:         rf["response"].(string),
-			Content:          rf["content"].(string),
-			ContentType:      rf["content_type"].(string),
-			RequestCondition: rf["request_condition"].(string),
-			CacheCondition:   rf["cache_condition"].(string),
+			Name:             resource["name"].(string),
+			Status:           uint(resource["status"].(int)),
+			Response:         resource["response"].(string),
+			Content:          resource["content"].(string),
+			ContentType:      resource["content_type"].(string),
+			RequestCondition: resource["request_condition"].(string),
+			CacheCondition:   resource["cache_condition"].(string),
 		}
 
 		log.Printf("[DEBUG] Create Response Object Opts: %#v", opts)
@@ -85,6 +88,55 @@ func (h *ResponseObjectServiceAttributeHandler) Process(d *schema.ResourceData, 
 			return err
 		}
 	}
+
+	// UPDATE modified resources
+	//
+	// NOTE: although the go-fastly API client enables updating of a resource by
+	// its 'name' attribute, this isn't possible within terraform due to
+	// constraints in the data model/schema of the resources not having a uid.
+	for _, resource := range diffResult.Modified {
+		resource := resource.(map[string]interface{})
+
+		opts := gofastly.UpdateResponseObjectInput{
+			ServiceID:      d.Id(),
+			ServiceVersion: latestVersion,
+			Name:           resource["name"].(string),
+		}
+
+		// only attempt to update attributes that have changed
+		modified := setDiff.Filter(resource, oldSet)
+
+		// NOTE: where we transition between interface{} we lose the ability to
+		// infer the underlying type being either a uint vs an int. This
+		// materializes as a panic (yay) and so it's only at runtime we discover
+		// this and so we've updated the below code to convert the type asserted
+		// int into a uint before passing the value to gofastly.Uint().
+		if v, ok := modified["status"]; ok {
+			opts.Status = gofastly.Uint(uint(v.(int)))
+		}
+		if v, ok := modified["response"]; ok {
+			opts.Response = gofastly.String(v.(string))
+		}
+		if v, ok := modified["content"]; ok {
+			opts.Content = gofastly.String(v.(string))
+		}
+		if v, ok := modified["content_type"]; ok {
+			opts.ContentType = gofastly.String(v.(string))
+		}
+		if v, ok := modified["request_condition"]; ok {
+			opts.RequestCondition = gofastly.String(v.(string))
+		}
+		if v, ok := modified["cache_condition"]; ok {
+			opts.CacheCondition = gofastly.String(v.(string))
+		}
+
+		log.Printf("[DEBUG] Update Response Object Opts: %#v", opts)
+		_, err := conn.UpdateResponseObject(&opts)
+		if err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 

--- a/fastly/block_fastly_service_v1_responseobject.go
+++ b/fastly/block_fastly_service_v1_responseobject.go
@@ -30,15 +30,15 @@ func (h *ResponseObjectServiceAttributeHandler) Process(d *schema.ResourceData, 
 		nr = new(schema.Set)
 	}
 
-	ors := or.(*schema.Set)
-	nrs := nr.(*schema.Set)
+	oldSet := or.(*schema.Set)
+	newSet := nr.(*schema.Set)
 
-	setDiff := NewSetDiff(func(respobj interface{}) (interface{}, error) {
-		// Use the response object name as the key
-		return respobj.(map[string]interface{})["name"], nil
+	setDiff := NewSetDiff(func(resource interface{}) (interface{}, error) {
+		// Use the resource name as the key
+		return resource.(map[string]interface{})["name"], nil
 	})
 
-	diffResult, err := setDiff.Diff(ors, nrs)
+	diffResult, err := setDiff.Diff(oldSet, newSet)
 	if err != nil {
 		return err
 	}

--- a/fastly/block_fastly_service_v1_s3logging.go
+++ b/fastly/block_fastly_service_v1_s3logging.go
@@ -58,7 +58,7 @@ func (h *S3LoggingServiceAttributeHandler) Process(d *schema.ResourceData, lates
 		}
 	}
 
-	// ADD new resources
+	// CREATE new resources
 	for _, resource := range diffResult.Added {
 		opts, err := h.buildCreate(resource, d.Id(), latestVersion)
 		if err != nil {

--- a/fastly/block_fastly_service_v1_s3logging.go
+++ b/fastly/block_fastly_service_v1_s3logging.go
@@ -37,8 +37,11 @@ func (h *S3LoggingServiceAttributeHandler) Process(d *schema.ResourceData, lates
 	newSet := ns.(*schema.Set)
 
 	setDiff := NewSetDiff(func(resource interface{}) (interface{}, error) {
-		// Use the resource endpoint name as the key
-		return resource.(map[string]interface{})["name"], nil
+		t, ok := resource.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("resource failed to be type asserted: %+v", resource)
+		}
+		return t["name"], nil
 	})
 
 	diffResult, err := setDiff.Diff(oldSet, newSet)
@@ -46,18 +49,18 @@ func (h *S3LoggingServiceAttributeHandler) Process(d *schema.ResourceData, lates
 		return err
 	}
 
-	// DELETE old S3 Log configurations.
-	for _, sRaw := range diffResult.Deleted {
-		opts := h.buildDelete(sRaw, serviceID, latestVersion)
+	// DELETE removed resources
+	for _, resource := range diffResult.Deleted {
+		opts := h.buildDelete(resource, serviceID, latestVersion)
 		err := deleteS3(conn, opts)
 		if err != nil {
 			return err
 		}
 	}
 
-	// POST new/updated S3 Logging.
-	for _, sRaw := range diffResult.Added {
-		opts, err := h.buildCreate(sRaw, d.Id(), latestVersion)
+	// ADD new resources
+	for _, resource := range diffResult.Added {
+		opts, err := h.buildCreate(resource, d.Id(), latestVersion)
 		if err != nil {
 			return err
 		}
@@ -81,6 +84,91 @@ func (h *S3LoggingServiceAttributeHandler) Process(d *schema.ResourceData, lates
 			return err
 		}
 	}
+
+	// UPDATE modified resources
+	//
+	// NOTE: although the go-fastly API client enables updating of a resource by
+	// its 'name' attribute, this isn't possible within terraform due to
+	// constraints in the data model/schema of the resources not having a uid.
+	for _, resource := range diffResult.Modified {
+		resource := resource.(map[string]interface{})
+
+		opts := gofastly.UpdateS3Input{
+			ServiceID:      d.Id(),
+			ServiceVersion: latestVersion,
+			Name:           resource["name"].(string),
+		}
+
+		// only attempt to update attributes that have changed
+		modified := setDiff.Filter(resource, oldSet)
+
+		// NOTE: where we transition between interface{} we lose the ability to
+		// infer the underlying type being either a uint vs an int. This
+		// materializes as a panic (yay) and so it's only at runtime we discover
+		// this and so we've updated the below code to convert the type asserted
+		// int into a uint before passing the value to gofastly.Uint().
+		if v, ok := modified["bucket_name"]; ok {
+			opts.BucketName = gofastly.String(v.(string))
+		}
+		if v, ok := modified["domain"]; ok {
+			opts.Domain = gofastly.String(v.(string))
+		}
+		if v, ok := modified["access_key"]; ok {
+			opts.AccessKey = gofastly.String(v.(string))
+		}
+		if v, ok := modified["secret_key"]; ok {
+			opts.SecretKey = gofastly.String(v.(string))
+		}
+		if v, ok := modified["path"]; ok {
+			opts.Path = gofastly.String(v.(string))
+		}
+		if v, ok := modified["period"]; ok {
+			opts.Period = gofastly.Uint(uint(v.(int)))
+		}
+		if v, ok := modified["compression_codec"]; ok {
+			opts.CompressionCodec = gofastly.String(v.(string))
+		}
+		if v, ok := modified["gzip_level"]; ok {
+			opts.GzipLevel = gofastly.Uint(uint(v.(int)))
+		}
+		if v, ok := modified["format"]; ok {
+			opts.Format = gofastly.String(v.(string))
+		}
+		if v, ok := modified["format_version"]; ok {
+			opts.FormatVersion = gofastly.Uint(uint(v.(int)))
+		}
+		if v, ok := modified["response_condition"]; ok {
+			opts.ResponseCondition = gofastly.String(v.(string))
+		}
+		if v, ok := modified["message_type"]; ok {
+			opts.MessageType = gofastly.String(v.(string))
+		}
+		if v, ok := modified["timestamp_format"]; ok {
+			opts.TimestampFormat = gofastly.String(v.(string))
+		}
+		if v, ok := modified["redundancy"]; ok {
+			opts.Redundancy = gofastly.S3Redundancy(v.(string))
+		}
+		if v, ok := modified["placement"]; ok {
+			opts.Placement = gofastly.String(v.(string))
+		}
+		if v, ok := modified["public_key"]; ok {
+			opts.PublicKey = gofastly.String(v.(string))
+		}
+		if v, ok := modified["server_side_encryption_kms_key_id"]; ok {
+			opts.ServerSideEncryptionKMSKeyID = gofastly.String(v.(string))
+		}
+		if v, ok := modified["server_side_encryption"]; ok {
+			opts.ServerSideEncryption = gofastly.S3ServerSideEncryption(v.(string))
+		}
+
+		log.Printf("[DEBUG] Update S3 Opts: %#v", opts)
+		_, err := conn.UpdateS3(&opts)
+		if err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 

--- a/fastly/block_fastly_service_v1_s3logging.go
+++ b/fastly/block_fastly_service_v1_s3logging.go
@@ -33,15 +33,15 @@ func (h *S3LoggingServiceAttributeHandler) Process(d *schema.ResourceData, lates
 		ns = new(schema.Set)
 	}
 
-	oss := os.(*schema.Set)
-	nss := ns.(*schema.Set)
+	oldSet := os.(*schema.Set)
+	newSet := ns.(*schema.Set)
 
-	setDiff := NewSetDiff(func(logging interface{}) (interface{}, error) {
-		// Use the logging endpoint name as the key
-		return logging.(map[string]interface{})["name"], nil
+	setDiff := NewSetDiff(func(resource interface{}) (interface{}, error) {
+		// Use the resource endpoint name as the key
+		return resource.(map[string]interface{})["name"], nil
 	})
 
-	diffResult, err := setDiff.Diff(oss, nss)
+	diffResult, err := setDiff.Diff(oldSet, newSet)
 	if err != nil {
 		return err
 	}

--- a/fastly/block_fastly_service_v1_s3logging.go
+++ b/fastly/block_fastly_service_v1_s3logging.go
@@ -198,7 +198,7 @@ func (h *S3LoggingServiceAttributeHandler) Register(s *schema.Resource) error {
 		"name": {
 			Type:        schema.TypeString,
 			Required:    true,
-			Description: "The unique name of the S3 logging endpoint",
+			Description: "The unique name of the S3 logging endpoint. It is important to note that changing this attribute will delete and recreate the resource",
 		},
 		"bucket_name": {
 			Type:        schema.TypeString,

--- a/fastly/block_fastly_service_v1_snippet.go
+++ b/fastly/block_fastly_service_v1_snippet.go
@@ -72,7 +72,7 @@ func (h *SnippetServiceAttributeHandler) Process(d *schema.ResourceData, latestV
 		}
 	}
 
-	// ADD new resources
+	// CREATE new resources
 	for _, resource := range diffResult.Added {
 		opts, err := buildSnippet(resource.(map[string]interface{}))
 		if err != nil {

--- a/fastly/block_fastly_service_v1_snippet.go
+++ b/fastly/block_fastly_service_v1_snippet.go
@@ -194,7 +194,7 @@ func (h *SnippetServiceAttributeHandler) Register(s *schema.Resource) error {
 				"name": {
 					Type:        schema.TypeString,
 					Required:    true,
-					Description: `A name that is unique across "regular" and "dynamic" VCL Snippet configuration blocks`,
+					Description: `A name that is unique across "regular" and "dynamic" VCL Snippet configuration blocks. It is important to note that changing this attribute will delete and recreate the resource`,
 				},
 				"type": {
 					Type:         schema.TypeString,

--- a/fastly/block_fastly_service_v1_snippet.go
+++ b/fastly/block_fastly_service_v1_snippet.go
@@ -48,9 +48,6 @@ func (h *SnippetServiceAttributeHandler) Process(d *schema.ResourceData, latestV
 	if err != nil {
 		return err
 	}
-	fmt.Printf("\n\nold values: %+v\n\n", oldSet)
-	fmt.Printf("\n\nnew values: %+v\n\n", newSet)
-	fmt.Printf("\n\ndiffResult: %+v\n\n", diffResult)
 
 	// DELETE removed resources
 	for _, resource := range diffResult.Deleted {

--- a/fastly/block_fastly_service_v1_snippet.go
+++ b/fastly/block_fastly_service_v1_snippet.go
@@ -33,15 +33,15 @@ func (h *SnippetServiceAttributeHandler) Process(d *schema.ResourceData, latestV
 		newSnippetVal = new(schema.Set)
 	}
 
-	oldSnippetSet := oldSnippetVal.(*schema.Set)
-	newSnippetSet := newSnippetVal.(*schema.Set)
+	oldSet := oldSnippetVal.(*schema.Set)
+	newSet := newSnippetVal.(*schema.Set)
 
-	setDiff := NewSetDiff(func(snippet interface{}) (interface{}, error) {
-		// Use the snippet name as the key
-		return snippet.(map[string]interface{})["name"], nil
+	setDiff := NewSetDiff(func(resource interface{}) (interface{}, error) {
+		// Use the resource name as the key
+		return resource.(map[string]interface{})["name"], nil
 	})
 
-	diffResult, err := setDiff.Diff(oldSnippetSet, newSnippetSet)
+	diffResult, err := setDiff.Diff(oldSet, newSet)
 	if err != nil {
 		return err
 	}

--- a/fastly/block_fastly_service_v1_snippet.go
+++ b/fastly/block_fastly_service_v1_snippet.go
@@ -37,22 +37,28 @@ func (h *SnippetServiceAttributeHandler) Process(d *schema.ResourceData, latestV
 	newSet := newSnippetVal.(*schema.Set)
 
 	setDiff := NewSetDiff(func(resource interface{}) (interface{}, error) {
-		// Use the resource name as the key
-		return resource.(map[string]interface{})["name"], nil
+		t, ok := resource.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("resource failed to be type asserted: %+v", resource)
+		}
+		return t["name"], nil
 	})
 
 	diffResult, err := setDiff.Diff(oldSet, newSet)
 	if err != nil {
 		return err
 	}
+	fmt.Printf("\n\nold values: %+v\n\n", oldSet)
+	fmt.Printf("\n\nnew values: %+v\n\n", newSet)
+	fmt.Printf("\n\ndiffResult: %+v\n\n", diffResult)
 
-	// Delete removed VCL Snippet configurations
-	for _, dRaw := range diffResult.Deleted {
-		df := dRaw.(map[string]interface{})
+	// DELETE removed resources
+	for _, resource := range diffResult.Deleted {
+		resource := resource.(map[string]interface{})
 		opts := gofastly.DeleteSnippetInput{
 			ServiceID:      d.Id(),
 			ServiceVersion: latestVersion,
-			Name:           df["name"].(string),
+			Name:           resource["name"].(string),
 		}
 
 		log.Printf("[DEBUG] Fastly VCL Snippet Removal opts: %#v", opts)
@@ -66,9 +72,9 @@ func (h *SnippetServiceAttributeHandler) Process(d *schema.ResourceData, latestV
 		}
 	}
 
-	// POST new VCL Snippet configurations
-	for _, dRaw := range diffResult.Added {
-		opts, err := buildSnippet(dRaw.(map[string]interface{}))
+	// ADD new resources
+	for _, resource := range diffResult.Added {
+		opts, err := buildSnippet(resource.(map[string]interface{}))
 		if err != nil {
 			log.Printf("[DEBUG] Error building VCL Snippet: %s", err)
 			return err
@@ -82,6 +88,85 @@ func (h *SnippetServiceAttributeHandler) Process(d *schema.ResourceData, latestV
 			return err
 		}
 	}
+
+	// UPDATE modified resources
+	//
+	// NOTE: although the go-fastly API client enables updating of a resource by
+	// its 'name' attribute, this isn't possible within terraform due to
+	// constraints in the data model/schema of the resources not having a uid.
+	for _, resource := range diffResult.Modified {
+		resource := resource.(map[string]interface{})
+
+		// Safety check in case keys aren't actually set in the HCL.
+		name, _ := resource["name"].(string)
+		priority, _ := resource["priority"].(int)
+		dynamic, _ := resource["dynamic"].(int)
+		content, _ := resource["content"].(string)
+		stype, _ := resource["type"].(string)
+
+		opts := gofastly.UpdateSnippetInput{
+			ServiceID:      d.Id(),
+			ServiceVersion: latestVersion,
+			Name:           name,
+			NewName:        name,
+			Priority:       priority,
+			Dynamic:        dynamic,
+			Content:        content,
+			Type:           gofastly.SnippetType(stype),
+		}
+
+		// only attempt to update attributes that have changed
+		modified := setDiff.Filter(resource, oldSet)
+
+		// NOTE: where we transition between interface{} we lose the ability to
+		// infer the underlying type being either a uint vs an int. This
+		// materializes as a panic (yay) and so it's only at runtime we discover
+		// this and so we've updated the below code to convert the type asserted
+		// int into a uint before passing the value to gofastly.Uint().
+		if v, ok := modified["priority"]; ok {
+			opts.Priority = v.(int)
+		}
+		if v, ok := modified["dynamic"]; ok {
+			opts.Dynamic = v.(int)
+		}
+		if v, ok := modified["content"]; ok {
+			opts.Content = v.(string)
+		}
+		if v, ok := modified["type"]; ok {
+			snippetType := strings.ToLower(v.(string))
+			switch snippetType {
+			case "init":
+				opts.Type = gofastly.SnippetTypeInit
+			case "recv":
+				opts.Type = gofastly.SnippetTypeRecv
+			case "hash":
+				opts.Type = gofastly.SnippetTypeHash
+			case "hit":
+				opts.Type = gofastly.SnippetTypeHit
+			case "miss":
+				opts.Type = gofastly.SnippetTypeMiss
+			case "pass":
+				opts.Type = gofastly.SnippetTypePass
+			case "fetch":
+				opts.Type = gofastly.SnippetTypeFetch
+			case "error":
+				opts.Type = gofastly.SnippetTypeError
+			case "deliver":
+				opts.Type = gofastly.SnippetTypeDeliver
+			case "log":
+				opts.Type = gofastly.SnippetTypeLog
+			case "none":
+				opts.Type = gofastly.SnippetTypeNone
+			}
+		}
+
+		log.Printf("[DEBUG] Update VCL Snippet Opts: %#v", opts)
+		_, err := conn.UpdateSnippet(&opts)
+		if err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 

--- a/fastly/block_fastly_service_v1_splunk.go
+++ b/fastly/block_fastly_service_v1_splunk.go
@@ -66,7 +66,7 @@ func (h *SplunkServiceAttributeHandler) Process(d *schema.ResourceData, latestVe
 		}
 	}
 
-	// ADD new resources
+	// CREATE new resources
 	for _, resource := range diffResult.Added {
 		resource := resource.(map[string]interface{})
 

--- a/fastly/block_fastly_service_v1_splunk.go
+++ b/fastly/block_fastly_service_v1_splunk.go
@@ -202,7 +202,7 @@ func (h *SplunkServiceAttributeHandler) Register(s *schema.Resource) error {
 		"name": {
 			Type:        schema.TypeString,
 			Required:    true,
-			Description: "A unique name to identify the Splunk endpoint",
+			Description: "A unique name to identify the Splunk endpoint. It is important to note that changing this attribute will delete and recreate the resource",
 		},
 		"url": {
 			Type:        schema.TypeString,

--- a/fastly/block_fastly_service_v1_splunk.go
+++ b/fastly/block_fastly_service_v1_splunk.go
@@ -34,8 +34,11 @@ func (h *SplunkServiceAttributeHandler) Process(d *schema.ResourceData, latestVe
 	newSet := ns.(*schema.Set)
 
 	setDiff := NewSetDiff(func(resource interface{}) (interface{}, error) {
-		// Use the resource endpoint name as the key
-		return resource.(map[string]interface{})["name"], nil
+		t, ok := resource.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("resource failed to be type asserted: %+v", resource)
+		}
+		return t["name"], nil
 	})
 
 	diffResult, err := setDiff.Diff(oldSet, newSet)
@@ -43,13 +46,13 @@ func (h *SplunkServiceAttributeHandler) Process(d *schema.ResourceData, latestVe
 		return err
 	}
 
-	// DELETE old Splunk logging configurations
-	for _, sRaw := range diffResult.Deleted {
-		sf := sRaw.(map[string]interface{})
+	// DELETE removed resources
+	for _, resource := range diffResult.Deleted {
+		resource := resource.(map[string]interface{})
 		opts := gofastly.DeleteSplunkInput{
 			ServiceID:      d.Id(),
 			ServiceVersion: latestVersion,
-			Name:           sf["name"].(string),
+			Name:           resource["name"].(string),
 		}
 
 		log.Printf("[DEBUG] Splunk removal opts: %#v", opts)
@@ -63,9 +66,9 @@ func (h *SplunkServiceAttributeHandler) Process(d *schema.ResourceData, latestVe
 		}
 	}
 
-	// POST new/updated Splunk configurations
-	for _, sRaw := range diffResult.Added {
-		sf := sRaw.(map[string]interface{})
+	// ADD new resources
+	for _, resource := range diffResult.Added {
+		resource := resource.(map[string]interface{})
 
 		// @HACK for a TF SDK Issue.
 		//
@@ -77,21 +80,21 @@ func (h *SplunkServiceAttributeHandler) Process(d *schema.ResourceData, latestVe
 		// This is caused by using a StateFunc in a nested TypeSet. While the StateFunc
 		// properly handles setting state with the StateFunc, it returns extra entries
 		// during state Gets, specifically `GetChange("splunk")` in this case.
-		if v, ok := sf["name"]; !ok || v.(string) == "" {
+		if v, ok := resource["name"]; !ok || v.(string) == "" {
 			continue
 		}
 
-		var vla = h.getVCLLoggingAttributes(sf)
+		var vla = h.getVCLLoggingAttributes(resource)
 		opts := gofastly.CreateSplunkInput{
 			ServiceID:         d.Id(),
 			ServiceVersion:    latestVersion,
-			Name:              sf["name"].(string),
-			URL:               sf["url"].(string),
-			Token:             sf["token"].(string),
-			TLSHostname:       sf["tls_hostname"].(string),
-			TLSCACert:         sf["tls_ca_cert"].(string),
-			TLSClientCert:     sf["tls_client_cert"].(string),
-			TLSClientKey:      sf["tls_client_key"].(string),
+			Name:              resource["name"].(string),
+			URL:               resource["url"].(string),
+			Token:             resource["token"].(string),
+			TLSHostname:       resource["tls_hostname"].(string),
+			TLSCACert:         resource["tls_ca_cert"].(string),
+			TLSClientCert:     resource["tls_client_cert"].(string),
+			TLSClientKey:      resource["tls_client_key"].(string),
 			Format:            vla.format,
 			FormatVersion:     uintOrDefault(vla.formatVersion),
 			ResponseCondition: vla.responseCondition,
@@ -104,6 +107,73 @@ func (h *SplunkServiceAttributeHandler) Process(d *schema.ResourceData, latestVe
 			return err
 		}
 	}
+
+	// UPDATE modified resources
+	//
+	// NOTE: although the go-fastly API client enables updating of a resource by
+	// its 'name' attribute, this isn't possible within terraform due to
+	// constraints in the data model/schema of the resources not having a uid.
+	for _, resource := range diffResult.Modified {
+		resource := resource.(map[string]interface{})
+
+		opts := gofastly.UpdateSplunkInput{
+			ServiceID:      d.Id(),
+			ServiceVersion: latestVersion,
+			Name:           resource["name"].(string),
+		}
+
+		// only attempt to update attributes that have changed
+		modified := setDiff.Filter(resource, oldSet)
+
+		// NOTE: where we transition between interface{} we lose the ability to
+		// infer the underlying type being either a uint vs an int. This
+		// materializes as a panic (yay) and so it's only at runtime we discover
+		// this and so we've updated the below code to convert the type asserted
+		// int into a uint before passing the value to gofastly.Uint().
+		if v, ok := modified["url"]; ok {
+			opts.URL = gofastly.String(v.(string))
+		}
+		if v, ok := modified["request_max_entries"]; ok {
+			opts.RequestMaxEntries = gofastly.Uint(uint(v.(int)))
+		}
+		if v, ok := modified["request_max_bytes"]; ok {
+			opts.RequestMaxBytes = gofastly.Uint(uint(v.(int)))
+		}
+		if v, ok := modified["format"]; ok {
+			opts.Format = gofastly.String(v.(string))
+		}
+		if v, ok := modified["format_version"]; ok {
+			opts.FormatVersion = gofastly.Uint(uint(v.(int)))
+		}
+		if v, ok := modified["response_condition"]; ok {
+			opts.ResponseCondition = gofastly.String(v.(string))
+		}
+		if v, ok := modified["placement"]; ok {
+			opts.Placement = gofastly.String(v.(string))
+		}
+		if v, ok := modified["token"]; ok {
+			opts.Token = gofastly.String(v.(string))
+		}
+		if v, ok := modified["tls_ca_cert"]; ok {
+			opts.TLSCACert = gofastly.String(v.(string))
+		}
+		if v, ok := modified["tls_hostname"]; ok {
+			opts.TLSHostname = gofastly.String(v.(string))
+		}
+		if v, ok := modified["tls_client_cert"]; ok {
+			opts.TLSClientCert = gofastly.String(v.(string))
+		}
+		if v, ok := modified["tls_client_key"]; ok {
+			opts.TLSClientKey = gofastly.String(v.(string))
+		}
+
+		log.Printf("[DEBUG] Update Splunk Opts: %#v", opts)
+		_, err := conn.UpdateSplunk(&opts)
+		if err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 

--- a/fastly/block_fastly_service_v1_splunk.go
+++ b/fastly/block_fastly_service_v1_splunk.go
@@ -30,15 +30,15 @@ func (h *SplunkServiceAttributeHandler) Process(d *schema.ResourceData, latestVe
 		ns = new(schema.Set)
 	}
 
-	oss := os.(*schema.Set)
-	nss := ns.(*schema.Set)
+	oldSet := os.(*schema.Set)
+	newSet := ns.(*schema.Set)
 
-	setDiff := NewSetDiff(func(logging interface{}) (interface{}, error) {
-		// Use the logging endpoint name as the key
-		return logging.(map[string]interface{})["name"], nil
+	setDiff := NewSetDiff(func(resource interface{}) (interface{}, error) {
+		// Use the resource endpoint name as the key
+		return resource.(map[string]interface{})["name"], nil
 	})
 
-	diffResult, err := setDiff.Diff(oss, nss)
+	diffResult, err := setDiff.Diff(oldSet, newSet)
 	if err != nil {
 		return err
 	}

--- a/fastly/block_fastly_service_v1_sumologic.go
+++ b/fastly/block_fastly_service_v1_sumologic.go
@@ -66,7 +66,7 @@ func (h *SumologicServiceAttributeHandler) Process(d *schema.ResourceData, lates
 		}
 	}
 
-	// ADD new resources
+	// CREATE new resources
 	for _, resource := range diffResult.Added {
 		resource := resource.(map[string]interface{})
 

--- a/fastly/block_fastly_service_v1_sumologic.go
+++ b/fastly/block_fastly_service_v1_sumologic.go
@@ -168,7 +168,7 @@ func (h *SumologicServiceAttributeHandler) Register(s *schema.Resource) error {
 		"name": {
 			Type:        schema.TypeString,
 			Required:    true,
-			Description: "A unique name to identify this Sumologic endpoint",
+			Description: "A unique name to identify this Sumologic endpoint. It is important to note that changing this attribute will delete and recreate the resource",
 		},
 		"url": {
 			Type:        schema.TypeString,

--- a/fastly/block_fastly_service_v1_sumologic.go
+++ b/fastly/block_fastly_service_v1_sumologic.go
@@ -30,15 +30,15 @@ func (h *SumologicServiceAttributeHandler) Process(d *schema.ResourceData, lates
 		ns = new(schema.Set)
 	}
 
-	oss := os.(*schema.Set)
-	nss := ns.(*schema.Set)
+	oldSet := os.(*schema.Set)
+	newSet := ns.(*schema.Set)
 
-	setDiff := NewSetDiff(func(logging interface{}) (interface{}, error) {
-		// Use the logging endpoint name as the key
-		return logging.(map[string]interface{})["name"], nil
+	setDiff := NewSetDiff(func(resource interface{}) (interface{}, error) {
+		// Use the resource endpoint name as the key
+		return resource.(map[string]interface{})["name"], nil
 	})
 
-	diffResult, err := setDiff.Diff(oss, nss)
+	diffResult, err := setDiff.Diff(oldSet, newSet)
 	if err != nil {
 		return err
 	}

--- a/fastly/block_fastly_service_v1_syslog.go
+++ b/fastly/block_fastly_service_v1_syslog.go
@@ -66,7 +66,7 @@ func (h *SyslogServiceAttributeHandler) Process(d *schema.ResourceData, latestVe
 		}
 	}
 
-	// ADD new resources
+	// CREATE new resources
 	for _, resource := range diffResult.Added {
 		resource := resource.(map[string]interface{})
 

--- a/fastly/block_fastly_service_v1_syslog.go
+++ b/fastly/block_fastly_service_v1_syslog.go
@@ -30,15 +30,15 @@ func (h *SyslogServiceAttributeHandler) Process(d *schema.ResourceData, latestVe
 		ns = new(schema.Set)
 	}
 
-	oss := os.(*schema.Set)
-	nss := ns.(*schema.Set)
+	oldSet := os.(*schema.Set)
+	newSet := ns.(*schema.Set)
 
-	setDiff := NewSetDiff(func(logging interface{}) (interface{}, error) {
-		// Use the logging endpoint name as the key
-		return logging.(map[string]interface{})["name"], nil
+	setDiff := NewSetDiff(func(resource interface{}) (interface{}, error) {
+		// Use the resource endpoint name as the key
+		return resource.(map[string]interface{})["name"], nil
 	})
 
-	diffResult, err := setDiff.Diff(oss, nss)
+	diffResult, err := setDiff.Diff(oldSet, newSet)
 	if err != nil {
 		return err
 	}

--- a/fastly/block_fastly_service_v1_syslog.go
+++ b/fastly/block_fastly_service_v1_syslog.go
@@ -200,7 +200,7 @@ func (h *SyslogServiceAttributeHandler) Register(s *schema.Resource) error {
 		"name": {
 			Type:        schema.TypeString,
 			Required:    true,
-			Description: "A unique name to identify this Syslog endpoint",
+			Description: "A unique name to identify this Syslog endpoint. It is important to note that changing this attribute will delete and recreate the resource",
 		},
 		"address": {
 			Type:        schema.TypeString,

--- a/fastly/block_fastly_service_v1_syslog.go
+++ b/fastly/block_fastly_service_v1_syslog.go
@@ -34,8 +34,11 @@ func (h *SyslogServiceAttributeHandler) Process(d *schema.ResourceData, latestVe
 	newSet := ns.(*schema.Set)
 
 	setDiff := NewSetDiff(func(resource interface{}) (interface{}, error) {
-		// Use the resource endpoint name as the key
-		return resource.(map[string]interface{})["name"], nil
+		t, ok := resource.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("resource failed to be type asserted: %+v", resource)
+		}
+		return t["name"], nil
 	})
 
 	diffResult, err := setDiff.Diff(oldSet, newSet)
@@ -43,13 +46,13 @@ func (h *SyslogServiceAttributeHandler) Process(d *schema.ResourceData, latestVe
 		return err
 	}
 
-	// DELETE old syslog configurations
-	for _, pRaw := range diffResult.Deleted {
-		slf := pRaw.(map[string]interface{})
+	// DELETE removed resources
+	for _, resource := range diffResult.Deleted {
+		resource := resource.(map[string]interface{})
 		opts := gofastly.DeleteSyslogInput{
 			ServiceID:      d.Id(),
 			ServiceVersion: latestVersion,
-			Name:           slf["name"].(string),
+			Name:           resource["name"].(string),
 		}
 
 		log.Printf("[DEBUG] Fastly Syslog removal opts: %#v", opts)
@@ -63,24 +66,24 @@ func (h *SyslogServiceAttributeHandler) Process(d *schema.ResourceData, latestVe
 		}
 	}
 
-	// POST new/updated Syslog
-	for _, pRaw := range diffResult.Added {
-		slf := pRaw.(map[string]interface{})
+	// ADD new resources
+	for _, resource := range diffResult.Added {
+		resource := resource.(map[string]interface{})
 
-		var vla = h.getVCLLoggingAttributes(slf)
+		var vla = h.getVCLLoggingAttributes(resource)
 		opts := gofastly.CreateSyslogInput{
 			ServiceID:         d.Id(),
 			ServiceVersion:    latestVersion,
-			Name:              slf["name"].(string),
-			Address:           slf["address"].(string),
-			Port:              uint(slf["port"].(int)),
-			Token:             slf["token"].(string),
-			UseTLS:            gofastly.Compatibool(slf["use_tls"].(bool)),
-			TLSHostname:       slf["tls_hostname"].(string),
-			TLSCACert:         slf["tls_ca_cert"].(string),
-			TLSClientCert:     slf["tls_client_cert"].(string),
-			TLSClientKey:      slf["tls_client_key"].(string),
-			MessageType:       slf["message_type"].(string),
+			Name:              resource["name"].(string),
+			Address:           resource["address"].(string),
+			Port:              uint(resource["port"].(int)),
+			Token:             resource["token"].(string),
+			UseTLS:            gofastly.Compatibool(resource["use_tls"].(bool)),
+			TLSHostname:       resource["tls_hostname"].(string),
+			TLSCACert:         resource["tls_ca_cert"].(string),
+			TLSClientCert:     resource["tls_client_cert"].(string),
+			TLSClientKey:      resource["tls_client_key"].(string),
+			MessageType:       resource["message_type"].(string),
 			Format:            vla.format,
 			FormatVersion:     uintOrDefault(vla.formatVersion),
 			ResponseCondition: vla.responseCondition,
@@ -93,6 +96,82 @@ func (h *SyslogServiceAttributeHandler) Process(d *schema.ResourceData, latestVe
 			return err
 		}
 	}
+
+	// UPDATE modified resources
+	//
+	// NOTE: although the go-fastly API client enables updating of a resource by
+	// its 'name' attribute, this isn't possible within terraform due to
+	// constraints in the data model/schema of the resources not having a uid.
+	for _, resource := range diffResult.Modified {
+		resource := resource.(map[string]interface{})
+
+		opts := gofastly.UpdateSyslogInput{
+			ServiceID:      d.Id(),
+			ServiceVersion: latestVersion,
+			Name:           resource["name"].(string),
+		}
+
+		// only attempt to update attributes that have changed
+		modified := setDiff.Filter(resource, oldSet)
+
+		// NOTE: where we transition between interface{} we lose the ability to
+		// infer the underlying type being either a uint vs an int. This
+		// materializes as a panic (yay) and so it's only at runtime we discover
+		// this and so we've updated the below code to convert the type asserted
+		// int into a uint before passing the value to gofastly.Uint().
+		if v, ok := modified["address"]; ok {
+			opts.Address = gofastly.String(v.(string))
+		}
+		if v, ok := modified["hostname"]; ok {
+			opts.Hostname = gofastly.String(v.(string))
+		}
+		if v, ok := modified["port"]; ok {
+			opts.Port = gofastly.Uint(uint(v.(int)))
+		}
+		if v, ok := modified["use_tls"]; ok {
+			opts.UseTLS = gofastly.CBool(v.(bool))
+		}
+		if v, ok := modified["ipv4"]; ok {
+			opts.IPV4 = gofastly.String(v.(string))
+		}
+		if v, ok := modified["tls_ca_cert"]; ok {
+			opts.TLSCACert = gofastly.String(v.(string))
+		}
+		if v, ok := modified["tls_hostname"]; ok {
+			opts.TLSHostname = gofastly.String(v.(string))
+		}
+		if v, ok := modified["tls_client_cert"]; ok {
+			opts.TLSClientCert = gofastly.String(v.(string))
+		}
+		if v, ok := modified["tls_client_key"]; ok {
+			opts.TLSClientKey = gofastly.String(v.(string))
+		}
+		if v, ok := modified["token"]; ok {
+			opts.Token = gofastly.String(v.(string))
+		}
+		if v, ok := modified["format"]; ok {
+			opts.Format = gofastly.String(v.(string))
+		}
+		if v, ok := modified["format_version"]; ok {
+			opts.FormatVersion = gofastly.Uint(uint(v.(int)))
+		}
+		if v, ok := modified["message_type"]; ok {
+			opts.MessageType = gofastly.String(v.(string))
+		}
+		if v, ok := modified["response_condition"]; ok {
+			opts.ResponseCondition = gofastly.String(v.(string))
+		}
+		if v, ok := modified["placement"]; ok {
+			opts.Placement = gofastly.String(v.(string))
+		}
+
+		log.Printf("[DEBUG] Update Syslog Opts: %#v", opts)
+		_, err := conn.UpdateSyslog(&opts)
+		if err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 

--- a/fastly/block_fastly_service_v1_vcl.go
+++ b/fastly/block_fastly_service_v1_vcl.go
@@ -159,7 +159,7 @@ func (h *VCLServiceAttributeHandler) Register(s *schema.Resource) error {
 				"name": {
 					Type:        schema.TypeString,
 					Required:    true,
-					Description: "A unique name for this configuration block",
+					Description: "A unique name for this configuration block. It is important to note that changing this attribute will delete and recreate the resource",
 				},
 				"content": {
 					Type:        schema.TypeString,

--- a/fastly/block_fastly_service_v1_vcl.go
+++ b/fastly/block_fastly_service_v1_vcl.go
@@ -33,15 +33,15 @@ func (h *VCLServiceAttributeHandler) Process(d *schema.ResourceData, latestVersi
 		newVCLVal = new(schema.Set)
 	}
 
-	oldVCLSet := oldVCLVal.(*schema.Set)
-	newVCLSet := newVCLVal.(*schema.Set)
+	oldSet := oldVCLVal.(*schema.Set)
+	newSet := newVCLVal.(*schema.Set)
 
-	setDiff := NewSetDiff(func(vcl interface{}) (interface{}, error) {
-		// Use the vcl name as the key
-		return vcl.(map[string]interface{})["name"], nil
+	setDiff := NewSetDiff(func(resource interface{}) (interface{}, error) {
+		// Use the resource name as the key
+		return resource.(map[string]interface{})["name"], nil
 	})
 
-	diffResult, err := setDiff.Diff(oldVCLSet, newVCLSet)
+	diffResult, err := setDiff.Diff(oldSet, newSet)
 	if err != nil {
 		return err
 	}

--- a/fastly/block_fastly_service_v1_vcl.go
+++ b/fastly/block_fastly_service_v1_vcl.go
@@ -69,7 +69,7 @@ func (h *VCLServiceAttributeHandler) Process(d *schema.ResourceData, latestVersi
 		}
 	}
 
-	// ADD new resources
+	// CREATE new resources
 	for _, resource := range diffResult.Added {
 		resource := resource.(map[string]interface{})
 		opts := gofastly.CreateVCLInput{

--- a/fastly/block_fastly_waf_configuration_v1_exclusion.go
+++ b/fastly/block_fastly_waf_configuration_v1_exclusion.go
@@ -112,15 +112,15 @@ func updateWAFRuleExclusions(d *schema.ResourceData, meta interface{}, wafID str
 		ns = new(schema.Set)
 	}
 
-	oss := os.(*schema.Set)
-	nss := ns.(*schema.Set)
+	oldSet := os.(*schema.Set)
+	newSet := ns.(*schema.Set)
 
-	setDiff := NewSetDiff(func(exclusion interface{}) (interface{}, error) {
-		// Use the exclusion name as the key
-		return exclusion.(map[string]interface{})["name"], nil
+	setDiff := NewSetDiff(func(resource interface{}) (interface{}, error) {
+		// Use the resource name as the key
+		return resource.(map[string]interface{})["name"], nil
 	})
 
-	diffResult, err := setDiff.Diff(oss, nss)
+	diffResult, err := setDiff.Diff(oldSet, newSet)
 	if err != nil {
 		return err
 	}

--- a/fastly/block_fastly_waf_configuration_v1_exclusion.go
+++ b/fastly/block_fastly_waf_configuration_v1_exclusion.go
@@ -112,25 +112,20 @@ func updateWAFRuleExclusions(d *schema.ResourceData, meta interface{}, wafID str
 		ns = new(schema.Set)
 	}
 
-	oldSet := os.(*schema.Set)
-	newSet := ns.(*schema.Set)
+	oss := os.(*schema.Set)
+	nss := ns.(*schema.Set)
 
-	setDiff := NewSetDiff(func(resource interface{}) (interface{}, error) {
-		// Use the resource name as the key
-		return resource.(map[string]interface{})["name"], nil
-	})
+	add := nss.Difference(oss).List()
+	remove := oss.Difference(nss).List()
 
-	diffResult, err := setDiff.Diff(oldSet, newSet)
+	var err error
+
+	err = deleteWAFRuleExclusion(remove, meta, wafID, wafVersionNumber)
 	if err != nil {
 		return err
 	}
 
-	err = deleteWAFRuleExclusion(diffResult.Deleted, meta, wafID, wafVersionNumber)
-	if err != nil {
-		return err
-	}
-
-	err = createWAFRuleExclusion(diffResult.Added, meta, wafID, wafVersionNumber)
+	err = createWAFRuleExclusion(add, meta, wafID, wafVersionNumber)
 	if err != nil {
 		return err
 	}

--- a/fastly/diff.go
+++ b/fastly/diff.go
@@ -38,6 +38,16 @@ func NewSetDiff(keyFunc KeyFunc) *SetDiff {
 // Diff diffs two Set objects and returns a DiffResult object containing the diffs.
 //
 // The DiffResult object will contain the elements from newSet on the Modified field.
+//
+// NOTE: there is a caveat with the current implementation which is related to
+// the lookup 'key' you specify. If the key you use (to lookup a resource
+// within the comparable set) is also updatable via the fastly API, then that
+// means you'll end up deleting and recreating the resource rather than simply
+// updating it (which is less efficient, as it's two separate operations).
+//
+// For example, a 'domain' can be updated by changing either its 'name' or its
+// 'comment' attribute, but in order to compare changes using SetDiff we only
+// really have the option to use 'name' as the lookup key.
 func (h *SetDiff) Diff(oldSet, newSet *schema.Set) (*DiffResult, error) {
 
 	// Convert the set into a map to facilitate lookup

--- a/fastly/diff.go
+++ b/fastly/diff.go
@@ -118,6 +118,11 @@ func (h *SetDiff) computeKey(elem interface{}) (interface{}, error) {
 
 // Filter filters out unmodified fields of a Set elements map data structure by ranging over
 // the original data and comparing each field against the new data.
+//
+// The motivation for this function is to avoid resetting a attribute on a
+// resource to a value that hasn't actually changed because (depending on the
+// attribute) it might have unexpected consequences (e.g. a nested resource
+// gets replaced/recreated). Safer to only update attributes that need to be.
 func (h *SetDiff) Filter(modified map[string]interface{}, oldSet *schema.Set) map[string]interface{} {
 	elements := oldSet.List()
 	filtered := make(map[string]interface{})

--- a/fastly/diff.go
+++ b/fastly/diff.go
@@ -119,7 +119,7 @@ func (h *SetDiff) computeKey(elem interface{}) (interface{}, error) {
 // Filter filters out unmodified fields of a Set elements map data structure by ranging over
 // the original data and comparing each field against the new data.
 //
-// The motivation for this function is to avoid resetting a attribute on a
+// The motivation for this function is to avoid resetting an attribute on a
 // resource to a value that hasn't actually changed because (depending on the
 // attribute) it might have unexpected consequences (e.g. a nested resource
 // gets replaced/recreated). Safer to only update attributes that need to be.

--- a/fastly/resource_fastly_service_acl_entries_v1.go
+++ b/fastly/resource_fastly_service_acl_entries_v1.go
@@ -167,7 +167,7 @@ func resourceServiceAclEntriesV1Update(d *schema.ResourceData, meta interface{})
 			})
 		}
 
-		// ADD new resources
+		// CREATE new resources
 		for _, resource := range diffResult.Added {
 			resource := resource.(map[string]interface{})
 

--- a/fastly/resource_fastly_service_acl_entries_v1.go
+++ b/fastly/resource_fastly_service_acl_entries_v1.go
@@ -141,15 +141,15 @@ func resourceServiceAclEntriesV1Update(d *schema.ResourceData, meta interface{})
 			ne = new(schema.Set)
 		}
 
-		oes := oe.(*schema.Set)
-		nes := ne.(*schema.Set)
+		oldSet := oe.(*schema.Set)
+		newSet := ne.(*schema.Set)
 
-		setDiff := NewSetDiff(func(entries interface{}) (interface{}, error) {
-			// Use the entry ID as the key
-			return entries.(map[string]interface{})["id"], nil
+		setDiff := NewSetDiff(func(resource interface{}) (interface{}, error) {
+			// Use the resource ID as the key
+			return resource.(map[string]interface{})["id"], nil
 		})
 
-		diffResult, err := setDiff.Diff(oes, nes)
+		diffResult, err := setDiff.Diff(oldSet, newSet)
 		if err != nil {
 			return err
 		}

--- a/fastly/resource_fastly_service_v1_test.go
+++ b/fastly/resource_fastly_service_v1_test.go
@@ -175,12 +175,24 @@ func TestAccFastlyServiceV1_updateDomain(t *testing.T) {
 			},
 
 			{
+				Config: testAccServiceV1Config_domainUpdateComment(nameUpdate, domainName1, domainName2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
+					testAccCheckFastlyServiceV1Attributes(&service, nameUpdate, []string{domainName1, domainName2}),
+					resource.TestCheckResourceAttr(
+						"fastly_service_v1.foo", "active_version", "3"),
+					resource.TestCheckResourceAttr(
+						"fastly_service_v1.foo", "domain.#", "2"),
+				),
+			},
+
+			{
 				Config: testAccServiceV1Config_domainUpdate(nameUpdate, domainName1, domainName3),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
 					testAccCheckFastlyServiceV1Attributes(&service, nameUpdate, []string{domainName1, domainName3}),
 					resource.TestCheckResourceAttr(
-						"fastly_service_v1.foo", "active_version", "3"),
+						"fastly_service_v1.foo", "active_version", "4"),
 					resource.TestCheckResourceAttr(
 						"fastly_service_v1.foo", "domain.#", "2"),
 				),
@@ -646,6 +658,30 @@ resource "fastly_service_v1" "foo" {
   domain {
     name    = "%s"
     comment = "tf-testing-domain"
+  }
+
+  domain {
+    name    = "%s"
+    comment = "tf-testing-other-domain"
+  }
+
+  backend {
+    address = "aws.amazon.com"
+    name    = "amazon docs"
+  }
+
+  force_destroy = true
+}`, name, domain1, domain2)
+}
+
+func testAccServiceV1Config_domainUpdateComment(name, domain1, domain2 string) string {
+	return fmt.Sprintf(`
+resource "fastly_service_v1" "foo" {
+  name = "%s"
+
+  domain {
+    name    = "%s"
+    comment = "tf-testing-domain-updated"
   }
 
   domain {

--- a/fastly/resource_fastly_service_v1_test.go
+++ b/fastly/resource_fastly_service_v1_test.go
@@ -139,6 +139,7 @@ func TestAccFastlyServiceV1_updateDomain(t *testing.T) {
 	nameUpdate := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	domainName1 := fmt.Sprintf("fastly-test.tf-%s.com", acctest.RandString(10))
 	domainName2 := fmt.Sprintf("fastly-test.tf-%s.com", acctest.RandString(10))
+	domainName3 := fmt.Sprintf("fastly-test.tf-%s.com", acctest.RandString(10))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -160,7 +161,7 @@ func TestAccFastlyServiceV1_updateDomain(t *testing.T) {
 			},
 
 			{
-				Config: testAccServiceV1Config_domainUpdate(nameUpdate, domainName1, domainName2),
+				Config: testAccServiceV1Config_domainAdd(nameUpdate, domainName1, domainName2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
 					testAccCheckFastlyServiceV1Attributes(&service, nameUpdate, []string{domainName1, domainName2}),
@@ -168,6 +169,18 @@ func TestAccFastlyServiceV1_updateDomain(t *testing.T) {
 						"fastly_service_v1.foo", "name", nameUpdate),
 					resource.TestCheckResourceAttr(
 						"fastly_service_v1.foo", "active_version", "2"),
+					resource.TestCheckResourceAttr(
+						"fastly_service_v1.foo", "domain.#", "2"),
+				),
+			},
+
+			{
+				Config: testAccServiceV1Config_domainUpdate(nameUpdate, domainName1, domainName3),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
+					testAccCheckFastlyServiceV1Attributes(&service, nameUpdate, []string{domainName1, domainName3}),
+					resource.TestCheckResourceAttr(
+						"fastly_service_v1.foo", "active_version", "3"),
 					resource.TestCheckResourceAttr(
 						"fastly_service_v1.foo", "domain.#", "2"),
 				),
@@ -625,7 +638,7 @@ resource "fastly_service_v1" "foo" {
 }`, name, comment, versionComment, domain)
 }
 
-func testAccServiceV1Config_domainUpdate(name, domain1, domain2 string) string {
+func testAccServiceV1Config_domainAdd(name, domain1, domain2 string) string {
 	return fmt.Sprintf(`
 resource "fastly_service_v1" "foo" {
   name = "%s"
@@ -647,6 +660,30 @@ resource "fastly_service_v1" "foo" {
 
   force_destroy = true
 }`, name, domain1, domain2)
+}
+
+func testAccServiceV1Config_domainUpdate(name, domain1, domain3 string) string {
+	return fmt.Sprintf(`
+resource "fastly_service_v1" "foo" {
+  name = "%s"
+
+  domain {
+    name    = "%s"
+    comment = "tf-testing-domain-updated"
+  }
+
+  domain {
+    name    = "%s"
+    comment = "tf-testing-other-domain"
+  }
+
+  backend {
+    address = "aws.amazon.com"
+    name    = "amazon docs"
+  }
+
+  force_destroy = true
+}`, name, domain1, domain3)
 }
 
 func testAccServiceV1Config_backend(name, domain, backend string) string {


### PR DESCRIPTION
**Background**: we implemented `SetDiff` to identify when two elements across _distinct_ sets have the same key. This helps avoid recreating an element (i.e. DELETE, then CREATE) which only needs an UPDATE.

**Problem**: not all schema.Set objects are using the `SetDiff` algorithm.

**Caveats**: there is a separate concern with some resources being deleted/recreated. Specifically resources that require a lookup key of "name" and who are also expecting the name field to be updated (e.g. updating the name of an ACL). This will be addressed in a separate PR.

**Notes**: I've not updated `block_fastly_waf_configuration_v1_active_rule.go` as it appears to be doing some kind of filtering of data which would be incompatible with the SetDiff implementation. Nor have I updated the `block_fastly_waf_configuration_v1_exclusion.go` as the nested structuring of the resources was quite complicated to follow and so it was safer not to mess with it for now.