### PR TITLE
Misleading diff bug, output variable refresh bug, support for plugin debug mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,23 @@ Alongside the newly built binary a file called `developer_overrides.tfrc` will b
 back details for setting the `TF_CLI_CONFIG_FILE` environment variable that will enable Terraform to use your locally built provider binary.
 * HashiCorp - [Development Overrides for Provider developers](https://www.terraform.io/docs/cli/config/config-file.html#development-overrides-for-provider-developers). 
 
+Alternatively, you can run the provider directly and tell Terraform how to communicate it with an environment variable.
+This is useful for attaching a debugger like [delve](https://github.com/go-delve/delve) to the provider.
+To do this, make sure the provider is built and present in the local `bin` directory (see above).
+Then, run the provider executable directly with the `--debug` flag.
+
+```sh
+$ ./bin/terraform-provider-fastly_v99.99.99 --debug
+{"@level":"debug","@message":"plugin address","@timestamp":"2021-03-25T14:35:39.743300Z","address":"/var/folders/qm/swg2hbnsjeutpyoansditmb6m0000gn/T/plugin276728528","network":"unix"}
+Provider started, to attach Terraform set the TF_REATTACH_PROVIDERS env var:
+
+        TF_REATTACH_PROVIDERS='{"fastly/fastly":{"Protocol":"grpc","Pid":78541,"Test":true,"Addr":{"Network":"unix","String":"/var/folders/qm/swg2hbnsjeutpyoansditmb6m0000gn/T/plugin276728528"}}}'
+
+```
+
+As the message instructs, set the `TF_REATTACH_PROVIDERS` environment variable in the shell where `terraform` will be run.
+This should enable the locally built version of the provider to be used instead of the officially released one.
+
 ## Testing
 
 In order to test the provider, you can simply run `make test`.

--- a/fastly/block_fastly_service_v1_backend.go
+++ b/fastly/block_fastly_service_v1_backend.go
@@ -318,6 +318,7 @@ func (h *BackendServiceAttributeHandler) Register(s *schema.Resource) error {
 		"override_host": {
 			Type:        schema.TypeString,
 			Optional:    true,
+			Default:     "",
 			Description: "The hostname to override the Host header",
 		},
 		"shield": {

--- a/fastly/block_fastly_service_v1_bigquerylogging_test.go
+++ b/fastly/block_fastly_service_v1_bigquerylogging_test.go
@@ -145,7 +145,7 @@ resource "fastly_service_v1" "foo" {
   bigquerylogging {
     name       = "%s"
     email      = "email@example.com"
-    secret_key = trimspace(%q)
+    secret_key = %q
     project_id = "example-gcp-project"
     dataset    = "example_bq_dataset"
     table      = "example_bq_table"
@@ -177,7 +177,7 @@ resource "fastly_service_compute" "foo" {
   bigquerylogging {
     name       = "%s"
     email      = "email@example.com"
-    secret_key = trimspace(%q)
+    secret_key = %q
     project_id = "example-gcp-project"
     dataset    = "example_bq_dataset"
     table      = "example_bq_table"

--- a/fastly/block_fastly_service_v1_bigquerylogging_test.go
+++ b/fastly/block_fastly_service_v1_bigquerylogging_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"strings"
 	"testing"
 
 	gofastly "github.com/fastly/go-fastly/v3/fastly"
@@ -76,7 +77,7 @@ func TestAccFastlyServiceV1_bigquerylogging_env(t *testing.T) {
 	}
 
 	// set env Vars to something we expect
-	resetEnv := setBQEnv("someEnv", secretKey, t)
+	resetEnv := setBQEnv("someEnv", strings.TrimSpace(secretKey), t)
 	defer resetEnv()
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -144,7 +145,7 @@ resource "fastly_service_v1" "foo" {
   bigquerylogging {
     name       = "%s"
     email      = "email@example.com"
-    secret_key = %q
+    secret_key = trimspace(%q)
     project_id = "example-gcp-project"
     dataset    = "example_bq_dataset"
     table      = "example_bq_table"
@@ -176,7 +177,7 @@ resource "fastly_service_compute" "foo" {
   bigquerylogging {
     name       = "%s"
     email      = "email@example.com"
-    secret_key = %q
+    secret_key = trimspace(%q)
     project_id = "example-gcp-project"
     dataset    = "example_bq_dataset"
     table      = "example_bq_table"

--- a/fastly/block_fastly_service_v1_blobstoragelogging.go
+++ b/fastly/block_fastly_service_v1_blobstoragelogging.go
@@ -70,20 +70,6 @@ func (h *BlobStorageLoggingServiceAttributeHandler) Process(d *schema.ResourceDa
 	for _, resource := range diffResult.Added {
 		resource := resource.(map[string]interface{})
 
-		// @HACK for a TF SDK Issue.
-		//
-		// This ensures that the required, `name`, field is present.
-		//
-		// If we have made it this far and `name` is not present, it is most-likely due
-		// to a defunct diff as noted here - https://github.com/hashicorp/terraform-plugin-sdk/issues/160#issuecomment-522935697.
-		//
-		// This is caused by using a StateFunc in a nested TypeSet. While the StateFunc
-		// properly handles setting state with the StateFunc, it returns extra entries
-		// during state Gets, specifically `GetChange("blobstoragelogging")` in this case.
-		if v, ok := resource["name"]; !ok || v.(string) == "" {
-			continue
-		}
-
 		var vla = h.getVCLLoggingAttributes(resource)
 		opts := gofastly.CreateBlobStorageInput{
 			ServiceID:         d.Id(),
@@ -262,8 +248,6 @@ func (h *BlobStorageLoggingServiceAttributeHandler) Register(s *schema.Resource)
 			Type:        schema.TypeString,
 			Optional:    true,
 			Description: "A PGP public key that Fastly will use to encrypt your log files before writing them to disk",
-			// Related issue for weird behavior - https://github.com/hashicorp/terraform-plugin-sdk/issues/160
-			StateFunc: trimSpaceStateFunc,
 		},
 		"message_type": {
 			Type:             schema.TypeString,

--- a/fastly/block_fastly_service_v1_httpslogging.go
+++ b/fastly/block_fastly_service_v1_httpslogging.go
@@ -250,8 +250,6 @@ func (h *HTTPSLoggingServiceAttributeHandler) Register(s *schema.Resource) error
 			Optional:    true,
 			Description: "A secure certificate to authenticate the server with. Must be in PEM format",
 			Sensitive:   true,
-			// Related issue for weird behavior - https://github.com/hashicorp/terraform-plugin-sdk/issues/160
-			StateFunc: trimSpaceStateFunc,
 		},
 
 		"tls_client_cert": {
@@ -259,8 +257,6 @@ func (h *HTTPSLoggingServiceAttributeHandler) Register(s *schema.Resource) error
 			Optional:    true,
 			Description: "The client certificate used to make authenticated requests. Must be in PEM format",
 			Sensitive:   true,
-			// Related issue for weird behavior - https://github.com/hashicorp/terraform-plugin-sdk/issues/160
-			StateFunc: trimSpaceStateFunc,
 		},
 
 		"tls_client_key": {
@@ -268,8 +264,6 @@ func (h *HTTPSLoggingServiceAttributeHandler) Register(s *schema.Resource) error
 			Optional:    true,
 			Description: "The client private key used to make authenticated requests. Must be in PEM format",
 			Sensitive:   true,
-			// Related issue for weird behavior - https://github.com/hashicorp/terraform-plugin-sdk/issues/160
-			StateFunc: trimSpaceStateFunc,
 		},
 
 		"tls_hostname": {

--- a/fastly/block_fastly_service_v1_logging_cloudfiles.go
+++ b/fastly/block_fastly_service_v1_logging_cloudfiles.go
@@ -64,19 +64,6 @@ func (h *CloudfilesServiceAttributeHandler) Process(d *schema.ResourceData, late
 	for _, resource := range diffResult.Added {
 		resource := resource.(map[string]interface{})
 
-		// @HACK for a TF SDK Issue.
-		//
-		// This ensures that the required, `name`, field is present.
-		//
-		// If we have made it this far and `name` is not present, it is most-likely due
-		// to a defunct diff as noted here - https://github.com/hashicorp/terraform-plugin-sdk/issues/160#issuecomment-522935697.
-		//
-		// This is caused by using a StateFunc in a nested TypeSet. While the StateFunc
-		// properly handles setting state with the StateFunc, it returns extra entries
-		// during state Gets, specifically `GetChange("logging_cloudfiles")` in this case.
-		if v, ok := resource["name"]; !ok || v.(string) == "" {
-			continue
-		}
 		opts := h.buildCreate(resource, serviceID, latestVersion)
 
 		log.Printf("[DEBUG] Fastly Cloud Files logging addition opts: %#v", opts)
@@ -311,8 +298,6 @@ func (h *CloudfilesServiceAttributeHandler) Register(s *schema.Resource) error {
 			Type:        schema.TypeString,
 			Optional:    true,
 			Description: "The PGP public key that Fastly will use to encrypt your log files before writing them to disk",
-			// Related issue for weird behavior - https://github.com/hashicorp/terraform-plugin-sdk/issues/160
-			StateFunc: trimSpaceStateFunc,
 		},
 
 		"gzip_level": {

--- a/fastly/block_fastly_service_v1_logging_digitalocean.go
+++ b/fastly/block_fastly_service_v1_logging_digitalocean.go
@@ -64,20 +64,6 @@ func (h *DigitalOceanServiceAttributeHandler) Process(d *schema.ResourceData, la
 	for _, resource := range diffResult.Added {
 		resource := resource.(map[string]interface{})
 
-		// @HACK for a TF SDK Issue.
-		//
-		// This ensures that the required, `name`, field is present.
-		//
-		// If we have made it this far and `name` is not present, it is most-likely due
-		// to a defunct diff as noted here - https://github.com/hashicorp/terraform-plugin-sdk/issues/160#issuecomment-522935697.
-		//
-		// This is caused by using a StateFunc in a nested TypeSet. While the StateFunc
-		// properly handles setting state with the StateFunc, it returns extra entries
-		// during state Gets, specifically `GetChange("logging_digitalocean")` in this case.
-		if v, ok := resource["name"]; !ok || v.(string) == "" {
-			continue
-		}
-
 		opts := h.buildCreate(resource, serviceID, latestVersion)
 
 		log.Printf("[DEBUG] Fastly DigitalOcean Spaces logging addition opts: %#v", opts)
@@ -320,8 +306,6 @@ func (h *DigitalOceanServiceAttributeHandler) Register(s *schema.Resource) error
 			Type:        schema.TypeString,
 			Optional:    true,
 			Description: "A PGP public key that Fastly will use to encrypt your log files before writing them to disk",
-			// Related issue for weird behavior - https://github.com/hashicorp/terraform-plugin-sdk/issues/160
-			StateFunc: trimSpaceStateFunc,
 		},
 
 		"path": {

--- a/fastly/block_fastly_service_v1_logging_elasticsearch.go
+++ b/fastly/block_fastly_service_v1_logging_elasticsearch.go
@@ -234,8 +234,6 @@ func (h *ElasticSearchServiceAttributeHandler) Register(s *schema.Resource) erro
 			Optional:    true,
 			Description: "A secure certificate to authenticate the server with. Must be in PEM format",
 			Sensitive:   true,
-			// Related issue for weird behavior - https://github.com/hashicorp/terraform-plugin-sdk/issues/160
-			StateFunc: trimSpaceStateFunc,
 		},
 
 		"tls_client_cert": {
@@ -243,8 +241,6 @@ func (h *ElasticSearchServiceAttributeHandler) Register(s *schema.Resource) erro
 			Optional:    true,
 			Description: "The client certificate used to make authenticated requests. Must be in PEM format",
 			Sensitive:   true,
-			// Related issue for weird behavior - https://github.com/hashicorp/terraform-plugin-sdk/issues/160
-			StateFunc: trimSpaceStateFunc,
 		},
 
 		"tls_client_key": {
@@ -252,8 +248,6 @@ func (h *ElasticSearchServiceAttributeHandler) Register(s *schema.Resource) erro
 			Optional:    true,
 			Description: "The client private key used to make authenticated requests. Must be in PEM format",
 			Sensitive:   true,
-			// Related issue for weird behavior - https://github.com/hashicorp/terraform-plugin-sdk/issues/160
-			StateFunc: trimSpaceStateFunc,
 		},
 
 		"tls_hostname": {

--- a/fastly/block_fastly_service_v1_logging_ftp.go
+++ b/fastly/block_fastly_service_v1_logging_ftp.go
@@ -64,20 +64,6 @@ func (h *FTPServiceAttributeHandler) Process(d *schema.ResourceData, latestVersi
 	for _, resource := range diffResult.Added {
 		resource := resource.(map[string]interface{})
 
-		// @HACK for a TF SDK Issue.
-		//
-		// This ensures that the required, `name`, field is present.
-		//
-		// If we have made it this far and `name` is not present, it is most-likely due
-		// to a defunct diff as noted here - https://github.com/hashicorp/terraform-plugin-sdk/issues/160#issuecomment-522935697.
-		//
-		// This is caused by using a StateFunc in a nested TypeSet. While the StateFunc
-		// properly handles setting state with the StateFunc, it returns extra entries
-		// during state Gets, specifically `GetChange("logging_ftp")` in this case.
-		if v, ok := resource["name"]; !ok || v.(string) == "" {
-			continue
-		}
-
 		opts := h.buildCreate(resource, serviceID, latestVersion)
 
 		log.Printf("[DEBUG] Fastly FTP logging addition opts: %#v", opts)
@@ -242,8 +228,6 @@ func (h *FTPServiceAttributeHandler) Register(s *schema.Resource) error {
 			Type:        schema.TypeString,
 			Optional:    true,
 			Description: "The PGP public key that Fastly will use to encrypt your log files before writing them to disk",
-			// Related issue for weird behavior - https://github.com/hashicorp/terraform-plugin-sdk/issues/160
-			StateFunc: trimSpaceStateFunc,
 		},
 
 		"gzip_level": {

--- a/fastly/block_fastly_service_v1_logging_kafka.go
+++ b/fastly/block_fastly_service_v1_logging_kafka.go
@@ -67,8 +67,6 @@ func (h *KafkaServiceAttributeHandler) Register(s *schema.Resource) error {
 			Optional:    true,
 			Description: "A secure certificate to authenticate the server with. Must be in PEM format",
 			Sensitive:   true,
-			// Related issue for weird behavior - https://github.com/hashicorp/terraform-plugin-sdk/issues/160
-			StateFunc: trimSpaceStateFunc,
 		},
 
 		"tls_client_cert": {
@@ -76,8 +74,6 @@ func (h *KafkaServiceAttributeHandler) Register(s *schema.Resource) error {
 			Optional:    true,
 			Description: "The client certificate used to make authenticated requests. Must be in PEM format",
 			Sensitive:   true,
-			// Related issue for weird behavior - https://github.com/hashicorp/terraform-plugin-sdk/issues/160
-			StateFunc: trimSpaceStateFunc,
 		},
 
 		"tls_client_key": {
@@ -85,8 +81,6 @@ func (h *KafkaServiceAttributeHandler) Register(s *schema.Resource) error {
 			Optional:    true,
 			Description: "The client private key used to make authenticated requests. Must be in PEM format",
 			Sensitive:   true,
-			// Related issue for weird behavior - https://github.com/hashicorp/terraform-plugin-sdk/issues/160
-			StateFunc: trimSpaceStateFunc,
 		},
 
 		"tls_hostname": {
@@ -205,20 +199,6 @@ func (h *KafkaServiceAttributeHandler) Process(d *schema.ResourceData, latestVer
 	// CREATE new resources
 	for _, resource := range diffResult.Added {
 		resource := resource.(map[string]interface{})
-
-		// @HACK for a TF SDK Issue.
-		//
-		// This ensures that the required, `name`, field is present.
-		//
-		// If we have made it this far and `name` is not present, it is most-likely due
-		// to a defunct diff as noted here - https://github.com/hashicorp/terraform-plugin-sdk/issues/160#issuecomment-522935697.
-		//
-		// This is caused by using a StateFunc in a nested TypeSet. While the StateFunc
-		// properly handles setting state with the StateFunc, it returns extra entries
-		// during state Gets, specifically `GetChange("logging_kafka")` in this case.
-		if v, ok := resource["name"]; !ok || v.(string) == "" {
-			continue
-		}
 
 		opts := h.buildCreate(resource, serviceID, latestVersion)
 

--- a/fastly/block_fastly_service_v1_logging_openstack.go
+++ b/fastly/block_fastly_service_v1_logging_openstack.go
@@ -64,20 +64,6 @@ func (h *OpenstackServiceAttributeHandler) Process(d *schema.ResourceData, lates
 	for _, resource := range diffResult.Added {
 		resource := resource.(map[string]interface{})
 
-		// @HACK for a TF SDK Issue.
-		//
-		// This ensures that the required, `name`, field is present.
-		//
-		// If we have made it this far and `name` is not present, it is most-likely due
-		// to a defunct diff as noted here - https://github.com/hashicorp/terraform-plugin-sdk/issues/160#issuecomment-522935697.
-		//
-		// This is caused by using a StateFunc in a nested TypeSet. While the StateFunc
-		// properly handles setting state with the StateFunc, it returns extra entries
-		// during state Gets, specifically `GetChange("logging_openstack")` in this case.
-		if v, ok := resource["name"]; !ok || v.(string) == "" {
-			continue
-		}
-
 		opts := h.buildCreate(resource, serviceID, latestVersion)
 
 		log.Printf("[DEBUG] Fastly OpenStack logging addition opts: %#v", opts)
@@ -321,8 +307,6 @@ func (h *OpenstackServiceAttributeHandler) Register(s *schema.Resource) error {
 			Type:        schema.TypeString,
 			Optional:    true,
 			Description: "A PGP public key that Fastly will use to encrypt your log files before writing them to disk",
-			// Related issue for weird behavior - https://github.com/hashicorp/terraform-plugin-sdk/issues/160
-			StateFunc: trimSpaceStateFunc,
 		},
 
 		"gzip_level": {

--- a/fastly/block_fastly_service_v1_logging_sftp.go
+++ b/fastly/block_fastly_service_v1_logging_sftp.go
@@ -74,16 +74,12 @@ func (h *SFTPServiceAttributeHandler) Register(s *schema.Resource) error {
 			Optional:    true,
 			Description: "The SSH private key for the server. If both `password` and `secret_key` are passed, `secret_key` will be preferred",
 			Sensitive:   true,
-			// Related issue for weird behavior - https://github.com/hashicorp/terraform-plugin-sdk/issues/160
-			StateFunc: trimSpaceStateFunc,
 		},
 
 		"public_key": {
 			Type:        schema.TypeString,
 			Optional:    true,
 			Description: "A PGP public key that Fastly will use to encrypt your log files before writing them to disk",
-			// Related issue for weird behavior - https://github.com/hashicorp/terraform-plugin-sdk/issues/160
-			StateFunc: trimSpaceStateFunc,
 		},
 
 		"period": {
@@ -195,20 +191,6 @@ func (h *SFTPServiceAttributeHandler) Process(d *schema.ResourceData, latestVers
 	// CREATE new resources
 	for _, resource := range diffResult.Added {
 		resource := resource.(map[string]interface{})
-
-		// @HACK for a TF SDK Issue.
-		//
-		// This ensures that the required, `name`, field is present.
-		//
-		// If we have made it this far and `name` is not present, it is most-likely due
-		// to a defunct diff as noted here - https://github.com/hashicorp/terraform-plugin-sdk/issues/160#issuecomment-522935697.
-		//
-		// This is caused by using a StateFunc in a nested TypeSet. While the StateFunc
-		// properly handles setting state with the StateFunc, it returns extra entries
-		// during state Gets, specifically `GetChange("logging_sftp")` in this case.
-		if v, ok := resource["name"]; !ok || v.(string) == "" {
-			continue
-		}
 
 		opts := h.buildCreate(resource, serviceID, latestVersion)
 

--- a/fastly/block_fastly_service_v1_s3logging.go
+++ b/fastly/block_fastly_service_v1_s3logging.go
@@ -65,20 +65,6 @@ func (h *S3LoggingServiceAttributeHandler) Process(d *schema.ResourceData, lates
 			return err
 		}
 
-		// @HACK for a TF SDK Issue.
-		//
-		// This ensures that the required, `name`, field is present.
-		//
-		// If we have made it this far and `name` is not present, it is most-likely due
-		// to a defunct diff as noted here - https://github.com/hashicorp/terraform-plugin-sdk/issues/160#issuecomment-522935697.
-		//
-		// This is caused by using a StateFunc in a nested TypeSet. While the StateFunc
-		// properly handles setting state with the StateFunc, it returns extra entries
-		// during state Gets, specifically `GetChange("s3logging")` in this case.
-		if opts.Name == "" {
-			continue
-		}
-
 		err = createS3(conn, opts)
 		if err != nil {
 			return err
@@ -262,8 +248,6 @@ func (h *S3LoggingServiceAttributeHandler) Register(s *schema.Resource) error {
 			Type:        schema.TypeString,
 			Optional:    true,
 			Description: "A PGP public key that Fastly will use to encrypt your log files before writing them to disk",
-			// Related issue for weird behavior - https://github.com/hashicorp/terraform-plugin-sdk/issues/160
-			StateFunc: trimSpaceStateFunc,
 		},
 		"message_type": {
 			Type:             schema.TypeString,

--- a/fastly/block_fastly_service_v1_splunk.go
+++ b/fastly/block_fastly_service_v1_splunk.go
@@ -70,20 +70,6 @@ func (h *SplunkServiceAttributeHandler) Process(d *schema.ResourceData, latestVe
 	for _, resource := range diffResult.Added {
 		resource := resource.(map[string]interface{})
 
-		// @HACK for a TF SDK Issue.
-		//
-		// This ensures that the required, `name`, field is present.
-		//
-		// If we have made it this far and `name` is not present, it is most-likely due
-		// to a defunct diff as noted here - https://github.com/hashicorp/terraform-plugin-sdk/issues/160#issuecomment-522935697.
-		//
-		// This is caused by using a StateFunc in a nested TypeSet. While the StateFunc
-		// properly handles setting state with the StateFunc, it returns extra entries
-		// during state Gets, specifically `GetChange("splunk")` in this case.
-		if v, ok := resource["name"]; !ok || v.(string) == "" {
-			continue
-		}
-
 		var vla = h.getVCLLoggingAttributes(resource)
 		opts := gofastly.CreateSplunkInput{
 			ServiceID:         d.Id(),

--- a/fastly/statefuncs.go
+++ b/fastly/statefuncs.go
@@ -1,7 +1,0 @@
-package fastly
-
-import "strings"
-
-func trimSpaceStateFunc(v interface{}) string {
-	return strings.TrimSpace(v.(string))
-}

--- a/main.go
+++ b/main.go
@@ -1,11 +1,30 @@
 package main
 
 import (
-	"github.com/fastly/terraform-provider-fastly/fastly"
+	"context"
+	"flag"
+	"log"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
+
+	"github.com/fastly/terraform-provider-fastly/fastly"
 )
 
 func main() {
-	plugin.Serve(&plugin.ServeOpts{
-		ProviderFunc: fastly.Provider})
+	var debugMode bool
+
+	flag.BoolVar(&debugMode, "debug", false, "set to true to run the provider with support for debuggers like delve")
+	flag.Parse()
+
+	opts := &plugin.ServeOpts{ProviderFunc: fastly.Provider}
+
+	if debugMode {
+		err := plugin.Debug(context.Background(), "fastly/fastly", opts)
+		if err != nil {
+			log.Fatal(err.Error())
+		}
+		return
+	}
+
+	plugin.Serve(opts)
 }

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff/compose.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff/compose.go
@@ -1,0 +1,75 @@
+package customdiff
+
+import (
+	"context"
+
+	"github.com/hashicorp/go-multierror"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// All returns a CustomizeDiffFunc that runs all of the given
+// CustomizeDiffFuncs and returns all of the errors produced.
+//
+// If one function produces an error, functions after it are still run.
+// If this is not desirable, use function Sequence instead.
+//
+// If multiple functions returns errors, the result is a multierror.
+//
+// For example:
+//
+//     &schema.Resource{
+//         // ...
+//         CustomizeDiff: customdiff.All(
+//             customdiff.ValidateChange("size", func (old, new, meta interface{}) error {
+//                 // If we are increasing "size" then the new value must be
+//                 // a multiple of the old value.
+//                 if new.(int) <= old.(int) {
+//                     return nil
+//                 }
+//                 if (new.(int) % old.(int)) != 0 {
+//                     return fmt.Errorf("new size value must be an integer multiple of old value %d", old.(int))
+//                 }
+//                 return nil
+//             }),
+//             customdiff.ForceNewIfChange("size", func (old, new, meta interface{}) bool {
+//                 // "size" can only increase in-place, so we must create a new resource
+//                 // if it is decreased.
+//                 return new.(int) < old.(int)
+//             }),
+//             customdiff.ComputedIf("version_id", func (d *schema.ResourceDiff, meta interface{}) bool {
+//                 // Any change to "content" causes a new "version_id" to be allocated.
+//                 return d.HasChange("content")
+//             }),
+//         ),
+//     }
+//
+func All(funcs ...schema.CustomizeDiffFunc) schema.CustomizeDiffFunc {
+	return func(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
+		var err error
+		for _, f := range funcs {
+			thisErr := f(ctx, d, meta)
+			if thisErr != nil {
+				err = multierror.Append(err, thisErr)
+			}
+		}
+		return err
+	}
+}
+
+// Sequence returns a CustomizeDiffFunc that runs all of the given
+// CustomizeDiffFuncs in sequence, stopping at the first one that returns
+// an error and returning that error.
+//
+// If all functions succeed, the combined function also succeeds.
+func Sequence(funcs ...schema.CustomizeDiffFunc) schema.CustomizeDiffFunc {
+	return func(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
+		for _, f := range funcs {
+			err := f(ctx, d, meta)
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+}

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff/computed.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff/computed.go
@@ -1,0 +1,18 @@
+package customdiff
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// ComputedIf returns a CustomizeDiffFunc that sets the given key's new value
+// as computed if the given condition function returns true.
+func ComputedIf(key string, f ResourceConditionFunc) schema.CustomizeDiffFunc {
+	return func(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
+		if f(ctx, d, meta) {
+			d.SetNewComputed(key)
+		}
+		return nil
+	}
+}

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff/condition.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff/condition.go
@@ -1,0 +1,62 @@
+package customdiff
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// ResourceConditionFunc is a function type that makes a boolean decision based
+// on an entire resource diff.
+type ResourceConditionFunc func(ctx context.Context, d *schema.ResourceDiff, meta interface{}) bool
+
+// ValueChangeConditionFunc is a function type that makes a boolean decision
+// by comparing two values.
+type ValueChangeConditionFunc func(ctx context.Context, old, new, meta interface{}) bool
+
+// ValueConditionFunc is a function type that makes a boolean decision based
+// on a given value.
+type ValueConditionFunc func(ctx context.Context, value, meta interface{}) bool
+
+// If returns a CustomizeDiffFunc that calls the given condition
+// function and then calls the given CustomizeDiffFunc only if the condition
+// function returns true.
+//
+// This can be used to include conditional customizations when composing
+// customizations using All and Sequence, but should generally be used only in
+// simple scenarios. Prefer directly writing a CustomizeDiffFunc containing
+// a conditional branch if the given CustomizeDiffFunc is already a
+// locally-defined function, since this avoids obscuring the control flow.
+func If(cond ResourceConditionFunc, f schema.CustomizeDiffFunc) schema.CustomizeDiffFunc {
+	return func(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
+		if cond(ctx, d, meta) {
+			return f(ctx, d, meta)
+		}
+		return nil
+	}
+}
+
+// IfValueChange returns a CustomizeDiffFunc that calls the given condition
+// function with the old and new values of the given key and then calls the
+// given CustomizeDiffFunc only if the condition function returns true.
+func IfValueChange(key string, cond ValueChangeConditionFunc, f schema.CustomizeDiffFunc) schema.CustomizeDiffFunc {
+	return func(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
+		old, new := d.GetChange(key)
+		if cond(ctx, old, new, meta) {
+			return f(ctx, d, meta)
+		}
+		return nil
+	}
+}
+
+// IfValue returns a CustomizeDiffFunc that calls the given condition
+// function with the new values of the given key and then calls the
+// given CustomizeDiffFunc only if the condition function returns true.
+func IfValue(key string, cond ValueConditionFunc, f schema.CustomizeDiffFunc) schema.CustomizeDiffFunc {
+	return func(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
+		if cond(ctx, d.Get(key), meta) {
+			return f(ctx, d, meta)
+		}
+		return nil
+	}
+}

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff/doc.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff/doc.go
@@ -1,0 +1,11 @@
+// Package customdiff provides a set of reusable and composable functions
+// to enable more "declarative" use of the CustomizeDiff mechanism available
+// for resources in package helper/schema.
+//
+// The intent of these helpers is to make the intent of a set of diff
+// customizations easier to see, rather than lost in a sea of Go function
+// boilerplate. They should _not_ be used in situations where they _obscure_
+// intent, e.g. by over-using the composition functions where a single
+// function containing normal Go control flow statements would be more
+// straightforward.
+package customdiff

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff/force_new.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff/force_new.go
@@ -1,0 +1,42 @@
+package customdiff
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// ForceNewIf returns a CustomizeDiffFunc that flags the given key as
+// requiring a new resource if the given condition function returns true.
+//
+// The return value of the condition function is ignored if the old and new
+// values of the field compare equal, since no attribute diff is generated in
+// that case.
+func ForceNewIf(key string, f ResourceConditionFunc) schema.CustomizeDiffFunc {
+	return func(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
+		if f(ctx, d, meta) {
+			d.ForceNew(key)
+		}
+		return nil
+	}
+}
+
+// ForceNewIfChange returns a CustomizeDiffFunc that flags the given key as
+// requiring a new resource if the given condition function returns true.
+//
+// The return value of the condition function is ignored if the old and new
+// values compare equal, since no attribute diff is generated in that case.
+//
+// This function is similar to ForceNewIf but provides the condition function
+// only the old and new values of the given key, which leads to more compact
+// and explicit code in the common case where the decision can be made with
+// only the specific field value.
+func ForceNewIfChange(key string, f ValueChangeConditionFunc) schema.CustomizeDiffFunc {
+	return func(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
+		old, new := d.GetChange(key)
+		if f(ctx, old, new, meta) {
+			d.ForceNew(key)
+		}
+		return nil
+	}
+}

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff/validate.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff/validate.go
@@ -1,0 +1,40 @@
+package customdiff
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// ValueChangeValidationFunc is a function type that validates the difference
+// (or lack thereof) between two values, returning an error if the change
+// is invalid.
+type ValueChangeValidationFunc func(ctx context.Context, old, new, meta interface{}) error
+
+// ValueValidationFunc is a function type that validates a particular value,
+// returning an error if the value is invalid.
+type ValueValidationFunc func(ctx context.Context, value, meta interface{}) error
+
+// ValidateChange returns a CustomizeDiffFunc that applies the given validation
+// function to the change for the given key, returning any error produced.
+func ValidateChange(key string, f ValueChangeValidationFunc) schema.CustomizeDiffFunc {
+	return func(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
+		old, new := d.GetChange(key)
+		return f(ctx, old, new, meta)
+	}
+}
+
+// ValidateValue returns a CustomizeDiffFunc that applies the given validation
+// function to value of the given key, returning any error produced.
+//
+// This should generally not be used since it is functionally equivalent to
+// a validation function applied directly to the schema attribute in question,
+// but is provided for situations where composing multiple CustomizeDiffFuncs
+// together makes intent clearer than spreading that validation across the
+// schema.
+func ValidateValue(key string, f ValueValidationFunc) schema.CustomizeDiffFunc {
+	return func(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
+		val := d.Get(key)
+		return f(ctx, val, meta)
+	}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -302,6 +302,7 @@ github.com/hashicorp/terraform-plugin-go/tfprotov5/tftypes
 ## explicit
 github.com/hashicorp/terraform-plugin-sdk/v2/diag
 github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest
+github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff
 github.com/hashicorp/terraform-plugin-sdk/v2/helper/logging
 github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource
 github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema


### PR DESCRIPTION
A few changes in one PR here (the first two are small):

- **Plugin debug mode:** Added a CLI flag to `main.go` to support `--debug`. This allows the provider to be run in its own process outside of `terraform` itself. The provider can then be run with a debugger with breakpoints etc
- **Misleading diff bug:** Added a `Default: ""` to the `override_host` attribute in the backend block. In my testing it appeared that this removed the weird bug where all of the backends were marked as recreated in the diff. For example this issue https://github.com/fastly/terraform-provider-fastly/issues/179. This was being caused by the internal TypeSet diffing logic and the shimming between the legacy flatmap typesystem in the `terraform-plugin-sdk` and the newer `cty`-based typesystem that Terraform Core now uses. When not set, the proposed state from the config was being set to `nil`, but the prior state was being shimmed to `""` and the set hash was therefore different. 
- **Output variable refresh bug:** I added a `CustomizeDiff` function to the service resource to mark the `cloned_version` and `active_version` attributes as recomputed when any of the other attributes change (with the exception of `name`, `comment` and `version_comment`). This solves the problem where an output variable referencing these attributes wouldn't be updated after an `apply` and would require another `apply` or `refresh` for this to propagate through.
- Removed `StateFunc`s from all of the logging blocks as these were causing unnecessary whitespace diffs for the `CustomizeDiff`s and forcing the tests to fail with non-empty plans (the version was being marked as recomputed). I couldn't find any adverse effects from doing this, but would appreciate some confirmation here as there were a lot of comments about a known issue and there might have been a good reason that they were added in.