### PR TITLE
Add director support for compute resource

### DIFF
--- a/docs/resources/service_compute.md
+++ b/docs/resources/service_compute.md
@@ -42,6 +42,39 @@ resource "fastly_service_compute" "demo" {
 }
 ```
 
+Basic usage with [custom Director](https://developer.fastly.com/reference/api/load-balancing/directors/director/):
+
+```hcl
+resource "fastly_service_compute" "demo" {
+    name = "demofastly"
+
+    domain {
+      name    = "demo.notexample.com"
+      comment = "demo"
+    }
+
+    backend {
+      address = "127.0.0.1"
+      name    = "localhost"
+      port    = 80
+    }
+
+    package {
+      filename = "package.tar.gz"
+      source_code_hash = filesha512("package.tar.gz")
+    }
+
+    director {
+      name = "mydirector"
+      quorum = 0
+      type = 3
+      backends = [ "origin1", "origin2" ]
+    }
+
+    force_destroy = true
+}
+```
+
 
 
 ### package block
@@ -82,6 +115,7 @@ $ terraform import fastly_service_compute.demo xxxxxxxxxxxxxxxxxxxx
 - **blobstoragelogging** (Block Set) (see [below for nested schema](#nestedblock--blobstoragelogging))
 - **comment** (String) Description field for the service. Default `Managed by Terraform`
 - **dictionary** (Block Set) (see [below for nested schema](#nestedblock--dictionary))
+- **director** (Block Set) (see [below for nested schema](#nestedblock--director))
 - **force_destroy** (Boolean) Services that are active cannot be destroyed. In order to destroy the Service, set `force_destroy` to `true`. Default `false`
 - **gcslogging** (Block Set) (see [below for nested schema](#nestedblock--gcslogging))
 - **healthcheck** (Block Set) (see [below for nested schema](#nestedblock--healthcheck))
@@ -228,6 +262,24 @@ Optional:
 Read-Only:
 
 - **dictionary_id** (String) The ID of the dictionary
+
+
+<a id="nestedblock--director"></a>
+### Nested Schema for `director`
+
+Required:
+
+- **backends** (Set of String) Names of defined backends to map the director to. Example: `[ "origin1", "origin2" ]`
+- **name** (String) Unique name for this Director. It is important to note that changing this attribute will delete and recreate the resource
+
+Optional:
+
+- **capacity** (Number) Load balancing weight for the backends. Default `100`
+- **comment** (String) An optional comment about the Director
+- **quorum** (Number) Percentage of capacity that needs to be up for the director itself to be considered up. Default `75`
+- **retries** (Number) How many backends to search if it fails. Default `5`
+- **shield** (String) Selected POP to serve as a "shield" for backends. Valid values for `shield` are included in the [`GET /datacenters`](https://developer.fastly.com/reference/api/utils/datacenter/) API response
+- **type** (Number) Type of load balance group to use. Integer, 1 to 4. Values: `1` (random), `3` (hash), `4` (client). Default `1`
 
 
 <a id="nestedblock--gcslogging"></a>

--- a/docs/resources/service_compute.md
+++ b/docs/resources/service_compute.md
@@ -42,39 +42,6 @@ resource "fastly_service_compute" "demo" {
 }
 ```
 
-Basic usage with [custom Director](https://developer.fastly.com/reference/api/load-balancing/directors/director/):
-
-```hcl
-resource "fastly_service_compute" "demo" {
-    name = "demofastly"
-
-    domain {
-      name    = "demo.notexample.com"
-      comment = "demo"
-    }
-
-    backend {
-      address = "127.0.0.1"
-      name    = "localhost"
-      port    = 80
-    }
-
-    package {
-      filename = "package.tar.gz"
-      source_code_hash = filesha512("package.tar.gz")
-    }
-
-    director {
-      name = "mydirector"
-      quorum = 0
-      type = 3
-      backends = [ "origin1", "origin2" ]
-    }
-
-    force_destroy = true
-}
-```
-
 
 
 ### package block

--- a/fastly/block_fastly_service_v1_director_test.go
+++ b/fastly/block_fastly_service_v1_director_test.go
@@ -193,12 +193,16 @@ func TestAccFastlyServiceV1_directors_basic(t *testing.T) {
 	})
 }
 
