### PR TITLE
Support usage of IAM role in S3 and Kinesis logging endpoints

### DIFF
--- a/docs/resources/service_compute.md
+++ b/docs/resources/service_compute.md
@@ -470,14 +470,15 @@ Optional:
 
 Required:
 
-- **access_key** (String, Sensitive) The AWS access key to be used to write to the stream
 - **name** (String) The unique name of the Kinesis logging endpoint. It is important to note that changing this attribute will delete and recreate the resource
-- **secret_key** (String, Sensitive) The AWS secret access key to authenticate with
 - **topic** (String) The Kinesis stream name
 
 Optional:
 
+- **access_key** (String, Sensitive) The AWS access key to be used to write to the stream
+- **iam_role** (String) The Amazon Resource Name (ARN) for the IAM role granting Fastly access to Kinesis. Not required if `access_key` and `secret_key` are provided.
 - **region** (String) The AWS region the stream resides in. (Default: `us-east-1`)
+- **secret_key** (String, Sensitive) The AWS secret access key to authenticate with
 
 
 <a id="nestedblock--logging_loggly"></a>
@@ -592,8 +593,9 @@ Optional:
 - **period** (Number) How frequently the logs should be transferred, in seconds. Default `3600`
 - **public_key** (String) A PGP public key that Fastly will use to encrypt your log files before writing them to disk
 - **redundancy** (String) The S3 redundancy level. Should be formatted; one of: `standard`, `reduced_redundancy` or null. Default `null`
-- **s3_access_key** (String, Sensitive) AWS Access Key of an account with the required permissions to post logs. It is **strongly** recommended you create a separate IAM user with permissions to only operate on this Bucket. This key will be not be encrypted. You can provide this key via an environment variable, `FASTLY_S3_ACCESS_KEY`
-- **s3_secret_key** (String, Sensitive) AWS Secret Key of an account with the required permissions to post logs. It is **strongly** recommended you create a separate IAM user with permissions to only operate on this Bucket. This secret will be not be encrypted. You can provide this secret via an environment variable, `FASTLY_S3_SECRET_KEY`
+- **s3_access_key** (String, Sensitive) AWS Access Key of an account with the required permissions to post logs. It is **strongly** recommended you create a separate IAM user with permissions to only operate on this Bucket. This key will be not be encrypted. Not required if `iam_role` is provided. You can provide this key via an environment variable, `FASTLY_S3_ACCESS_KEY`
+- **s3_iam_role** (String) The Amazon Resource Name (ARN) for the IAM role granting Fastly access to S3. Not required if `access_key` and `secret_key` are provided. You can provide this value via an environment variable, `FASTLY_S3_IAM_ROLE`
+- **s3_secret_key** (String, Sensitive) AWS Secret Key of an account with the required permissions to post logs. It is **strongly** recommended you create a separate IAM user with permissions to only operate on this Bucket. This secret will be not be encrypted. Not required if `iam_role` is provided. You can provide this secret via an environment variable, `FASTLY_S3_SECRET_KEY`
 - **server_side_encryption** (String) Specify what type of server side encryption should be used. Can be either `AES256` or `aws:kms`
 - **server_side_encryption_kms_key_id** (String) Optional server-side KMS Key Id. Must be set if server_side_encryption is set to `aws:kms`
 - **timestamp_format** (String) `strftime` specified timestamp formatting (default `%Y-%m-%dT%H:%M:%S.000`)

--- a/docs/resources/service_v1.md
+++ b/docs/resources/service_v1.md
@@ -806,18 +806,19 @@ Optional:
 
 Required:
 
-- **access_key** (String, Sensitive) The AWS access key to be used to write to the stream
 - **name** (String) The unique name of the Kinesis logging endpoint. It is important to note that changing this attribute will delete and recreate the resource
-- **secret_key** (String, Sensitive) The AWS secret access key to authenticate with
 - **topic** (String) The Kinesis stream name
 
 Optional:
 
+- **access_key** (String, Sensitive) The AWS access key to be used to write to the stream
 - **format** (String) Apache style log formatting.
 - **format_version** (Number) The version of the custom logging format used for the configured endpoint. Can be either `1` or `2`. (default: `2`).
