### PR TITLE
Add support for compression_codec to logging file sink endpoints

### DIFF
--- a/docs/resources/service_compute.md
+++ b/docs/resources/service_compute.md
@@ -202,6 +202,7 @@ Required:
 
 Optional:
 
+- **compression_codec** (String) The codec used for compression of your logs. Valid values are zstd, snappy, and gzip. If the specified codec is "gzip", gzip_level will default to 3. To specify a different level, leave compression_codec blank and explicitly set the level using gzip_level. Specifying both compression_codec and gzip_level in the same API request will result in an error.
 - **file_max_bytes** (Number) Maximum size of an uploaded log file, if non-zero.
 - **gzip_level** (Number) Level of Gzip compression from `0-9`. `0` means no compression. `1` is the fastest and the least compressed version, `9` is the slowest and the most compressed version. Default `0`
 - **message_type** (String) How the message should be formatted. Can be either `classic`, `loggly`, `logplex` or `blank`. Default `classic`
@@ -239,6 +240,7 @@ Required:
 
 Optional:
 
+- **compression_codec** (String) The codec used for compression of your logs. Valid values are zstd, snappy, and gzip. If the specified codec is "gzip", gzip_level will default to 3. To specify a different level, leave compression_codec blank and explicitly set the level using gzip_level. Specifying both compression_codec and gzip_level in the same API request will result in an error.
 - **email** (String) The email address associated with the target GCS bucket on your account. You may optionally provide this secret via an environment variable, `FASTLY_GCS_EMAIL`
 - **gzip_level** (Number) Level of Gzip compression, from `0-9`. `0` is no compression. `1` is fastest and least compressed, `9` is slowest and most compressed. Default `0`
 - **message_type** (String) How the message should be formatted; one of: `classic`, `loggly`, `logplex` or `blank`. Default `classic`. [Fastly Documentation](https://developer.fastly.com/reference/api/logging/gcs/)
@@ -319,6 +321,7 @@ Required:
 
 Optional:
 
+- **compression_codec** (String) The codec used for compression of your logs. Valid values are zstd, snappy, and gzip. If the specified codec is "gzip", gzip_level will default to 3. To specify a different level, leave compression_codec blank and explicitly set the level using gzip_level. Specifying both compression_codec and gzip_level in the same API request will result in an error.
 - **gzip_level** (Number) What level of GZIP encoding to have when dumping logs (default `0`, no compression)
 - **message_type** (String) How the message should be formatted. One of: `classic` (default), `loggly`, `logplex` or `blank`
 - **path** (String) The path to upload logs to
@@ -353,6 +356,7 @@ Required:
 
 Optional:
 
+- **compression_codec** (String) The codec used for compression of your logs. Valid values are zstd, snappy, and gzip. If the specified codec is "gzip", gzip_level will default to 3. To specify a different level, leave compression_codec blank and explicitly set the level using gzip_level. Specifying both compression_codec and gzip_level in the same API request will result in an error.
 - **domain** (String) The domain of the DigitalOcean Spaces endpoint (default `nyc3.digitaloceanspaces.com`)
 - **gzip_level** (Number) What level of Gzip encoding to have when dumping logs (default `0`, no compression)
 - **message_type** (String) How the message should be formatted. One of: `classic` (default), `loggly`, `logplex` or `blank`
@@ -397,6 +401,7 @@ Required:
 
 Optional:
 
+- **compression_codec** (String) The codec used for compression of your logs. Valid values are zstd, snappy, and gzip. If the specified codec is "gzip", gzip_level will default to 3. To specify a different level, leave compression_codec blank and explicitly set the level using gzip_level. Specifying both compression_codec and gzip_level in the same API request will result in an error.
 - **gzip_level** (Number) Gzip Compression level. Default `0`
 - **message_type** (String) How the message should be formatted (default: `classic`)
 - **period** (Number) How frequently the logs should be transferred, in seconds (Default `3600`)
@@ -522,6 +527,7 @@ Required:
 
 Optional:
 
+- **compression_codec** (String) The codec used for compression of your logs. Valid values are zstd, snappy, and gzip. If the specified codec is "gzip", gzip_level will default to 3. To specify a different level, leave compression_codec blank and explicitly set the level using gzip_level. Specifying both compression_codec and gzip_level in the same API request will result in an error.
 - **gzip_level** (Number) What level of Gzip encoding to have when dumping logs (default `0`, no compression)
 - **message_type** (String) How the message should be formatted; one of: `classic`, `loggly`, `logplex` or `blank`. Default `classic`. [Fastly Documentation](https://developer.fastly.com/reference/api/logging/gcs/)
 - **path** (String) Path to store the files. Must end with a trailing slash. If this field is left empty, the files will be saved in the bucket's root path
@@ -556,6 +562,7 @@ Required:
 
 Optional:
 
+- **compression_codec** (String) The codec used for compression of your logs. Valid values are zstd, snappy, and gzip. If the specified codec is "gzip", gzip_level will default to 3. To specify a different level, leave compression_codec blank and explicitly set the level using gzip_level. Specifying both compression_codec and gzip_level in the same API request will result in an error.
 - **gzip_level** (Number) What level of Gzip encoding to have when dumping logs (default `0`, no compression)
 - **message_type** (String) How the message should be formatted. One of: `classic` (default), `loggly`, `logplex` or `blank`
 - **password** (String, Sensitive) The password for the server. If both `password` and `secret_key` are passed, `secret_key` will be preferred
@@ -586,6 +593,7 @@ Required:
 
 Optional:
 
+- **compression_codec** (String) The codec used for compression of your logs. Valid values are zstd, snappy, and gzip. If the specified codec is "gzip", gzip_level will default to 3. To specify a different level, leave compression_codec blank and explicitly set the level using gzip_level. Specifying both compression_codec and gzip_level in the same API request will result in an error.
 - **domain** (String) If you created the S3 bucket outside of `us-east-1`, then specify the corresponding bucket endpoint. Example: `s3-us-west-2.amazonaws.com`
 - **gzip_level** (Number) Level of Gzip compression, from `0-9`. `0` is no compression. `1` is fastest and least compressed, `9` is slowest and most compressed. Default `0`
 - **message_type** (String) How the message should be formatted; one of: `classic`, `loggly`, `logplex` or `blank`. Default `classic`

--- a/docs/resources/service_v1.md
+++ b/docs/resources/service_v1.md
@@ -381,6 +381,7 @@ Required:
 
 Optional:
 
+- **compression_codec** (String) The codec used for compression of your logs. Valid values are zstd, snappy, and gzip. If the specified codec is "gzip", gzip_level will default to 3. To specify a different level, leave compression_codec blank and explicitly set the level using gzip_level. Specifying both compression_codec and gzip_level in the same API request will result in an error.
 - **file_max_bytes** (Number) Maximum size of an uploaded log file, if non-zero.
 - **format** (String) Apache-style string or VCL variables to use for log formatting (default: `%h %l %u %t "%r" %>s %b`)
 - **format_version** (Number) The version of the custom logging format used for the configured endpoint. Can be either 1 or 2. (default: 2)
@@ -486,6 +487,7 @@ Required:
 
 Optional:
 
+- **compression_codec** (String) The codec used for compression of your logs. Valid values are zstd, snappy, and gzip. If the specified codec is "gzip", gzip_level will default to 3. To specify a different level, leave compression_codec blank and explicitly set the level using gzip_level. Specifying both compression_codec and gzip_level in the same API request will result in an error.
 - **email** (String) The email address associated with the target GCS bucket on your account. You may optionally provide this secret via an environment variable, `FASTLY_GCS_EMAIL`
 - **format** (String) Apache-style string or VCL variables to use for log formatting
 - **gzip_level** (Number) Level of Gzip compression, from `0-9`. `0` is no compression. `1` is fastest and least compressed, `9` is slowest and most compressed. Default `0`
@@ -613,6 +615,7 @@ Required:
 
 Optional:
 
+- **compression_codec** (String) The codec used for compression of your logs. Valid values are zstd, snappy, and gzip. If the specified codec is "gzip", gzip_level will default to 3. To specify a different level, leave compression_codec blank and explicitly set the level using gzip_level. Specifying both compression_codec and gzip_level in the same API request will result in an error.
 - **format** (String) Apache style log formatting.
 - **format_version** (Number) The version of the custom logging format used for the configured endpoint. Can be either `1` or `2`. (default: `2`).
 - **gzip_level** (Number) What level of GZIP encoding to have when dumping logs (default `0`, no compression)
@@ -655,6 +658,7 @@ Required:
 
 Optional:
 
+- **compression_codec** (String) The codec used for compression of your logs. Valid values are zstd, snappy, and gzip. If the specified codec is "gzip", gzip_level will default to 3. To specify a different level, leave compression_codec blank and explicitly set the level using gzip_level. Specifying both compression_codec and gzip_level in the same API request will result in an error.
 - **domain** (String) The domain of the DigitalOcean Spaces endpoint (default `nyc3.digitaloceanspaces.com`)
 - **format** (String) Apache style log formatting.
 - **format_version** (Number) The version of the custom logging format used for the configured endpoint. Can be either `1` or `2`. (default: `2`).
@@ -707,6 +711,7 @@ Required:
 
 Optional:
 
+- **compression_codec** (String) The codec used for compression of your logs. Valid values are zstd, snappy, and gzip. If the specified codec is "gzip", gzip_level will default to 3. To specify a different level, leave compression_codec blank and explicitly set the level using gzip_level. Specifying both compression_codec and gzip_level in the same API request will result in an error.
 - **format** (String) Apache-style string or VCL variables to use for log formatting.
 - **format_version** (Number) The version of the custom logging format used for the configured endpoint. Can be either 1 or 2. (default: 2).
 - **gzip_level** (Number) Gzip Compression level. Default `0`
@@ -883,6 +888,7 @@ Required:
 
 Optional:
 
+- **compression_codec** (String) The codec used for compression of your logs. Valid values are zstd, snappy, and gzip. If the specified codec is "gzip", gzip_level will default to 3. To specify a different level, leave compression_codec blank and explicitly set the level using gzip_level. Specifying both compression_codec and gzip_level in the same API request will result in an error.
 - **format** (String) Apache style log formatting.
 - **format_version** (Number) The version of the custom logging format used for the configured endpoint. Can be either `1` or `2`. (default: `2`).
 - **gzip_level** (Number) What level of Gzip encoding to have when dumping logs (default `0`, no compression)
@@ -925,6 +931,7 @@ Required:
 
 Optional:
 
+- **compression_codec** (String) The codec used for compression of your logs. Valid values are zstd, snappy, and gzip. If the specified codec is "gzip", gzip_level will default to 3. To specify a different level, leave compression_codec blank and explicitly set the level using gzip_level. Specifying both compression_codec and gzip_level in the same API request will result in an error.
 - **format** (String) Apache-style string or VCL variables to use for log formatting.
 - **format_version** (Number) The version of the custom logging format used for the configured endpoint. Can be either 1 or 2. (default: 2).
 - **gzip_level** (Number) What level of Gzip encoding to have when dumping logs (default `0`, no compression)
@@ -1005,6 +1012,7 @@ Required:
 
 Optional:
 
+- **compression_codec** (String) The codec used for compression of your logs. Valid values are zstd, snappy, and gzip. If the specified codec is "gzip", gzip_level will default to 3. To specify a different level, leave compression_codec blank and explicitly set the level using gzip_level. Specifying both compression_codec and gzip_level in the same API request will result in an error.
 - **domain** (String) If you created the S3 bucket outside of `us-east-1`, then specify the corresponding bucket endpoint. Example: `s3-us-west-2.amazonaws.com`
 - **format** (String) Apache-style string or VCL variables to use for log formatting.
 - **format_version** (Number) The version of the custom logging format used for the configured endpoint. Can be either 1 or 2. (Default: 1).

--- a/fastly/block_fastly_service_v1_blobstoragelogging.go
+++ b/fastly/block_fastly_service_v1_blobstoragelogging.go
@@ -103,6 +103,7 @@ func (h *BlobStorageLoggingServiceAttributeHandler) Process(d *schema.ResourceDa
 			Placement:         vla.placement,
 			ResponseCondition: vla.responseCondition,
 			FileMaxBytes:      uint(resource["file_max_bytes"].(int)),
+			CompressionCodec:  resource["compression_codec"].(string),
 		}
 
 		log.Printf("[DEBUG] Blob Storage logging create opts: %#v", opts)
@@ -281,6 +282,12 @@ func (h *BlobStorageLoggingServiceAttributeHandler) Register(s *schema.Resource)
 			Optional:    true,
 			Description: "Maximum size of an uploaded log file, if non-zero.",
 		},
+		"compression_codec": {
+			Type:             schema.TypeString,
+			Optional:         true,
+			Description:      `The codec used for compression of your logs. Valid values are zstd, snappy, and gzip. If the specified codec is "gzip", gzip_level will default to 3. To specify a different level, leave compression_codec blank and explicitly set the level using gzip_level. Specifying both compression_codec and gzip_level in the same API request will result in an error.`,
+			ValidateDiagFunc: validateLoggingCompressionCodec(),
+		},
 	}
 
 	if h.GetServiceMetadata().serviceType == ServiceTypeVCL {
@@ -341,6 +348,7 @@ func flattenBlobStorages(blobStorageList []*gofastly.BlobStorage) []map[string]i
 			"placement":          bs.Placement,
 			"response_condition": bs.ResponseCondition,
 			"file_max_bytes":     bs.FileMaxBytes,
+			"compression_codec":  bs.CompressionCodec,
 		}
 
 		// prune any empty values that come from the default string value in structs