+// This test validates that two directors are created successfully
+// (dir1 and dir2), and in the next Terraform run the first
+// director is updated (dir1Update) while the second director is unchanged
+// and a third director is added (dir3).
 func TestAccFastlyServiceV1_directors_basic_compute(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	domainName1 := fmt.Sprintf("fastly-test.tf-%s.com", acctest.RandString(10))
 
-	createdDir1 := gofastly.Director{
+	dir1 := gofastly.Director{
 		ServiceVersion: 1,
 		Name:           "mydirector",
 		Type:           3,
@@ -207,7 +211,7 @@ func TestAccFastlyServiceV1_directors_basic_compute(t *testing.T) {
 		Retries:        5,
 	}
 
-	updatedDir1 := gofastly.Director{
+	dir1Update := gofastly.Director{
 		ServiceVersion: 1,
 		Name:           "mydirector",
 		Type:           4,
@@ -216,7 +220,7 @@ func TestAccFastlyServiceV1_directors_basic_compute(t *testing.T) {
 		Retries:        10,
 	}
 
-	createdDir2 := gofastly.Director{
+	dir2 := gofastly.Director{
 		ServiceVersion: 1,
 		Name:           "unchangeddirector",
 		Type:           3,
@@ -225,10 +229,7 @@ func TestAccFastlyServiceV1_directors_basic_compute(t *testing.T) {
 		Retries:        5,
 	}
 
-	// Updated director should be the same as the created ones
-	updatedDir2 := createdDir2
-
-	updatedDir3 := gofastly.Director{
+	dir3 := gofastly.Director{
 		ServiceVersion: 1,
 		Name:           "myotherdirector",
 		Type:           3,
@@ -243,12 +244,12 @@ func TestAccFastlyServiceV1_directors_basic_compute(t *testing.T) {
 		CheckDestroy:      testAccCheckServiceV1Destroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccServiceDirectorsComputeConfig(name, domainName1),
+				Config: testAccServiceV1DirectorsComputeConfig(name, domainName1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceV1Exists("fastly_service_compute.foo", &service),
 					testAccCheckFastlyServiceV1DirectorsAttributes(
 						&service,
-						[]*gofastly.Director{&createdDir1, &createdDir2}),
+						[]*gofastly.Director{&dir1, &dir2}),
 					resource.TestCheckResourceAttr(
 						"fastly_service_compute.foo", "name", name),
 					resource.TestCheckResourceAttr(
@@ -262,7 +263,7 @@ func TestAccFastlyServiceV1_directors_basic_compute(t *testing.T) {
 					testAccCheckServiceV1Exists("fastly_service_compute.foo", &service),
 					testAccCheckFastlyServiceV1DirectorsAttributes(
 						&service,
-						[]*gofastly.Director{&updatedDir1, &updatedDir2, &updatedDir3}),
+						[]*gofastly.Director{&dir1Update, &dir2, &dir3}),
 					resource.TestCheckResourceAttr(
 						"fastly_service_compute.foo", "name", name),
 					resource.TestCheckResourceAttr(
@@ -407,7 +408,7 @@ resource "fastly_service_v1" "foo" {
 }`, name, domain)
 }
 
-func testAccServiceDirectorsComputeConfig(name, domain string) string {
+func testAccServiceV1DirectorsComputeConfig(name, domain string) string {
 	return fmt.Sprintf(`
 resource "fastly_service_compute" "foo" {
   name = "%s"
@@ -442,7 +443,7 @@ resource "fastly_service_compute" "foo" {
 
   package {
     filename = "test_fixtures/package/valid.tar.gz"
-	source_code_hash = filesha512("test_fixtures/package/valid.tar.gz")
+    source_code_hash = filesha512("test_fixtures/package/valid.tar.gz")
   }
 
   force_destroy = true
@@ -503,7 +504,7 @@ resource "fastly_service_compute" "foo" {
 
   package {
     filename = "test_fixtures/package/valid.tar.gz"
-	source_code_hash = filesha512("test_fixtures/package/valid.tar.gz")
+    source_code_hash = filesha512("test_fixtures/package/valid.tar.gz")
   }
 
   force_destroy = true

--- a/fastly/resource_fastly_service_compute.go
+++ b/fastly/resource_fastly_service_compute.go
@@ -17,6 +17,7 @@ var computeService = &BaseServiceDefinition{
 		NewServiceDomain(computeAttributes),
 		NewServiceHealthCheck(computeAttributes),
 		NewServiceBackend(computeAttributes),
+		NewServiceDirector(computeAttributes),
 		NewServiceS3Logging(computeAttributes),
 		NewServicePaperTrail(computeAttributes),
 		NewServiceSumologic(computeAttributes),


### PR DESCRIPTION
Directors now work with C@E services. Simple PR to add directors to the compute service definition.