### PR TITLE
Add support for ACL and extra redundancy options in S3 logging block

### DIFF
--- a/docs/resources/service_compute.md
+++ b/docs/resources/service_compute.md
@@ -612,6 +612,7 @@ Required:
 
 Optional:
 
+- **acl** (String) The AWS [Canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/userguide/acl-overview.html#canned-acl) to use for objects uploaded to the S3 bucket. Options are: `private`, `public-read`, `public-read-write`, `aws-exec-read`, `authenticated-read`, `bucket-owner-read`, `bucket-owner-full-control`
 - **compression_codec** (String) The codec used for compression of your logs. Valid values are zstd, snappy, and gzip. If the specified codec is "gzip", gzip_level will default to 3. To specify a different level, leave compression_codec blank and explicitly set the level using gzip_level. Specifying both compression_codec and gzip_level in the same API request will result in an error.
 - **domain** (String) If you created the S3 bucket outside of `us-east-1`, then specify the corresponding bucket endpoint. Example: `s3-us-west-2.amazonaws.com`
 - **gzip_level** (Number) Level of Gzip compression, from `0-9`. `0` is no compression. `1` is fastest and least compressed, `9` is slowest and most compressed. Default `0`
@@ -619,7 +620,7 @@ Optional:
 - **path** (String) Path to store the files. Must end with a trailing slash. If this field is left empty, the files will be saved in the bucket's root path
 - **period** (Number) How frequently the logs should be transferred, in seconds. Default `3600`
 - **public_key** (String) A PGP public key that Fastly will use to encrypt your log files before writing them to disk
-- **redundancy** (String) The S3 redundancy level. Should be formatted; one of: `standard`, `reduced_redundancy` or null. Default `null`
+- **redundancy** (String) The S3 storage class (redundancy level). Should be one of: `standard`, `reduced_redundancy`, `standard_ia`, or `onezone_ia`
 - **s3_access_key** (String, Sensitive) AWS Access Key of an account with the required permissions to post logs. It is **strongly** recommended you create a separate IAM user with permissions to only operate on this Bucket. This key will be not be encrypted. Not required if `iam_role` is provided. You can provide this key via an environment variable, `FASTLY_S3_ACCESS_KEY`
 - **s3_iam_role** (String) The Amazon Resource Name (ARN) for the IAM role granting Fastly access to S3. Not required if `access_key` and `secret_key` are provided. You can provide this value via an environment variable, `FASTLY_S3_IAM_ROLE`
 - **s3_secret_key** (String, Sensitive) AWS Secret Key of an account with the required permissions to post logs. It is **strongly** recommended you create a separate IAM user with permissions to only operate on this Bucket. This secret will be not be encrypted. Not required if `iam_role` is provided. You can provide this secret via an environment variable, `FASTLY_S3_SECRET_KEY`

--- a/docs/resources/service_v1.md
+++ b/docs/resources/service_v1.md
@@ -1012,6 +1012,7 @@ Required:
 
 Optional:
 
+- **acl** (String) The AWS [Canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/userguide/acl-overview.html#canned-acl) to use for objects uploaded to the S3 bucket. Options are: `private`, `public-read`, `public-read-write`, `aws-exec-read`, `authenticated-read`, `bucket-owner-read`, `bucket-owner-full-control`
 - **compression_codec** (String) The codec used for compression of your logs. Valid values are zstd, snappy, and gzip. If the specified codec is "gzip", gzip_level will default to 3. To specify a different level, leave compression_codec blank and explicitly set the level using gzip_level. Specifying both compression_codec and gzip_level in the same API request will result in an error.
 - **domain** (String) If you created the S3 bucket outside of `us-east-1`, then specify the corresponding bucket endpoint. Example: `s3-us-west-2.amazonaws.com`
 - **format** (String) Apache-style string or VCL variables to use for log formatting.
@@ -1022,7 +1023,7 @@ Optional:
 - **period** (Number) How frequently the logs should be transferred, in seconds. Default `3600`
 - **placement** (String) Where in the generated VCL the logging call should be placed.
 - **public_key** (String) A PGP public key that Fastly will use to encrypt your log files before writing them to disk
-- **redundancy** (String) The S3 redundancy level. Should be formatted; one of: `standard`, `reduced_redundancy` or null. Default `null`
+- **redundancy** (String) The S3 storage class (redundancy level). Should be one of: `standard`, `reduced_redundancy`, `standard_ia`, or `onezone_ia`
 - **response_condition** (String) Name of blockAttributes condition to apply this logging.
 - **s3_access_key** (String, Sensitive) AWS Access Key of an account with the required permissions to post logs. It is **strongly** recommended you create a separate IAM user with permissions to only operate on this Bucket. This key will be not be encrypted. Not required if `iam_role` is provided. You can provide this key via an environment variable, `FASTLY_S3_ACCESS_KEY`
 - **s3_iam_role** (String) The Amazon Resource Name (ARN) for the IAM role granting Fastly access to S3. Not required if `access_key` and `secret_key` are provided. You can provide this value via an environment variable, `FASTLY_S3_IAM_ROLE`

--- a/fastly/block_fastly_service_v1_s3logging_test.go
+++ b/fastly/block_fastly_service_v1_s3logging_test.go
@@ -3,6 +3,7 @@ package fastly
 import (
 	"fmt"
 	"os"
+	"strconv"
 	"testing"
 
 	gofastly "github.com/fastly/go-fastly/v3/fastly"
@@ -70,6 +71,7 @@ func TestResourceFastlyFlattenS3(t *testing.T) {
 					"server_side_encryption":            gofastly.S3ServerSideEncryptionAES,
 					"server_side_encryption_kms_key_id": "kmskey",
 					"compression_codec":                 "zstd",
+					"acl":                               gofastly.S3AccessControlList(""),
 				},
 			},
 		},
@@ -93,6 +95,7 @@ func TestResourceFastlyFlattenS3(t *testing.T) {
 					Redundancy:                   "reduced_redundancy",
 					ServerSideEncryptionKMSKeyID: "kmskey",
 					ServerSideEncryption:         gofastly.S3ServerSideEncryptionAES,
+					ACL:                          gofastly.S3AccessControlListPrivate,
 				},
 			},
 			local: []map[string]interface{}{
@@ -114,16 +117,19 @@ func TestResourceFastlyFlattenS3(t *testing.T) {
 					"redundancy":                        gofastly.S3RedundancyReduced,
 					"server_side_encryption":            gofastly.S3ServerSideEncryptionAES,
 					"server_side_encryption_kms_key_id": "kmskey",
+					"acl":                               gofastly.S3AccessControlListPrivate,
 				},
 			},
 		},
 	}
 