--- a/fastly/block_fastly_service_v1_blobstoragelogging_test.go
+++ b/fastly/block_fastly_service_v1_blobstoragelogging_test.go
@@ -27,7 +27,7 @@ func TestResourceFastlyFlattenBlobStorage(t *testing.T) {
 					SASToken:          "test-sas-token",
 					Period:            12,
 					TimestampFormat:   "%Y-%m-%dT%H:%M:%S.000",
-					GzipLevel:         9,
+					GzipLevel:         0,
 					PublicKey:         "test-public-key",
 					Format:            "%h %l %u %t \"%r\" %>s %b",
 					FormatVersion:     1,
@@ -35,6 +35,7 @@ func TestResourceFastlyFlattenBlobStorage(t *testing.T) {
 					Placement:         "waf_debug",
 					ResponseCondition: "error_response",
 					FileMaxBytes:      1048576,
+					CompressionCodec:  "zstd",
 				},
 			},
 			local: []map[string]interface{}{
@@ -46,14 +47,15 @@ func TestResourceFastlyFlattenBlobStorage(t *testing.T) {
 					"sas_token":          "test-sas-token",
 					"period":             uint(12),
 					"timestamp_format":   "%Y-%m-%dT%H:%M:%S.000",
-					"gzip_level":         uint(9),
 					"public_key":         "test-public-key",
 					"format":             "%h %l %u %t \"%r\" %>s %b",
 					"format_version":     uint(1),
+					"gzip_level":         uint(0),
 					"message_type":       "classic",
 					"placement":          "waf_debug",
 					"response_condition": "error_response",
 					"file_max_bytes":     uint(1048576),
+					"compression_codec":  "zstd",
 				},
 			},
 		},
