### PR TITLE
Catch case where state from older version could be unexpected

### DIFF
--- a/fastly/base_fastly_service_v1.go
+++ b/fastly/base_fastly_service_v1.go
@@ -489,7 +489,14 @@ func resourceServiceRead(ctx context.Context, d *schema.ResourceData, meta inter
 	// the latest version supplied via the get service version details call.
 	// This is to ensure we still read all of the state below. Then set the
 	// cloned_version to this version.
-	if isImport {
+	// In addition to this, we need to do the same thing if cloned_version is
+	// not yet set to anything. This could happen if the current state was from
+	// v0.28.0 of the provider or lower, i.e. the user has upgraded from an
+	// earlier version. This prevents us from getting into the state where the
+	// attribute has never been set and gets passed into CloneVersion in the
+	// Update function and fails.
+	clonedVersionNotSet := d.Get("cloned_version") == 0
+	if isImport || clonedVersionNotSet {
 		if s.ActiveVersion.Number == 0 {
 			s.ActiveVersion.Number = s.Version.Number
 		}


### PR DESCRIPTION
A change in v0.28.1 moved to use `cloned_version` much more heavily. This
made a few assumptions that during import/create, the cloned_version
would be set, and that therefore in a usual Read, this would already be
taken care of. However this missed a situation where the user has an
existing state file from v0.28.0 or earlier and upgrades to v0.28.1. In
this situation, neither the Create nor the Import logic would be
triggered and the `cloned_version` would have evaded attention. This then
causes problems in the Update function where we assume `cloned_version` is
correct and use it to clone a new version to make changes. In particular
this commit addresses the case where `cloned_version` is 0, which leads to
an error message when calling CloneVersion:
```
Error: missing required field 'ServiceVersion'
```
To get around this, we look for the case where `cloned_version` is 0 in
the Read function and use the same logic as Import in that case too.