### PR TITLE
[bug] fix fastly_tls_subscription resource to properly handle challenges for multi-SAN

### DIFF
--- a/docs/resources/tls_subscription.md
+++ b/docs/resources/tls_subscription.md
@@ -78,11 +78,12 @@ data "aws_route53_zone" "demo" {
 
 # Set up DNS record for managed DNS domain validation method
 resource "aws_route53_record" "domain_validation" {
-  name            = fastly_tls_subscription.example.managed_dns_challenges.record_name
-  type            = fastly_tls_subscription.example.managed_dns_challenges.record_type
+  for_each = { for domain in fastly_tls_subscription.example.managed_dns_challenges : domain.record_name => domain }
+  name            = each.value.record_name
+  type            = each.value.record_type
   zone_id         = data.aws_route53_zone.demo.id
   allow_overwrite = true
-  records         = [fastly_tls_subscription.example.managed_dns_challenges.record_value]
+  records         = [each.value.record_value]
   ttl             = 60
 }
 

--- a/docs/resources/tls_subscription.md
+++ b/docs/resources/tls_subscription.md
@@ -161,6 +161,7 @@ $ terraform import fastly_tls_subscription.demo xxxxxxxxxxx
 ### Read-Only
 
 - **created_at** (String) Timestamp (GMT) when the subscription was created.
+- **managed_dns_challenge** (Map of String) (DEPRECATED) The details required to configure DNS to respond to ACME DNS challenge in order to verify domain ownership.
 - **managed_dns_challenges** (Set of Object) A list of options for configuring DNS to respond to ACME DNS challenge in order to verify domain ownership. (see [below for nested schema](#nestedatt--managed_dns_challenges))
 - **managed_http_challenges** (Set of Object) A list of options for configuring DNS to respond to ACME HTTP challenge in order to verify domain ownership. Best accessed through a `for` expression to filter the relevant record. (see [below for nested schema](#nestedatt--managed_http_challenges))
 - **state** (String) The current state of the subscription. The list of possible states are: `pending`, `processing`, `issued`, and `renewing`.

--- a/docs/resources/tls_subscription.md
+++ b/docs/resources/tls_subscription.md
@@ -12,7 +12,7 @@ Enables TLS on a domain using a certificate managed by Fastly.
 
 DNS records need to be modified on the domain being secured, in order to respond to the ACME domain ownership challenge.
 
-There are two options for doing this: the `managed_dns_challenge`, which is the default method; and the `managed_http_challenges`, which points production traffic to Fastly.
+There are two options for doing this: the `managed_dns_challenges`, which is the default method; and the `managed_http_challenges`, which points production traffic to Fastly.
 
 ~> See the [Fastly documentation](https://docs.fastly.com/en/guides/serving-https-traffic-using-fastly-managed-certificates#verifying-domain-ownership) for more information on verifying domain ownership.
 
@@ -78,11 +78,11 @@ data "aws_route53_zone" "demo" {
 
 # Set up DNS record for managed DNS domain validation method
 resource "aws_route53_record" "domain_validation" {
-  name            = fastly_tls_subscription.example.managed_dns_challenge.record_name
-  type            = fastly_tls_subscription.example.managed_dns_challenge.record_type
+  name            = fastly_tls_subscription.example.managed_dns_challenges.record_name
+  type            = fastly_tls_subscription.example.managed_dns_challenges.record_type
   zone_id         = data.aws_route53_zone.demo.id
   allow_overwrite = true
-  records         = [fastly_tls_subscription.example.managed_dns_challenge.record_value]
+  records         = [fastly_tls_subscription.example.managed_dns_challenges.record_value]
   ttl             = 60
 }
 
@@ -112,14 +112,14 @@ In addition to the arguments listed above, the following attributes are exported
 * `created_at` - Timestamp (GMT) when the subscription was created.
 * `updated_at` - Timestamp (GMT) when the subscription was last updated.
 * `state` - The current state of the subscription. The list of possible states are: `pending`, `processing`, `issued`, and `renewing`.
-* `managed_dns_challenge` - The details required to configure DNS to respond to ACME DNS challenge in order to verify domain ownership. See Managed DNS Challenge below for details.
+* `managed_dns_challenges` - A list of options for configuring DNS to respond to ACME DNS challenge in order to verify domain ownership. See Managed DNS Challenge below for details.
 * `managed_http_challenges` - A list of options for configuring DNS to respond to ACME HTTP challenge in order to verify domain ownership. See Managed HTTP Challenges below for details.
 
 ### Managed DNS Challenge
 
-The available attributes in the `managed_dns_challenge` block are:
+The available attributes in the `managed_dns_challenges` block are:
 
-* `record_name` - The name of the DNS record to add. For example `_acme-challenge.example.com`. Accessed like this, `fastly_tls_subscription.tls.managed_dns_challenge.record_name`.
+* `record_name` - The name of the DNS record to add. For example `_acme-challenge.example.com`. Accessed like this, `fastly_tls_subscription.tls.managed_dns_challenges.record_name`.
 * `record_type` - The type of DNS record to add, e.g. `A`, or `CNAME`.
 * `record_value` - The value to which the DNS record should point, e.g. `xxxxx.fastly-validations.com`.
 
@@ -160,10 +160,20 @@ $ terraform import fastly_tls_subscription.demo xxxxxxxxxxx
 ### Read-Only
 
 - **created_at** (String) Timestamp (GMT) when the subscription was created.
-- **managed_dns_challenge** (Map of String) The details required to configure DNS to respond to ACME DNS challenge in order to verify domain ownership.
+- **managed_dns_challenges** (Set of Object) A list of options for configuring DNS to respond to ACME DNS challenge in order to verify domain ownership. (see [below for nested schema](#nestedatt--managed_dns_challenges))
 - **managed_http_challenges** (Set of Object) A list of options for configuring DNS to respond to ACME HTTP challenge in order to verify domain ownership. Best accessed through a `for` expression to filter the relevant record. (see [below for nested schema](#nestedatt--managed_http_challenges))
 - **state** (String) The current state of the subscription. The list of possible states are: `pending`, `processing`, `issued`, and `renewing`.
 - **updated_at** (String) Timestamp (GMT) when the subscription was updated.
+
+<a id="nestedatt--managed_dns_challenges"></a>
+### Nested Schema for `managed_dns_challenges`
+
+Read-Only:
+
+- **record_name** (String)
+- **record_type** (String)
+- **record_value** (String)
+
 
 <a id="nestedatt--managed_http_challenges"></a>
 ### Nested Schema for `managed_http_challenges`

--- a/docs/resources/tls_subscription.md
+++ b/docs/resources/tls_subscription.md
@@ -161,7 +161,7 @@ $ terraform import fastly_tls_subscription.demo xxxxxxxxxxx
 ### Read-Only
 
 - **created_at** (String) Timestamp (GMT) when the subscription was created.
-- **managed_dns_challenge** (Map of String) (DEPRECATED) The details required to configure DNS to respond to ACME DNS challenge in order to verify domain ownership.
+- **managed_dns_challenge** (Map of String, Deprecated) The details required to configure DNS to respond to ACME DNS challenge in order to verify domain ownership.
 - **managed_dns_challenges** (Set of Object) A list of options for configuring DNS to respond to ACME DNS challenge in order to verify domain ownership. (see [below for nested schema](#nestedatt--managed_dns_challenges))
 - **managed_http_challenges** (Set of Object) A list of options for configuring DNS to respond to ACME HTTP challenge in order to verify domain ownership. Best accessed through a `for` expression to filter the relevant record. (see [below for nested schema](#nestedatt--managed_http_challenges))
 - **state** (String) The current state of the subscription. The list of possible states are: `pending`, `processing`, `issued`, and `renewing`.

--- a/fastly/resource_fastly_tls_subscription.go
+++ b/fastly/resource_fastly_tls_subscription.go
@@ -219,7 +219,7 @@ func resourceFastlyTLSSubscriptionRead(_ context.Context, d *schema.ResourceData
 		}
 	}
 
-	// NOTE: This block of code contains a bug where the state file will only include
+	// TODO: This block of code contains a bug where the state file will only include
 	// the first domain's challenge data in the case of multi-SAN cert subscriptions.
 	// Users should use the new "managed_dns_challenges" attribute instead.
 	// We're leaving this for backward compatibility but is planned to be removed in v1.0.0.

--- a/fastly/resource_fastly_tls_subscription.go
+++ b/fastly/resource_fastly_tls_subscription.go
@@ -70,9 +70,10 @@ func resourceFastlyTLSSubscription() *schema.Resource {
 			},
 			"managed_dns_challenge": {
 				Type:        schema.TypeMap,
-				Description: "(DEPRECATED) The details required to configure DNS to respond to ACME DNS challenge in order to verify domain ownership.",
+				Description: "The details required to configure DNS to respond to ACME DNS challenge in order to verify domain ownership.",
 				Computed:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
+				Deprecated:  "Use 'managed_http_challenges' attribute instead",
 			},
 			"managed_dns_challenges": {
 				Type:        schema.TypeSet,

--- a/fastly/resource_fastly_tls_subscription.go
+++ b/fastly/resource_fastly_tls_subscription.go
@@ -73,7 +73,7 @@ func resourceFastlyTLSSubscription() *schema.Resource {
 				Description: "The details required to configure DNS to respond to ACME DNS challenge in order to verify domain ownership.",
 				Computed:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
-				Deprecated:  "Use 'managed_http_challenges' attribute instead",
+				Deprecated:  "Use 'managed_dns_challenges' attribute instead",
 			},
 			"managed_dns_challenges": {
 				Type:        schema.TypeSet,

--- a/templates/resources/tls_subscription.md.tmpl
+++ b/templates/resources/tls_subscription.md.tmpl
@@ -78,11 +78,12 @@ data "aws_route53_zone" "demo" {
 
 # Set up DNS record for managed DNS domain validation method
 resource "aws_route53_record" "domain_validation" {
-  name            = fastly_tls_subscription.example.managed_dns_challenges.record_name
-  type            = fastly_tls_subscription.example.managed_dns_challenges.record_type
+  for_each = { for domain in fastly_tls_subscription.example.managed_dns_challenges : domain.record_name => domain }
+  name            = each.value.record_name
+  type            = each.value.record_type
   zone_id         = data.aws_route53_zone.demo.id
   allow_overwrite = true
-  records         = [fastly_tls_subscription.example.managed_dns_challenges.record_value]
+  records         = [each.value.record_value]
   ttl             = 60
 }
 

--- a/templates/resources/tls_subscription.md.tmpl
+++ b/templates/resources/tls_subscription.md.tmpl
@@ -12,7 +12,7 @@ Enables TLS on a domain using a certificate managed by Fastly.
 
 DNS records need to be modified on the domain being secured, in order to respond to the ACME domain ownership challenge.
 
-There are two options for doing this: the `managed_dns_challenge`, which is the default method; and the `managed_http_challenges`, which points production traffic to Fastly.
+There are two options for doing this: the `managed_dns_challenges`, which is the default method; and the `managed_http_challenges`, which points production traffic to Fastly.
 
 ~> See the [Fastly documentation](https://docs.fastly.com/en/guides/serving-https-traffic-using-fastly-managed-certificates#verifying-domain-ownership) for more information on verifying domain ownership.
 
@@ -78,11 +78,11 @@ data "aws_route53_zone" "demo" {
 
 # Set up DNS record for managed DNS domain validation method
 resource "aws_route53_record" "domain_validation" {
-  name            = fastly_tls_subscription.example.managed_dns_challenge.record_name
-  type            = fastly_tls_subscription.example.managed_dns_challenge.record_type
+  name            = fastly_tls_subscription.example.managed_dns_challenges.record_name
+  type            = fastly_tls_subscription.example.managed_dns_challenges.record_type
   zone_id         = data.aws_route53_zone.demo.id
   allow_overwrite = true
-  records         = [fastly_tls_subscription.example.managed_dns_challenge.record_value]
+  records         = [fastly_tls_subscription.example.managed_dns_challenges.record_value]
   ttl             = 60
 }
 
@@ -112,14 +112,14 @@ In addition to the arguments listed above, the following attributes are exported
 * `created_at` - Timestamp (GMT) when the subscription was created.
 * `updated_at` - Timestamp (GMT) when the subscription was last updated.
 * `state` - The current state of the subscription. The list of possible states are: `pending`, `processing`, `issued`, and `renewing`.
-* `managed_dns_challenge` - The details required to configure DNS to respond to ACME DNS challenge in order to verify domain ownership. See Managed DNS Challenge below for details.
+* `managed_dns_challenges` - A list of options for configuring DNS to respond to ACME DNS challenge in order to verify domain ownership. See Managed DNS Challenge below for details.
 * `managed_http_challenges` - A list of options for configuring DNS to respond to ACME HTTP challenge in order to verify domain ownership. See Managed HTTP Challenges below for details.
 
 ### Managed DNS Challenge
 
-The available attributes in the `managed_dns_challenge` block are:
+The available attributes in the `managed_dns_challenges` block are:
 
-* `record_name` - The name of the DNS record to add. For example `_acme-challenge.example.com`. Accessed like this, `fastly_tls_subscription.tls.managed_dns_challenge.record_name`.
+* `record_name` - The name of the DNS record to add. For example `_acme-challenge.example.com`. Accessed like this, `fastly_tls_subscription.tls.managed_dns_challenges.record_name`.
 * `record_type` - The type of DNS record to add, e.g. `A`, or `CNAME`.
 * `record_value` - The value to which the DNS record should point, e.g. `xxxxx.fastly-validations.com`.
 


### PR DESCRIPTION
fix for: https://github.com/fastly/terraform-provider-fastly/issues/430

Looks like when this resource was originally implemented, multi-SAN cert subscription wasn't taken into account. Specifically, this part...
https://github.com/fastly/terraform-provider-fastly/blob/v0.32.0/fastly/resource_fastly_tls_subscription.go#L176

Therefore, the state file only includes the first domain's challenge data, which is a bug.

Though this is definitely going to be a breaking change.