### PR TITLE
set main field on CreateVCL to reduce redundant subsequent call

### DIFF
--- a/fastly/block_fastly_service_v1_vcl.go
+++ b/fastly/block_fastly_service_v1_vcl.go
@@ -77,27 +77,13 @@ func (h *VCLServiceAttributeHandler) Process(d *schema.ResourceData, latestVersi
 			ServiceVersion: latestVersion,
 			Name:           resource["name"].(string),
 			Content:        resource["content"].(string),
+			Main:           resource["main"].(bool),
 		}
 
 		log.Printf("[DEBUG] Fastly VCL Addition opts: %#v", opts)
 		_, err := conn.CreateVCL(&opts)
 		if err != nil {
 			return err
-		}
-
-		// if this new VCL is the main
-		if resource["main"].(bool) {
-			opts := gofastly.ActivateVCLInput{
-				ServiceID:      d.Id(),
-				ServiceVersion: latestVersion,
-				Name:           resource["name"].(string),
-			}
-			log.Printf("[DEBUG] Fastly VCL activation opts: %#v", opts)
-			_, err := conn.ActivateVCL(&opts)
-			if err != nil {
-				return err
-			}
-
 		}
 	}
 


### PR DESCRIPTION
For: https://github.com/fastly/terraform-provider-fastly/issues/112