-	for _, c := range cases {
-		out := flattenS3s(c.remote)
-		if diff := cmp.Diff(out, c.local); diff != "" {
-			t.Fatalf("Error matching:%s", diff)
-		}
+	for i, c := range cases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			out := flattenS3s(c.remote)
+			if diff := cmp.Diff(out, c.local); diff != "" {
+				t.Fatalf("Error matching:%s", diff)
+			}
+		})
 	}
 }
 
@@ -164,6 +170,7 @@ func TestAccFastlyServiceV1_s3logging_basic(t *testing.T) {
 		Redundancy:        "reduced_redundancy",
 		TimestampFormat:   "%Y-%m-%dT%H:%M:%S.000",
 		ResponseCondition: "response_condition_test",
+		ACL:               gofastly.S3AccessControlListAWSExecRead,
 	}
 
 	log2 := gofastly.S3{
@@ -569,6 +576,7 @@ resource "fastly_service_v1" "foo" {
     message_type = "blank"
     public_key = file("test_fixtures/fastly_test_publickey")
     redundancy = "reduced_redundancy"
+	acl = "aws-exec-read"
     gzip_level = 3
   }
 

--- a/go.mod
+++ b/go.mod
@@ -5,12 +5,10 @@ go 1.14
 require (
 	github.com/ajg/form v0.0.0-20160822230020-523a5da1a92f // indirect
 	github.com/bflad/tfproviderlint v0.22.0
-	github.com/fastly/go-fastly/v3 v3.6.0
+	github.com/fastly/go-fastly/v3 v3.7.0
 	github.com/google/go-cmp v0.5.2
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/terraform-plugin-docs v0.4.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.4.4
 	github.com/stretchr/testify v1.6.1
 )
-
-replace github.com/fastly/go-fastly/v3 => github.com/opencredo/go-fastly/v3 v3.0.0-20210610083644-cf703e5fd36b

--- a/go.mod
+++ b/go.mod
@@ -12,3 +12,5 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.4.4
 	github.com/stretchr/testify v1.6.1
 )
