### PR TITLE
Include dns_records in TLS configuration when performing lookup by ID

### DIFF
--- a/fastly/data_source_fastly_tls_configuration.go
+++ b/fastly/data_source_fastly_tls_configuration.go
@@ -111,7 +111,8 @@ func dataSourceFastlyTLSConfigurationRead(_ context.Context, d *schema.ResourceD
 
 	if v, ok := d.GetOk("id"); ok {
 		config, err := conn.GetCustomTLSConfiguration(&fastly.GetCustomTLSConfigurationInput{
-			ID: v.(string),
+			ID:      v.(string),
+			Include: "dns_records",
 		})
 		if err != nil {
 			return diag.FromErr(err)


### PR DESCRIPTION
Fixes issue #391 

The fix was already in the issue so a fairly easy one. I've tested it and it works as expected.