### PR TITLE
When updating service, clone the cloned_version instead of active_version

### DIFF
--- a/docs/resources/service_compute.md
+++ b/docs/resources/service_compute.md
@@ -114,7 +114,7 @@ $ terraform import fastly_service_compute.demo xxxxxxxxxxxxxxxxxxxx
 ### Read-Only
 
 - **active_version** (Number) The currently active version of your Fastly Service
-- **cloned_version** (Number) The latest cloned version by the provider. The value gets only set after running `terraform apply`
+- **cloned_version** (Number) The latest cloned version by the provider
 
 <a id="nestedblock--backend"></a>
 ### Nested Schema for `backend`

--- a/docs/resources/service_v1.md
+++ b/docs/resources/service_v1.md
@@ -285,7 +285,7 @@ $ terraform import fastly_service_v1.demo xxxxxxxxxxxxxxxxxxxx
 ### Read-Only
 
 - **active_version** (Number) The currently active version of your Fastly Service
-- **cloned_version** (Number) The latest cloned version by the provider. The value gets only set after running `terraform apply`
+- **cloned_version** (Number) The latest cloned version by the provider
 
 <a id="nestedblock--backend"></a>
 ### Nested Schema for `backend`

--- a/fastly/base_fastly_service_v1.go
+++ b/fastly/base_fastly_service_v1.go
@@ -346,6 +346,10 @@ func resourceServiceUpdate(ctx context.Context, d *schema.ResourceData, meta int
 			// If the service was just created, there is an empty Version 1 available
 			// that is unlocked and can be updated.
 			latestVersion = 1
+			err := d.Set("cloned_version", latestVersion)
+			if err != nil {
+				return diag.FromErr(err)
+			}
 		} else {
 			// Clone the latest version, giving us an unlocked version we can modify.
 			log.Printf("[DEBUG] Creating clone of version (%d) for updates", latestVersion)
@@ -474,10 +478,6 @@ func resourceServiceRead(ctx context.Context, d *schema.ResourceData, meta inter
 		return diag.FromErr(err)
 	}
 	err = d.Set("active_version", s.ActiveVersion.Number)
-	if err != nil {
-		return diag.FromErr(err)
-	}
-	err = d.Set("cloned_version", s.Version.Number)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/fastly/base_fastly_service_v1.go
+++ b/fastly/base_fastly_service_v1.go
@@ -340,7 +340,7 @@ func resourceServiceUpdate(ctx context.Context, d *schema.ResourceData, meta int
 	initialVersion := false
 
 	if needsChange {
-		latestVersion := d.Get("active_version").(int)
+		latestVersion := d.Get("cloned_version").(int)
 		if latestVersion == 0 {
 			initialVersion = true
 			// If the service was just created, there is an empty Version 1 available
@@ -461,10 +461,26 @@ func resourceServiceRead(ctx context.Context, d *schema.ResourceData, meta inter
 		return diag.Errorf("[ERR] Service type mismatch in READ, expected: %s, got: %s", serviceDef.GetType(), s.Type)
 	}
 
-	d.Set("name", s.Name)
-	d.Set("comment", s.Comment)
-	d.Set("version_comment", s.Version.Comment)
-	d.Set("active_version", s.ActiveVersion.Number)
+	err = d.Set("name", s.Name)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	err = d.Set("comment", s.Comment)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	err = d.Set("version_comment", s.Version.Comment)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	err = d.Set("active_version", s.ActiveVersion.Number)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	err = d.Set("cloned_version", s.Version.Number)
+	if err != nil {
+		return diag.FromErr(err)
+	}
 
 	// If we are importing or `activate` is set to false, temporarily set the
 	// service.ActiveVersion number to the latest version supplied via the get

--- a/fastly/resource_fastly_service_v1_test.go
+++ b/fastly/resource_fastly_service_v1_test.go
@@ -335,7 +335,7 @@ func TestAccFastlyServiceV1_basic(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				// These attributes are not stored on the Fastly API and must be ignored.
-				ImportStateVerifyIgnore: []string{"activate", "force_destroy", "cloned_version"},
+				ImportStateVerifyIgnore: []string{"activate", "force_destroy"},
 			},
 		},
 	})


### PR DESCRIPTION
## Problem
When the provider updates a Fastly service, it clones a version, makes the changes to that, then optionally activates it depending on the value of the `activate` attribute. When `activate` is `true`, it doesn't matter whether `cloned_version` or `active_version` is used as the source of this clone as they are both equal (unless something failed between cloning and activating). However, when `activate` is `false`, and the user is making incremental updates to a service via "draft" versions, the `cloned_version` could be further ahead of the `active_version`. The current behaviour in this case is to keep cloning the active version each time. However, the Terraform state will track the `cloned_version` due to this code in the service Read function:
```
	// If we are importing or `activate` is set to false, temporarily set the
	// service.ActiveVersion number to the latest version supplied via the get
	// service version details call. This is to ensure we still read all of the
	// state below.
        isInactive := d.Get("activate").(bool) == false
        if s.ActiveVersion.Number == 0 && isImport || isInactive {
	        s.ActiveVersion.Number = s.Version.Number
        }
```
Therefore the plan that Terraform makes for each intermediate version to get to the next is essentially based on an incorrect view of the state.
```
   TF State
┌────┬────┬────┐
│    │    │    │
│    ▼    ▼    ▼
1    2    3    4
│    ▲    ▲    ▲
│    │    │    │
├────┘    │    │
│         │    │
├─────────┘    │
│              │
└──────────────┘
   Fastly Cloning
```
I don't believe this would actually be an issue if we didn't have TypeSets involved behind the nested blocks, because a state refresh as part of a reapply should generate a correct plan to get the new version into the desired state. However, for reasons previously discussed, TypeSets are a fact of life for now. The fact that the `SetDiff` algorithm is then used to conditionally Update a block instead of a Delete/Create operation means that there are certain sequences of updates where the order of operations matters. 

The `backend` block is a good example of this as it will always use the `UpdateBackend` method in go-fastly unless the `name` attribute has changed. In this case, an unfortunate combination of updates and name changes can cause unexpected results.

## Solution
The solution is to use the `cloned_version` instead of the `active_version` to clone from when making updates, so that the new version is identical to the TF state/previous HCL instead of the potentially arbitrary active version.

This also exposed a problem with the ACL test where the domain/backend names were being recalculated on each test step so this is fixed too. There is a better description in d1f15f21f0d0d76bb4745845caa80068f05be36a.

## Implications
As the ACL test failure demonstrates, there is a behaviour change in this fix, and the previous behaviour could be being depended on. Therefore, on a technicality, this is a breaking change fix.