### PR TITLE
use TypeList schema for gzip block attributes

### DIFF
--- a/docs/resources/service_v1.md
+++ b/docs/resources/service_v1.md
@@ -510,8 +510,8 @@ Required:
 Optional:
 
 - **cache_condition** (String) Name of already defined `condition` controlling when this gzip configuration applies. This `condition` must be of type `CACHE`. For detailed information about Conditionals, see [Fastly's Documentation on Conditionals](https://docs.fastly.com/en/guides/using-conditions)
-- **content_types** (Set of String) The content-type for each type of content you wish to have dynamically gzip'ed. Example: `["text/html", "text/css"]`
-- **extensions** (Set of String) File extensions for each file type to dynamically gzip. Example: `["css", "js"]`
+- **content_types** (List of String) The content-type for each type of content you wish to have dynamically gzip'ed. Example: `["text/html", "text/css"]`
+- **extensions** (List of String) File extensions for each file type to dynamically gzip. Example: `["css", "js"]`
 
 
 <a id="nestedblock--header"></a>

--- a/fastly/block_fastly_service_v1_gzip.go
+++ b/fastly/block_fastly_service_v1_gzip.go
@@ -107,7 +107,7 @@ func (h *GzipServiceAttributeHandler) Process(d *schema.ResourceData, latestVers
 		}
 
 		// NOTE: []interface{} is not comparable in Filter function
-		// covert it into string in advance
+		// convert it into string in advance
 		resource["content_types"] = sliceToString(resource["content_types"].([]interface{}))
 		resource["extensions"] = sliceToString(resource["extensions"].([]interface{}))
 

--- a/fastly/block_fastly_service_v1_gzip_test.go
+++ b/fastly/block_fastly_service_v1_gzip_test.go
@@ -8,7 +8,6 @@ import (
 	gofastly "github.com/fastly/go-fastly/v3/fastly"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
@@ -27,7 +26,7 @@ func TestResourceFastlyFlattenGzips(t *testing.T) {
 			local: []map[string]interface{}{
 				{
 					"name":       "somegzip",
-					"extensions": schema.NewSet(schema.HashString, []interface{}{"css"}),
+					"extensions": []interface{}{"css"},
 				},
 			},
 		},
@@ -47,13 +46,13 @@ func TestResourceFastlyFlattenGzips(t *testing.T) {
 			local: []map[string]interface{}{
 				{
 					"name":          "somegzip",
-					"extensions":    schema.NewSet(schema.HashString, []interface{}{"css", "json", "js"}),
-					"content_types": schema.NewSet(schema.HashString, []interface{}{"text/html"}),
+					"extensions":    []interface{}{"css", "json", "js"},
+					"content_types": []interface{}{"text/html"},
 				},
 				{
 					"name":          "someothergzip",
-					"extensions":    schema.NewSet(schema.HashString, []interface{}{"css", "js"}),
-					"content_types": schema.NewSet(schema.HashString, []interface{}{"text/html", "text/xml"}),
+					"extensions":    []interface{}{"css", "js"},
+					"content_types": []interface{}{"text/html", "text/xml"},
 				},
 			},
 		},
@@ -61,43 +60,8 @@ func TestResourceFastlyFlattenGzips(t *testing.T) {
 
 	for _, c := range cases {
 		out := flattenGzips(c.remote)
-		// loop, because deepequal wont work with our sets
-		expectedCount := len(c.local)
-		var found int
-		for _, o := range out {
-			for _, l := range c.local {
-				if o["name"].(string) == l["name"].(string) {
-					found++
-					if o["extensions"] == nil && l["extensions"] != nil {
-						t.Fatalf("output extensions are nil, local are not")
-					}
-
-					if o["extensions"] != nil {
-						oex := o["extensions"].(*schema.Set)
-						lex := l["extensions"].(*schema.Set)
-						if !oex.Equal(lex) {
-							t.Fatalf("Extensions don't match, expected: %#v, got: %#v", lex, oex)
-						}
-					}
-
-					if o["content_types"] == nil && l["content_types"] != nil {
-						t.Fatalf("output content types are nil, local are not")
-					}
-
-					if o["content_types"] != nil {
-						oct := o["content_types"].(*schema.Set)
-						lct := l["content_types"].(*schema.Set)
-						if !oct.Equal(lct) {
-							t.Fatalf("ContentTypes don't match, expected: %#v, got: %#v", lct, oct)
-						}
-					}
-
-				}
-			}
-		}
-
-		if found != expectedCount {
-			t.Fatalf("Found and expected mismatch: %d / %d", found, expectedCount)
+		if !reflect.DeepEqual(out, c.local) {
+			t.Fatalf("Error matching:\nexpected: %#v\ngot: %#v", c.local, out)
 		}
 	}
 }
@@ -110,7 +74,7 @@ func TestAccFastlyServiceV1_gzips_basic(t *testing.T) {
 	log1 := gofastly.Gzip{
 		ServiceVersion: 1,
 		Name:           "gzip file types",
-		Extensions:     "js css",
+		Extensions:     "css js",
 		CacheCondition: "testing_condition",
 	}
 
@@ -123,7 +87,7 @@ func TestAccFastlyServiceV1_gzips_basic(t *testing.T) {
 	log3 := gofastly.Gzip{
 		ServiceVersion: 1,
 		Name:           "all",
-		Extensions:     "js html css",
+		Extensions:     "css js html",
 		ContentTypes:   "text/javascript application/x-javascript application/javascript text/css text/html",
 	}
 
@@ -131,7 +95,7 @@ func TestAccFastlyServiceV1_gzips_basic(t *testing.T) {
 		ServiceVersion: 1,
 		Name:           "all",
 		Extensions:     "css",
-		ContentTypes:   "text/javascript application/x-javascript",
+		ContentTypes:   "application/x-javascript text/javascript",
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -252,7 +216,7 @@ resource "fastly_service_v1" "foo" {
 
   gzip {
     name          = "gzip extensions"
-    content_types = ["text/html", "text/css"]
+    content_types = ["text/css", "text/html"]
   }
 
   force_destroy = true
@@ -279,12 +243,11 @@ resource "fastly_service_v1" "foo" {
     extensions = ["css", "js", "html"]
 
     content_types = [
-      "text/html",
-      "text/css",
-      "application/x-javascript",
-      "text/css",
-      "application/javascript",
-      "text/javascript",
+	  "text/javascript",
+	  "application/x-javascript",
+	  "application/javascript",
+	  "text/css",
+	  "text/html",
     ]
   }
 


### PR DESCRIPTION
Unfortunately, the value of `extensions` and `content_types` parameters for Gzip endpoint is just a list of strings (space-separated):
https://developer.fastly.com/reference/api/vcl-services/gzip/#create-gzip-config

and since they are defined as `schema.TypeSet` in the provider, ordering is [not retained](https://www.terraform.io/docs/extend/schemas/schema-types.html#typeset) when sending them in the API request:
https://github.com/fastly/terraform-provider-fastly/blob/v0.32.0/fastly/block_fastly_service_v1_gzip.go#L196-L207

For example, this gzip block configuration:

```
  gzip {
    name          = "Generated by default gzip policy"
    extensions    = ["js", "css", "html", "eot", "ico", "otf", "ttf", "json", "svg"]
    content_types = ["text/html", "application/x-javascript", "text/css", "application/javascript", "text/javascript", "application/json", "application/vnd.ms-fontobject", "application/x-font-opentype", "application/x-font-truetype", "application/x-font-ttf", "application/xml", "font/eot", "font/opentype", "font/otf", "image/svg+xml", "image/vnd.microsoft.icon", "text/plain", "text/xml"]
  }
```

would produce this in terminal output:
<img width="492" alt="Screen Shot 2021-06-26 at 16 36 57" src="https://user-images.githubusercontent.com/11495867/123505999-e7f88c00-d69c-11eb-95ae-a11a5c6e4c3e.png">

and would result in this in the actual configuration:
<img width="1082" alt="Screen Shot 2021-06-26 at 16 37 56" src="https://user-images.githubusercontent.com/11495867/123505994-e3cc6e80-d69c-11eb-8fe3-a0cc7a7c8c98.png">

Using `schema.TypeList` fixes this.
https://www.terraform.io/docs/extend/schemas/schema-types.html#typelist

That said, this will be a breaking change as the first run after the provider version update will modify the gzip object to change the string order.

While the current implementation causes no real issues (at least it produces the valid configuration from the service VCL point of view), retaining the ordering makes users much easier to review and compare the actual changes.