### PR TITLE
Fix parsing of log-levels by removing date/time prefix

### DIFF
--- a/main.go
+++ b/main.go
@@ -18,6 +18,9 @@ func main() {
 
 	opts := &plugin.ServeOpts{ProviderFunc: fastly.Provider}
 
+	// Prevent logger from prepending date/time to logs, which breaks log-level parsing/filtering
+	log.SetFlags(0)
+
 	if debugMode {
 		err := plugin.Debug(context.Background(), "fastly/fastly", opts)
 		if err != nil {


### PR DESCRIPTION
The `TF_LOG` and `TF_LOG_PROVIDER` environment variables should be able to filter the provider logs based on the log level (`DEBUG`, `INFO`, `WARN`, `ERROR` etc). However, the default logger in the `log` package prepends the date and time to each log line. This breaks the parsing of the logs in Terraform core, as it expects each line to start with the log level in square brackets. Instead, it finds the date and defaults every line to `INFO` regardless of the intended severity. An example of how this line is outputed is as follows:

```
2021-07-08T10:41:00.615+0100 [INFO]  provider.terraform-provider-fastly_v0.32.0-5-gba6a3dbd: 2021/07/08 10:41:00 [DEBUG] Refreshing WAFs for (1F5jhDFJKHKhdfjDF0On28Pj7): timestamp=2021-07-08T10:41:00.615+0100
```

Here you can see that we intended to log as a `DEBUG` level, but it ended up coming out as `INFO`. The timestamp is also duplicated everywhere.

To fix this, the default logger can be configured to skip prepending the timestamp using `log.SetFlags(0)`. With this change, the log line now becomes:

```
2021-07-08T10:48:23.189+0100 [DEBUG] provider.terraform-provider-fastly_v0.32.0-6-g6e80f288: Refreshing WAFs for (1F5jhDFJKHKhdfjDF0On28Pj7): timestamp=2021-07-08T10:48:23.189+0100
```

Setting the `TF_LOG` environment variable to `INFO` also means that this line prevented from being outputted. This should help to filter the logs better in some situations.