### PR TITLE
Add force_destroy flag to ACLs and Dicts to allow deleting non-empty lists

### DIFF
--- a/docs/resources/service_compute.md
+++ b/docs/resources/service_compute.md
@@ -220,6 +220,7 @@ Required:
 
 Optional:
 
+- **force_destroy** (Boolean) Allow the dictionary to be deleted, even if it contains entries. Defaults to false.
 - **write_only** (Boolean) If `true`, the dictionary is a private dictionary, and items are not readable in the UI or via API. Default is `false`. It is important to note that changing this attribute will delete and recreate the dictionary, and discard the current items in the dictionary. Using a write-only/private dictionary should only be done if the items are managed outside of Terraform
 
 Read-Only:

--- a/docs/resources/service_v1.md
+++ b/docs/resources/service_v1.md
@@ -306,6 +306,10 @@ Required:
 
 - **name** (String) A unique name to identify this ACL. It is important to note that changing this attribute will delete and recreate the ACL, and discard the current items in the ACL
 
+Optional:
+
+- **force_destroy** (Boolean) Allow the ACL to be deleted, even if it contains entries. Defaults to false.
+
 Read-Only:
 
 - **acl_id** (String) The ID of the ACL
@@ -428,6 +432,7 @@ Required:
 
 Optional:
 
+- **force_destroy** (Boolean) Allow the dictionary to be deleted, even if it contains entries. Defaults to false.
 - **write_only** (Boolean) If `true`, the dictionary is a private dictionary, and items are not readable in the UI or via API. Default is `false`. It is important to note that changing this attribute will delete and recreate the dictionary, and discard the current items in the dictionary. Using a write-only/private dictionary should only be done if the items are managed outside of Terraform
 
 Read-Only:

--- a/fastly/block_fastly_service_v1_acl.go
+++ b/fastly/block_fastly_service_v1_acl.go
@@ -57,7 +57,7 @@ func (h *ACLServiceAttributeHandler) Process(d *schema.ResourceData, latestVersi
 			}
 
 			if !mayDelete {
-				return fmt.Errorf("Cannot delete ACL (%s), list is not empty. Either delete the entries, or set force_destroy to true.", resource["acl_id"].(string))
+				return fmt.Errorf("Cannot delete ACL (%s), list is not empty. Either delete the entries first, or set force_destroy to true and apply it before making this change.", resource["acl_id"].(string))
 			}
 		}
 