+
+replace github.com/fastly/go-fastly/v3 => github.com/opencredo/go-fastly/v3 v3.0.0-20210610083644-cf703e5fd36b

--- a/go.sum
+++ b/go.sum
@@ -96,8 +96,6 @@ github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymF
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
-github.com/fastly/go-fastly/v3 v3.6.0 h1:sRnI+MhyMkgZbQWaUnhr70gHk39kfpG9JpMUlSoIsCg=
-github.com/fastly/go-fastly/v3 v3.6.0/go.mod h1:KOaCWsmkIKSASPzADl8PT/bTQIghOw/eEaxlHOu3jMA=
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568 h1:BHsljHzVlRcyQhjrss6TZTdY2VfCqZPbv5k3iBFa2ZQ=
@@ -313,6 +311,8 @@ github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k
 github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce/go.mod h1:uFMI8w+ref4v2r9jz+c9i1IfIttS/OkmLfrk1jne5hs=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
+github.com/opencredo/go-fastly/v3 v3.0.0-20210610083644-cf703e5fd36b h1:Z3O2JqcPXgXybxQCtom+lpfP2EgweuRlOQ9BfgdKskU=
+github.com/opencredo/go-fastly/v3 v3.0.0-20210610083644-cf703e5fd36b/go.mod h1:KOaCWsmkIKSASPzADl8PT/bTQIghOw/eEaxlHOu3jMA=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/go.sum
+++ b/go.sum
@@ -96,6 +96,8 @@ github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymF
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
+github.com/fastly/go-fastly/v3 v3.7.0 h1:T7Hf2cUvTuUAae/EY7aDVwVVZLFhI2IQnuRWsMfQq10=
+github.com/fastly/go-fastly/v3 v3.7.0/go.mod h1:KOaCWsmkIKSASPzADl8PT/bTQIghOw/eEaxlHOu3jMA=
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568 h1:BHsljHzVlRcyQhjrss6TZTdY2VfCqZPbv5k3iBFa2ZQ=
@@ -311,8 +313,6 @@ github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k
 github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce/go.mod h1:uFMI8w+ref4v2r9jz+c9i1IfIttS/OkmLfrk1jne5hs=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/opencredo/go-fastly/v3 v3.0.0-20210610083644-cf703e5fd36b h1:Z3O2JqcPXgXybxQCtom+lpfP2EgweuRlOQ9BfgdKskU=
-github.com/opencredo/go-fastly/v3 v3.0.0-20210610083644-cf703e5fd36b/go.mod h1:KOaCWsmkIKSASPzADl8PT/bTQIghOw/eEaxlHOu3jMA=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/vendor/github.com/fastly/go-fastly/v3/fastly/client.go
+++ b/vendor/github.com/fastly/go-fastly/v3/fastly/client.go
@@ -46,7 +46,7 @@ const DefaultRealtimeStatsEndpoint = "https://rt.fastly.com"
 var ProjectURL = "github.com/fastly/go-fastly"
 
 // ProjectVersion is the version of this library.
