### PR TITLE
Fix panic in requestsetting update logic caused by incorrect cast from interface{} to uint

### DIFF
--- a/fastly/block_fastly_service_v1_requestsetting.go
+++ b/fastly/block_fastly_service_v1_requestsetting.go
@@ -119,7 +119,7 @@ func (h *RequestSettingServiceAttributeHandler) Process(d *schema.ResourceData, 
 			opts.BypassBusyWait = gofastly.CBool(v.(bool))
 		}
 		if v, ok := modified["max_stale_age"]; ok {
-			opts.MaxStaleAge = gofastly.Uint(v.(uint))
+			opts.MaxStaleAge = gofastly.Uint(uint(v.(int)))
 		}
 		if v, ok := modified["hash_keys"]; ok {
 			opts.HashKeys = gofastly.String(v.(string))


### PR DESCRIPTION
Fixes #415

As indentified in the issue, it needed to be cast to `int` first, then converted to a `uint` with `uint()`.

I also added a test to validate this change, which failed with the panic before the fix and passes afterwards.