--- a/fastly/block_fastly_service_v1_acl.go
+++ b/fastly/block_fastly_service_v1_acl.go
@@ -49,6 +49,18 @@ func (h *ACLServiceAttributeHandler) Process(d *schema.ResourceData, latestVersi
 	// DELETE removed resources
 	for _, resource := range diffResult.Deleted {
 		resource := resource.(map[string]interface{})
+
+		if !resource["force_destroy"].(bool) {
+			mayDelete, err := isACLEmpty(d.Id(), resource["acl_id"].(string), conn)
+			if err != nil {
+				return err
+			}
+
+			if !mayDelete {
+				return fmt.Errorf("Cannot delete ACL (%s), list is not empty. Either delete the entries, or set force_destroy to true.", resource["acl_id"].(string))
+			}
+		}
+
 		opts := gofastly.DeleteACLInput{
 			ServiceID:      d.Id(),
 			ServiceVersion: latestVersion,
@@ -108,6 +120,18 @@ func (h *ACLServiceAttributeHandler) Read(d *schema.ResourceData, s *gofastly.Se
 
 	al := flattenACLs(aclList)
 
+	// Match up force_destroy on each ACL from schema.ResourceData to avoid d.Set overwriting it with null
+	stateACLs := d.Get(h.GetKey()).(*schema.Set).List()
+	for _, acl := range al {
+		for _, sa := range stateACLs {
+			stateACL := sa.(map[string]interface{})
+			if acl["name"] == stateACL["name"] {
+				acl["force_destroy"] = stateACL["force_destroy"]
+				break
+			}
+		}
+	}
+
 	if err := d.Set(h.GetKey(), al); err != nil {
 		log.Printf("[WARN] Error setting ACLs for (%s): %s", d.Id(), err)
 	}
@@ -132,6 +156,12 @@ func (h *ACLServiceAttributeHandler) Register(s *schema.Resource) error {
 					Type:        schema.TypeString,
 					Computed:    true,
 					Description: "The ID of the ACL",
+				},
+				"force_destroy": {
+					Type:        schema.TypeBool,
+					Default:     false,
+					Optional:    true,
+					Description: "Allow the ACL to be deleted, even if it contains entries. Defaults to false.",
 				},
 			},
 		},
@@ -159,4 +189,16 @@ func flattenACLs(aclList []*gofastly.ACL) []map[string]interface{} {
 	}
 
 	return al
+}
+
+func isACLEmpty(serviceID, aclID string, conn *gofastly.Client) (bool, error) {
+	entries, err := conn.ListACLEntries(&gofastly.ListACLEntriesInput{
+		ServiceID: serviceID,
+		ACLID:     aclID,
+	})
+	if err != nil {
+		return false, err
+	}
+
+	return len(entries) == 0, nil
 }

--- a/fastly/block_fastly_service_v1_acl_test.go
+++ b/fastly/block_fastly_service_v1_acl_test.go
@@ -78,7 +78,7 @@ func TestAccFastlyServiceV1_acl(t *testing.T) {
 			},
 			{
 				Config: testAccServiceV1Config_acl(name, aclNameUpdated),
-				Check:  testAccAddACLEntries(&acl),
+				Check:  testAccAddACLEntries(&acl), // triggers side-effect of adding an ACL Entry
 			},
 			{
 				Config:      testAccServiceV1Config_acl(name, aclName),

--- a/fastly/block_fastly_service_v1_acl_test.go
+++ b/fastly/block_fastly_service_v1_acl_test.go
@@ -3,6 +3,7 @@ package fastly
 import (
 	"fmt"
 	"reflect"
+	"regexp"
 	"testing"
 
 	gofastly "github.com/fastly/go-fastly/v3/fastly"
@@ -42,10 +43,18 @@ func TestResourceFastlyFlattenAcl(t *testing.T) {
 
 func TestAccFastlyServiceV1_acl(t *testing.T) {
 	var service gofastly.ServiceDetail
-	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	var acl gofastly.ACL
+	name := acctest.RandomWithPrefix(testResourcePrefix)
 	aclName := fmt.Sprintf("acl_%s", acctest.RandString(10))
 	aclNameUpdated := fmt.Sprintf("acl_updated_%s", acctest.RandString(10))
 
+	// Six part test:
+	// 1. Create service with 2 ACLs
+	// 2. Rename both the ACLs, should succeed because the ACLs are empty
+	// 3. Keep both ACLs the same and add an entry to one of them
+	// 4. Try to rename the ACLs, expect to fail with "list not empty error"
+	// 5. Without renaming the ACLs, set force_destroy=true to skip the deletion check
+	// 6. Try to rename the ACLs again, expect to succeed
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -55,23 +64,47 @@ func TestAccFastlyServiceV1_acl(t *testing.T) {
 				Config: testAccServiceV1Config_acl(name, aclName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
-					testAccCheckFastlyServiceV1Attributes_acl(&service, name, "a_"+aclName),
-					testAccCheckFastlyServiceV1Attributes_acl(&service, name, "b_"+aclName),
+					testAccCheckFastlyServiceV1Attributes_acl(&service, name, "a_"+aclName, &acl),
+					testAccCheckFastlyServiceV1Attributes_acl(&service, name, "b_"+aclName, &acl),
 				),
 			},
 			{
 				Config: testAccServiceV1Config_acl(name, aclNameUpdated),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
-					testAccCheckFastlyServiceV1Attributes_acl(&service, name, "a_"+aclNameUpdated),
-					testAccCheckFastlyServiceV1Attributes_acl(&service, name, "b_"+aclNameUpdated),
+					testAccCheckFastlyServiceV1Attributes_acl(&service, name, "a_"+aclNameUpdated, &acl),
+					testAccCheckFastlyServiceV1Attributes_acl(&service, name, "b_"+aclNameUpdated, &acl),
+				),
+			},
+			{
+				Config: testAccServiceV1Config_acl(name, aclNameUpdated),
+				Check:  testAccAddACLEntries(&acl),
+			},
+			{
+				Config:      testAccServiceV1Config_acl(name, aclName),
+				ExpectError: regexp.MustCompile("Cannot delete.*list is not empty.*"),
+			},
+			{
+				Config: testAccServiceV1Config_aclForceDestroy(name, aclNameUpdated),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
+					testAccCheckFastlyServiceV1Attributes_acl(&service, name, "a_"+aclNameUpdated, &acl),
+					testAccCheckFastlyServiceV1Attributes_acl(&service, name, "b_"+aclNameUpdated, &acl),
+				),
+			},
+			{
+				Config: testAccServiceV1Config_aclForceDestroy(name, aclName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
+					testAccCheckFastlyServiceV1Attributes_acl(&service, name, "a_"+aclName, &acl),
+					testAccCheckFastlyServiceV1Attributes_acl(&service, name, "b_"+aclName, &acl),
 				),
 			},
 		},
 	})
 }
 
