### PR TITLE
Fix misleading diff bug for backends

### DIFF
--- a/fastly/block_fastly_service_v1_backend.go
+++ b/fastly/block_fastly_service_v1_backend.go
@@ -318,6 +318,7 @@ func (h *BackendServiceAttributeHandler) Register(s *schema.Resource) error {
 		"override_host": {
 			Type:        schema.TypeString,
 			Optional:    true,
+			Default:     "",
 			Description: "The hostname to override the Host header",
 		},
 		"shield": {


### PR DESCRIPTION
Added a `Default: ""` to the `override_host` attribute in the backend block. In my testing it appeared that this removed the weird bug where all of the backends were marked as recreated in the diff. For example this issue https://github.com/fastly/terraform-provider-fastly/issues/179. This was being caused by the internal TypeSet diffing logic and the shimming between the legacy flatmap typesystem in the `terraform-plugin-sdk` and the newer `cty`-based typesystem that Terraform Core now uses. When not set, the proposed state from the config was being set to `nil`, but the prior state was being shimmed to `""` and the set hash was therefore different. 