### PR TITLE
fix default_host not being removed

### DIFF
--- a/fastly/block_fastly_service_v1_settings.go
+++ b/fastly/block_fastly_service_v1_settings.go
@@ -26,6 +26,8 @@ func (h *SettingsServiceAttributeHandler) Process(d *schema.ResourceData, latest
 
 	if attr, ok := d.GetOk("default_host"); ok {
 		opts.DefaultHost = gofastly.String(attr.(string))
+	} else if d.HasChanges("default_host") {
+		opts.DefaultHost = gofastly.String("")
 	}
 
 	log.Printf("[DEBUG] Update Settings opts: %#v", opts)
@@ -70,7 +72,6 @@ func (h *SettingsServiceAttributeHandler) Register(s *schema.Resource) error {
 	s.Schema["default_host"] = &schema.Schema{
 		Type:        schema.TypeString,
 		Optional:    true,
-		Computed:    true,
 		Description: "The default hostname",
 	}
 	return nil

--- a/fastly/block_fastly_service_v1_settings.go
+++ b/fastly/block_fastly_service_v1_settings.go
@@ -19,15 +19,10 @@ func (h *SettingsServiceAttributeHandler) Process(d *schema.ResourceData, latest
 	opts := gofastly.UpdateSettingsInput{
 		ServiceID:      d.Id(),
 		ServiceVersion: latestVersion,
+		DefaultHost:    gofastly.String(d.Get("default_host").(string)),
 		// default_ttl has the same default value of 3600 that is provided by
 		// the Fastly API, so it's safe to include here
 		DefaultTTL: uint(d.Get("default_ttl").(int)),
-	}
-
-	if attr, ok := d.GetOk("default_host"); ok {
-		opts.DefaultHost = gofastly.String(attr.(string))
-	} else if d.HasChanges("default_host") {
-		opts.DefaultHost = gofastly.String("")
 	}
 
 	log.Printf("[DEBUG] Update Settings opts: %#v", opts)


### PR DESCRIPTION
fix for: https://github.com/fastly/terraform-provider-fastly/issues/85 and https://github.com/fastly/terraform-provider-fastly/issues/75

To clarify, this is to allow go-fastly client to send `...&general.default_host=&...` in query parameters when it's removed. This lets our API backend actually removes this field value from DB.

In this case, `opts.DefaultHost` must exist with an empty value.