### PR TITLE
Test speedup

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,11 @@ Prefix the `make` command with `TEST_PARALLELISM`, as in the following example, 
 $ TEST_PARALLELISM=8 make testacc
 ```
 
+Depending on the Fastly account used, some features may not be enabled (e.g. Platform TLS).
+This may result in some tests failing, potentially with `403 Unauthorised` errors, when the full test suite is being run.
+Check the [Fastly API documentation](https://developer.fastly.com/reference/api/) to confirm if the failing tests use features in Limited Availability or only available to certain customers.
+If this is the case, either use the `TESTARGS` regular expressions described above, or temporarily add `t.SkipNow()` to the top of any tests that should be excluded. 
+
 ## Building The Documentation
 
 The documentation is built from components (go templates) stored in the `templates` folder.

--- a/README.md
+++ b/README.md
@@ -75,6 +75,14 @@ In order to run the tests with extra debugging context, prefix the `make` comman
 $ TF_LOG=trace make testacc
 ```
 
+By default, the tests run with a parallelism of 4.
+This can be reduced if some tests are failing due to network-related issues, or increased if possible, to reduce the running time of the tests.
+Prefix the `make` command with `TEST_PARALLELISM`, as in the following example, to configure this.
+
+```sh
+$ TEST_PARALLELISM=8 make testacc
+```
+
 ## Building The Documentation
 
 The documentation is built from components (go templates) stored in the `templates` folder.

