### PR TITLE
[bug] check StateFunc entries both on CREATE and DELETE

### DIFF
--- a/fastly/block_fastly_service_v1_bigquerylogging.go
+++ b/fastly/block_fastly_service_v1_bigquerylogging.go
@@ -44,10 +44,19 @@ func (h *BigQueryLoggingServiceAttributeHandler) Process(d *schema.ResourceData,
 	// properly handles setting state with the StateFunc, it returns extra entries
 	// during state Gets, specifically `GetChange("bigquerylogging")` in this case.
 	filteredNewSet := schema.CopySet(newSet)
+	isRealDiff := true
 	for _, elem := range newSet.List() {
 		if v, ok := elem.(map[string]interface{})["name"]; !ok || v.(string) == "" {
 			filteredNewSet.Remove(elem)
 		}
+		if len(filteredNewSet.List()) == 0 {
+			isRealDiff = false
+		}
+	}
+
+	// newSet has no real diff other than extra entreis returned by StateFunc
+	if !isRealDiff {
+		return nil
 	}
 
 	setDiff := NewSetDiff(func(resource interface{}) (interface{}, error) {

--- a/fastly/block_fastly_service_v1_bigquerylogging.go
+++ b/fastly/block_fastly_service_v1_bigquerylogging.go
@@ -54,7 +54,7 @@ func (h *BigQueryLoggingServiceAttributeHandler) Process(d *schema.ResourceData,
 		}
 	}
 
-	// newSet has no real diff other than extra entreis returned by StateFunc
+	// newSet has no real diff other than extra entries returned by StateFunc
 	if !isRealDiff {
 		return nil
 	}


### PR DESCRIPTION
This attempts to fix: https://github.com/fastly/terraform-provider-fastly/issues/326

but I suspect this is a bit more broader issue in our provider where any logging implementation that uses `trimSpaceStateFunc` function may be affected as well in the same way.

### The issue

`strings.TrimSpace()` also removes a trailing `\n` character, as well as `\f\r\t` (+ regular whitespace) == the Unicode definition of "space".
https://golang.org/pkg/strings/#TrimSpace

For example,

```tf
  bigquerylogging {
    name = "test"
    dataset = "test_dataset"
    email = "foo@example.com"
    format = "%h %l %u %t \"%r\" %>s %b"
    project_id = "test"
    secret_key = "-----BEGIN PRIVATE KEY-----\nyour_key_here\n-----END PRIVATE KEY-----\n"
    table = "test"
  }
```

The `secret_key` value gets processed by `trimSpaceStateFunc` function. This means we send `-----BEGIN PRIVATE KEY-----\nyour_key_here\n-----END PRIVATE KEY-----` in the API request by removing the trailing `\n`, and TF state file also gets this value as well.

Then, if I change something other than this `bigquerylogging` block and run `$ terraform apply`, this will actually remove this logging configuration from the service and activate it.

This is because we're checking this only for CREATE operation:
https://github.com/fastly/terraform-provider-fastly/blob/v0.32.0/fastly/block_fastly_service_v1_bigquerylogging.go#L69-L85

We need to do this for DELETE operation as well. Otherwise, `newSet` always contains useless data such as this:

> newSet: *Set(map[string]interface {}{"453975081":map[string]interface {}{"dataset":"", "email":"", "format":"", "name":"", "placement":"", "project_id":"", "response_condition":"", "secret_key":"-----BEGIN PRIVATE KEY-----\nyour_key_here\n-----END PRIVATE KEY-----\n", "table":"", "template":""}})

in this case, only `secret_key` has the actual data, and all other keys are empty. This entry **MUST** be ignored.
Otherwise, our `Diff` function thinks there's actually a diff, and hence `diffResult.Deleted` data is produced. This will trigger DELETE call.

### Workaround

Users can also remove the trailing `\n` (or any space-like) characters in their logging configuration block, specifically for the `secret_key` field. This also resolves the issue.

```tf
  bigquerylogging {
    name = "test"
    dataset = "test_dataset"
    email = "foo@example.com"
    format = "%h %l %u %t \"%r\" %>s %b"
    project_id = "test"
    secret_key = "-----BEGIN PRIVATE KEY-----\nyour_key_here\n-----END PRIVATE KEY-----"  # manually remove trailing space characters
    table = "test"
  }
```

or, use `trimspace()` TF [built-in function](https://www.terraform.io/docs/language/functions/trimspace.html):

```
  bigquerylogging {
    name = "test"
    dataset = "test_dataset"
    email = "foo@example.com"
    format = "%h %l %u %t \"%r\" %>s %b"
    project_id = "test"
    secret_key = trimspace("-----BEGIN PRIVATE KEY-----\nyour_key_here\n-----END PRIVATE KEY-----\n")  # remove trailing space characters
    table = "test"
  }
```