### PR TITLE
Only set cloned_version after the version has been successfully validated

### DIFF
--- a/fastly/base_fastly_service_v1.go
+++ b/fastly/base_fastly_service_v1.go
@@ -3,9 +3,10 @@ package fastly
 import (
 	"context"
 	"errors"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"log"
 	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 
 	gofastly "github.com/fastly/go-fastly/v3/fastly"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -360,7 +361,6 @@ func resourceServiceUpdate(ctx context.Context, d *schema.ResourceData, meta int
 
 			// The new version number is named "Number", but it's actually a string.
 			latestVersion = newVersion.Number
-			d.Set("cloned_version", latestVersion)
 
 			// New versions are not immediately found in the API, or are not
 			// immediately mutable, so we need to sleep a few and let Fastly ready
@@ -409,6 +409,10 @@ func resourceServiceUpdate(ctx context.Context, d *schema.ResourceData, meta int
 			return diag.Errorf("[ERR] Invalid configuration for Fastly Service (%s): %s", d.Id(), msg)
 		}
 
+		err = d.Set("cloned_version", latestVersion)
+		if err != nil {
+			return diag.FromErr(err)
+		}
 	}
 
 	shouldActivate := d.Get("activate").(bool)

--- a/fastly/resource_fastly_service_v1_test.go
+++ b/fastly/resource_fastly_service_v1_test.go
@@ -551,6 +551,11 @@ func TestAccFastlyServiceV1_createDefaultTTL(t *testing.T) {
 	})
 }
 
+// TestAccFastlyServiceV1_brokenSnippet tests that a service can still be updated after it has failed during an apply.
+// This avoids a bug when activate=true, where setting an invalid snippet causes the resourceServiceUpdate function to
+// return early before activating the version. This broke the assumption that cloned_version always tracks the active
+// version when activate=true, and means that the version we read from, and the one we clone from in order to make changes,
+// are different, meaning the plan is applied to a different version and 409 conflict errors can occur.
 func TestAccFastlyServiceV1_brokenSnippet(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))


### PR DESCRIPTION
Fixes #369.

Also adds the test case which previously failed with a 409 error prior to this fix (do we want to keep this?)

Beforehand, if there was an error midway through an update, and `activate` was true, there would be a half-updated draft version left on the service, which wouldn't be activated. The next apply would then read the active version but clone this half-updated version and try to apply the plan to it. This could cause a 409 error in some cases as the provider would be applying changes to a different version from which it had read.

This issue only applied when `activate` was true because, when `activate` was false, the provider would both read and clone from `cloned_version`, and could plan accordingly. The `activate=true` problem came from the false assumption that `cloned_version` and `active_version` would always be equal, but this isn't true when there's an error during the apply!

The fix for this is to only set `cloned_version` after the version validation has successfully passed.
This means that the next apply after an unsuccessful one will clone from the active version, as expected.