+- **iam_role** (String) The Amazon Resource Name (ARN) for the IAM role granting Fastly access to Kinesis. Not required if `access_key` and `secret_key` are provided.
 - **placement** (String) Where in the generated VCL the logging call should be placed. Can be `none` or `waf_debug`.
 - **region** (String) The AWS region the stream resides in. (Default: `us-east-1`)
 - **response_condition** (String) The name of an existing condition in the configured endpoint, or leave blank to always execute.
+- **secret_key** (String, Sensitive) The AWS secret access key to authenticate with
 
 
 <a id="nestedblock--logging_loggly"></a>
@@ -1015,8 +1016,9 @@ Optional:
 - **public_key** (String) A PGP public key that Fastly will use to encrypt your log files before writing them to disk
 - **redundancy** (String) The S3 redundancy level. Should be formatted; one of: `standard`, `reduced_redundancy` or null. Default `null`
 - **response_condition** (String) Name of blockAttributes condition to apply this logging.
-- **s3_access_key** (String, Sensitive) AWS Access Key of an account with the required permissions to post logs. It is **strongly** recommended you create a separate IAM user with permissions to only operate on this Bucket. This key will be not be encrypted. You can provide this key via an environment variable, `FASTLY_S3_ACCESS_KEY`
-- **s3_secret_key** (String, Sensitive) AWS Secret Key of an account with the required permissions to post logs. It is **strongly** recommended you create a separate IAM user with permissions to only operate on this Bucket. This secret will be not be encrypted. You can provide this secret via an environment variable, `FASTLY_S3_SECRET_KEY`
+- **s3_access_key** (String, Sensitive) AWS Access Key of an account with the required permissions to post logs. It is **strongly** recommended you create a separate IAM user with permissions to only operate on this Bucket. This key will be not be encrypted. Not required if `iam_role` is provided. You can provide this key via an environment variable, `FASTLY_S3_ACCESS_KEY`
+- **s3_iam_role** (String) The Amazon Resource Name (ARN) for the IAM role granting Fastly access to S3. Not required if `access_key` and `secret_key` are provided. You can provide this value via an environment variable, `FASTLY_S3_IAM_ROLE`
+- **s3_secret_key** (String, Sensitive) AWS Secret Key of an account with the required permissions to post logs. It is **strongly** recommended you create a separate IAM user with permissions to only operate on this Bucket. This secret will be not be encrypted. Not required if `iam_role` is provided. You can provide this secret via an environment variable, `FASTLY_S3_SECRET_KEY`
 - **server_side_encryption** (String) Specify what type of server side encryption should be used. Can be either `AES256` or `aws:kms`
 - **server_side_encryption_kms_key_id** (String) Optional server-side KMS Key Id. Must be set if server_side_encryption is set to `aws:kms`
 - **timestamp_format** (String) `strftime` specified timestamp formatting (default `%Y-%m-%dT%H:%M:%S.000`)

--- a/fastly/block_fastly_service_v1_logging_kinesis_test.go
+++ b/fastly/block_fastly_service_v1_logging_kinesis_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
+const testKinesisIAMRole = "arn:aws:iam::123456789012:role/KinesisAccess"
+
 func TestResourceFastlyFlattenKinesis(t *testing.T) {
 	cases := []struct {
 		remote []*gofastly.Kinesis
@@ -46,6 +48,33 @@ func TestResourceFastlyFlattenKinesis(t *testing.T) {
 				},
 			},
 		},
