### PR TITLE
In fastly_waf_rules data source, request rule revisions from API

### DIFF
--- a/fastly/data_source_waf_rules.go
+++ b/fastly/data_source_waf_rules.go
@@ -3,13 +3,13 @@ package fastly
 import (
 	"context"
 	"errors"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"log"
 	"sort"
 	"strconv"
 
 	gofastly "github.com/fastly/go-fastly/v3/fastly"
 	"github.com/fastly/terraform-provider-fastly/fastly/hashcode"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -67,7 +67,9 @@ func dataSourceFastlyWAFRules() *schema.Resource {
 func dataSourceFastlyWAFRulesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 
 	conn := meta.(*FastlyClient).conn
-	input := &gofastly.ListAllWAFRulesInput{}
+	input := &gofastly.ListAllWAFRulesInput{
+		Include: "waf_rule_revisions",
+	}
 
 	if v, ok := d.GetOk("publishers"); ok {
 		l := v.([]interface{})

--- a/fastly/data_source_waf_rules_test.go
+++ b/fastly/data_source_waf_rules_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
-func TestAccFastlyWAFRulesDetermineRevision(t *testing.T) {
+func TestFastlyWAFRulesDetermineRevision(t *testing.T) {
 
 	cases := []struct {
 		remote  []*gofastly.WAFRuleRevision
@@ -63,7 +63,7 @@ func TestAccFastlyWAFRulesDetermineRevision(t *testing.T) {
 	}
 }
 
-func TestAccFastlyWAFRulesFlattenWAFRules(t *testing.T) {
+func TestFastlyWAFRulesFlattenWAFRules(t *testing.T) {
 	cases := []struct {
 		remote []*gofastly.WAFRule
 		local  []map[string]interface{}


### PR DESCRIPTION
Addresses #425 with the fix suggested there.

To populate the Revisions field of the rules returned from `ListAllWAFRules`, the `Include` field of the request must specify `"waf_rule_revisions"`, otherwise this field is always `nil`. This PR adds it to the request.

Furthermore there were a couple of tests for the same data source which didn't match the naming convention for acceptance tests and unit tests so I've fixed those.