### PR TITLE
Better sensitive value handling in Google pub/sub logging provider

### DIFF
--- a/docs/resources/service_compute.md
+++ b/docs/resources/service_compute.md
@@ -411,9 +411,12 @@ Required:
 
 - **name** (String) The unique name of the Google Cloud Pub/Sub logging endpoint. It is important to note that changing this attribute will delete and recreate the resource
 - **project_id** (String) The ID of your Google Cloud Platform project
-- **secret_key** (String) Your Google Cloud Platform account secret key. The `private_key` field in your service account authentication JSON
 - **topic** (String) The Google Cloud Pub/Sub topic to which logs will be published
-- **user** (String) Your Google Cloud Platform service account email address. The `client_email` field in your service account authentication JSON
+
+Optional:
+
+- **secret_key** (String, Sensitive) Your Google Cloud Platform account secret key. The `private_key` field in your service account authentication JSON. You may optionally provide this secret via an environment variable, `FASTLY_GOOGLE_PUBSUB_SECRET_KEY`.
+- **user** (String) Your Google Cloud Platform service account email address. The `client_email` field in your service account authentication JSON. You may optionally provide this via an environment variable, `FASTLY_GOOGLE_PUBSUB_EMAIL`.
 
 
 <a id="nestedblock--logging_heroku"></a>

--- a/docs/resources/service_v1.md
+++ b/docs/resources/service_v1.md
@@ -725,9 +725,7 @@ Required:
 
 - **name** (String) The unique name of the Google Cloud Pub/Sub logging endpoint. It is important to note that changing this attribute will delete and recreate the resource
 - **project_id** (String) The ID of your Google Cloud Platform project
-- **secret_key** (String) Your Google Cloud Platform account secret key. The `private_key` field in your service account authentication JSON
 - **topic** (String) The Google Cloud Pub/Sub topic to which logs will be published
-- **user** (String) Your Google Cloud Platform service account email address. The `client_email` field in your service account authentication JSON
 
 Optional:
 
@@ -735,6 +733,8 @@ Optional:
 - **format_version** (Number) The version of the custom logging format used for the configured endpoint. Can be either 1 or 2. (default: 2).
 - **placement** (String) Where in the generated VCL the logging call should be placed.
 - **response_condition** (String) The name of an existing condition in the configured endpoint, or leave blank to always execute.
+- **secret_key** (String, Sensitive) Your Google Cloud Platform account secret key. The `private_key` field in your service account authentication JSON. You may optionally provide this secret via an environment variable, `FASTLY_GOOGLE_PUBSUB_SECRET_KEY`.
+- **user** (String) Your Google Cloud Platform service account email address. The `client_email` field in your service account authentication JSON. You may optionally provide this via an environment variable, `FASTLY_GOOGLE_PUBSUB_EMAIL`.
 
 
 <a id="nestedblock--logging_heroku"></a>

--- a/fastly/block_fastly_service_v1_logging_googlepubsub.go
+++ b/fastly/block_fastly_service_v1_logging_googlepubsub.go
@@ -33,13 +33,16 @@ func (h *GooglePubSubServiceAttributeHandler) Register(s *schema.Resource) error
 		"user": {
 			Type:        schema.TypeString,
 			Required:    true,
-			Description: "Your Google Cloud Platform service account email address. The `client_email` field in your service account authentication JSON",
+			Description: "Your Google Cloud Platform service account email address. The `client_email` field in your service account authentication JSON. You may optionally provide this via an environment variable, `FASTLY_GOOGLE_PUBSUB_EMAIL`.",
+			DefaultFunc: schema.EnvDefaultFunc("FASTLY_GOOGLE_PUBSUB_EMAIL", ""),
 		},
 
 		"secret_key": {
 			Type:        schema.TypeString,
 			Required:    true,
-			Description: "Your Google Cloud Platform account secret key. The `private_key` field in your service account authentication JSON",
+			Description: "Your Google Cloud Platform account secret key. The `private_key` field in your service account authentication JSON. You may optionally provide this secret via an environment variable, `FASTLY_GOOGLE_PUBSUB_SECRET_KEY`.",
+			DefaultFunc: schema.EnvDefaultFunc("FASTLY_GOOGLE_PUBSUB_SECRET_KEY", ""),
+			Sensitive:   true,
 		},
 
 		"project_id": {


### PR DESCRIPTION
This allows users to provide secret values for the Google pub/sub log integration, in a similar way that is already implemented for BigQuery and GCS (via an optional environment variable). Importantly, it also marks the private key as a sensitive value so it won't be logged during plan / apply.

cc @jw2340