### PR TITLE
Add support for file_max_bytes configuration for azure logging endpoint

### DIFF
--- a/docs/resources/service_compute.md
+++ b/docs/resources/service_compute.md
@@ -202,6 +202,7 @@ Required:
 
 Optional:
 
+- **file_max_bytes** (Number) Maximum size of an uploaded log file, if non-zero.
 - **gzip_level** (Number) Level of Gzip compression from `0-9`. `0` means no compression. `1` is the fastest and the least compressed version, `9` is the slowest and the most compressed version. Default `0`
 - **message_type** (String) How the message should be formatted. Can be either `classic`, `loggly`, `logplex` or `blank`. Default `classic`
 - **path** (String) The path to upload logs to. Must end with a trailing slash. If this field is left empty, the files will be saved in the container's root path

--- a/docs/resources/service_v1.md
+++ b/docs/resources/service_v1.md
@@ -381,6 +381,7 @@ Required:
 
 Optional:
 
+- **file_max_bytes** (Number) Maximum size of an uploaded log file, if non-zero.
 - **format** (String) Apache-style string or VCL variables to use for log formatting (default: `%h %l %u %t "%r" %>s %b`)
 - **format_version** (Number) The version of the custom logging format used for the configured endpoint. Can be either 1 or 2. (default: 2)
 - **gzip_level** (Number) Level of Gzip compression from `0-9`. `0` means no compression. `1` is the fastest and the least compressed version, `9` is the slowest and the most compressed version. Default `0`

--- a/fastly/block_fastly_service_v1_blobstoragelogging.go
+++ b/fastly/block_fastly_service_v1_blobstoragelogging.go
@@ -102,6 +102,7 @@ func (h *BlobStorageLoggingServiceAttributeHandler) Process(d *schema.ResourceDa
 			FormatVersion:     uintOrDefault(vla.formatVersion),
 			Placement:         vla.placement,
 			ResponseCondition: vla.responseCondition,
+			FileMaxBytes:      uint(resource["file_max_bytes"].(int)),
 		}
 
 		log.Printf("[DEBUG] Blob Storage logging create opts: %#v", opts)
@@ -174,6 +175,9 @@ func (h *BlobStorageLoggingServiceAttributeHandler) Process(d *schema.ResourceDa
 		}
 		if v, ok := modified["response_condition"]; ok {
 			opts.ResponseCondition = gofastly.String(v.(string))
+		}
+		if v, ok := modified["file_max_bytes"]; ok {
+			opts.FileMaxBytes = gofastly.Uint(uint(v.(int)))
 		}
 
 		log.Printf("[DEBUG] Update Blob Storage Opts: %#v", opts)
@@ -272,6 +276,11 @@ func (h *BlobStorageLoggingServiceAttributeHandler) Register(s *schema.Resource)
 			Description:      "How the message should be formatted. Can be either `classic`, `loggly`, `logplex` or `blank`. Default `classic`",
 			ValidateDiagFunc: validateLoggingMessageType(),
 		},
+		"file_max_bytes": {
+			Type:        schema.TypeInt,
+			Optional:    true,
+			Description: "Maximum size of an uploaded log file, if non-zero.",
+		},
 	}
 
 	if h.GetServiceMetadata().serviceType == ServiceTypeVCL {
@@ -331,6 +340,7 @@ func flattenBlobStorages(blobStorageList []*gofastly.BlobStorage) []map[string]i
 			"message_type":       bs.MessageType,
 			"placement":          bs.Placement,
 			"response_condition": bs.ResponseCondition,
+			"file_max_bytes":     bs.FileMaxBytes,
 		}
 
 		// prune any empty values that come from the default string value in structs

--- a/fastly/block_fastly_service_v1_blobstoragelogging_test.go
+++ b/fastly/block_fastly_service_v1_blobstoragelogging_test.go
@@ -34,6 +34,7 @@ func TestResourceFastlyFlattenBlobStorage(t *testing.T) {
 					MessageType:       "classic",
 					Placement:         "waf_debug",
 					ResponseCondition: "error_response",
+					FileMaxBytes:      1048576,
 				},
 			},
 			local: []map[string]interface{}{
@@ -52,6 +53,7 @@ func TestResourceFastlyFlattenBlobStorage(t *testing.T) {
 					"message_type":       "classic",
 					"placement":          "waf_debug",
 					"response_condition": "error_response",
+					"file_max_bytes":     uint(1048576),
 				},
 			},
 		},
@@ -84,6 +86,7 @@ func TestAccFastlyServiceV1_blobstoragelogging_basic(t *testing.T) {
 		MessageType:       "blank",
 		Placement:         "waf_debug",
 		ResponseCondition: "error_response_5XX",
+		FileMaxBytes:      1048576,
 	}
 
 	blobStorageLogOneUpdated := gofastly.BlobStorage{
@@ -101,6 +104,7 @@ func TestAccFastlyServiceV1_blobstoragelogging_basic(t *testing.T) {
 		MessageType:       "blank",
 		Placement:         "waf_debug",
 		ResponseCondition: "error_response_5XX",
+		FileMaxBytes:      1048576,
 	}
 
 	blobStorageLogTwo := gofastly.BlobStorage{
@@ -118,6 +122,7 @@ func TestAccFastlyServiceV1_blobstoragelogging_basic(t *testing.T) {
 		MessageType:       "blank",
 		Placement:         "waf_debug",
 		ResponseCondition: "ok_response_2XX",
+		FileMaxBytes:      2097152,
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -167,6 +172,7 @@ func TestAccFastlyServiceV1_blobstoragelogging_basic_compute(t *testing.T) {
 		GzipLevel:       9,
 		PublicKey:       pgpPublicKey(t),
 		MessageType:     "blank",
+		FileMaxBytes:    1048576,
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -360,6 +366,7 @@ resource "fastly_service_v1" "foo" {
     message_type       = "blank"
     placement          = "waf_debug"
     response_condition = "error_response_5XX"
+    file_max_bytes     = 1048576
   }
 
   force_destroy = true
@@ -394,6 +401,7 @@ resource "fastly_service_compute" "foo" {
     gzip_level         = 9
     public_key         = file("test_fixtures/fastly_test_publickey")
     message_type       = "blank"
+    file_max_bytes     = 1048576
   }
 
   package {
@@ -452,6 +460,7 @@ resource "fastly_service_v1" "foo" {
     message_type       = "blank"
     placement          = "waf_debug"
     response_condition = "error_response_5XX"
+    file_max_bytes     = 1048576
   }
 
   blobstoragelogging {
@@ -469,6 +478,7 @@ resource "fastly_service_v1" "foo" {
     message_type       = "blank"
     placement          = "waf_debug"
     response_condition = "ok_response_2XX"
+    file_max_bytes     = 2097152
   }
 
   force_destroy = true


### PR DESCRIPTION
Support file_max_bytes configuration option for azure blob storage logging endpoint. Follows from fastly/go-fastly#255.