### PR TITLE
Update default initial value for health check.

### DIFF
--- a/docs/resources/service_compute.md
+++ b/docs/resources/service_compute.md
@@ -283,7 +283,7 @@ Optional:
 - **check_interval** (Number) How often to run the Healthcheck in milliseconds. Default `5000`
 - **expected_response** (Number) The status code expected from the host. Default `200`
 - **http_version** (String) Whether to use version 1.0 or 1.1 HTTP. Default `1.1`
-- **initial** (Number) When loading a config, the initial number of probes to be seen as OK. Default `2`
+- **initial** (Number) When loading a config, the initial number of probes to be seen as OK. Default `3`
 - **method** (String) Which HTTP method to use. Default `HEAD`
 - **threshold** (Number) How many Healthchecks must succeed to be considered healthy. Default `3`
 - **timeout** (Number) Timeout in milliseconds. Default `500`

--- a/docs/resources/service_v1.md
+++ b/docs/resources/service_v1.md
@@ -550,7 +550,7 @@ Optional:
 - **check_interval** (Number) How often to run the Healthcheck in milliseconds. Default `5000`
 - **expected_response** (Number) The status code expected from the host. Default `200`
 - **http_version** (String) Whether to use version 1.0 or 1.1 HTTP. Default `1.1`
-- **initial** (Number) When loading a config, the initial number of probes to be seen as OK. Default `2`
+- **initial** (Number) When loading a config, the initial number of probes to be seen as OK. Default `3`
 - **method** (String) Which HTTP method to use. Default `HEAD`
 - **threshold** (Number) How many Healthchecks must succeed to be considered healthy. Default `3`
 - **timeout** (Number) Timeout in milliseconds. Default `500`

--- a/fastly/block_fastly_service_v1_healthcheck.go
+++ b/fastly/block_fastly_service_v1_healthcheck.go
@@ -223,8 +223,8 @@ func (h *HealthCheckServiceAttributeHandler) Register(s *schema.Resource) error 
 				"initial": {
 					Type:        schema.TypeInt,
 					Optional:    true,
-					Default:     2,
-					Description: "When loading a config, the initial number of probes to be seen as OK. Default `2`",
+					Default:     3,
+					Description: "When loading a config, the initial number of probes to be seen as OK. Default `3`",
 				},
 				"method": {
 					Type:        schema.TypeString,


### PR DESCRIPTION
Takes into account the change where the VCL is lazy-loaded on nodes as
needed.  The lazy-load may cause the first couple of health check
attempts to fail, and can be enough to mark the backend as unhealthy
until enough successful checks occur to reach the threshold again.

It is highly recommended that the initial and threshold values be the
same for health checks going forward.