### PR TITLE
Terraform 0.11 and earlier required all non-constant expressions to be provided via interpolation syntax

### DIFF
--- a/docs/data-sources/ip_ranges.md
+++ b/docs/data-sources/ip_ranges.md
@@ -22,8 +22,8 @@ resource "aws_security_group" "from_fastly" {
     from_port         = "443"
     to_port           = "443"
     protocol          = "tcp"
-    cidr_blocks       = [data.fastly_ip_ranges.fastly.cidr_blocks]
-    ipv6_cidr_blocks  = [data.fastly_ip_ranges.fastly.ipv6_cidr_blocks]
+    cidr_blocks       = data.fastly_ip_ranges.fastly.cidr_blocks
+    ipv6_cidr_blocks  = data.fastly_ip_ranges.fastly.ipv6_cidr_blocks
   }
 }
 ```

--- a/docs/data-sources/ip_ranges.md
+++ b/docs/data-sources/ip_ranges.md
@@ -22,8 +22,8 @@ resource "aws_security_group" "from_fastly" {
     from_port         = "443"
     to_port           = "443"
     protocol          = "tcp"
-    cidr_blocks       = ["${data.fastly_ip_ranges.fastly.cidr_blocks}"]
-    ipv6_cidr_blocks  = ["${data.fastly_ip_ranges.fastly.ipv6_cidr_blocks}"]
+    cidr_blocks       = [data.fastly_ip_ranges.fastly.cidr_blocks]
+    ipv6_cidr_blocks  = [data.fastly_ip_ranges.fastly.ipv6_cidr_blocks]
   }
 }
 ```

--- a/templates/data-sources/ip_ranges.md.tmpl
+++ b/templates/data-sources/ip_ranges.md.tmpl
@@ -22,8 +22,8 @@ resource "aws_security_group" "from_fastly" {
     from_port         = "443"
     to_port           = "443"
     protocol          = "tcp"
-    cidr_blocks       = [data.fastly_ip_ranges.fastly.cidr_blocks]
-    ipv6_cidr_blocks  = [data.fastly_ip_ranges.fastly.ipv6_cidr_blocks]
+    cidr_blocks       = data.fastly_ip_ranges.fastly.cidr_blocks
+    ipv6_cidr_blocks  = data.fastly_ip_ranges.fastly.ipv6_cidr_blocks
   }
 }
 ```

--- a/templates/data-sources/ip_ranges.md.tmpl
+++ b/templates/data-sources/ip_ranges.md.tmpl
@@ -22,8 +22,8 @@ resource "aws_security_group" "from_fastly" {
     from_port         = "443"
     to_port           = "443"
     protocol          = "tcp"
-    cidr_blocks       = ["${data.fastly_ip_ranges.fastly.cidr_blocks}"]
-    ipv6_cidr_blocks  = ["${data.fastly_ip_ranges.fastly.ipv6_cidr_blocks}"]
+    cidr_blocks       = [data.fastly_ip_ranges.fastly.cidr_blocks]
+    ipv6_cidr_blocks  = [data.fastly_ip_ranges.fastly.ipv6_cidr_blocks]
   }
 }
 ```


### PR DESCRIPTION
Terraform 0.11 and earlier required all non-constant expressions to be
provided via interpolation syntax, but this pattern is now deprecated. To
silence this warning, remove the "${ sequence from the start and the }"
sequence from the end of this expression, leaving just the inner expression.

Template interpolation syntax is still used to construct strings from
expressions when the template includes multiple interpolation sequences or a
mixture of literal strings and interpolations. This deprecation applies only
to templates that consist entirely of a single interpolation sequence.