-var ProjectVersion = "3.6.0"
+var ProjectVersion = "3.7.0"
 
 // UserAgent is the user agent for this particular client.
 var UserAgent = fmt.Sprintf("FastlyGo/%s (+%s; %s)",

--- a/vendor/github.com/fastly/go-fastly/v3/fastly/s3.go
+++ b/vendor/github.com/fastly/go-fastly/v3/fastly/s3.go
@@ -8,13 +8,33 @@ import (
 )
 
 type S3Redundancy string
+
+func S3RedundancyPtr(v S3Redundancy) *S3Redundancy { return &v }
+
 type S3ServerSideEncryption string
 
+func S3ServerSideEncryptionPtr(v S3ServerSideEncryption) *S3ServerSideEncryption { return &v }
+
+type S3AccessControlList string
+
+func S3AccessControlListPtr(v S3AccessControlList) *S3AccessControlList { return &v }
+
 const (
-	S3RedundancyStandard      S3Redundancy           = "standard"
-	S3RedundancyReduced       S3Redundancy           = "reduced_redundancy"
+	S3RedundancyStandard   S3Redundancy = "standard"
+	S3RedundancyReduced    S3Redundancy = "reduced_redundancy"
+	S3RedundancyOneZoneIA  S3Redundancy = "onezone_ia"
+	S3RedundancyStandardIA S3Redundancy = "standard_ia"
+
 	S3ServerSideEncryptionAES S3ServerSideEncryption = "AES256"
 	S3ServerSideEncryptionKMS S3ServerSideEncryption = "aws:kms"
+
+	S3AccessControlListPrivate                S3AccessControlList = "private"
+	S3AccessControlListPublicRead             S3AccessControlList = "public-read"
+	S3AccessControlListPublicReadWrite        S3AccessControlList = "public-read-write"
+	S3AccessControlListAWSExecRead            S3AccessControlList = "aws-exec-read"
+	S3AccessControlListAuthenticatedRead      S3AccessControlList = "authenticated-read"
+	S3AccessControlListBucketOwnerRead        S3AccessControlList = "bucket-owner-read"
+	S3AccessControlListBucketOwnerFullControl S3AccessControlList = "bucket-owner-full-control"
 )
 
 // S3 represents a S3 response from the Fastly API.
@@ -45,6 +65,7 @@ type S3 struct {
 	CreatedAt                    *time.Time             `mapstructure:"created_at"`
 	UpdatedAt                    *time.Time             `mapstructure:"updated_at"`
 	DeletedAt                    *time.Time             `mapstructure:"deleted_at"`
+	ACL                          S3AccessControlList    `mapstructure:"acl"`
 }
 
 // s3sByName is a sortable list of S3s.
@@ -118,6 +139,7 @@ type CreateS3Input struct {
 	PublicKey                    string                 `form:"public_key,omitempty"`
 	ServerSideEncryptionKMSKeyID string                 `form:"server_side_encryption_kms_key_id,omitempty"`
 	ServerSideEncryption         S3ServerSideEncryption `form:"server_side_encryption,omitempty"`
+	ACL                          S3AccessControlList    `form:"acl,omitempty"`
 }
 
 // CreateS3 creates a new Fastly S3.
@@ -197,26 +219,27 @@ type UpdateS3Input struct {
 	// Name is the name of the S3 to update.
 	Name string
 
-	NewName                      *string                `form:"name,omitempty"`
-	BucketName                   *string                `form:"bucket_name,omitempty"`
-	Domain                       *string                `form:"domain,omitempty"`
-	AccessKey                    *string                `form:"access_key,omitempty"`
-	SecretKey                    *string                `form:"secret_key,omitempty"`
-	IAMRole                      *string                `form:"iam_role,omitempty"`
-	Path                         *string                `form:"path,omitempty"`
-	Period                       *uint                  `form:"period,omitempty"`
-	CompressionCodec             *string                `form:"compression_codec,omitempty"`
-	GzipLevel                    *uint                  `form:"gzip_level,omitempty"`
-	Format                       *string                `form:"format,omitempty"`
-	FormatVersion                *uint                  `form:"format_version,omitempty"`
-	ResponseCondition            *string                `form:"response_condition,omitempty"`
-	MessageType                  *string                `form:"message_type,omitempty"`
-	TimestampFormat              *string                `form:"timestamp_format,omitempty"`
-	Redundancy                   S3Redundancy           `form:"redundancy,omitempty"`
-	Placement                    *string                `form:"placement,omitempty"`
-	PublicKey                    *string                `form:"public_key,omitempty"`
-	ServerSideEncryptionKMSKeyID *string                `form:"server_side_encryption_kms_key_id,omitempty"`
-	ServerSideEncryption         S3ServerSideEncryption `form:"server_side_encryption,omitempty"`
+	NewName                      *string                 `form:"name,omitempty"`
+	BucketName                   *string                 `form:"bucket_name,omitempty"`
+	Domain                       *string                 `form:"domain,omitempty"`
+	AccessKey                    *string                 `form:"access_key,omitempty"`
+	SecretKey                    *string                 `form:"secret_key,omitempty"`
+	IAMRole                      *string                 `form:"iam_role,omitempty"`
+	Path                         *string                 `form:"path,omitempty"`
+	Period                       *uint                   `form:"period,omitempty"`
+	CompressionCodec             *string                 `form:"compression_codec,omitempty"`
+	GzipLevel                    *uint                   `form:"gzip_level,omitempty"`
+	Format                       *string                 `form:"format,omitempty"`
+	FormatVersion                *uint                   `form:"format_version,omitempty"`
+	ResponseCondition            *string                 `form:"response_condition,omitempty"`
+	MessageType                  *string                 `form:"message_type,omitempty"`
+	TimestampFormat              *string                 `form:"timestamp_format,omitempty"`
+	Redundancy                   *S3Redundancy           `form:"redundancy,omitempty"`
+	Placement                    *string                 `form:"placement,omitempty"`
+	PublicKey                    *string                 `form:"public_key,omitempty"`
+	ServerSideEncryptionKMSKeyID *string                 `form:"server_side_encryption_kms_key_id,omitempty"`
+	ServerSideEncryption         *S3ServerSideEncryption `form:"server_side_encryption,omitempty"`
+	ACL                          *S3AccessControlList    `form:"acl,omitempty"`
 }
 
 // UpdateS3 updates a specific S3.
@@ -233,7 +256,7 @@ func (c *Client) UpdateS3(i *UpdateS3Input) (*S3, error) {
 		return nil, ErrMissingName
 	}
 
-	if i.ServerSideEncryption == S3ServerSideEncryptionKMS && *i.ServerSideEncryptionKMSKeyID == "" {
+	if i.ServerSideEncryption != nil && *i.ServerSideEncryption == S3ServerSideEncryptionKMS && *i.ServerSideEncryptionKMSKeyID == "" {
 		return nil, ErrMissingServerSideEncryptionKMSKeyID
 	}
 

--- a/vendor/github.com/fastly/go-fastly/v3/fastly/stats.go
+++ b/vendor/github.com/fastly/go-fastly/v3/fastly/stats.go
@@ -50,6 +50,7 @@ type Stats struct {
 	ImageOptimizer            uint64      `mapstructure:"imgopto"`                  // Number of responses that came from the Fastly Image Optimizer service.
 	Status200                 uint64      `mapstructure:"status_200"`               // Number of responses sent with status code 200 (Success).
 	Status204                 uint64      `mapstructure:"status_204"`               // Number of responses sent with status code 204 (No Content).
+	Status206                 uint64      `mapstructure:"status_206"`               // Number of responses sent with status code 206 (Partial Content).
 	Status301                 uint64      `mapstructure:"status_301"`               // Number of responses sent with status code 301 (Moved Permanently).
 	Status302                 uint64      `mapstructure:"status_302"`               // Number of responses sent with status code 302 (Found).
 	Status304                 uint64      `mapstructure:"status_304"`               // Number of responses sent with status code 304 (Not Modified).

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -211,7 +211,7 @@ github.com/bgentry/go-netrc/netrc
 github.com/bgentry/speakeasy
 # github.com/davecgh/go-spew v1.1.1
 github.com/davecgh/go-spew/spew
-# github.com/fastly/go-fastly/v3 v3.6.0 => github.com/opencredo/go-fastly/v3 v3.0.0-20210610083644-cf703e5fd36b
+# github.com/fastly/go-fastly/v3 v3.7.0
 ## explicit
 github.com/fastly/go-fastly/v3/fastly
 # github.com/fatih/color v1.7.0
@@ -593,4 +593,3 @@ google.golang.org/protobuf/types/known/timestamppb
 google.golang.org/protobuf/types/pluginpb
 # gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c
 gopkg.in/yaml.v3
-# github.com/fastly/go-fastly/v3 => github.com/opencredo/go-fastly/v3 v3.0.0-20210610083644-cf703e5fd36b

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -211,7 +211,7 @@ github.com/bgentry/go-netrc/netrc
 github.com/bgentry/speakeasy
 # github.com/davecgh/go-spew v1.1.1
 github.com/davecgh/go-spew/spew
-# github.com/fastly/go-fastly/v3 v3.6.0
+# github.com/fastly/go-fastly/v3 v3.6.0 => github.com/opencredo/go-fastly/v3 v3.0.0-20210610083644-cf703e5fd36b
 ## explicit
 github.com/fastly/go-fastly/v3/fastly
 # github.com/fatih/color v1.7.0
@@ -593,3 +593,4 @@ google.golang.org/protobuf/types/known/timestamppb
 google.golang.org/protobuf/types/pluginpb
 # gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c
 gopkg.in/yaml.v3
+# github.com/fastly/go-fastly/v3 => github.com/opencredo/go-fastly/v3 v3.0.0-20210610083644-cf703e5fd36b


### PR DESCRIPTION
Fixes #409, this PR adds support for the `acl` parameter and two extra options for `redundancy` (the infrequently accessed storage classes). The `acl` parameter allows you to set the permissions of the objects uploaded to S3, including `private`, `public-read`, and some others like `bucket-owner-read`.