### PR TITLE
Allow developer overrides to enable Terraform to locate and use locally built provider

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -16,7 +16,8 @@ TEST_PARALLELISM?=4
 default: build
 
 build:
-	go install -ldflags="-X $(FULL_PKG_NAME)/$(VERSION_PLACEHOLDER)=$(VERSION)"
+	go build -o bin/terraform-provider-$(PKG_NAME)_$(VERSION) -ldflags="-X $(FULL_PKG_NAME)/$(VERSION_PLACEHOLDER)=$(VERSION)"
+	@sh -c "'$(CURDIR)/scripts/generate-dev-overrides.sh'"
 
 test:
 	go test -i $(TEST) || exit 1
@@ -74,4 +75,7 @@ sweep:
 	@echo "WARNING: This will destroy infrastructure. Use only in development accounts."
 	go test ./fastly -v -sweep=ALL $(SWEEPARGS) -timeout 30m
 
-.PHONY: build test testacc vet fmt fmtcheck errcheck test-compile sweep validate-docs generate-docs
+clean:
+	rm -rf ./bin
+
+.PHONY: build test testacc vet fmt fmtcheck errcheck test-compile sweep validate-docs generate-docs clean

--- a/README.md
+++ b/README.md
@@ -31,14 +31,16 @@ $ make build
 
 If you wish to work on the provider, you'll first need [Go](http://www.golang.org) installed on your machine (version 1.14+ is *required*).
 
-To compile the provider, run `make build`. This will build the provider and put the provider binary in the `$GOPATH/bin` directory.
+To compile the provider, run `make build`. This will build the provider and put the provider binary in a local `bin` directory.
 
 ```sh
 $ make build
 ...
-$ $GOPATH/bin/terraform-provider-fastly
-...
 ```
+
+Alongside the newly built binary a file called `developer_overrides.tfrc` will be created.  The `make build` target will communicate 
+back details for setting the `TF_CLI_CONFIG_FILE` environment variable that will enable Terraform to use your locally built provider binary.
+* HashiCorp - [Development Overrides for Provider developers](https://www.terraform.io/docs/cli/config/config-file.html#development-overrides-for-provider-developers). 
 
 ## Testing
 

--- a/scripts/generate-dev-overrides.sh
+++ b/scripts/generate-dev-overrides.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 
 BIN_DIR=$PWD/bin
+OVERRIDES_FILENAME=developer_overrides.tfrc
 
-cat << EOF > $BIN_DIR/developer_overrides.tfrc
+cat << EOF > $BIN_DIR/$OVERRIDES_FILENAME
 provider_installation {
 
   dev_overrides {
@@ -14,8 +15,8 @@ provider_installation {
 EOF
 
 echo ""
-echo "A development overrides file has been generated at ./bin/developer_overrides.tfrc."
+echo "A development overrides file has been generated at ./bin/$OVERRIDES_FILENAME."
 echo "To make Terraform temporarily use your locally built version of the provider, set TF_CLI_CONFIG_FILE within your terminal"
 echo ""
-printf "\texport TF_CLI_CONFIG_FILE=$BIN_DIR/developer_overrides.tfrc"
+printf "\texport TF_CLI_CONFIG_FILE=$BIN_DIR/$OVERRIDES_FILENAME"
 echo ""

--- a/scripts/generate-dev-overrides.sh
+++ b/scripts/generate-dev-overrides.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+BIN_DIR=$PWD/bin
+
+cat << EOF > $BIN_DIR/developer_overrides.tfrc
+provider_installation {
+
+  dev_overrides {
+    "fastly/fastly" = "$BIN_DIR"
+  }
+
+  direct {}
+}
+EOF
+
+echo ""
+echo "A development overrides file has been generated at ./bin/developer_overrides.tfrc."
+echo "To make Terraform temporarily use your locally built version of the provider, set TF_CLI_CONFIG_FILE within your terminal"
+echo ""
+printf "\texport TF_CLI_CONFIG_FILE=$BIN_DIR/developer_overrides.tfrc"
+echo ""


### PR DESCRIPTION
This PR is focused on enabling Terraform to discover a locally built provider binary through the developer overrides mechanism.  The PR introduces a new script to generate a overrides files that references a local provider binary.
Updates include

- Update Makefile to build binary into local bin directory
- Generate a developer overrides file alongside provider binary
- Returns environment variable line to instruct Terraform to use overrides file and binary
- Updates README.md to cover local build and execution.