@@ -79,7 +81,6 @@ func TestAccFastlyServiceV1_blobstoragelogging_basic(t *testing.T) {
 		SASToken:          "sv=2018-04-05&ss=b&srt=sco&sp=rw&se=2050-07-21T18%3A00%3A00Z&sig=3ABdLOJZosCp0o491T%2BqZGKIhafF1nlM3MzESDDD3Gg%3D",
 		Period:            12,
 		TimestampFormat:   "%Y-%m-%dT%H:%M:%S.000",
-		GzipLevel:         9,
 		PublicKey:         pgpPublicKey(t),
 		Format:            "%h %l %u %t \"%r\" %>s %b",
 		FormatVersion:     1,
@@ -87,6 +88,7 @@ func TestAccFastlyServiceV1_blobstoragelogging_basic(t *testing.T) {
 		Placement:         "waf_debug",
 		ResponseCondition: "error_response_5XX",
 		FileMaxBytes:      1048576,
+		CompressionCodec:  "zstd",
 	}
 
 	blobStorageLogOneUpdated := gofastly.BlobStorage{
@@ -97,10 +99,10 @@ func TestAccFastlyServiceV1_blobstoragelogging_basic(t *testing.T) {
 		SASToken:          "sv=2018-04-05&ss=b&srt=sco&sp=rw&se=2050-07-21T18%3A00%3A00Z&sig=3ABdLOJZosCp0o491T%2BqZGKIhafF1nlM3MzESDDD3Gg%3D",
 		Period:            12,
 		TimestampFormat:   "%Y-%m-%dT%H:%M:%S.000",
-		GzipLevel:         9,
 		PublicKey:         pgpPublicKey(t),
 		Format:            "%h %l %u %{now}V %{req.method}V %{req.url}V %>s %{resp.http.Content-Length}V",
 		FormatVersion:     2,
+		GzipLevel:         1,
 		MessageType:       "blank",
 		Placement:         "waf_debug",
 		ResponseCondition: "error_response_5XX",
@@ -115,7 +117,6 @@ func TestAccFastlyServiceV1_blobstoragelogging_basic(t *testing.T) {
 		SASToken:          "sv=2018-04-05&ss=b&srt=sco&sp=rw&se=2050-07-21T18%3A00%3A00Z&sig=3ABdLOJZosCp0o491T%2BqZGKIhafF1nlM3MzESDDD3Gg%3D",
 		Period:            12,
 		TimestampFormat:   "%Y-%m-%dT%H:%M:%S.000",
-		GzipLevel:         9,
 		PublicKey:         pgpPublicKey(t),
 		Format:            "%h %l %u %{now}V %{req.method}V %{req.url}V %>s %{resp.http.Content-Length}V",
 		FormatVersion:     2,
@@ -123,6 +124,7 @@ func TestAccFastlyServiceV1_blobstoragelogging_basic(t *testing.T) {
 		Placement:         "waf_debug",
 		ResponseCondition: "ok_response_2XX",
 		FileMaxBytes:      2097152,
+		CompressionCodec:  "zstd",
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -162,17 +164,17 @@ func TestAccFastlyServiceV1_blobstoragelogging_basic_compute(t *testing.T) {
 	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 
 	blobStorageLogOne := gofastly.BlobStorage{
-		Name:            "test-blobstorage-1",
-		Path:            "/5XX/",
-		AccountName:     "test",
-		Container:       "fastly",
-		SASToken:        "sv=2018-04-05&ss=b&srt=sco&sp=rw&se=2050-07-21T18%3A00%3A00Z&sig=3ABdLOJZosCp0o491T%2BqZGKIhafF1nlM3MzESDDD3Gg%3D",
-		Period:          12,
-		TimestampFormat: "%Y-%m-%dT%H:%M:%S.000",
-		GzipLevel:       9,
-		PublicKey:       pgpPublicKey(t),
-		MessageType:     "blank",
-		FileMaxBytes:    1048576,
+		Name:             "test-blobstorage-1",
+		Path:             "/5XX/",
+		AccountName:      "test",
+		Container:        "fastly",
+		SASToken:         "sv=2018-04-05&ss=b&srt=sco&sp=rw&se=2050-07-21T18%3A00%3A00Z&sig=3ABdLOJZosCp0o491T%2BqZGKIhafF1nlM3MzESDDD3Gg%3D",
+		Period:           12,
+		TimestampFormat:  "%Y-%m-%dT%H:%M:%S.000",
+		PublicKey:        pgpPublicKey(t),
+		MessageType:      "blank",
+		FileMaxBytes:     1048576,
+		CompressionCodec: "zstd",
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -206,7 +208,6 @@ func TestAccFastlyServiceV1_blobstoragelogging_default(t *testing.T) {
 		SASToken:        "sv=2018-04-05&ss=b&srt=sco&sp=rw&se=2050-07-21T18%3A00%3A00Z&sig=3ABdLOJZosCp0o491T%2BqZGKIhafF1nlM3MzESDDD3Gg%3D",
 		Period:          3600,
 		TimestampFormat: "%Y-%m-%dT%H:%M:%S.000",
-		GzipLevel:       0,
 		Format:          "%h %l %u %t \"%r\" %>s %b",
 		FormatVersion:   2,
 		MessageType:     "classic",
@@ -247,7 +248,6 @@ func TestAccFastlyServiceV1_blobstoragelogging_env(t *testing.T) {
 		SASToken:        "sv=2018-04-05&ss=b&srt=sco&sp=rw&se=2050-07-21T18%3A00%3A00Z&sig=3ABdLOJZosCp0o491T%2BqZGKIhafF1nlM3MzESDDD3Gg%3D",
 		Period:          3600,
 		TimestampFormat: "%Y-%m-%dT%H:%M:%S.000",
-		GzipLevel:       0,
 		Format:          "%h %l %u %t \"%r\" %>s %b",
 		FormatVersion:   2,
 		MessageType:     "classic",
@@ -335,38 +335,38 @@ resource "fastly_service_v1" "foo" {
   name = "%s"
 
   domain {
-    name    = "%s"
+    name = "%s"
     comment = "tf-testing-domain"
   }
 
   backend {
     address = "aws.amazon.com"
-    name    = "tf-test-backend"
+    name = "tf-test-backend"
   }
 
   condition {
-    name      = "error_response_5XX"
+    name = "error_response_5XX"
     statement = "resp.status >= 500 && resp.status < 600"
-    priority  = 10
-    type      = "RESPONSE"
+    priority = 10
+    type = "RESPONSE"
   }
 
   blobstoragelogging {
-    name               = "test-blobstorage-1"
-    path               = "/5XX/"
-    account_name       = "test"
-    container          = "fastly"
-    sas_token          = "sv=2018-04-05&ss=b&srt=sco&sp=rw&se=2050-07-21T18%%3A00%%3A00Z&sig=3ABdLOJZosCp0o491T%%2BqZGKIhafF1nlM3MzESDDD3Gg%%3D"
-    period             = 12
-    timestamp_format   = "%%Y-%%m-%%dT%%H:%%M:%%S.000"
-    gzip_level         = 9
-    public_key         = file("test_fixtures/fastly_test_publickey")
-    format             = %q
-    format_version     = 1
-    message_type       = "blank"
-    placement          = "waf_debug"
+    name = "test-blobstorage-1"
+    path = "/5XX/"
+    account_name = "test"
+    container = "fastly"
+    sas_token = "sv=2018-04-05&ss=b&srt=sco&sp=rw&se=2050-07-21T18%%3A00%%3A00Z&sig=3ABdLOJZosCp0o491T%%2BqZGKIhafF1nlM3MzESDDD3Gg%%3D"
+    period = 12
+    timestamp_format = "%%Y-%%m-%%dT%%H:%%M:%%S.000"
+    public_key = file("test_fixtures/fastly_test_publickey")
+    format = %q
+    format_version = 1
+    message_type = "blank"
+    placement = "waf_debug"
     response_condition = "error_response_5XX"
     file_max_bytes     = 1048576
+    compression_codec = "zstd"
   }
 
   force_destroy = true
@@ -381,32 +381,32 @@ resource "fastly_service_compute" "foo" {
   name = "%s"
 
   domain {
-    name    = "%s"
+    name = "%s"
     comment = "tf-testing-domain"
   }
 
   backend {
     address = "aws.amazon.com"
-    name    = "tf-test-backend"
+    name = "tf-test-backend"
   }
 
   blobstoragelogging {
-    name               = "test-blobstorage-1"
-    path               = "/5XX/"
-    account_name       = "test"
-    container          = "fastly"
-    sas_token          = "sv=2018-04-05&ss=b&srt=sco&sp=rw&se=2050-07-21T18%%3A00%%3A00Z&sig=3ABdLOJZosCp0o491T%%2BqZGKIhafF1nlM3MzESDDD3Gg%%3D"
-    period             = 12
-    timestamp_format   = "%%Y-%%m-%%dT%%H:%%M:%%S.000"
-    gzip_level         = 9
-    public_key         = file("test_fixtures/fastly_test_publickey")
-    message_type       = "blank"
+    name = "test-blobstorage-1"
+    path = "/5XX/"
+    account_name = "test"
+    container = "fastly"
+    sas_token = "sv=2018-04-05&ss=b&srt=sco&sp=rw&se=2050-07-21T18%%3A00%%3A00Z&sig=3ABdLOJZosCp0o491T%%2BqZGKIhafF1nlM3MzESDDD3Gg%%3D"
+    period = 12
+    timestamp_format = "%%Y-%%m-%%dT%%H:%%M:%%S.000"
+    public_key = file("test_fixtures/fastly_test_publickey")
+    message_type = "blank"
     file_max_bytes     = 1048576
+    compression_codec = "zstd"
   }
 
   package {
     filename = "test_fixtures/package/valid.tar.gz"
-	source_code_hash = filesha512("test_fixtures/package/valid.tar.gz")
+    source_code_hash = filesha512("test_fixtures/package/valid.tar.gz")
   }
 
   force_destroy = true
@@ -422,63 +422,63 @@ resource "fastly_service_v1" "foo" {
   name = "%s"
 
   domain {
-    name    = "%s"
+    name = "%s"
     comment = "tf-testing-domain"
   }
 
   backend {
     address = "aws.amazon.com"
-    name    = "tf-test-backend"
+    name = "tf-test-backend"
   }
 
   condition {
-    name      = "error_response_5XX"
+    name = "error_response_5XX"
     statement = "resp.status >= 500 && resp.status < 600"
-    priority  = 10
-    type      = "RESPONSE"
+    priority = 10
+    type = "RESPONSE"
   }
 
   condition {
-    name      = "ok_response_2XX"
+    name = "ok_response_2XX"
     statement = "resp.status >= 200 && resp.status < 300"
-    priority  = 10
-    type      = "RESPONSE"
+    priority = 10
+    type = "RESPONSE"
   }
 
   blobstoragelogging {
-    name               = "test-blobstorage-1"
-    path               = "/5XX/"
-    account_name       = "test"
-    container          = "fastly"
-    sas_token          = "sv=2018-04-05&ss=b&srt=sco&sp=rw&se=2050-07-21T18%%3A00%%3A00Z&sig=3ABdLOJZosCp0o491T%%2BqZGKIhafF1nlM3MzESDDD3Gg%%3D"
-    period             = 12
-    timestamp_format   = "%%Y-%%m-%%dT%%H:%%M:%%S.000"
-    gzip_level         = 9
-    public_key         = file("test_fixtures/fastly_test_publickey")
-    format             = %q
-    format_version     = 2
-    message_type       = "blank"
-    placement          = "waf_debug"
+    name = "test-blobstorage-1"
+    path = "/5XX/"
+    account_name = "test"
+    container = "fastly"
+    sas_token = "sv=2018-04-05&ss=b&srt=sco&sp=rw&se=2050-07-21T18%%3A00%%3A00Z&sig=3ABdLOJZosCp0o491T%%2BqZGKIhafF1nlM3MzESDDD3Gg%%3D"
+    period = 12
+    timestamp_format = "%%Y-%%m-%%dT%%H:%%M:%%S.000"
+    public_key = file("test_fixtures/fastly_test_publickey")
+    format = %q
+    gzip_level = 1
+    format_version = 2
+    message_type = "blank"
+    placement = "waf_debug"
     response_condition = "error_response_5XX"
     file_max_bytes     = 1048576
   }
 
   blobstoragelogging {
-    name               = "test-blobstorage-2"
-    path               = "/2XX/"
-    account_name       = "test"
-    container          = "fastly"
-    sas_token          = "sv=2018-04-05&ss=b&srt=sco&sp=rw&se=2050-07-21T18%%3A00%%3A00Z&sig=3ABdLOJZosCp0o491T%%2BqZGKIhafF1nlM3MzESDDD3Gg%%3D"
-    period             = 12
-    timestamp_format   = "%%Y-%%m-%%dT%%H:%%M:%%S.000"
-    gzip_level         = 9
-    public_key         = file("test_fixtures/fastly_test_publickey")
-    format             = %q
-    format_version     = 2
-    message_type       = "blank"
-    placement          = "waf_debug"
+    name = "test-blobstorage-2"
+    path = "/2XX/"
+    account_name = "test"
+    container = "fastly"
+    sas_token = "sv=2018-04-05&ss=b&srt=sco&sp=rw&se=2050-07-21T18%%3A00%%3A00Z&sig=3ABdLOJZosCp0o491T%%2BqZGKIhafF1nlM3MzESDDD3Gg%%3D"
+    period = 12
+    timestamp_format = "%%Y-%%m-%%dT%%H:%%M:%%S.000"
+    public_key = file("test_fixtures/fastly_test_publickey")
+    format = %q
+    format_version = 2
+    message_type = "blank"
+    placement = "waf_debug"
     response_condition = "ok_response_2XX"
     file_max_bytes     = 2097152
+    compression_codec  = "zstd"
   }
 
   force_destroy = true
@@ -493,20 +493,20 @@ resource "fastly_service_v1" "foo" {
   name = "%s"
 
   domain {
-    name    = "%s"
+    name = "%s"
     comment = "tf-testing-domain"
   }
 
   backend {
     address = "aws.amazon.com"
-    name    = "tf-test-backend"
+    name = "tf-test-backend"
   }
 
   blobstoragelogging {
-    name         = "test-blobstorage"
+    name = "test-blobstorage"
     account_name = "test"
-    container    = "fastly"
-    sas_token    = "sv=2018-04-05&ss=b&srt=sco&sp=rw&se=2050-07-21T18%%3A00%%3A00Z&sig=3ABdLOJZosCp0o491T%%2BqZGKIhafF1nlM3MzESDDD3Gg%%3D"
+    container = "fastly"
+    sas_token = "sv=2018-04-05&ss=b&srt=sco&sp=rw&se=2050-07-21T18%%3A00%%3A00Z&sig=3ABdLOJZosCp0o491T%%2BqZGKIhafF1nlM3MzESDDD3Gg%%3D"
   }
 
   force_destroy = true
@@ -521,19 +521,19 @@ resource "fastly_service_v1" "foo" {
   name = "%s"
 
   domain {
-    name    = "%s"
+    name = "%s"
     comment = "tf-testing-domain"
   }
 
   backend {
     address = "aws.amazon.com"
-    name    = "tf-test-backend"
+    name = "tf-test-backend"
   }
 
   blobstoragelogging {
-    name         = "test-blobstorage"
+    name = "test-blobstorage"
     account_name = "test"
-    container    = "fastly"
+    container = "fastly"
   }
 
   force_destroy = true

--- a/fastly/block_fastly_service_v1_gcslogging_test.go
+++ b/fastly/block_fastly_service_v1_gcslogging_test.go
@@ -25,24 +25,26 @@ func TestResourceFastlyFlattenGCS(t *testing.T) {
 		{
 			remote: []*gofastly.GCS{
 				{
-					Name:      "GCS collector",
-					User:      "email@example.com",
-					Bucket:    "bucketname",
-					SecretKey: secretKey,
-					Format:    "log format",
-					Period:    3600,
-					GzipLevel: 0,
+					Name:             "GCS collector",
+					User:             "email@example.com",
+					Bucket:           "bucketname",
+					SecretKey:        secretKey,
+					Format:           "log format",
+					Period:           3600,
+					GzipLevel:        0,
+					CompressionCodec: "zstd",
 				},
 			},
 			local: []map[string]interface{}{
 				{
-					"name":        "GCS collector",
-					"email":       "email@example.com",
-					"bucket_name": "bucketname",
-					"secret_key":  secretKey,
-					"format":      "log format",
-					"period":      3600,
-					"gzip_level":  0,
+					"name":              "GCS collector",
+					"email":             "email@example.com",
+					"bucket_name":       "bucketname",
+					"secret_key":        secretKey,
+					"format":            "log format",
+					"period":            3600,
+					"gzip_level":        0,
+					"compression_codec": "zstd",
 				},
 			},
 		},
@@ -173,23 +175,24 @@ resource "fastly_service_v1" "foo" {
   name = "%s"
 
   domain {
-    name    = "%s"
+    name = "%s"
     comment = "tf-testing-domain"
   }
 
   backend {
     address = "%s"
-    name    = "tf -test backend"
+    name = "tf -test backend"
   }
 
-	gcslogging {
-	  name =  "%s"
-		email = "email@example.com"
-		bucket_name = "bucketname"
-		secret_key = %q
-		format = "log format"
-		response_condition = ""
-	}
+  gcslogging {
+    name = "%s"
+    email = "email@example.com"
+    bucket_name = "bucketname"
+    secret_key = %q
+    format = "log format"
+    response_condition = ""
+    compression_codec = "zstd"
+  }
 
   force_destroy = true
 }`, name, domainName, backendName, gcsName, secretKey)
@@ -204,25 +207,26 @@ resource "fastly_service_compute" "foo" {
   name = "%s"
 
   domain {
-    name    = "%s"
+    name = "%s"
     comment = "tf-testing-domain"
   }
 
   backend {
     address = "%s"
-    name    = "tf -test backend"
+    name = "tf -test backend"
   }
 
-	gcslogging {
-	  name =  "%s"
-		email = "email@example.com"
-		bucket_name = "bucketname"
-		secret_key = %q
-	}
+  gcslogging {
+    name = "%s"
+    email = "email@example.com"
+    bucket_name = "bucketname"
+    secret_key = %q
+    compression_codec = "zstd"
+  }
 
  package {
     filename = "test_fixtures/package/valid.tar.gz"
-	source_code_hash = filesha512("test_fixtures/package/valid.tar.gz")
+    source_code_hash = filesha512("test_fixtures/package/valid.tar.gz")
   }
 
   force_destroy = true
@@ -238,21 +242,21 @@ resource "fastly_service_v1" "foo" {
   name = "%s"
 
   domain {
-    name    = "%s"
+    name = "%s"
     comment = "tf-testing-domain"
   }
 
   backend {
     address = "%s"
-    name    = "tf -test backend"
+    name = "tf -test backend"
   }
 
-	gcslogging {
-	  name =  "%s"
-		bucket_name = "bucketname"
-		format = "log format"
-		response_condition = ""
-	}
+  gcslogging {
+    name = "%s"
+    bucket_name = "bucketname"
+    format = "log format"
+    response_condition = ""
+  }
 
   force_destroy = true
 }`, name, domainName, backendName, gcsName)

--- a/fastly/block_fastly_service_v1_logging_cloudfiles.go
+++ b/fastly/block_fastly_service_v1_logging_cloudfiles.go
@@ -228,6 +228,7 @@ func flattenCloudfiles(cloudfilesList []*gofastly.Cloudfiles) []map[string]inter
 			"format_version":     ll.FormatVersion,
 			"placement":          ll.Placement,
 			"response_condition": ll.ResponseCondition,
+			"compression_codec":  ll.CompressionCodec,
 		}
 
 		// Prune any empty values that come from the default string value in structs.
@@ -261,6 +262,7 @@ func (h *CloudfilesServiceAttributeHandler) buildCreate(cloudfilesMap interface{
 		Region:            df["region"].(string),
 		Period:            uint(df["period"].(int)),
 		TimestampFormat:   df["timestamp_format"].(string),
+		CompressionCodec:  df["compression_codec"].(string),
 		Format:            vla.format,
 		FormatVersion:     uintOrDefault(vla.formatVersion),
 		Placement:         vla.placement,
@@ -354,6 +356,12 @@ func (h *CloudfilesServiceAttributeHandler) Register(s *schema.Resource) error {
 			Optional:    true,
 			Default:     "%Y-%m-%dT%H:%M:%S.000",
 			Description: "The `strftime` specified timestamp formatting (default `%Y-%m-%dT%H:%M:%S.000`)",
+		},
+		"compression_codec": {
+			Type:             schema.TypeString,
+			Optional:         true,
+			Description:      `The codec used for compression of your logs. Valid values are zstd, snappy, and gzip. If the specified codec is "gzip", gzip_level will default to 3. To specify a different level, leave compression_codec blank and explicitly set the level using gzip_level. Specifying both compression_codec and gzip_level in the same API request will result in an error.`,
+			ValidateDiagFunc: validateLoggingCompressionCodec(),
 		},
 	}
 

--- a/fastly/block_fastly_service_v1_logging_cloudfiles_test.go
+++ b/fastly/block_fastly_service_v1_logging_cloudfiles_test.go
@@ -36,6 +36,7 @@ func TestResourceFastlyFlattenCloudfiles(t *testing.T) {
 					Placement:         "none",
 					ResponseCondition: "response_condition",
 					TimestampFormat:   "%Y-%m-%dT%H:%M:%S.000",
+					CompressionCodec:  "zstd",
 				},
 			},
 			local: []map[string]interface{}{
@@ -55,6 +56,7 @@ func TestResourceFastlyFlattenCloudfiles(t *testing.T) {
 					"placement":          "none",
 					"response_condition": "response_condition",
 					"timestamp_format":   "%Y-%m-%dT%H:%M:%S.000",
+					"compression_codec":  "zstd",
 				},
 			},
 		},
@@ -90,6 +92,7 @@ func TestAccFastlyServiceV1_logging_cloudfiles_basic(t *testing.T) {
 		Placement:         "none",
 		ResponseCondition: "response_condition_test",
 		TimestampFormat:   "%Y-%m-%dT%H:%M:%S.000",
+		CompressionCodec:  "zstd",
 	}
 
 	log1_after_update := gofastly.Cloudfiles{
@@ -109,6 +112,7 @@ func TestAccFastlyServiceV1_logging_cloudfiles_basic(t *testing.T) {
 		Placement:         "none",
 		ResponseCondition: "response_condition_test",
 		TimestampFormat:   "%Y-%m-%dT%H:%M:%S.000",
+		CompressionCodec:  "",
 	}
 
 	log2 := gofastly.Cloudfiles{
@@ -128,6 +132,7 @@ func TestAccFastlyServiceV1_logging_cloudfiles_basic(t *testing.T) {
 		Placement:         "none",
 		ResponseCondition: "response_condition_test",
 		TimestampFormat:   "%Y-%m-%dT%H:%M:%S.000",
+		CompressionCodec:  "zstd",
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -168,18 +173,19 @@ func TestAccFastlyServiceV1_logging_cloudfiles_basic_compute(t *testing.T) {
 	domain := fmt.Sprintf("fastly-test.%s.com", name)
 
 	log1Compute := gofastly.Cloudfiles{
-		ServiceVersion:  1,
-		Name:            "cloudfiles-endpoint",
-		BucketName:      "bucket",
-		User:            "user",
-		AccessKey:       "secret",
-		PublicKey:       pgpPublicKey(t),
-		GzipLevel:       0,
-		MessageType:     "classic",
-		Path:            "/",
-		Region:          "ORD",
-		Period:          3600,
-		TimestampFormat: "%Y-%m-%dT%H:%M:%S.000",
+		ServiceVersion:   1,
+		Name:             "cloudfiles-endpoint",
+		BucketName:       "bucket",
+		User:             "user",
+		AccessKey:        "secret",
+		PublicKey:        pgpPublicKey(t),
+		GzipLevel:        0,
+		MessageType:      "classic",
+		Path:             "/",
+		Region:           "ORD",
+		Period:           3600,
+		TimestampFormat:  "%Y-%m-%dT%H:%M:%S.000",
+		CompressionCodec: "zstd",
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -257,32 +263,32 @@ resource "fastly_service_compute" "none" {
   name = "%s"
 
   domain {
-    name    = "%s"
+    name = "%s"
     comment = "tf-cloudfiles-logging"
   }
 
   backend {
     address = "aws.amazon.com"
-    name    = "amazon docs"
+    name = "amazon docs"
   }
 
   logging_cloudfiles {
-    name   = "cloudfiles-endpoint"
+    name = "cloudfiles-endpoint"
     bucket_name = "bucket"
     user = "user"
     access_key = "secret"
     public_key = file("test_fixtures/fastly_test_publickey")
     message_type = "classic"
-	path = "/"
-	region = "ORD"
-	period = 3600
-	gzip_level = 0
-	timestamp_format = "%%Y-%%m-%%dT%%H:%%M:%%S.000"
+    path = "/"
+    region = "ORD"
+    period = 3600
+    timestamp_format = "%%Y-%%m-%%dT%%H:%%M:%%S.000"
+    compression_codec = "zstd"
   }
 
   package {
     filename = "test_fixtures/package/valid.tar.gz"
-	source_code_hash = filesha512("test_fixtures/package/valid.tar.gz")
+    source_code_hash = filesha512("test_fixtures/package/valid.tar.gz")
   }
 
   force_destroy = true
@@ -296,38 +302,38 @@ resource "fastly_service_v1" "none" {
   name = "%s"
 
   domain {
-    name    = "%s"
+    name = "%s"
     comment = "tf-cloudfiles-logging"
   }
 
   backend {
     address = "aws.amazon.com"
-    name    = "amazon docs"
+    name = "amazon docs"
   }
 
   condition {
-    name      = "response_condition_test"
-    type      = "RESPONSE"
+    name = "response_condition_test"
+    type = "RESPONSE"
     priority  = 8
     statement = "resp.status == 418"
   }
 
   logging_cloudfiles {
-    name   = "cloudfiles-endpoint"
+    name = "cloudfiles-endpoint"
     bucket_name = "bucket"
     user = "user"
     access_key = "secret"
     public_key = file("test_fixtures/fastly_test_publickey")
     format = "%%h %%l %%u %%t \"%%r\" %%>s %%b"
-		message_type = "classic"
-		path = "/"
-		region = "ORD"
-		period = 3600
-		placement = "none"
-		response_condition = "response_condition_test"
-    gzip_level = 0
+    message_type = "classic"
+    path = "/"
+    region = "ORD"
+    period = 3600
+    placement = "none"
+    response_condition = "response_condition_test"
     format_version = 2
-		timestamp_format = "%%Y-%%m-%%dT%%H:%%M:%%S.000"
+    timestamp_format = "%%Y-%%m-%%dT%%H:%%M:%%S.000"
+    compression_codec = "zstd"
   }
 
   force_destroy = true
@@ -341,56 +347,56 @@ resource "fastly_service_v1" "none" {
   name = "%s"
 
   domain {
-    name    = "%s"
+    name = "%s"
     comment = "tf-cloudfiles-logging"
   }
 
   backend {
     address = "aws.amazon.com"
-    name    = "amazon docs"
+    name = "amazon docs"
   }
 
   condition {
-    name      = "response_condition_test"
-    type      = "RESPONSE"
-    priority  = 8
+    name = "response_condition_test"
+    type = "RESPONSE"
+    priority = 8
     statement = "resp.status == 418"
   }
 
   logging_cloudfiles {
-    name   = "cloudfiles-endpoint"
+    name = "cloudfiles-endpoint"
     bucket_name = "bucketupdate"
     user = "userupdate"
     access_key = "secretupdate"
     public_key = file("test_fixtures/fastly_test_publickey")
     format = "%%h %%l %%u %%t \"%%r\" %%>s %%b %%T"
-		message_type = "blank"
-		path = "new/"
-		region = "LON"
-		period = 3601
-		placement = "none"
-		response_condition = "response_condition_test"
+    message_type = "blank"
+    path = "new/"
+    region = "LON"
+    period = 3601
+    placement = "none"
+    response_condition = "response_condition_test"
     gzip_level = 1
     format_version = 2
-		timestamp_format = "%%Y-%%m-%%dT%%H:%%M:%%S.000"
+    timestamp_format = "%%Y-%%m-%%dT%%H:%%M:%%S.000"
   }
 
   logging_cloudfiles {
-    name   = "another-cloudfiles-endpoint"
+    name = "another-cloudfiles-endpoint"
     bucket_name = "bucket2"
     user = "user2"
     access_key = "secret2"
     public_key = file("test_fixtures/fastly_test_publickey")
     format = "%%h %%l %%u %%t \"%%r\" %%>s %%b"
-		message_type = "classic"
-		path = "two/"
-		region = "SYD"
-		period = 3600
-		placement = "none"
-		response_condition = "response_condition_test"
-    gzip_level = 0
+    message_type = "classic"
+    path = "two/"
+    region = "SYD"
+    period = 3600
+    placement = "none"
+    response_condition = "response_condition_test"
     format_version = 2
-		timestamp_format = "%%Y-%%m-%%dT%%H:%%M:%%S.000"
+    timestamp_format = "%%Y-%%m-%%dT%%H:%%M:%%S.000"
+    compression_codec = "zstd"
   }
 
   force_destroy = true

--- a/fastly/block_fastly_service_v1_logging_digitalocean.go
+++ b/fastly/block_fastly_service_v1_logging_digitalocean.go
@@ -229,6 +229,7 @@ func flattenDigitalOcean(digitaloceanList []*gofastly.DigitalOcean) []map[string
 			"message_type":       ll.MessageType,
 			"placement":          ll.Placement,
 			"response_condition": ll.ResponseCondition,
+			"compression_codec":  ll.CompressionCodec,
 		}
 
 		// Prune any empty values that come from the default string value in structs.
@@ -262,6 +263,7 @@ func (h *DigitalOceanServiceAttributeHandler) buildCreate(digitaloceanMap interf
 		GzipLevel:         uint(df["gzip_level"].(int)),
 		TimestampFormat:   df["timestamp_format"].(string),
 		MessageType:       df["message_type"].(string),
+		CompressionCodec:  df["compression_codec"].(string),
 		Format:            vla.format,
 		FormatVersion:     uintOrDefault(vla.formatVersion),
 		Placement:         vla.placement,
@@ -354,6 +356,12 @@ func (h *DigitalOceanServiceAttributeHandler) Register(s *schema.Resource) error
 			Default:          "classic",
 			Description:      "How the message should be formatted. One of: `classic` (default), `loggly`, `logplex` or `blank`",
 			ValidateDiagFunc: validateLoggingMessageType(),
+		},
+		"compression_codec": {
+			Type:             schema.TypeString,
+			Optional:         true,
+			Description:      `The codec used for compression of your logs. Valid values are zstd, snappy, and gzip. If the specified codec is "gzip", gzip_level will default to 3. To specify a different level, leave compression_codec blank and explicitly set the level using gzip_level. Specifying both compression_codec and gzip_level in the same API request will result in an error.`,
+			ValidateDiagFunc: validateLoggingCompressionCodec(),
 		},
 	}
 

--- a/fastly/block_fastly_service_v1_logging_digitalocean_test.go
+++ b/fastly/block_fastly_service_v1_logging_digitalocean_test.go
@@ -30,12 +30,13 @@ func TestResourceFastlyFlattenDigitalOcean(t *testing.T) {
 					Path:              "/",
 					Period:            3600,
 					TimestampFormat:   "%Y-%m-%dT%H:%M:%S.000",
-					GzipLevel:         1,
+					GzipLevel:         0,
 					Format:            "%h %l %u %t \"%r\" %>s %b",
 					FormatVersion:     2,
 					MessageType:       "classic",
 					Placement:         "none",
 					ResponseCondition: "always",
+					CompressionCodec:  "zstd",
 				},
 			},
 			local: []map[string]interface{}{
@@ -49,12 +50,13 @@ func TestResourceFastlyFlattenDigitalOcean(t *testing.T) {
 					"path":               "/",
 					"period":             uint(3600),
 					"timestamp_format":   "%Y-%m-%dT%H:%M:%S.000",
-					"gzip_level":         uint(1),
+					"gzip_level":         uint(0),
 					"format":             "%h %l %u %t \"%r\" %>s %b",
 					"format_version":     uint(2),
 					"message_type":       "classic",
 					"placement":          "none",
 					"response_condition": "always",
+					"compression_codec":  "zstd",
 				},
 			},
 		},
@@ -84,12 +86,12 @@ func TestAccFastlyServiceV1_logging_digitalocean_basic(t *testing.T) {
 		Path:              "/",
 		Period:            3600,
 		TimestampFormat:   "%Y-%m-%dT%H:%M:%S.000",
-		GzipLevel:         0,
 		Format:            "%h %l %u %t \"%r\" %>s %b",
 		FormatVersion:     2,
 		MessageType:       "classic",
 		Placement:         "none",
 		ResponseCondition: "response_condition_test",
+		CompressionCodec:  "zstd",
 	}
 
 	log1_after_update := gofastly.DigitalOcean{
@@ -123,11 +125,12 @@ func TestAccFastlyServiceV1_logging_digitalocean_basic(t *testing.T) {
 		Period:            3600,
 		Format:            "%h %l %u %t \"%r\" %>s %b",
 		TimestampFormat:   "%Y-%m-%dT%H:%M:%S.000",
-		GzipLevel:         1,
+		GzipLevel:         0,
 		FormatVersion:     2,
 		MessageType:       "classic",
 		Placement:         "none",
 		ResponseCondition: "response_condition_test",
+		CompressionCodec:  "zstd",
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -168,18 +171,18 @@ func TestAccFastlyServiceV1_logging_digitalocean_basic_compute(t *testing.T) {
 	domain := fmt.Sprintf("fastly-test.%s.com", name)
 
 	log1 := gofastly.DigitalOcean{
-		ServiceVersion:  1,
-		Name:            "digitalocean-endpoint",
-		BucketName:      "bucket",
-		AccessKey:       "access",
-		SecretKey:       "secret",
-		Domain:          "nyc3.digitaloceanspaces.com",
-		PublicKey:       pgpPublicKey(t),
-		Path:            "/",
-		Period:          3600,
-		TimestampFormat: "%Y-%m-%dT%H:%M:%S.000",
-		GzipLevel:       0,
-		MessageType:     "classic",
+		ServiceVersion:   1,
+		Name:             "digitalocean-endpoint",
+		BucketName:       "bucket",
+		AccessKey:        "access",
+		SecretKey:        "secret",
+		Domain:           "nyc3.digitaloceanspaces.com",
+		PublicKey:        pgpPublicKey(t),
+		Path:             "/",
+		Period:           3600,
+		TimestampFormat:  "%Y-%m-%dT%H:%M:%S.000",
+		MessageType:      "classic",
+		CompressionCodec: "zstd",
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -257,24 +260,24 @@ resource "fastly_service_v1" "foo" {
   name = "%s"
 
   domain {
-    name    = "%s"
+    name = "%s"
     comment = "tf-digitalocean-logging"
   }
 
   backend {
     address = "aws.amazon.com"
-    name    = "amazon docs"
+    name = "amazon docs"
   }
 
   condition {
-    name      = "response_condition_test"
-    type      = "RESPONSE"
-    priority  = 8
+    name = "response_condition_test"
+    type = "RESPONSE"
+    priority = 8
     statement = "resp.status == 418"
   }
 
   logging_digitalocean {
-    name   = "digitalocean-endpoint"
+    name = "digitalocean-endpoint"
     bucket_name = "bucket"
     access_key = "access"
     secret_key = "secret"
@@ -283,11 +286,11 @@ resource "fastly_service_v1" "foo" {
     path = "/"
     period = 3600
     timestamp_format = "%%Y-%%m-%%dT%%H:%%M:%%S.000"
-    gzip_level = 0
     format = "%%h %%l %%u %%t \"%%r\" %%>s %%b"
     message_type = "classic"
     placement = "none"
     response_condition = "response_condition_test"
+    compression_codec = "zstd"
   }
 
   force_destroy = true
@@ -301,24 +304,24 @@ resource "fastly_service_v1" "foo" {
   name = "%s"
 
   domain {
-    name    = "%s"
+    name = "%s"
     comment = "tf-digitalocean-logging"
   }
 
   backend {
     address = "aws.amazon.com"
-    name    = "amazon docs"
+    name = "amazon docs"
   }
 
   condition {
-    name      = "response_condition_test"
-    type      = "RESPONSE"
-    priority  = 8
+    name = "response_condition_test"
+    type = "RESPONSE"
+    priority = 8
     statement = "resp.status == 418"
   }
 
   logging_digitalocean {
-    name   = "digitalocean-endpoint"
+    name = "digitalocean-endpoint"
     bucket_name = "bucketupdate"
     access_key = "accessupdate"
     secret_key = "secretupdate"
@@ -335,7 +338,7 @@ resource "fastly_service_v1" "foo" {
   }
 
   logging_digitalocean {
-    name   = "another-digitalocean-endpoint"
+    name = "another-digitalocean-endpoint"
     bucket_name = "bucket2"
     access_key = "access2"
     secret_key = "secret2"
@@ -344,11 +347,11 @@ resource "fastly_service_v1" "foo" {
     path = "two/"
     period = 3600
     timestamp_format = "%%Y-%%m-%%dT%%H:%%M:%%S.000"
-    gzip_level = 1
     format = "%%h %%l %%u %%t \"%%r\" %%>s %%b"
     message_type = "classic"
     placement = "none"
     response_condition = "response_condition_test"
+    compression_codec = "zstd"
   }
 
   force_destroy = true
@@ -362,17 +365,17 @@ resource "fastly_service_compute" "foo" {
   name = "%s"
 
   domain {
-    name    = "%s"
+    name = "%s"
     comment = "tf-digitalocean-logging"
   }
 
   backend {
     address = "aws.amazon.com"
-    name    = "amazon docs"
+    name = "amazon docs"
   }
 
   logging_digitalocean {
-    name   = "digitalocean-endpoint"
+    name = "digitalocean-endpoint"
     bucket_name = "bucket"
     access_key = "access"
     secret_key = "secret"
@@ -381,13 +384,13 @@ resource "fastly_service_compute" "foo" {
     path = "/"
     period = 3600
     timestamp_format = "%%Y-%%m-%%dT%%H:%%M:%%S.000"
-    gzip_level = 0
     message_type = "classic"
+    compression_codec = "zstd"
   }
 
   package {
     filename = "test_fixtures/package/valid.tar.gz"
-	source_code_hash = filesha512("test_fixtures/package/valid.tar.gz")
+    source_code_hash = filesha512("test_fixtures/package/valid.tar.gz")
   }
 
   force_destroy = true

--- a/fastly/block_fastly_service_v1_logging_ftp.go
+++ b/fastly/block_fastly_service_v1_logging_ftp.go
@@ -267,6 +267,12 @@ func (h *FTPServiceAttributeHandler) Register(s *schema.Resource) error {
 			Description:      "How the message should be formatted (default: `classic`)",
 			ValidateDiagFunc: validateLoggingMessageType(),
 		},
+		"compression_codec": {
+			Type:             schema.TypeString,
+			Optional:         true,
+			Description:      `The codec used for compression of your logs. Valid values are zstd, snappy, and gzip. If the specified codec is "gzip", gzip_level will default to 3. To specify a different level, leave compression_codec blank and explicitly set the level using gzip_level. Specifying both compression_codec and gzip_level in the same API request will result in an error.`,
+			ValidateDiagFunc: validateLoggingCompressionCodec(),
+		},
 	}
 
 	if h.GetServiceMetadata().serviceType == ServiceTypeVCL {
@@ -346,6 +352,7 @@ func flattenFTP(ftpList []*gofastly.FTP) []map[string]interface{} {
 			"message_type":       fl.MessageType,
 			"placement":          fl.Placement,
 			"response_condition": fl.ResponseCondition,
+			"compression_codec":  fl.CompressionCodec,
 		}
 
 		// Prune any empty values that come from the default string value in structs.
@@ -379,6 +386,7 @@ func (h *FTPServiceAttributeHandler) buildCreate(ftpMap interface{}, serviceID s
 		GzipLevel:         uint8(df["gzip_level"].(int)),
 		TimestampFormat:   df["timestamp_format"].(string),
 		MessageType:       df["message_type"].(string),
+		CompressionCodec:  df["compression_codec"].(string),
 		Format:            vla.format,
 		FormatVersion:     uintOrDefault(vla.formatVersion),
 		Placement:         vla.placement,

--- a/fastly/block_fastly_service_v1_logging_ftp_test.go
+++ b/fastly/block_fastly_service_v1_logging_ftp_test.go
@@ -20,39 +20,41 @@ func TestResourceFastlyFlattenFTP(t *testing.T) {
 		{
 			remote: []*gofastly.FTP{
 				{
-					ServiceVersion:  1,
-					Name:            "ftp-endpoint",
-					Address:         "ftp.example.com",
-					Username:        "username",
-					Password:        "password",
-					PublicKey:       pgpPublicKey(t),
-					Path:            "/path",
-					Port:            21,
-					Period:          3600,
-					GzipLevel:       3,
-					Format:          "%h %l %u %t \"%r\" %>s %b",
-					FormatVersion:   2,
-					TimestampFormat: "%Y-%m-%dT%H:%M:%S.000",
-					Placement:       "none",
-					MessageType:     "classic",
+					ServiceVersion:   1,
+					Name:             "ftp-endpoint",
+					Address:          "ftp.example.com",
+					Username:         "username",
+					Password:         "password",
+					PublicKey:        pgpPublicKey(t),
+					Path:             "/path",
+					Port:             21,
+					Period:           3600,
+					GzipLevel:        0,
+					Format:           "%h %l %u %t \"%r\" %>s %b",
+					FormatVersion:    2,
+					TimestampFormat:  "%Y-%m-%dT%H:%M:%S.000",
+					Placement:        "none",
+					MessageType:      "classic",
+					CompressionCodec: "zstd",
 				},
 			},
 			local: []map[string]interface{}{
 				{
-					"name":             "ftp-endpoint",
-					"address":          "ftp.example.com",
-					"user":             "username",
-					"password":         "password",
-					"public_key":       pgpPublicKey(t),
-					"path":             "/path",
-					"period":           uint(3600),
-					"port":             uint(21),
-					"gzip_level":       uint8(3),
-					"format_version":   uint(2),
-					"format":           "%h %l %u %t \"%r\" %>s %b",
-					"timestamp_format": "%Y-%m-%dT%H:%M:%S.000",
-					"placement":        "none",
-					"message_type":     "classic",
+					"name":              "ftp-endpoint",
+					"address":           "ftp.example.com",
+					"user":              "username",
+					"password":          "password",
+					"public_key":        pgpPublicKey(t),
+					"path":              "/path",
+					"period":            uint(3600),
+					"port":              uint(21),
+					"gzip_level":        uint8(0),
+					"format_version":    uint(2),
+					"format":            "%h %l %u %t \"%r\" %>s %b",
+					"timestamp_format":  "%Y-%m-%dT%H:%M:%S.000",
+					"placement":         "none",
+					"message_type":      "classic",
+					"compression_codec": "zstd",
 				},
 			},
 		},
@@ -72,21 +74,21 @@ func TestAccFastlyServiceV1_logging_ftp_basic(t *testing.T) {
 	domain := fmt.Sprintf("fastly-test.%s.com", name)
 
 	log1 := gofastly.FTP{
-		ServiceVersion:  1,
-		Name:            "ftp-endpoint",
-		Address:         "ftp.example.com",
-		Username:        "user",
-		Password:        "p@ssw0rd",
-		PublicKey:       pgpPublicKey(t),
-		Path:            "/path",
-		Port:            27,
-		GzipLevel:       3,
-		Period:          3600,
-		TimestampFormat: "%Y-%m-%dT%H:%M:%S.000",
-		Format:          "%h %l %u %t \"%r\" %>s %b",
-		FormatVersion:   2,
-		Placement:       "none",
-		MessageType:     "classic",
+		ServiceVersion:   1,
+		Name:             "ftp-endpoint",
+		Address:          "ftp.example.com",
+		Username:         "user",
+		Password:         "p@ssw0rd",
+		PublicKey:        pgpPublicKey(t),
+		Path:             "/path",
+		Port:             27,
+		Period:           3600,
+		TimestampFormat:  "%Y-%m-%dT%H:%M:%S.000",
+		Format:           "%h %l %u %t \"%r\" %>s %b",
+		FormatVersion:    2,
+		Placement:        "none",
+		MessageType:      "classic",
+		CompressionCodec: "zstd",
 	}
 
 	log1_after_update := gofastly.FTP{
@@ -108,21 +110,21 @@ func TestAccFastlyServiceV1_logging_ftp_basic(t *testing.T) {
 	}
 
 	log2 := gofastly.FTP{
-		ServiceVersion:  1,
-		Name:            "another-ftp-endpoint",
-		Address:         "ftp.example.com",
-		Username:        "user",
-		Password:        "p@ssw0rd",
-		Path:            "/",
-		PublicKey:       pgpPublicKey(t),
-		Port:            21,
-		GzipLevel:       3,
-		Period:          360,
-		TimestampFormat: "%Y-%m-%dT%H:%M:%S.000",
-		Format:          "%h %l %u %t \"%r\" %>s %b",
-		FormatVersion:   2,
-		Placement:       "none",
-		MessageType:     "classic",
+		ServiceVersion:   1,
+		Name:             "another-ftp-endpoint",
+		Address:          "ftp.example.com",
+		Username:         "user",
+		Password:         "p@ssw0rd",
+		Path:             "/",
+		PublicKey:        pgpPublicKey(t),
+		Port:             21,
+		Period:           360,
+		TimestampFormat:  "%Y-%m-%dT%H:%M:%S.000",
+		Format:           "%h %l %u %t \"%r\" %>s %b",
+		FormatVersion:    2,
+		Placement:        "none",
+		MessageType:      "classic",
+		CompressionCodec: "zstd",
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -163,17 +165,17 @@ func TestAccFastlyServiceV1_logging_ftp_basic_compute(t *testing.T) {
 	domain := fmt.Sprintf("fastly-test.%s.com", name)
 
 	log1 := gofastly.FTP{
-		ServiceVersion:  1,
-		Name:            "ftp-endpoint",
-		Address:         "ftp.example.com",
-		Username:        "user",
-		Password:        "p@ssw0rd",
-		PublicKey:       pgpPublicKey(t),
-		Path:            "/path",
-		Port:            27,
-		GzipLevel:       3,
-		Period:          3600,
-		TimestampFormat: "%Y-%m-%dT%H:%M:%S.000",
+		ServiceVersion:   1,
+		Name:             "ftp-endpoint",
+		Address:          "ftp.example.com",
+		Username:         "user",
+		Password:         "p@ssw0rd",
+		PublicKey:        pgpPublicKey(t),
+		Path:             "/path",
+		Port:             27,
+		Period:           3600,
+		TimestampFormat:  "%Y-%m-%dT%H:%M:%S.000",
+		CompressionCodec: "zstd",
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -258,26 +260,26 @@ resource "fastly_service_compute" "foo" {
   name = "%s"
 
   domain {
-    name    = "%s"
+    name = "%s"
     comment = "tf-ftp-logging"
   }
 
   backend {
     address = "aws.amazon.com"
-    name    = "amazon docs"
+    name = "amazon docs"
   }
 
   logging_ftp {
-    name       = "ftp-endpoint"
-    address    = "ftp.example.com"
-    user       = "user"
+    name = "ftp-endpoint"
+    address = "ftp.example.com"
+    user = "user"
     public_key = file("test_fixtures/fastly_test_publickey")
-    password         = "p@ssw0rd"
-    path             = "/path"
-    port             = 27
-    gzip_level       = 3
+    password = "p@ssw0rd"
+    path = "/path"
+    port = 27
     timestamp_format = "%%Y-%%m-%%dT%%H:%%M:%%S.000"
-    message_type     = "classic"
+    message_type = "classic"
+    compression_codec = "zstd"
   }
 
   package {
@@ -286,8 +288,7 @@ resource "fastly_service_compute" "foo" {
   }
 
   force_destroy = true
-}
-`, name, domain)
+}`, name, domain)
 }
 
 func testAccServiceV1FTPConfig(name string, domain string) string {
@@ -296,32 +297,31 @@ resource "fastly_service_v1" "foo" {
   name = "%s"
 
   domain {
-    name    = "%s"
+    name = "%s"
     comment = "tf-ftp-logging"
   }
 
   backend {
     address = "aws.amazon.com"
-    name    = "amazon docs"
+    name = "amazon docs"
   }
 
   logging_ftp {
-    name       = "ftp-endpoint"
-    address    = "ftp.example.com"
-    user       = "user"
+    name = "ftp-endpoint"
+    address = "ftp.example.com"
+    user = "user"
     public_key = file("test_fixtures/fastly_test_publickey")
-    password         = "p@ssw0rd"
-    path             = "/path"
-    port             = 27
-    format           = "%%h %%l %%u %%t \"%%r\" %%>s %%b"
-    gzip_level       = 3
+    password = "p@ssw0rd"
+    path = "/path"
+    port = 27
+    format = "%%h %%l %%u %%t \"%%r\" %%>s %%b"
     timestamp_format = "%%Y-%%m-%%dT%%H:%%M:%%S.000"
-    placement        = "none"
+    placement = "none"
+    compression_codec = "zstd"
   }
 
   force_destroy = true
-}
-`, name, domain)
+}`, name, domain)
 }
 
 func testAccServiceV1FTPConfig_update(name, domain string) string {
@@ -330,43 +330,42 @@ resource "fastly_service_v1" "foo" {
   name = "%s"
 
   domain {
-    name    = "%s"
+    name = "%s"
     comment = "tf-ftp-logging"
   }
 
   backend {
     address = "aws.amazon.com"
-    name    = "amazon docs"
+    name = "amazon docs"
   }
 
   logging_ftp {
-    name       = "ftp-endpoint"
-    address    = "ftp2.example.com"
-    user       = "user"
-    password   = "p@ssw0rd2"
+    name = "ftp-endpoint"
+    address = "ftp2.example.com"
+    user = "user"
+    password = "p@ssw0rd2"
     public_key = file("test_fixtures/fastly_test_publickey")
-    path             = "/path"
-    format           = "%%h %%l %%u %%t \"%%r\" %%>s %%b %%T"
-    gzip_level       = 4
+    path = "/path"
+    format = "%%h %%l %%u %%t \"%%r\" %%>s %%b %%T"
+    gzip_level = 4
     timestamp_format = "%%Y-%%m-%%dT%%H:%%M:%%S.000"
-    placement        = "waf_debug"
+    placement = "waf_debug"
   }
 
   logging_ftp {
-    name       = "another-ftp-endpoint"
-    address    = "ftp.example.com"
-    user       = "user"
-    password   = "p@ssw0rd"
+    name = "another-ftp-endpoint"
+    address = "ftp.example.com"
+    user = "user"
+    password = "p@ssw0rd"
     public_key = file("test_fixtures/fastly_test_publickey")
-    path             = "/"
-    period           = 360
-    format           = "%%h %%l %%u %%t \"%%r\" %%>s %%b"
-    gzip_level       = 3
+    path = "/"
+    period = 360
+    format = "%%h %%l %%u %%t \"%%r\" %%>s %%b"
     timestamp_format = "%%Y-%%m-%%dT%%H:%%M:%%S.000"
-    placement        = "none"
+    placement = "none"
+    compression_codec = "zstd"
   }
 
   force_destroy = true
-}
-`, name, domain)
+}`, name, domain)
 }

--- a/fastly/block_fastly_service_v1_logging_openstack.go
+++ b/fastly/block_fastly_service_v1_logging_openstack.go
@@ -232,6 +232,7 @@ func flattenOpenstack(openstackList []*gofastly.Openstack) []map[string]interfac
 			"format_version":     ll.FormatVersion,
 			"placement":          ll.Placement,
 			"response_condition": ll.ResponseCondition,
+			"compression_codec":  ll.CompressionCodec,
 		}
 
 		// Prune any empty values that come from the default string value in structs.
@@ -265,6 +266,7 @@ func (h *OpenstackServiceAttributeHandler) buildCreate(openstackMap interface{},
 		Path:              df["path"].(string),
 		Period:            uint(df["period"].(int)),
 		TimestampFormat:   df["timestamp_format"].(string),
+		CompressionCodec:  df["compression_codec"].(string),
 		Format:            vla.format,
 		FormatVersion:     uintOrDefault(vla.formatVersion),
 		Placement:         vla.placement,
@@ -358,6 +360,12 @@ func (h *OpenstackServiceAttributeHandler) Register(s *schema.Resource) error {
 			Optional:    true,
 			Default:     "%Y-%m-%dT%H:%M:%S.000",
 			Description: "specified timestamp formatting (default `%Y-%m-%dT%H:%M:%S.000`)",
+		},
+		"compression_codec": {
+			Type:             schema.TypeString,
+			Optional:         true,
+			Description:      `The codec used for compression of your logs. Valid values are zstd, snappy, and gzip. If the specified codec is "gzip", gzip_level will default to 3. To specify a different level, leave compression_codec blank and explicitly set the level using gzip_level. Specifying both compression_codec and gzip_level in the same API request will result in an error.`,
+			ValidateDiagFunc: validateLoggingCompressionCodec(),
 		},
 	}
 

--- a/fastly/block_fastly_service_v1_logging_openstack_test.go
+++ b/fastly/block_fastly_service_v1_logging_openstack_test.go
@@ -35,6 +35,7 @@ func TestResourceFastlyFlattenOpenstack(t *testing.T) {
 					ResponseCondition: "always",
 					Period:            3600,
 					GzipLevel:         0,
+					CompressionCodec:  "zstd",
 				},
 			},
 			local: []map[string]interface{}{
@@ -54,6 +55,7 @@ func TestResourceFastlyFlattenOpenstack(t *testing.T) {
 					"response_condition": "always",
 					"period":             uint(3600),
 					"gzip_level":         uint(0),
+					"compression_codec":  "zstd",
 				},
 			},
 		},
@@ -88,7 +90,7 @@ func TestAccFastlyServiceV1_logging_openstack_basic(t *testing.T) {
 		TimestampFormat:   `%Y-%m-%dT%H:%M:%S.000`,
 		ResponseCondition: "response_condition_test",
 		Period:            3600,
-		GzipLevel:         0,
+		CompressionCodec:  "zstd",
 	}
 
 	log1_after_update := gofastly.Openstack{
@@ -126,7 +128,7 @@ func TestAccFastlyServiceV1_logging_openstack_basic(t *testing.T) {
 		TimestampFormat:   `%Y-%m-%dT%H:%M:%S.000`,
 		ResponseCondition: "response_condition_test",
 		Period:            3600,
-		GzipLevel:         0,
+		CompressionCodec:  "zstd",
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -167,18 +169,18 @@ func TestAccFastlyServiceV1_logging_openstack_basic_compute(t *testing.T) {
 	domain := fmt.Sprintf("fastly-test.%s.com", name)
 
 	log1 := gofastly.Openstack{
-		ServiceVersion:  1,
-		Name:            "openstack-endpoint",
-		URL:             "https://auth.example.com/v1", // /v1, /v2 or /v3 are required to be in the path.
-		User:            "user",
-		BucketName:      "bucket",
-		AccessKey:       "s3cr3t",
-		PublicKey:       pgpPublicKey(t),
-		MessageType:     "classic",
-		Path:            "/",
-		TimestampFormat: `%Y-%m-%dT%H:%M:%S.000`,
-		Period:          3600,
-		GzipLevel:       0,
+		ServiceVersion:   1,
+		Name:             "openstack-endpoint",
+		URL:              "https://auth.example.com/v1", // /v1, /v2 or /v3 are required to be in the path.
+		User:             "user",
+		BucketName:       "bucket",
+		AccessKey:        "s3cr3t",
+		PublicKey:        pgpPublicKey(t),
+		MessageType:      "classic",
+		Path:             "/",
+		TimestampFormat:  `%Y-%m-%dT%H:%M:%S.000`,
+		Period:           3600,
+		CompressionCodec: "zstd",
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -284,11 +286,11 @@ resource "fastly_service_v1" "foo" {
     placement = "none"
 		timestamp_format = "%%Y-%%m-%%dT%%H:%%M:%%S.000"
     response_condition = "response_condition_test"
+    compression_codec = "zstd"
   }
 
   force_destroy = true
-}
-`, name, domain)
+}`, name, domain)
 }
 
 func testAccServiceV1OpenstackConfig_update(name, domain string) string {
@@ -297,43 +299,43 @@ resource "fastly_service_v1" "foo" {
   name = "%s"
 
   domain {
-    name    = "%s"
+    name = "%s"
     comment = "tf-openstack-logging"
   }
 
   backend {
     address = "aws.amazon.com"
-    name    = "amazon docs"
+    name = "amazon docs"
   }
 
   condition {
-    name      = "response_condition_test"
-    type      = "RESPONSE"
-    priority  = 8
+    name = "response_condition_test"
+    type = "RESPONSE"
+    priority = 8
     statement = "resp.status == 418"
   }
 
   logging_openstack {
-    name   = "openstack-endpoint"
-    user   = "userupdate"
-		url    = "https://auth.example.com/v2"
+    name = "openstack-endpoint"
+    user = "userupdate"
+    url = "https://auth.example.com/v2"
     bucket_name = "bucketupdate"
     access_key = "s3cr3tupdate"
     public_key = file("test_fixtures/fastly_test_publickey")
     format = "%%h %%l %%u %%t \"%%r\" %%>s %%b %%T"
     path = "new/"
     placement = "none"
-		timestamp_format = "%%Y-%%m-%%dT%%H:%%M:%%S.000"
+    timestamp_format = "%%Y-%%m-%%dT%%H:%%M:%%S.000"
     response_condition = "response_condition_test"
-		message_type = "blank"
-		gzip_level = 1
+    message_type = "blank"
+    gzip_level = 1
     period = 3601
   }
 
   logging_openstack {
-    name   = "another-openstack-endpoint"
-		url    = "https://auth.example.com/v3"
-    user   = "user2"
+    name = "another-openstack-endpoint"
+    url = "https://auth.example.com/v3"
+    user = "user2"
     bucket_name = "bucket2"
     access_key = "s3cr3t2"
     public_key = file("test_fixtures/fastly_test_publickey")
@@ -342,11 +344,11 @@ resource "fastly_service_v1" "foo" {
     placement = "none"
     timestamp_format = "%%Y-%%m-%%dT%%H:%%M:%%S.000"
     response_condition = "response_condition_test"
+    compression_codec = "zstd"
   }
 
   force_destroy = true
-}
-`, name, domain)
+}`, name, domain)
 }
 
 func testAccServiceV1OpenstackComputeConfig(name string, domain string) string {
@@ -355,32 +357,32 @@ resource "fastly_service_compute" "foo" {
   name = "%s"
 
   domain {
-    name    = "%s"
+    name = "%s"
     comment = "tf-openstack-logging"
   }
 
   backend {
     address = "aws.amazon.com"
-    name    = "amazon docs"
+    name = "amazon docs"
   }
 
   logging_openstack {
-    name   = "openstack-endpoint"
-    url    = "https://auth.example.com/v1"
-    user   = "user"
+    name = "openstack-endpoint"
+    url = "https://auth.example.com/v1"
+    user = "user"
     bucket_name = "bucket"
     access_key = "s3cr3t"
     public_key = file("test_fixtures/fastly_test_publickey")
     path = "/"
     timestamp_format = "%%Y-%%m-%%dT%%H:%%M:%%S.000"
+    compression_codec = "zstd"
   }
 
   package {
-      	filename = "test_fixtures/package/valid.tar.gz"
-	  	source_code_hash = filesha512("test_fixtures/package/valid.tar.gz")
+    filename = "test_fixtures/package/valid.tar.gz"
+    source_code_hash = filesha512("test_fixtures/package/valid.tar.gz")
   }
 
   force_destroy = true
-}
-`, name, domain)
+}`, name, domain)
 }

--- a/fastly/block_fastly_service_v1_logging_sftp.go
+++ b/fastly/block_fastly_service_v1_logging_sftp.go
@@ -114,6 +114,12 @@ func (h *SFTPServiceAttributeHandler) Register(s *schema.Resource) error {
 			Description:      "How the message should be formatted. One of: `classic` (default), `loggly`, `logplex` or `blank`",
 			ValidateDiagFunc: validateLoggingMessageType(),
 		},
+		"compression_codec": {
+			Type:             schema.TypeString,
+			Optional:         true,
+			Description:      `The codec used for compression of your logs. Valid values are zstd, snappy, and gzip. If the specified codec is "gzip", gzip_level will default to 3. To specify a different level, leave compression_codec blank and explicitly set the level using gzip_level. Specifying both compression_codec and gzip_level in the same API request will result in an error.`,
+			ValidateDiagFunc: validateLoggingCompressionCodec(),
+		},
 	}
 
 	if h.GetServiceMetadata().serviceType == ServiceTypeVCL {
@@ -376,6 +382,7 @@ func flattenSFTP(sftpList []*gofastly.SFTP) []map[string]interface{} {
 			"format_version":     sl.FormatVersion,
 			"response_condition": sl.ResponseCondition,
 			"placement":          sl.Placement,
+			"compression_codec":  sl.CompressionCodec,
 		}
 
 		// prune any empty values that come from the default string value in structs
@@ -410,6 +417,7 @@ func (h *SFTPServiceAttributeHandler) buildCreate(sftpMap interface{}, serviceID
 		GzipLevel:         uint(df["gzip_level"].(int)),
 		TimestampFormat:   df["timestamp_format"].(string),
 		MessageType:       df["message_type"].(string),
+		CompressionCodec:  df["compression_codec"].(string),
 		Format:            vla.format,
 		FormatVersion:     uintOrDefault(vla.formatVersion),
 		Placement:         vla.placement,

--- a/fastly/block_fastly_service_v1_logging_sftp_test.go
+++ b/fastly/block_fastly_service_v1_logging_sftp_test.go
@@ -31,7 +31,6 @@ func TestResourceFastlyFlattenSFTP(t *testing.T) {
 					SSHKnownHosts:     "sftp.example.com",
 					Format:            "%h %l %u %t \"%r\" %>s %b",
 					Password:          "password",
-					GzipLevel:         5,
 					MessageType:       "classic",
 					FormatVersion:     2,
 					Period:            3600,
@@ -39,6 +38,8 @@ func TestResourceFastlyFlattenSFTP(t *testing.T) {
 					TimestampFormat:   "%Y-%m-%dT%H:%M:%S.000",
 					ResponseCondition: "response_condition",
 					Placement:         "none",
+					GzipLevel:         0,
+					CompressionCodec:  "zstd",
 				},
 			},
 			local: []map[string]interface{}{
@@ -53,13 +54,14 @@ func TestResourceFastlyFlattenSFTP(t *testing.T) {
 					"format":             "%h %l %u %t \"%r\" %>s %b",
 					"password":           "password",
 					"message_type":       "classic",
-					"gzip_level":         uint8(5),
+					"gzip_level":         uint8(0),
 					"format_version":     uint(2),
 					"period":             uint(3600),
 					"port":               uint(22),
 					"response_condition": "response_condition",
 					"timestamp_format":   "%Y-%m-%dT%H:%M:%S.000",
 					"placement":          "none",
+					"compression_codec":  "zstd",
 				},
 			},
 		},
@@ -91,6 +93,7 @@ func TestAccFastlyServiceV1_logging_sftp_basic(t *testing.T) {
 		SSHKnownHosts:     "sftp.example.com",
 		Placement:         "none",
 		ResponseCondition: "response_condition_test",
+		CompressionCodec:  "zstd",
 
 		// Defaults
 		Port:            22,
@@ -116,10 +119,10 @@ func TestAccFastlyServiceV1_logging_sftp_basic(t *testing.T) {
 		Format:            "%h %l %u %t \"%r\" %>s %b %T",
 		Placement:         "waf_debug",
 		ResponseCondition: "response_condition_test",
+		GzipLevel:         3,
 
 		// Defaults
 		Period:          3600,
-		GzipLevel:       0,
 		TimestampFormat: "%Y-%m-%dT%H:%M:%S.000",
 		FormatVersion:   2,
 	}
@@ -136,6 +139,7 @@ func TestAccFastlyServiceV1_logging_sftp_basic(t *testing.T) {
 		ResponseCondition: "response_condition_test",
 		MessageType:       "loggly",
 		Placement:         "none",
+		CompressionCodec:  "zstd",
 
 		// Defaults
 		Port:            22,
@@ -188,13 +192,14 @@ func TestAccFastlyServiceV1_logging_sftp_basic_compute(t *testing.T) {
 		ServiceVersion: 1,
 
 		// Configured
-		Name:          "sftp-endpoint",
-		Address:       "sftp.example.com",
-		User:          "username",
-		Password:      "password",
-		PublicKey:     pgpPublicKey(t),
-		Path:          "/",
-		SSHKnownHosts: "sftp.example.com",
+		Name:             "sftp-endpoint",
+		Address:          "sftp.example.com",
+		User:             "username",
+		Password:         "password",
+		PublicKey:        pgpPublicKey(t),
+		Path:             "/",
+		SSHKnownHosts:    "sftp.example.com",
+		CompressionCodec: "zstd",
 
 		// Defaults
 		Port:            22,
@@ -299,158 +304,158 @@ func testAccCheckFastlyServiceV1SFTPAttributes(service *gofastly.ServiceDetail, 
 func testAccServiceV1SFTPComputeConfig(name string, domain string) string {
 	return fmt.Sprintf(`
 resource "fastly_service_compute" "foo" {
-	name = "%s"
+  name = "%s"
 
-	domain {
-		name		= "%s"
-		comment = "tf-sftp-logging"
-	}
+  domain {
+    name = "%s"
+    comment = "tf-sftp-logging"
+  }
 
-	backend {
-		address = "aws.amazon.com"
-		name		= "amazon docs"
-	}
+  backend {
+    address = "aws.amazon.com"
+    name = "amazon docs"
+  }
 
-	logging_sftp {
-		name						= "sftp-endpoint"
-		address					= "sftp.example.com"
-		user						= "username"
-		password				= "password"
-		public_key      = file("test_fixtures/fastly_test_publickey")
-		path						   = "/"
-		ssh_known_hosts    = "sftp.example.com"
-		message_type       = "classic"
-	}
+  logging_sftp {
+    name = "sftp-endpoint"
+    address = "sftp.example.com"
+    user = "username"
+    password  = "password"
+    public_key = file("test_fixtures/fastly_test_publickey")
+    path = "/"
+    ssh_known_hosts = "sftp.example.com"
+    message_type = "classic"
+    compression_codec = "zstd"
+  }
 
-	package {
-      	filename = "test_fixtures/package/valid.tar.gz"
-	  	source_code_hash = filesha512("test_fixtures/package/valid.tar.gz")
-   	}
+  package {
+    filename = "test_fixtures/package/valid.tar.gz"
+    source_code_hash = filesha512("test_fixtures/package/valid.tar.gz")
+  }
 
-	force_destroy = true
-}
-`, name, domain)
+  force_destroy = true
+}`, name, domain)
 }
 
 func testAccServiceV1SFTPConfig(name string, domain string) string {
 	return fmt.Sprintf(`
 resource "fastly_service_v1" "foo" {
-	name = "%s"
+  name = "%s"
 
-	domain {
-		name		= "%s"
-		comment = "tf-sftp-logging"
-	}
+  domain {
+    name = "%s"
+    comment = "tf-sftp-logging"
+  }
 
-	backend {
-		address = "aws.amazon.com"
-		name		= "amazon docs"
-	}
+  backend {
+    address = "aws.amazon.com"
+    name = "amazon docs"
+  }
 
-	condition {
-    name      = "response_condition_test"
-    type      = "RESPONSE"
-    priority  = 8
+  condition {
+    name = "response_condition_test"
+    type = "RESPONSE"
+    priority = 8
     statement = "resp.status == 418"
   }
 
-	logging_sftp {
-		name						= "sftp-endpoint"
-		address					= "sftp.example.com"
-		user						= "username"
-		password				= "password"
-		public_key      = file("test_fixtures/fastly_test_publickey")
-		path						   = "/"
-		ssh_known_hosts    = "sftp.example.com"
-		message_type       = "classic"
-		format					   = "%%h %%l %%u %%t \"%%r\" %%>s %%b"
-		placement          = "none"
-		response_condition = "response_condition_test"
-	}
-	force_destroy = true
-}
-`, name, domain)
+  logging_sftp {
+    name = "sftp-endpoint"
+    address = "sftp.example.com"
+    user = "username"
+    password = "password"
+    public_key = file("test_fixtures/fastly_test_publickey")
+    path = "/"
+    ssh_known_hosts = "sftp.example.com"
+    message_type = "classic"
+    format = "%%h %%l %%u %%t \"%%r\" %%>s %%b"
+    placement = "none"
+    response_condition = "response_condition_test"
+    compression_codec = "zstd"
+  }
+  force_destroy = true
+}`, name, domain)
 }
 
 func testAccServiceV1SFTPConfig_update(name, domain string) string {
 	return fmt.Sprintf(`
 resource "fastly_service_v1" "foo" {
-	name = "%s"
+  name = "%s"
 
-	domain {
-		name		= "%s"
-		comment = "tf-sftp-logging"
-	}
+  domain {
+    name = "%s"
+    comment = "tf-sftp-logging"
+  }
 
-	backend {
-		address = "aws.amazon.com"
-		name		= "amazon docs"
-	}
+  backend {
+    address = "aws.amazon.com"
+    name = "amazon docs"
+  }
 
-	condition {
-    name      = "response_condition_test"
-    type      = "RESPONSE"
-    priority  = 8
+  condition {
+    name = "response_condition_test"
+    type = "RESPONSE"
+    priority = 8
     statement = "resp.status == 418"
   }
 
-	logging_sftp {
-		name						= "sftp-endpoint"
-		address					= "sftp.example.com"
-		port						= 2600
-		user						= "user"
-		public_key      = file("test_fixtures/fastly_test_publickey")
-		secret_key      = file("test_fixtures/fastly_test_privatekey")
-		path						   = "/logs/"
-		ssh_known_hosts    = "sftp.example.com"
-		format					   = "%%h %%l %%u %%t \"%%r\" %%>s %%b %%T"
-		message_type       = "blank"
-		response_condition = "response_condition_test"
-		placement          = "waf_debug"
-	}
+  logging_sftp {
+    name = "sftp-endpoint"
+    address = "sftp.example.com"
+    port = 2600
+    user = "user"
+    public_key = file("test_fixtures/fastly_test_publickey")
+    secret_key = file("test_fixtures/fastly_test_privatekey")
+    path = "/logs/"
+    ssh_known_hosts = "sftp.example.com"
+    format = "%%h %%l %%u %%t \"%%r\" %%>s %%b %%T"
+    message_type = "blank"
+    response_condition = "response_condition_test"
+    placement = "waf_debug"
+    gzip_level = 3
+  }
 
-	logging_sftp {
-		name						= "another-sftp-endpoint"
-		address					= "sftp2.example.com"
-		user						= "user"
-		public_key      = file("test_fixtures/fastly_test_publickey")
-		secret_key      = file("test_fixtures/fastly_test_privatekey")
-		path						   = "/dir/"
-		ssh_known_hosts    = "sftp2.example.com"
-		format					   = "%%h %%l %%u %%t \"%%r\" %%>s %%b"
-		message_type       = "loggly"
-		response_condition = "response_condition_test"
-		placement          = "none"
-	}
-	force_destroy = true
-}
-`, name, domain)
+  logging_sftp {
+    name = "another-sftp-endpoint"
+    address = "sftp2.example.com"
+    user = "user"
+    public_key = file("test_fixtures/fastly_test_publickey")
+    secret_key = file("test_fixtures/fastly_test_privatekey")
+    path = "/dir/"
+    ssh_known_hosts = "sftp2.example.com"
+    format = "%%h %%l %%u %%t \"%%r\" %%>s %%b"
+    message_type = "loggly"
+    response_condition = "response_condition_test"
+    placement = "none"
+    compression_codec = "zstd"
+  }
+  force_destroy = true
+}`, name, domain)
 }
 
 func testAccServiceV1SFTPConfig_no_password_secret_key(name, domain string) string {
 	return fmt.Sprintf(`
 resource "fastly_service_v1" "foo" {
-	name = "%s"
+  name = "%s"
 
-	domain {
-		name		= "%s"
-		comment = "tf-sftp-logging"
-	}
+  domain {
+    name = "%s"
+    comment = "tf-sftp-logging"
+  }
 
-	backend {
-		address = "aws.amazon.com"
-		name		= "amazon docs"
-	}
+  backend {
+    address = "aws.amazon.com"
+    name = "amazon docs"
+  }
 
-	logging_sftp {
-		name						= "sftp-endpoint"
-		address					= "sftp.example.com"
-		user						= "username"
-		path						= "/"
-		ssh_known_hosts = "sftp.example.com"
-	}
-	force_destroy = true
+  logging_sftp {
+    name = "sftp-endpoint"
+    address = "sftp.example.com"
+    user = "username"
+    path = "/"
+    ssh_known_hosts = "sftp.example.com"
+  }
+  force_destroy = true
 
-}
-`, name, domain)
+}`, name, domain)
 }

--- a/fastly/block_fastly_service_v1_s3logging.go
+++ b/fastly/block_fastly_service_v1_s3logging.go
@@ -293,6 +293,12 @@ func (h *S3LoggingServiceAttributeHandler) Register(s *schema.Resource) error {
 			Optional:    true,
 			Description: "Optional server-side KMS Key Id. Must be set if server_side_encryption is set to `aws:kms`",
 		},
+		"compression_codec": {
+			Type:             schema.TypeString,
+			Optional:         true,
+			Description:      `The codec used for compression of your logs. Valid values are zstd, snappy, and gzip. If the specified codec is "gzip", gzip_level will default to 3. To specify a different level, leave compression_codec blank and explicitly set the level using gzip_level. Specifying both compression_codec and gzip_level in the same API request will result in an error.`,
+			ValidateDiagFunc: validateLoggingCompressionCodec(),
+		},
 	}
 
 	if h.GetServiceMetadata().serviceType == ServiceTypeVCL {
@@ -382,6 +388,7 @@ func flattenS3s(s3List []*gofastly.S3) []map[string]interface{} {
 			"placement":                         s.Placement,
 			"server_side_encryption":            s.ServerSideEncryption,
 			"server_side_encryption_kms_key_id": s.ServerSideEncryptionKMSKeyID,
+			"compression_codec":                 s.CompressionCodec,
 		}
 
 		// Prune any empty values that come from the default string value in structs.
@@ -417,6 +424,7 @@ func (h *S3LoggingServiceAttributeHandler) buildCreate(s3Map interface{}, servic
 		MessageType:                  df["message_type"].(string),
 		PublicKey:                    df["public_key"].(string),
 		ServerSideEncryptionKMSKeyID: df["server_side_encryption_kms_key_id"].(string),
+		CompressionCodec:             df["compression_codec"].(string),
 		Format:                       vla.format,
 		FormatVersion:                uintOrDefault(vla.formatVersion),
 		ResponseCondition:            vla.responseCondition,

--- a/fastly/validators.go
+++ b/fastly/validators.go
@@ -3,6 +3,7 @@ package fastly
 import (
 	"encoding/pem"
 	"fmt"
+
 	gofastly "github.com/fastly/go-fastly/v3/fastly"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -18,6 +19,14 @@ func validateLoggingMessageType() schema.SchemaValidateDiagFunc {
 		"loggly",
 		"logplex",
 		"blank",
+	}, false))
+}
+
+func validateLoggingCompressionCodec() schema.SchemaValidateDiagFunc {
+	return validation.ToDiagFunc(validation.StringInSlice([]string{
+		"zstd",
+		"snappy",
+		"gzip",
 	}, false))
 }
 


### PR DESCRIPTION
Add support for `compression_codec` to file-based logging endpoints. Follows from https://github.com/fastly/go-fastly/pull/235.

_Note:_ There was quite a bit of whitespace inconsistency in the test files that are part of this change. I tried to make that more uniform in the files I touched so viewing the diff with the whitespace filter may be useful.