### PR TITLE
Fix panic caused by incorrect type assert.

### DIFF
--- a/fastly/block_fastly_service_v1_gzip.go
+++ b/fastly/block_fastly_service_v1_gzip.go
@@ -127,10 +127,24 @@ func (h *GzipServiceAttributeHandler) Process(d *schema.ResourceData, latestVers
 		// this and so we've updated the below code to convert the type asserted
 		// int into a uint before passing the value to gofastly.Uint().
 		if v, ok := modified["content_types"]; ok {
-			opts.ContentTypes = gofastly.String(v.(string))
+			set := v.(*schema.Set)
+			if len(set.List()) > 0 {
+				var s []string
+				for _, elem := range set.List() {
+					s = append(s, elem.(string))
+				}
+				opts.ContentTypes = gofastly.String(strings.Join(s, " "))
+			}
 		}
 		if v, ok := modified["extensions"]; ok {
-			opts.Extensions = gofastly.String(v.(string))
+			set := v.(*schema.Set)
+			if len(set.List()) > 0 {
+				var s []string
+				for _, elem := range set.List() {
+					s = append(s, elem.(string))
+				}
+				opts.Extensions = gofastly.String(strings.Join(s, " "))
+			}
 		}
 		if v, ok := modified["cache_condition"]; ok {
 			opts.CacheCondition = gofastly.String(v.(string))


### PR DESCRIPTION
**Problem**: the gzip resource was [recently migrated to using the `DiffSet` algorithm for determining changes](https://github.com/fastly/terraform-provider-fastly/pull/366), which introduced a bug where we incorrectly were type asserting a Set into a String which would cause a panic at runtime.

**Notes**: the tests didn't catch this because the pre-existing gzip tests were written in such a way that the 'update' test was actually causing the gzip resource to be deleted and recreated anew (because it was modifying the 'name' field) and so I've modified the tests to address this.