### PR TITLE
[bug] suppress gzip diff unless fields are explicitly set

### DIFF
--- a/fastly/block_fastly_service_v1_gzip_test.go
+++ b/fastly/block_fastly_service_v1_gzip_test.go
@@ -206,6 +206,14 @@ func testAccCheckFastlyServiceV1GzipsAttributes(service *gofastly.ServiceDetail,
 					// these ahead of time
 					lg.CreatedAt = nil
 					lg.UpdatedAt = nil
+					// If empty value is sent, default value is assigned automatically by the API
+					// and so we ignore these fields in response
+					if g.Extensions == "" {
+						lg.Extensions = ""
+					}
+					if g.ContentTypes == "" {
+						lg.ContentTypes = ""
+					}
 					if !reflect.DeepEqual(g, lg) {
 						return fmt.Errorf("Bad match Gzip match, expected (%#v), got (%#v)", g, lg)
 					}


### PR DESCRIPTION
We recently made some changes to our [Gzip API](https://developer.fastly.com/reference/api/vcl-services/gzip/) endpoint.

Previously, the endpoint accepted an empty value for `content_types` and `extensions` parameters (ie., `""` is stored in DB as the value). But after the change, API will set their default values if an empty value is sent for these parameters from clients.

This results in unexpected (and potentially infinite) diff as the TF state file contains no data for these parameters but the API returns different data upon refresh.

Since Terraform Plugin SDK currently does not support a way to configure a `Default` for `TypeList/TypeSet`, the only workaround seems to be ignoring these fields in the API response IF those values are not set explicitly in the TF file by the user. Or, we can also make these fields `Required` (+ disallow empty value) even though they're optional in the API spec.

This PR also introduces a downside where remote changes for those particular fields will be ignored unless users set them in TF file.

For example, with this gzip block setting:

```tf
  gzip {
    name = "Test gzip"
  }
```

and if I change `content_types` or `extensions` value on the UI, the subsequent TF runs won't report any diff. But I think that's acceptable.