--- a/fastly/block_fastly_service_v1_acl_test.go
+++ b/fastly/block_fastly_service_v1_acl_test.go
@@ -46,7 +46,7 @@ func TestAccFastlyServiceV1_acl(t *testing.T) {
 	aclName := fmt.Sprintf("acl_%s", acctest.RandString(10))
 	aclNameUpdated := fmt.Sprintf("acl_updated_%s", acctest.RandString(10))
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,

--- a/fastly/block_fastly_service_v1_bigquerylogging_test.go
+++ b/fastly/block_fastly_service_v1_bigquerylogging_test.go
@@ -23,7 +23,7 @@ func TestAccFastlyServiceV1_bigquerylogging(t *testing.T) {
 		t.Errorf("Failed to generate key: %s", err)
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,
@@ -50,7 +50,7 @@ func TestAccFastlyServiceV1_bigquerylogging_compute(t *testing.T) {
 		t.Errorf("Failed to generate key: %s", err)
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,
@@ -79,7 +79,7 @@ func TestAccFastlyServiceV1_bigquerylogging_env(t *testing.T) {
 	resetEnv := setBQEnv("someEnv", secretKey, t)
 	defer resetEnv()
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,

--- a/fastly/block_fastly_service_v1_blobstoragelogging_test.go
+++ b/fastly/block_fastly_service_v1_blobstoragelogging_test.go
@@ -120,7 +120,7 @@ func TestAccFastlyServiceV1_blobstoragelogging_basic(t *testing.T) {
 		ResponseCondition: "ok_response_2XX",
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,
@@ -169,7 +169,7 @@ func TestAccFastlyServiceV1_blobstoragelogging_basic_compute(t *testing.T) {
 		MessageType:     "blank",
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,
@@ -206,7 +206,7 @@ func TestAccFastlyServiceV1_blobstoragelogging_default(t *testing.T) {
 		MessageType:     "classic",
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,
@@ -247,7 +247,7 @@ func TestAccFastlyServiceV1_blobstoragelogging_env(t *testing.T) {
 		MessageType:     "classic",
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,

--- a/fastly/block_fastly_service_v1_cachesetting_test.go
+++ b/fastly/block_fastly_service_v1_cachesetting_test.go
@@ -68,7 +68,7 @@ func TestAccFastlyServiceV1CacheSetting_basic(t *testing.T) {
 		TTL:            uint(300),
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,

--- a/fastly/block_fastly_service_v1_condition_test.go
+++ b/fastly/block_fastly_service_v1_condition_test.go
@@ -58,7 +58,7 @@ func TestAccFastlyServiceV1_conditional_basic(t *testing.T) {
 		Statement: `req.url ~ "^/yolo/"`,
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,

--- a/fastly/block_fastly_service_v1_dictionary_test.go
+++ b/fastly/block_fastly_service_v1_dictionary_test.go
@@ -49,7 +49,7 @@ func TestAccFastlyServiceV1_dictionary(t *testing.T) {
 	backendName := fmt.Sprintf("%s.aws.amazon.com", acctest.RandString(3))
 	domainName := fmt.Sprintf("fastly-test.tf-%s.com", acctest.RandString(10))
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,
@@ -72,7 +72,7 @@ func TestAccFastlyServiceV1_dictionary_write_only(t *testing.T) {
 	backendName := fmt.Sprintf("%s.aws.amazon.com", acctest.RandString(3))
 	domainName := fmt.Sprintf("fastly-test.tf-%s.com", acctest.RandString(10))
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,
@@ -97,7 +97,7 @@ func TestAccFastlyServiceV1_dictionary_update_name(t *testing.T) {
 	backendName := fmt.Sprintf("%s.aws.amazon.com", acctest.RandString(3))
 	domainName := fmt.Sprintf("fastly-test.tf-%s.com", acctest.RandString(10))
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,

--- a/fastly/block_fastly_service_v1_director_test.go
+++ b/fastly/block_fastly_service_v1_director_test.go
@@ -181,7 +181,7 @@ func TestAccFastlyServiceV1_directors_basic(t *testing.T) {
 		Backend:  "demo",
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,

--- a/fastly/block_fastly_service_v1_dynamicsnippet_test.go
+++ b/fastly/block_fastly_service_v1_dynamicsnippet_test.go
@@ -83,7 +83,7 @@ func TestAccFastlyServiceV1DynamicSnippet_basic(t *testing.T) {
 		Dynamic:  1,
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,

--- a/fastly/block_fastly_service_v1_gcslogging_test.go
+++ b/fastly/block_fastly_service_v1_gcslogging_test.go
@@ -65,7 +65,7 @@ func TestAccFastlyServiceV1_gcslogging(t *testing.T) {
 		t.Errorf("Failed to generate key: %s", err)
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,
@@ -90,7 +90,7 @@ func TestAccFastlyServiceV1_gcslogging_compute(t *testing.T) {
 		t.Errorf("Failed to generate key: %s", err)
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,
@@ -119,7 +119,7 @@ func TestAccFastlyServiceV1_gcslogging_env(t *testing.T) {
 	resetEnv := setGcsEnv("someEnv", secretKey, t)
 	defer resetEnv()
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,

--- a/fastly/block_fastly_service_v1_gzip_test.go
+++ b/fastly/block_fastly_service_v1_gzip_test.go
@@ -127,7 +127,7 @@ func TestAccFastlyServiceV1_gzips_basic(t *testing.T) {
 		ContentTypes:   "text/javascript application/x-javascript application/javascript text/css text/html",
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,

--- a/fastly/block_fastly_service_v1_header_test.go
+++ b/fastly/block_fastly_service_v1_header_test.go
@@ -166,7 +166,7 @@ func TestAccFastlyServiceV1_headers_basic(t *testing.T) {
 		ResponseCondition: "test_res_condition",
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,

--- a/fastly/block_fastly_service_v1_healthcheck_test.go
+++ b/fastly/block_fastly_service_v1_healthcheck_test.go
@@ -96,7 +96,7 @@ func TestAccFastlyServiceV1_healthcheck_basic(t *testing.T) {
 		Window:           10,
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,

--- a/fastly/block_fastly_service_v1_httpslogging_test.go
+++ b/fastly/block_fastly_service_v1_httpslogging_test.go
@@ -100,7 +100,7 @@ func TestAccFastlyServiceV1_httpslogging_basic(t *testing.T) {
 		JSONFormat:        "0",
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,
@@ -148,7 +148,7 @@ func TestAccFastlyServiceV1_httpslogging_basic_compute(t *testing.T) {
 		JSONFormat:        "0",
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,

--- a/fastly/block_fastly_service_v1_logentries_test.go
+++ b/fastly/block_fastly_service_v1_logentries_test.go
@@ -80,7 +80,7 @@ func TestAccFastlyServiceV1_logentries_basic(t *testing.T) {
 		ResponseCondition: "response_condition_test",
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,
@@ -127,7 +127,7 @@ func TestAccFastlyServiceV1_logentries_basic_compute(t *testing.T) {
 		ResponseCondition: "response_condition_test",
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,
@@ -218,7 +218,7 @@ func TestAccFastlyServiceV1_logentries_formatVersion(t *testing.T) {
 		ResponseCondition: "response_condition_test",
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,

--- a/fastly/block_fastly_service_v1_logging_cloudfiles_test.go
+++ b/fastly/block_fastly_service_v1_logging_cloudfiles_test.go
@@ -130,7 +130,7 @@ func TestAccFastlyServiceV1_logging_cloudfiles_basic(t *testing.T) {
 		TimestampFormat:   "%Y-%m-%dT%H:%M:%S.000",
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,
@@ -182,7 +182,7 @@ func TestAccFastlyServiceV1_logging_cloudfiles_basic_compute(t *testing.T) {
 		TimestampFormat: "%Y-%m-%dT%H:%M:%S.000",
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,

--- a/fastly/block_fastly_service_v1_logging_datadog_test.go
+++ b/fastly/block_fastly_service_v1_logging_datadog_test.go
@@ -160,7 +160,7 @@ func TestAccFastlyServiceV1_logging_datadog_basic(t *testing.T) {
 		Format:         datadogDefaultFormat + "\n",
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,
@@ -204,7 +204,7 @@ func TestAccFastlyServiceV1_logging_datadog_basic_compute(t *testing.T) {
 		Region:         "US",
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,

--- a/fastly/block_fastly_service_v1_logging_digitalocean_test.go
+++ b/fastly/block_fastly_service_v1_logging_digitalocean_test.go
@@ -130,7 +130,7 @@ func TestAccFastlyServiceV1_logging_digitalocean_basic(t *testing.T) {
 		ResponseCondition: "response_condition_test",
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,
@@ -182,7 +182,7 @@ func TestAccFastlyServiceV1_logging_digitalocean_basic_compute(t *testing.T) {
 		MessageType:     "classic",
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,

--- a/fastly/block_fastly_service_v1_logging_elasticsearch_test.go
+++ b/fastly/block_fastly_service_v1_logging_elasticsearch_test.go
@@ -135,7 +135,7 @@ func TestAccFastlyServiceV1_logging_elasticsearch_basic(t *testing.T) {
 		Placement:         "none",
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,
@@ -189,7 +189,7 @@ func TestAccFastlyServiceV1_logging_elasticsearch_basic_compute(t *testing.T) {
 		TLSHostname:       "example.com",
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,

--- a/fastly/block_fastly_service_v1_logging_ftp_test.go
+++ b/fastly/block_fastly_service_v1_logging_ftp_test.go
@@ -125,7 +125,7 @@ func TestAccFastlyServiceV1_logging_ftp_basic(t *testing.T) {
 		MessageType:     "classic",
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,
@@ -176,7 +176,7 @@ func TestAccFastlyServiceV1_logging_ftp_basic_compute(t *testing.T) {
 		TimestampFormat: "%Y-%m-%dT%H:%M:%S.000",
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,

--- a/fastly/block_fastly_service_v1_logging_googlepubsub_test.go
+++ b/fastly/block_fastly_service_v1_logging_googlepubsub_test.go
@@ -102,7 +102,7 @@ func TestAccFastlyServiceV1_googlepubsublogging_basic(t *testing.T) {
 		Placement:         "none",
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,
@@ -148,7 +148,7 @@ func TestAccFastlyServiceV1_googlepubsublogging_basic_compute(t *testing.T) {
 		Topic:          "topic",
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,

--- a/fastly/block_fastly_service_v1_logging_heroku_test.go
+++ b/fastly/block_fastly_service_v1_logging_heroku_test.go
@@ -86,7 +86,7 @@ func TestAccFastlyServiceV1_logging_heroku_basic(t *testing.T) {
 		Format:         "%h %l %u %t \"%r\" %>s %b",
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,
@@ -130,7 +130,7 @@ func TestAccFastlyServiceV1_logging_heroku_basic_compute(t *testing.T) {
 		Token:          "s3cr3t",
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,

--- a/fastly/block_fastly_service_v1_logging_honeycomb_test.go
+++ b/fastly/block_fastly_service_v1_logging_honeycomb_test.go
@@ -119,7 +119,7 @@ func TestAccFastlyServiceV1_logging_honeycomb_basic(t *testing.T) {
 		ResponseCondition: "response_condition_test",
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,
@@ -163,7 +163,7 @@ func TestAccFastlyServiceV1_logging_honeycomb_basic_compute(t *testing.T) {
 		Dataset:        "dataset",
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,

--- a/fastly/block_fastly_service_v1_logging_kafka_test.go
+++ b/fastly/block_fastly_service_v1_logging_kafka_test.go
@@ -150,7 +150,7 @@ func TestAccFastlyServiceV1_kafkalogging_basic(t *testing.T) {
 		Password:          "password",
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,
@@ -202,7 +202,7 @@ func TestAccFastlyServiceV1_kafkalogging_basic_compute(t *testing.T) {
 		TLSHostname:      "example.com",
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,

--- a/fastly/block_fastly_service_v1_logging_kinesis_test.go
+++ b/fastly/block_fastly_service_v1_logging_kinesis_test.go
@@ -94,7 +94,7 @@ func TestAccFastlyServiceV1_logging_kinesis_basic(t *testing.T) {
 		Format:         "%h %l %u %t \"%r\" %>s %b",
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,
@@ -140,7 +140,7 @@ func TestAccFastlyServiceV1_logging_kinesis_basic_compute(t *testing.T) {
 		SecretKey:      "thisisthesecretthatneedstobe40characters",
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,

--- a/fastly/block_fastly_service_v1_logging_loggly_test.go
+++ b/fastly/block_fastly_service_v1_logging_loggly_test.go
@@ -73,7 +73,7 @@ func TestAccFastlyServiceV1_logging_loggly_basic(t *testing.T) {
 		Format:         "%h %l %u %t \"%r\" %>s %b",
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,
@@ -117,7 +117,7 @@ func TestAccFastlyServiceV1_logging_loggly_basic_compute(t *testing.T) {
 		Token:          "s3cr3t",
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,

--- a/fastly/block_fastly_service_v1_logging_logshuttle_test.go
+++ b/fastly/block_fastly_service_v1_logging_logshuttle_test.go
@@ -86,7 +86,7 @@ func TestAccFastlyServiceV1_logging_logshuttle_basic(t *testing.T) {
 		Format:            "%h %l %u %t \"%r\" %>s %b",
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,
@@ -130,7 +130,7 @@ func TestAccFastlyServiceV1_logging_logshuttle_basic_compute(t *testing.T) {
 		URL:            "https://example.com",
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,

--- a/fastly/block_fastly_service_v1_logging_newrelic_test.go
+++ b/fastly/block_fastly_service_v1_logging_newrelic_test.go
@@ -89,7 +89,7 @@ func TestAccFastlyServiceV1_logging_newrelic_basic(t *testing.T) {
 		Format:         appendNewLine(newrelicDefaultFormat),
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,
@@ -135,7 +135,7 @@ func TestAccFastlyServiceV1_logging_newrelic_basic_compute(t *testing.T) {
 		Format:         "%h %l %u %t \"%r\" %>s %b",
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,

--- a/fastly/block_fastly_service_v1_logging_openstack_test.go
+++ b/fastly/block_fastly_service_v1_logging_openstack_test.go
@@ -129,7 +129,7 @@ func TestAccFastlyServiceV1_logging_openstack_basic(t *testing.T) {
 		GzipLevel:         0,
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,
@@ -181,7 +181,7 @@ func TestAccFastlyServiceV1_logging_openstack_basic_compute(t *testing.T) {
 		GzipLevel:       0,
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,

--- a/fastly/block_fastly_service_v1_logging_scalyr_test.go
+++ b/fastly/block_fastly_service_v1_logging_scalyr_test.go
@@ -93,7 +93,7 @@ func TestAccFastlyServiceV1_scalyrlogging_basic(t *testing.T) {
 		FormatVersion: 2,
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,
@@ -138,7 +138,7 @@ func TestAccFastlyServiceV1_scalyrlogging_basic_compute(t *testing.T) {
 		Region:         "US",
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,

--- a/fastly/block_fastly_service_v1_logging_sftp_test.go
+++ b/fastly/block_fastly_service_v1_logging_sftp_test.go
@@ -146,7 +146,7 @@ func TestAccFastlyServiceV1_logging_sftp_basic(t *testing.T) {
 		Format:          "%h %l %u %t \"%r\" %>s %b",
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,
@@ -204,7 +204,7 @@ func TestAccFastlyServiceV1_logging_sftp_basic_compute(t *testing.T) {
 		TimestampFormat: "%Y-%m-%dT%H:%M:%S.000",
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,
@@ -228,7 +228,7 @@ func TestAccFastlyServiceV1_logging_sftp_password_secret_key(t *testing.T) {
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	domain := fmt.Sprintf("fastly-test.%s.com", name)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,

--- a/fastly/block_fastly_service_v1_package_test.go
+++ b/fastly/block_fastly_service_v1_package_test.go
@@ -39,7 +39,7 @@ func TestAccFastlyServiceV1_package_basic(t *testing.T) {
 		},
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,

--- a/fastly/block_fastly_service_v1_papertrail_test.go
+++ b/fastly/block_fastly_service_v1_papertrail_test.go
@@ -75,7 +75,7 @@ func TestAccFastlyServiceV1_papertrail_basic(t *testing.T) {
 		FormatVersion:  uint(2),
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,
@@ -120,7 +120,7 @@ func TestAccFastlyServiceV1_papertrail_basic_compute(t *testing.T) {
 		Port:           uint(3600),
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,

--- a/fastly/block_fastly_service_v1_requestsetting_test.go
+++ b/fastly/block_fastly_service_v1_requestsetting_test.go
@@ -68,7 +68,7 @@ func TestAccFastlyServiceV1RequestSetting_basic(t *testing.T) {
 		MaxStaleAge:      uint(90),
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,

--- a/fastly/block_fastly_service_v1_responseobject_test.go
+++ b/fastly/block_fastly_service_v1_responseobject_test.go
@@ -80,7 +80,7 @@ func TestAccFastlyServiceV1_response_object_basic(t *testing.T) {
 		CacheCondition:   "another-test-cache-condition",
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,

--- a/fastly/block_fastly_service_v1_s3logging_test.go
+++ b/fastly/block_fastly_service_v1_s3logging_test.go
@@ -134,7 +134,7 @@ func TestAccFastlyServiceV1_s3logging_basic(t *testing.T) {
 		TimestampFormat: "%Y-%m-%dT%H:%M:%S.000",
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,
@@ -186,7 +186,7 @@ func TestAccFastlyServiceV1_s3logging_basic_compute(t *testing.T) {
 		TimestampFormat: "%Y-%m-%dT%H:%M:%S.000",
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,
@@ -227,7 +227,7 @@ func TestAccFastlyServiceV1_s3logging_domain_default(t *testing.T) {
 		ResponseCondition: "response_condition_test",
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,
@@ -272,7 +272,7 @@ func TestAccFastlyServiceV1_s3logging_s3_env(t *testing.T) {
 		TimestampFormat: "%Y-%m-%dT%H:%M:%S.000",
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,
@@ -312,7 +312,7 @@ func TestAccFastlyServiceV1_s3logging_formatVersion(t *testing.T) {
 		TimestampFormat: "%Y-%m-%dT%H:%M:%S.000",
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,

--- a/fastly/block_fastly_service_v1_snippet_test.go
+++ b/fastly/block_fastly_service_v1_snippet_test.go
@@ -83,7 +83,7 @@ func TestAccFastlyServiceV1Snippet_basic(t *testing.T) {
 		Content:  "restart;\n",
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,

--- a/fastly/block_fastly_service_v1_splunk_test.go
+++ b/fastly/block_fastly_service_v1_splunk_test.go
@@ -108,7 +108,7 @@ func TestAccFastlyServiceV1_splunk_basic(t *testing.T) {
 		ResponseCondition: "ok_response_2XX",
 	}
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,
@@ -150,7 +150,7 @@ func TestAccFastlyServiceV1_splunk_basic_compute(t *testing.T) {
 		Token: "test-token",
 	}
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,
@@ -182,7 +182,7 @@ func TestAccFastlyServiceV1_splunk_default(t *testing.T) {
 		FormatVersion: 2,
 	}
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,
@@ -268,7 +268,7 @@ func TestAccFastlyServiceV1_splunk_complete(t *testing.T) {
 		TLSClientKey:  key,
 	}
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,
@@ -322,7 +322,7 @@ func TestAccFastlyServiceV1_splunk_env(t *testing.T) {
 		FormatVersion: 2,
 	}
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,

--- a/fastly/block_fastly_service_v1_splunk_test.go
+++ b/fastly/block_fastly_service_v1_splunk_test.go
@@ -108,7 +108,7 @@ func TestAccFastlyServiceV1_splunk_basic(t *testing.T) {
 		ResponseCondition: "ok_response_2XX",
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,
@@ -150,7 +150,7 @@ func TestAccFastlyServiceV1_splunk_basic_compute(t *testing.T) {
 		Token: "test-token",
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,
@@ -182,7 +182,7 @@ func TestAccFastlyServiceV1_splunk_default(t *testing.T) {
 		FormatVersion: 2,
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,
@@ -268,7 +268,7 @@ func TestAccFastlyServiceV1_splunk_complete(t *testing.T) {
 		TLSClientKey:  key,
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,

--- a/fastly/block_fastly_service_v1_splunk_test.go
+++ b/fastly/block_fastly_service_v1_splunk_test.go
@@ -108,7 +108,7 @@ func TestAccFastlyServiceV1_splunk_basic(t *testing.T) {
 		ResponseCondition: "ok_response_2XX",
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,
@@ -150,7 +150,7 @@ func TestAccFastlyServiceV1_splunk_basic_compute(t *testing.T) {
 		Token: "test-token",
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,
@@ -182,7 +182,7 @@ func TestAccFastlyServiceV1_splunk_default(t *testing.T) {
 		FormatVersion: 2,
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,
@@ -268,7 +268,7 @@ func TestAccFastlyServiceV1_splunk_complete(t *testing.T) {
 		TLSClientKey:  key,
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,
@@ -322,7 +322,7 @@ func TestAccFastlyServiceV1_splunk_env(t *testing.T) {
 		FormatVersion: 2,
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,

--- a/fastly/block_fastly_service_v1_splunk_test.go
+++ b/fastly/block_fastly_service_v1_splunk_test.go
@@ -300,6 +300,8 @@ func TestAccFastlyServiceV1_splunk_complete(t *testing.T) {
 	})
 }
 
+// This test should not be run in parallel due to its use of schema.EnvDefaultFunc to set/reset environment variables,
+// which conflicts with other running tests.
 func TestAccFastlyServiceV1_splunk_env(t *testing.T) {
 	var service gofastly.ServiceDetail
 	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))

--- a/fastly/block_fastly_service_v1_sumologic_test.go
+++ b/fastly/block_fastly_service_v1_sumologic_test.go
@@ -68,7 +68,7 @@ func TestAccFastlyServiceV1_sumologic(t *testing.T) {
 		Format:        "my format new",
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,
@@ -110,7 +110,7 @@ func TestAccFastlyServiceV1_sumologic_compute(t *testing.T) {
 		URL:  "https://collectors.sumologic.com/receiver/1",
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,

--- a/fastly/block_fastly_service_v1_syslog_test.go
+++ b/fastly/block_fastly_service_v1_syslog_test.go
@@ -112,7 +112,7 @@ func TestAccFastlyServiceV1_syslog_basic(t *testing.T) {
 		MessageType:    "classic",
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,
@@ -159,7 +159,7 @@ func TestAccFastlyServiceV1_syslog_basic_compute(t *testing.T) {
 		MessageType:    "classic",
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,
@@ -195,7 +195,7 @@ func TestAccFastlyServiceV1_syslog_formatVersion(t *testing.T) {
 		MessageType:    "classic",
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,
@@ -244,7 +244,7 @@ func TestAccFastlyServiceV1_syslog_useTls(t *testing.T) {
 		TLSClientKey:   key,
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,

--- a/fastly/block_fastly_service_v1_syslog_test.go
+++ b/fastly/block_fastly_service_v1_syslog_test.go
@@ -112,7 +112,7 @@ func TestAccFastlyServiceV1_syslog_basic(t *testing.T) {
 		MessageType:    "classic",
 	}
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,
@@ -159,7 +159,7 @@ func TestAccFastlyServiceV1_syslog_basic_compute(t *testing.T) {
 		MessageType:    "classic",
 	}
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,
@@ -195,7 +195,7 @@ func TestAccFastlyServiceV1_syslog_formatVersion(t *testing.T) {
 		MessageType:    "classic",
 	}
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,
@@ -215,7 +215,7 @@ func TestAccFastlyServiceV1_syslog_formatVersion(t *testing.T) {
 	})
 }
 
-func TestAccFastlyServiceV1_syslog_useTls(t *testing.T) {
+func TestAccFastlyServiceV1_syslog_useTLS(t *testing.T) {
 	key, cert, err := generateKeyAndCert()
 	if err != nil {
 		t.Errorf("Failed to generate key and cert: %s", err)
@@ -244,7 +244,7 @@ func TestAccFastlyServiceV1_syslog_useTls(t *testing.T) {
 		TLSClientKey:   key,
 	}
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,

--- a/fastly/block_fastly_service_v1_syslog_test.go
+++ b/fastly/block_fastly_service_v1_syslog_test.go
@@ -112,7 +112,7 @@ func TestAccFastlyServiceV1_syslog_basic(t *testing.T) {
 		MessageType:    "classic",
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,
@@ -159,7 +159,7 @@ func TestAccFastlyServiceV1_syslog_basic_compute(t *testing.T) {
 		MessageType:    "classic",
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,
@@ -195,7 +195,7 @@ func TestAccFastlyServiceV1_syslog_formatVersion(t *testing.T) {
 		MessageType:    "classic",
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,

--- a/fastly/block_fastly_service_v1_syslog_test.go
+++ b/fastly/block_fastly_service_v1_syslog_test.go
@@ -215,6 +215,8 @@ func TestAccFastlyServiceV1_syslog_formatVersion(t *testing.T) {
 	})
 }
 
+// This test should not be run in parallel due to its use of schema.EnvDefaultFunc to set/reset environment variables,
+// which conflicts with other running tests.
 func TestAccFastlyServiceV1_syslog_useTLS(t *testing.T) {
 	key, cert, err := generateKeyAndCert()
 	if err != nil {

--- a/fastly/block_fastly_service_v1_vcl_test.go
+++ b/fastly/block_fastly_service_v1_vcl_test.go
@@ -49,7 +49,7 @@ func TestAccFastlyServiceV1_VCL_basic(t *testing.T) {
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	domainName1 := fmt.Sprintf("fastly-test.tf-%s.com", acctest.RandString(10))
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,

--- a/fastly/block_fastly_waf_configuration_v1_exclusion_test.go
+++ b/fastly/block_fastly_waf_configuration_v1_exclusion_test.go
@@ -92,8 +92,9 @@ func TestAccFastlyServiceWAFVersionV1FlattenWAFRuleExclusions(t *testing.T) {
 }
 
 func TestAccFastlyServiceWAFVersionV1Validation(t *testing.T) {
-	// Must set test to parallel outside of resource.ParallelTest due to the for loop. Otherwise t.Parallel() would be
-	// called multiple times, leading to a panic
+	// As we use a 'table test' which executes a `resource.Test` multiple times within a for-loop, we don't utilise the
+	// `resource.ParallelTest` function but instead call t.Parallel(). The use of t.Parallel() must happen outside of 
+	// the for-loop otherwise it would be executed multiple times, leading to a runtime panic.
 	t.Parallel()
 
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))

--- a/fastly/block_fastly_waf_configuration_v1_exclusion_test.go
+++ b/fastly/block_fastly_waf_configuration_v1_exclusion_test.go
@@ -92,6 +92,10 @@ func TestAccFastlyServiceWAFVersionV1FlattenWAFRuleExclusions(t *testing.T) {
 }
 
 func TestAccFastlyServiceWAFVersionV1Validation(t *testing.T) {
+	// Must set test to parallel outside of resource.ParallelTest due to the for loop. Otherwise t.Parallel() would be
+	// called multiple times, leading to a panic
+	t.Parallel()
+
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 
 	cases := []struct {

--- a/fastly/data_source_ip_ranges_test.go
+++ b/fastly/data_source_ip_ranges_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestAccFastlyIPRanges(t *testing.T) {
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{

--- a/fastly/data_source_waf_rules_test.go
+++ b/fastly/data_source_waf_rules_test.go
@@ -103,7 +103,7 @@ func TestAccFastlyWAFRulesPublisherFilter(t *testing.T) {
 	wafrulesHCL2 := `
     publishers = ["owasp","fastly"]
     `
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,
@@ -130,7 +130,7 @@ func TestAccFastlyWAFRulesExcludeFilter(t *testing.T) {
     publishers = ["owasp"]
     exclude_modsec_rule_ids = [1010020]
     `
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,
@@ -153,7 +153,7 @@ func TestAccFastlyWAFRulesTagFilter(t *testing.T) {
 	wafrulesHCL2 := `
     tags = ["CVE-2018-17384", "attack-rce"]
     `
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,

--- a/fastly/resource_fastly_service_acl_entries_v1_test.go
+++ b/fastly/resource_fastly_service_acl_entries_v1_test.go
@@ -77,7 +77,7 @@ func TestAccFastlyServiceAclEntriesV1_create(t *testing.T) {
 		},
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,
@@ -119,7 +119,7 @@ func TestAccFastlyServiceAclEntriesV1_update(t *testing.T) {
 		},
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,
@@ -169,7 +169,7 @@ func TestAccFastlyServiceAclEntriesV1_update_additional_fields(t *testing.T) {
 		},
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,
@@ -217,7 +217,7 @@ func TestAccFastlyServiceAclEntriesV1_delete(t *testing.T) {
 		},
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,
@@ -258,7 +258,7 @@ func TestAccFastlyServiceAclEntriesV1_import(t *testing.T) {
 		},
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,
@@ -309,7 +309,7 @@ func TestAccFastlyServiceAclEntriesV1_process_1001_entries(t *testing.T) {
 		ipPart4++
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,

--- a/fastly/resource_fastly_service_compute_test.go
+++ b/fastly/resource_fastly_service_compute_test.go
@@ -93,7 +93,7 @@ func TestAccFastlyServiceCompute_basic(t *testing.T) {
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	domainName1 := fmt.Sprintf("fastly-test1.tf-%s.com", acctest.RandString(10))
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceComputeDestroy,
@@ -146,7 +146,7 @@ func testAccCheckServiceComputeDestroy(s *terraform.State) error {
 
 func TestAccFastlyServiceCompute_import(t *testing.T) {
 	var service gofastly.ServiceDetail
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,

--- a/fastly/resource_fastly_service_dictionary_items_v1_test.go
+++ b/fastly/resource_fastly_service_dictionary_items_v1_test.go
@@ -57,7 +57,7 @@ func TestAccFastlyServiceDictionaryItemV1_create(t *testing.T) {
 		"key2": "value2",
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,
@@ -94,7 +94,7 @@ func TestAccFastlyServiceDictionaryItemV1_create_inactive_service(t *testing.T) 
 		"key2": "value2",
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,
@@ -123,7 +123,7 @@ func TestAccFastlyServiceDictionaryItemV1_create_dynamic(t *testing.T) {
 		"delta": "delta.demo.notexample.com",
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,
@@ -156,7 +156,7 @@ func TestAccFastlyServiceDictionaryItemV1_update(t *testing.T) {
 		"key3": "value3",
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,
@@ -195,7 +195,7 @@ func TestAccFastlyServiceDictionaryItemV1_external_item_is_removed(t *testing.T)
 
 	config := testAccServiceDictionaryItemsV1Config_one_dictionary_with_items(name, dictName, expectedRemoteItems, true)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,
@@ -235,7 +235,7 @@ func TestAccFastlyServiceDictionaryItemV1_external_item_deleted(t *testing.T) {
 
 	expectedRemoteItemsAfterUpdate := map[string]string{}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,
@@ -275,7 +275,7 @@ func TestAccFastlyServiceDictionaryItemV1_batch_1001_items(t *testing.T) {
 		expectedRemoteItems[fmt.Sprintf("key%d", i)] = fmt.Sprintf("value%d", i)
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,
@@ -304,7 +304,7 @@ func TestAccFastlyServiceDictionaryItemV1_import(t *testing.T) {
 		"key2": "value2",
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,

--- a/fastly/resource_fastly_service_dynamic_snippet_content_v1_test.go
+++ b/fastly/resource_fastly_service_dynamic_snippet_content_v1_test.go
@@ -20,7 +20,7 @@ func TestAccFastlyServiceDynamicSnippetContentV1_create(t *testing.T) {
 	expectedSnippetPriority := "100"
 	expectedSnippetContent := "if ( req.url ) {\n set req.http.my-snippet-test-header = \"true\";\n}"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,
@@ -50,7 +50,7 @@ func TestAccFastlyServiceDynamicSnippetContentV1_update(t *testing.T) {
 
 	expectedRemoteItemsAfterUpdate := "if ( req.url ) {\n set req.http.my-updated-test-header = \"true\";\n}"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,
@@ -87,7 +87,7 @@ func TestAccFastlyServiceDynamicSnippetContentV1_external_snippet_is_removed(t *
 	managedDynamicSnippetName := fmt.Sprintf("dynamic snippet %s", acctest.RandString(10))
 	managedContent := "if ( req.url ) {\n set req.http.my-updated-test-header = \"true\";\n}"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,
@@ -126,7 +126,7 @@ func TestAccFastlyServiceDynamicSnippetContentV1_normal_snippet_is_not_removed(t
 	dynamicSnippetName := fmt.Sprintf("existing dynamic snippet %s", acctest.RandString(10))
 	dynamicContent := "if ( req.url ) {\n set req.http.my-new-content-test-header = \"true\";\n}"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,
@@ -164,7 +164,7 @@ func TestAccFastlyServiceDynamicSnippetContentV1_import(t *testing.T) {
 	expectedSnippetPriority := "100"
 	expectedSnippetContent := "if ( req.url ) {\n set req.http.my-snippet-test-header = \"true\";\n}"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,

--- a/fastly/resource_fastly_service_v1_test.go
+++ b/fastly/resource_fastly_service_v1_test.go
@@ -141,7 +141,7 @@ func TestAccFastlyServiceV1_updateDomain(t *testing.T) {
 	domainName2 := fmt.Sprintf("fastly-test.tf-%s.com", acctest.RandString(10))
 	domainName3 := fmt.Sprintf("fastly-test.tf-%s.com", acctest.RandString(10))
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,
@@ -208,7 +208,7 @@ func TestAccFastlyServiceV1_updateBackend(t *testing.T) {
 	backendName := fmt.Sprintf("%s.aws.amazon.com", acctest.RandString(3))
 	backendName2 := fmt.Sprintf("%s.aws.amazon.com", acctest.RandString(3))
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,
@@ -244,7 +244,7 @@ func TestAccFastlyServiceV1_updateInvalidBackend(t *testing.T) {
 	backendName := fmt.Sprintf("%s.aws.amazon.com", acctest.RandString(3))
 	backendName2 := fmt.Sprintf("%s.aws.amazon.com", acctest.RandString(3))
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,
@@ -281,7 +281,7 @@ func TestAccFastlyServiceV1_basic(t *testing.T) {
 	domainName1 := fmt.Sprintf("fastly-test.tf-%s.com", acctest.RandString(10))
 	domainName2 := fmt.Sprintf("fastly-test.tf-%s.com", acctest.RandString(10))
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,
@@ -353,7 +353,7 @@ func TestAccFastlyServiceV1_disappears(t *testing.T) {
 		})
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,
@@ -471,7 +471,7 @@ func TestAccFastlyServiceV1_defaultTTL(t *testing.T) {
 	backendName := fmt.Sprintf("%s.aws.amazon.com", acctest.RandString(3))
 	backendName2 := fmt.Sprintf("%s.aws.amazon.com", acctest.RandString(3))
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,
@@ -519,7 +519,7 @@ func TestAccFastlyServiceV1_createDefaultTTL(t *testing.T) {
 	domain := fmt.Sprintf("fastly-test.tf-%s.com", acctest.RandString(10))
 	backendName := fmt.Sprintf("%s.aws.amazon.com", acctest.RandString(3))
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,
@@ -543,7 +543,7 @@ func TestAccFastlyServiceV1_createZeroDefaultTTL(t *testing.T) {
 	domain := fmt.Sprintf("fastly-test.tf-%s.com", acctest.RandString(10))
 	backendName := fmt.Sprintf("%s.aws.amazon.com", acctest.RandString(3))
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,
@@ -587,7 +587,7 @@ func TestAccFastlyServiceV1_import(t *testing.T) {
 	var service gofastly.ServiceDetail
 	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,

--- a/fastly/resource_fastly_service_v1_versionless_test.go
+++ b/fastly/resource_fastly_service_v1_versionless_test.go
@@ -19,7 +19,7 @@ func TestAccFastlyServiceV1_creation_with_versionless_resources(t *testing.T) {
 
 	domainName := fmt.Sprintf("fastly-test.tf-%s.com", acctest.RandString(10))
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,

--- a/fastly/resource_fastly_user_v1_test.go
+++ b/fastly/resource_fastly_user_v1_test.go
@@ -18,7 +18,7 @@ func TestAccFastlyUserV1_basic(t *testing.T) {
 	name2 := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	role2 := "superuser"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckUserV1Destroy,
@@ -57,7 +57,7 @@ func TestAccFastlyUserV1_updateLogin(t *testing.T) {
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	role := "engineer"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckUserV1Destroy,


### PR DESCRIPTION
Mostly a find/replace of `resource.Test` to `resource.ParallelTest` with a couple of exceptions:

- **`TestAccFastlyServiceV1_splunk_env`** and **`TestAccFastlyServiceV1_syslog_useTls`** have to stay serial because they set/reset environment variables within the test to exercise the `schema.EnvDefaultFunc`, which interferes with the other tests
- **`TestAccFastlyServiceWAFVersionV1Validation`** had to do `t.Parallel` directly because `resource.Test` was getting called in a loop as part of a table driven test

Total test time reduced from ~2:13:00 to ~00:21:00 (sample size of 1, `GOMAXPROCS=8`). This is excluding the running of the kinesis logging tests which would add a few more minutes. They could potentially add some unforeseen test failures which need fixing too, but it's unlikely as it doesn't look like they do anything with env variables etc