-func testAccCheckFastlyServiceV1Attributes_acl(service *gofastly.ServiceDetail, name, aclName string) resource.TestCheckFunc {
+func testAccCheckFastlyServiceV1Attributes_acl(service *gofastly.ServiceDetail, name, aclName string, acl *gofastly.ACL) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 
 		if service.Name != name {
@@ -79,7 +112,7 @@ func testAccCheckFastlyServiceV1Attributes_acl(service *gofastly.ServiceDetail, 
 		}
 
 		conn := testAccProvider.Meta().(*FastlyClient).conn
-		acl, err := conn.GetACL(&gofastly.GetACLInput{
+		remoteACL, err := conn.GetACL(&gofastly.GetACLInput{
 			ServiceID:      service.ID,
 			ServiceVersion: service.ActiveVersion.Number,
 			Name:           aclName,
@@ -89,8 +122,28 @@ func testAccCheckFastlyServiceV1Attributes_acl(service *gofastly.ServiceDetail, 
 			return fmt.Errorf("[ERR] Error looking up ACL records for (%s), version (%v): %s", service.Name, service.ActiveVersion.Number, err)
 		}
 
-		if acl.Name != aclName {
-			return fmt.Errorf("ACL logging endpoint name mismatch, expected: %s, got: %#v", aclName, acl.Name)
+		if remoteACL.Name != aclName {
+			return fmt.Errorf("ACL logging endpoint name mismatch, expected: %s, got: %#v", aclName, remoteACL.Name)
+		}
+
+		*acl = *remoteACL
+
+		return nil
+	}
+}
+
+// testAccAddACLEntries doesn't technically check for anything despite returning a TestCheckFunc. Instead it is used for
+// its side effect of adding an ACL Entry
+func testAccAddACLEntries(acl *gofastly.ACL) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*FastlyClient).conn
+		_, err := conn.CreateACLEntry(&gofastly.CreateACLEntryInput{
+			ServiceID: acl.ServiceID,
+			ACLID:     acl.ID,
+			IP:        "192.168.0.1",
+		})
+		if err != nil {
+			return fmt.Errorf("[ERR] Error adding entry to ACL (%s) on service (%s): %w", acl.ID, acl.ServiceID, err)
 		}
 
 		return nil
@@ -121,6 +174,38 @@ resource "fastly_service_v1" "foo" {
 
   acl {
     name = "b_%s"
+  }
+
+  force_destroy = true
+}`, name, domainName, backendName, aclName, aclName)
+}
+
+func testAccServiceV1Config_aclForceDestroy(name, aclName string) string {
+	backendName := fmt.Sprintf("%s.aws.amazon.com", acctest.RandString(3))
+	domainName := fmt.Sprintf("fastly-test.tf-%s.com", acctest.RandString(10))
+
+	return fmt.Sprintf(`
+resource "fastly_service_v1" "foo" {
+  name = "%s"
+
+  domain {
+    name    = "%s"
+    comment = "tf-testing-domain"
+	}
+
+  backend {
+    address = "%s"
+    name    = "tf-test-backend"
+  }
+
+  acl {
+	name          = "a_%s"
+    force_destroy = true
+  }
+
+  acl {
+    name          = "b_%s"
+    force_destroy = true
   }
 
   force_destroy = true

--- a/fastly/block_fastly_service_v1_acl_test.go
+++ b/fastly/block_fastly_service_v1_acl_test.go
@@ -112,15 +112,15 @@ resource "fastly_service_v1" "foo" {
 
   backend {
     address = "%s"
-    name    = "tf -test backend"
+    name    = "tf-test-backend"
   }
 
   acl {
-		name       = "a_%s"
+	name = "a_%s"
   }
 
   acl {
-		name       = "b_%s"
+    name = "b_%s"
   }
 
   force_destroy = true

--- a/fastly/block_fastly_service_v1_dictionary_test.go
+++ b/fastly/block_fastly_service_v1_dictionary_test.go
@@ -162,7 +162,7 @@ resource "fastly_service_v1" "foo" {
 
   backend {
     address = "%s"
-    name    = "tf -test backend"
+    name    = "tf-test backend"
   }
 
   dictionary {

--- a/fastly/block_fastly_service_v1_dictionary_test.go
+++ b/fastly/block_fastly_service_v1_dictionary_test.go
@@ -84,7 +84,7 @@ func TestAccFastlyServiceV1_dictionary(t *testing.T) {
 			},
 			{
 				Config:      testAccServiceV1Config_dictionary(name, dictName, backendName, domainName),
-				ExpectError: regexp.MustCompile(""),
+				ExpectError: regexp.MustCompile("Cannot delete.*not empty.*"),
 			},
 			{
 				Config: testAccServiceV1Config_dictionaryForceDestroy(name, updatedDictName, backendName, domainName),

--- a/fastly/block_fastly_service_v1_dictionary_test.go
+++ b/fastly/block_fastly_service_v1_dictionary_test.go
@@ -3,6 +3,7 @@ package fastly
 import (
 	"fmt"
 	"reflect"
+	"regexp"
 	"testing"
 
 	gofastly "github.com/fastly/go-fastly/v3/fastly"
@@ -44,11 +45,20 @@ func TestResourceFastlyFlattenDictionary(t *testing.T) {
 
 func TestAccFastlyServiceV1_dictionary(t *testing.T) {
 	var service gofastly.ServiceDetail
-	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	var dictionary gofastly.Dictionary
+	name := acctest.RandomWithPrefix(testResourcePrefix)
 	dictName := fmt.Sprintf("dict %s", acctest.RandString(10))
+	updatedDictName := fmt.Sprintf("new dict %s", acctest.RandString(10))
 	backendName := fmt.Sprintf("%s.aws.amazon.com", acctest.RandString(3))
 	domainName := fmt.Sprintf("fastly-test.tf-%s.com", acctest.RandString(10))
 
+	// Six part test:
+	// 1. Create service with dictionary
+	// 2. Rename the dictionary, should succeed because it is empty
+	// 3. Keep dictionary the same and add an item to it
+	// 4. Try to rename it, expect to fail with "dictionary not empty error"
+	// 5. Without renaming, set force_destroy=true to skip the deletion check
+	// 6. Try to rename again, expect to succeed
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -58,7 +68,36 @@ func TestAccFastlyServiceV1_dictionary(t *testing.T) {
 				Config: testAccServiceV1Config_dictionary(name, dictName, backendName, domainName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
-					testAccCheckFastlyServiceV1Attributes_dictionary(&service, name, dictName, false),
+					testAccCheckFastlyServiceV1Attributes_dictionary(&service, &dictionary, name, dictName, false),
+				),
+			},
+			{
+				Config: testAccServiceV1Config_dictionary(name, updatedDictName, backendName, domainName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
+					testAccCheckFastlyServiceV1Attributes_dictionary(&service, &dictionary, name, updatedDictName, false),
+				),
+			},
+			{
+				Config: testAccServiceV1Config_dictionary(name, updatedDictName, backendName, domainName),
+				Check:  testAccAddDictionaryItems(&dictionary),
+			},
+			{
+				Config:      testAccServiceV1Config_dictionary(name, dictName, backendName, domainName),
+				ExpectError: regexp.MustCompile(""),
+			},
+			{
+				Config: testAccServiceV1Config_dictionaryForceDestroy(name, updatedDictName, backendName, domainName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
+					testAccCheckFastlyServiceV1Attributes_dictionary(&service, &dictionary, name, updatedDictName, false),
+				),
+			},
+			{
+				Config: testAccServiceV1Config_dictionaryForceDestroy(name, dictName, backendName, domainName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
+					testAccCheckFastlyServiceV1Attributes_dictionary(&service, &dictionary, name, dictName, false),
 				),
 			},
 		},
@@ -67,6 +106,7 @@ func TestAccFastlyServiceV1_dictionary(t *testing.T) {
 
 func TestAccFastlyServiceV1_dictionary_write_only(t *testing.T) {
 	var service gofastly.ServiceDetail
+	var dictionary gofastly.Dictionary
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	dictName := fmt.Sprintf("dict %s", acctest.RandString(10))
 	backendName := fmt.Sprintf("%s.aws.amazon.com", acctest.RandString(3))
@@ -81,46 +121,14 @@ func TestAccFastlyServiceV1_dictionary_write_only(t *testing.T) {
 				Config: testAccServiceV1Config_dictionary_write_only(name, dictName, backendName, domainName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
-					testAccCheckFastlyServiceV1Attributes_dictionary(&service, name, dictName, true),
+					testAccCheckFastlyServiceV1Attributes_dictionary(&service, &dictionary, name, dictName, true),
 				),
 			},
 		},
 	})
 }
 
-func TestAccFastlyServiceV1_dictionary_update_name(t *testing.T) {
-	var service gofastly.ServiceDetail
-	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
-	dictName := fmt.Sprintf("dict %s", acctest.RandString(10))
-	updatedDictName := fmt.Sprintf("new dict %s", acctest.RandString(10))
-
-	backendName := fmt.Sprintf("%s.aws.amazon.com", acctest.RandString(3))
-	domainName := fmt.Sprintf("fastly-test.tf-%s.com", acctest.RandString(10))
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckServiceV1Destroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccServiceV1Config_dictionary(name, dictName, backendName, domainName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
-					testAccCheckFastlyServiceV1Attributes_dictionary(&service, name, dictName, false),
-				),
-			},
-			{
-				Config: testAccServiceV1Config_dictionary(name, updatedDictName, backendName, domainName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
-					testAccCheckFastlyServiceV1Attributes_dictionary(&service, name, updatedDictName, false),
-				),
-			},
-		},
-	})
-}
-
-func testAccCheckFastlyServiceV1Attributes_dictionary(service *gofastly.ServiceDetail, name, dictName string, writeOnly bool) resource.TestCheckFunc {
+func testAccCheckFastlyServiceV1Attributes_dictionary(service *gofastly.ServiceDetail, dictionary *gofastly.Dictionary, name, dictName string, writeOnly bool) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 
 		if service.Name != name {
@@ -146,6 +154,27 @@ func testAccCheckFastlyServiceV1Attributes_dictionary(service *gofastly.ServiceD
 			return fmt.Errorf("Dictionary write_only attribute mismatch, expected: %#v, got: %#v", writeOnly, dict.WriteOnly)
 		}
 
+		*dictionary = *dict
+
+		return nil
+	}
+}
+
+// testAccAddDictionaryItems doesn't technically check for anything despite returning a TestCheckFunc. Instead it is
+// used for its side effect of adding a Dictionary Item
+func testAccAddDictionaryItems(dictionary *gofastly.Dictionary) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*FastlyClient).conn
+		_, err := conn.CreateDictionaryItem(&gofastly.CreateDictionaryItemInput{
+			ServiceID:    dictionary.ServiceID,
+			DictionaryID: dictionary.ID,
+			ItemKey:      "testKey",
+			ItemValue:    "testItem",
+		})
+		if err != nil {
+			return fmt.Errorf("[ERR] Error adding item to dictionary (%s) on service (%s): %w", dictionary.ID, dictionary.ServiceID, err)
+		}
+
 		return nil
 	}
 }
@@ -167,6 +196,30 @@ resource "fastly_service_v1" "foo" {
 
   dictionary {
     name = "%s"
+  }
+
+  force_destroy = true
+}`, name, domainName, backendName, dictName)
+}
+
+func testAccServiceV1Config_dictionaryForceDestroy(name, dictName, backendName, domainName string) string {
+	return fmt.Sprintf(`
+resource "fastly_service_v1" "foo" {
+  name = "%s"
+
+  domain {
+    name    = "%s"
+    comment = "tf-testing-domain"
+  }
+
+  backend {
+    address = "%s"
+    name    = "tf-test backend"
+  }
+
+  dictionary {
+    name          = "%s"
+    force_destroy = true
   }
 
   force_destroy = true

--- a/fastly/block_fastly_service_v1_dictionary_test.go
+++ b/fastly/block_fastly_service_v1_dictionary_test.go
@@ -80,7 +80,7 @@ func TestAccFastlyServiceV1_dictionary(t *testing.T) {
 			},
 			{
 				Config: testAccServiceV1Config_dictionary(name, updatedDictName, backendName, domainName),
-				Check:  testAccAddDictionaryItems(&dictionary),
+				Check:  testAccAddDictionaryItems(&dictionary), // triggers side-effect of adding a Dictionary Item
 			},
 			{
 				Config:      testAccServiceV1Config_dictionary(name, dictName, backendName, domainName),


### PR DESCRIPTION
Updates service ACL and Dictionary blocks with extra protection to prevent the deletion of populated data that is dynamically added outside of a Terraform workflow.

Checks for non-empty ACL entries and Dictionary items before deleting ACLs and Dictionaries to reduce potential loss when updating either collection name.

Returns an error to the terraform user if `force_destroy` is not set on the ACL/Dictionary prior to updating.