### PR TITLE
Output variable refresh bug

### DIFF
--- a/fastly/base_fastly_service_v1.go
+++ b/fastly/base_fastly_service_v1.go
@@ -6,9 +6,9 @@ import (
 	"log"
 	"time"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-
 	gofastly "github.com/fastly/go-fastly/v3/fastly"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -148,6 +148,25 @@ func resourceService(serviceDef ServiceDefinition) *schema.Resource {
 		UpdateContext: resourceUpdate(serviceDef),
 		DeleteContext: resourceDelete(serviceDef),
 		Importer:      resourceImport(serviceDef),
+		CustomizeDiff: customdiff.All(
+			customdiff.ComputedIf("cloned_version", func(_ context.Context, d *schema.ResourceDiff, _ interface{}) bool {
+				// If anything other than name, comment and version_comment has changed, the current version will be
+				// cloned in resourceServiceUpdate so set it as recomputed. These three fields can be updated without
+				// creating a new version
+				for _, changedKey := range d.GetChangedKeysPrefix("") {
+					if changedKey == "name" || changedKey == "comment" || changedKey == "version_comment" {
+						continue
+					}
+					return true
+				}
+				return false
+			}),
+			customdiff.ComputedIf("active_version", func(_ context.Context, d *schema.ResourceDiff, _ interface{}) bool {
+				// If cloned_version is recomputed and we are automatically activating new versions (controlled with the
+				// activate flag) then the active_version will be recomputed too.
+				return d.HasChange("cloned_version") && d.Get("activate") == true
+			}),
+		),
 
 		Schema: map[string]*schema.Schema{
 			"name": {
@@ -388,6 +407,15 @@ func resourceServiceUpdate(ctx context.Context, d *schema.ResourceData, meta int
 		// for their own attributes.
 		for _, a := range serviceDef.GetAttributeHandler() {
 			if a.MustProcess(d, initialVersion) {
+				// Check if the Update has been cancelled and return early if so
+				if err := ctx.Err(); err != nil {
+					if errors.Is(err, context.Canceled) {
+						return nil
+					}
+
+					return diag.FromErr(err)
+				}
+
 				if err := a.Process(d, latestVersion, conn); err != nil {
 					return diag.FromErr(err)
 				}

--- a/fastly/block_fastly_service_v1_bigquerylogging_test.go
+++ b/fastly/block_fastly_service_v1_bigquerylogging_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"reflect"
-	"strings"
 	"testing"
 
 	gofastly "github.com/fastly/go-fastly/v3/fastly"
@@ -77,7 +76,7 @@ func TestAccFastlyServiceV1_bigquerylogging_env(t *testing.T) {
 	}
 
 	// set env Vars to something we expect
-	resetEnv := setBQEnv("someEnv", strings.TrimSpace(secretKey), t)
+	resetEnv := setBQEnv("someEnv", secretKey, t)
 	defer resetEnv()
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/fastly/block_fastly_service_v1_bigquerylogging_test.go
+++ b/fastly/block_fastly_service_v1_bigquerylogging_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"strings"
 	"testing"
 
 	gofastly "github.com/fastly/go-fastly/v3/fastly"
@@ -76,7 +77,7 @@ func TestAccFastlyServiceV1_bigquerylogging_env(t *testing.T) {
 	}
 
 	// set env Vars to something we expect
-	resetEnv := setBQEnv("someEnv", secretKey, t)
+	resetEnv := setBQEnv("someEnv", strings.TrimSpace(secretKey), t)
 	defer resetEnv()
 
 	resource.ParallelTest(t, resource.TestCase{


### PR DESCRIPTION
- **Output variable refresh bug:** I added a `CustomizeDiff` function to the service resource to mark the `cloned_version` and `active_version` attributes as recomputed when any of the other attributes change (with the exception of `name`, `comment` and `version_comment`). This solves the problem where an output variable referencing these attributes wouldn't be updated after an `apply` and would require another `apply` or `refresh` for this to propagate through.
- Removed `StateFunc`s from all of the logging blocks as these were causing unnecessary whitespace diffs for the `CustomizeDiff`s and forcing the tests to fail with non-empty plans (the version was being marked as recomputed). I couldn't find any adverse effects from doing this, but would appreciate some confirmation here as there were a lot of comments about a known issue and there might have been a good reason that they were added in.