### PR TITLE
Improve error message when importing non-existent service by returning the 404 message instead of nil

### DIFF
--- a/fastly/base_fastly_service_v1.go
+++ b/fastly/base_fastly_service_v1.go
@@ -456,7 +456,7 @@ func resourceServiceRead(ctx context.Context, d *schema.ResourceData, meta inter
 		if e, ok := err.(*gofastly.HTTPError); ok && e.IsNotFound() {
 			log.Printf("[WARN] %s for ID (%s)", fastlyNoServiceFoundErr, d.Id())
 			d.SetId("")
-			return nil
+			return diag.FromErr(err)
 		}
 		return diag.FromErr(err)
 	}


### PR DESCRIPTION
The change I described in #421.

Changes the error message from:

![image](https://user-images.githubusercontent.com/5968462/122200286-cc1e0a80-ce92-11eb-9a1e-d67f74aeb630.png)

To:

![image](https://user-images.githubusercontent.com/5968462/122200307-d213eb80-ce92-11eb-9212-70072a0ce0a4.png)