+		{
+			remote: []*gofastly.Kinesis{
+				{
+					ServiceVersion:    1,
+					Name:              "kinesis-endpoint",
+					StreamName:        "stream-name",
+					Region:            "us-east-1",
+					IAMRole:           testKinesisIAMRole,
+					Format:            "%h %l %u %t \"%r\" %>s %b %T",
+					Placement:         "none",
+					ResponseCondition: "always",
+					FormatVersion:     2,
+				},
+			},
+			local: []map[string]interface{}{
+				{
+					"name":               "kinesis-endpoint",
+					"topic":              "stream-name",
+					"region":             "us-east-1",
+					"iam_role":           testKinesisIAMRole,
+					"format":             "%h %l %u %t \"%r\" %>s %b %T",
+					"placement":          "none",
+					"response_condition": "always",
+					"format_version":     uint(2),
+				},
+			},
+		},
 	}
 
 	for _, c := range cases {
@@ -57,7 +86,6 @@ func TestResourceFastlyFlattenKinesis(t *testing.T) {
 }
 
 func TestAccFastlyServiceV1_logging_kinesis_basic(t *testing.T) {
-	t.SkipNow()
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	domain := fmt.Sprintf("fastly-test.%s.com", name)
@@ -78,8 +106,7 @@ func TestAccFastlyServiceV1_logging_kinesis_basic(t *testing.T) {
 		Name:           "kinesis-endpoint",
 		StreamName:     "new-stream-name",
 		Region:         "us-east-1",
-		AccessKey:      "whywouldyoucheckthis",
-		SecretKey:      "thisisthesecretthatneedstobe40characters",
+		IAMRole:        testKinesisIAMRole,
 		FormatVersion:  2,
 		Format:         "%h %l %u %t \"%r\" %>s %b %T",
 	}
@@ -89,8 +116,7 @@ func TestAccFastlyServiceV1_logging_kinesis_basic(t *testing.T) {
 		Name:           "another-kinesis-endpoint",
 		StreamName:     "another-stream-name",
 		Region:         "us-east-1",
-		AccessKey:      "whywouldyoucheckthis",
-		SecretKey:      "thisisthesecretthatneedstobe40characters",
+		IAMRole:        testKinesisIAMRole,
 		FormatVersion:  2,
 		Format:         "%h %l %u %t \"%r\" %>s %b",
 	}
@@ -128,7 +154,6 @@ func TestAccFastlyServiceV1_logging_kinesis_basic(t *testing.T) {
 }
 
 func TestAccFastlyServiceV1_logging_kinesis_basic_compute(t *testing.T) {
-	t.SkipNow()
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	domain := fmt.Sprintf("fastly-test.%s.com", name)
@@ -266,8 +291,7 @@ resource "fastly_service_v1" "foo" {
     name        = "kinesis-endpoint"
     topic       = "new-stream-name"
     region      = "us-east-1"
-    access_key  = "whywouldyoucheckthis"
-    secret_key  = "thisisthesecretthatneedstobe40characters"
+    iam_role    = "%s"
     format      = "%%h %%l %%u %%t \"%%r\" %%>s %%b %%T"
   }
 
@@ -275,14 +299,13 @@ resource "fastly_service_v1" "foo" {
     name        = "another-kinesis-endpoint"
     topic       = "another-stream-name"
     region      = "us-east-1"
-    access_key  = "whywouldyoucheckthis"
-    secret_key  = "thisisthesecretthatneedstobe40characters"
+    iam_role    = "%s"
     format      = "%%h %%l %%u %%t \"%%r\" %%>s %%b"
   }
 
   force_destroy = true
 }
-`, name, domain)
+`, name, domain, testKinesisIAMRole, testKinesisIAMRole)
 }
 
 func testAccServiceV1KinesisComputeConfig(name string, domain string) string {

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.14
 require (
 	github.com/ajg/form v0.0.0-20160822230020-523a5da1a92f // indirect
 	github.com/bflad/tfproviderlint v0.22.0
-	github.com/fastly/go-fastly/v3 v3.4.1
+	github.com/fastly/go-fastly/v3 v3.6.0
 	github.com/google/go-cmp v0.5.2
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/terraform-plugin-docs v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -96,8 +96,8 @@ github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymF
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
-github.com/fastly/go-fastly/v3 v3.4.1 h1:ljska0Cc2rwloXZsrgMCqm2JsnoGHC5i9A2KmTYqrL4=
-github.com/fastly/go-fastly/v3 v3.4.1/go.mod h1:KOaCWsmkIKSASPzADl8PT/bTQIghOw/eEaxlHOu3jMA=
+github.com/fastly/go-fastly/v3 v3.6.0 h1:sRnI+MhyMkgZbQWaUnhr70gHk39kfpG9JpMUlSoIsCg=
+github.com/fastly/go-fastly/v3 v3.6.0/go.mod h1:KOaCWsmkIKSASPzADl8PT/bTQIghOw/eEaxlHOu3jMA=
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568 h1:BHsljHzVlRcyQhjrss6TZTdY2VfCqZPbv5k3iBFa2ZQ=

--- a/vendor/github.com/fastly/go-fastly/v3/fastly/client.go
+++ b/vendor/github.com/fastly/go-fastly/v3/fastly/client.go
@@ -46,7 +46,7 @@ const DefaultRealtimeStatsEndpoint = "https://rt.fastly.com"
 var ProjectURL = "github.com/fastly/go-fastly"
 
 // ProjectVersion is the version of this library.
-var ProjectVersion = "3.4.1"
+var ProjectVersion = "3.6.0"
 
 // UserAgent is the user agent for this particular client.
 var UserAgent = fmt.Sprintf("FastlyGo/%s (+%s; %s)",

--- a/vendor/github.com/fastly/go-fastly/v3/fastly/kinesis.go
+++ b/vendor/github.com/fastly/go-fastly/v3/fastly/kinesis.go
@@ -17,6 +17,7 @@ type Kinesis struct {
 	Region            string     `mapstructure:"region"`
 	AccessKey         string     `mapstructure:"access_key"`
 	SecretKey         string     `mapstructure:"secret_key"`
+	IAMRole           string     `mapstructure:"iam_role"`
 	Format            string     `mapstructure:"format"`
 	FormatVersion     uint       `mapstructure:"format_version"`
 	ResponseCondition string     `mapstructure:"response_condition"`
@@ -82,6 +83,7 @@ type CreateKinesisInput struct {
 	Region            string `form:"region,omitempty"`
 	AccessKey         string `form:"access_key,omitempty"`
 	SecretKey         string `form:"secret_key,omitempty"`
+	IAMRole           string `form:"iam_role,omitempty"`
 	Format            string `form:"format,omitempty"`
 	FormatVersion     uint   `form:"format_version,omitempty"`
 	ResponseCondition string `form:"response_condition,omitempty"`
@@ -166,6 +168,7 @@ type UpdateKinesisInput struct {
 	Region            *string `form:"region,omitempty"`
 	AccessKey         *string `form:"access_key,omitempty"`
 	SecretKey         *string `form:"secret_key,omitempty"`
+	IAMRole           *string `form:"iam_role,omitempty"`
 	Format            *string `form:"format,omitempty"`
 	FormatVersion     *uint   `form:"format_version,omitempty"`
 	ResponseCondition *string `form:"response_condition,omitempty"`

--- a/vendor/github.com/fastly/go-fastly/v3/fastly/s3.go
+++ b/vendor/github.com/fastly/go-fastly/v3/fastly/s3.go
@@ -27,6 +27,7 @@ type S3 struct {
 	Domain                       string                 `mapstructure:"domain"`
 	AccessKey                    string                 `mapstructure:"access_key"`
 	SecretKey                    string                 `mapstructure:"secret_key"`
+	IAMRole                      string                 `mapstructure:"iam_role"`
 	Path                         string                 `mapstructure:"path"`
 	Period                       uint                   `mapstructure:"period"`
 	CompressionCodec             string                 `mapstructure:"compression_codec"`
@@ -102,6 +103,7 @@ type CreateS3Input struct {
 	Domain                       string                 `form:"domain,omitempty"`
 	AccessKey                    string                 `form:"access_key,omitempty"`
 	SecretKey                    string                 `form:"secret_key,omitempty"`
+	IAMRole                      string                 `form:"iam_role,omitempty"`
 	Path                         string                 `form:"path,omitempty"`
 	Period                       uint                   `form:"period,omitempty"`
 	CompressionCodec             string                 `form:"compression_codec,omitempty"`
@@ -200,6 +202,7 @@ type UpdateS3Input struct {
 	Domain                       *string                `form:"domain,omitempty"`
 	AccessKey                    *string                `form:"access_key,omitempty"`
 	SecretKey                    *string                `form:"secret_key,omitempty"`
+	IAMRole                      *string                `form:"iam_role,omitempty"`
 	Path                         *string                `form:"path,omitempty"`
 	Period                       *uint                  `form:"period,omitempty"`
 	CompressionCodec             *string                `form:"compression_codec,omitempty"`

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -211,7 +211,7 @@ github.com/bgentry/go-netrc/netrc
 github.com/bgentry/speakeasy
 # github.com/davecgh/go-spew v1.1.1
 github.com/davecgh/go-spew/spew
-# github.com/fastly/go-fastly/v3 v3.4.1
+# github.com/fastly/go-fastly/v3 v3.6.0
 ## explicit
 github.com/fastly/go-fastly/v3/fastly
 # github.com/fatih/color v1.7.0


### PR DESCRIPTION
* Add the ability to specify an IAM role for the S3 and Kinesis logging endpoints
* Bump go-fastly to v3.6.0

Follows from https://github.com/fastly/go-fastly/pull/269.