### PR TITLE
don't use ParallelTest for no_auth data source

### DIFF
--- a/fastly/data_source_ip_ranges_test.go
+++ b/fastly/data_source_ip_ranges_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestAccFastlyIPRanges(t *testing.T) {
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{
 			{

--- a/fastly/data_source_ip_ranges_test.go
+++ b/fastly/data_source_ip_ranges_test.go
@@ -94,9 +94,11 @@ func testAccFastlyIPRanges(n string) resource.TestCheckFunc {
 
 const testAccFastlyIPRangesConfig = `
 provider "fastly" {
+  alias   = "noauth"
   api_key = ""
   no_auth = true
 }
 data "fastly_ip_ranges" "some" {
+  provider = fastly.noauth
 }
 `

--- a/fastly/data_source_ip_ranges_test.go
+++ b/fastly/data_source_ip_ranges_test.go
@@ -12,6 +12,10 @@ import (
 )
 
 func TestAccFastlyIPRanges(t *testing.T) {
+	// NOTE: due to how providers are instantiated during ParallelTest
+	// there may be a case where some tests get polluted with an instance of the provider
+	// with no API key created in this particular test (ie., the "no_auth" option).
+	// Using Test instead.
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{
@@ -94,11 +98,9 @@ func testAccFastlyIPRanges(n string) resource.TestCheckFunc {
 
 const testAccFastlyIPRangesConfig = `
 provider "fastly" {
-  alias   = "noauth"
   api_key = ""
   no_auth = true
 }
 data "fastly_ip_ranges" "some" {
-  provider = fastly.noauth
 }
 `


### PR DESCRIPTION
... when running full acceptance tests.

https://www.terraform.io/docs/language/providers/configuration.html#default-provider-configurations

It looks like when tests are running in parallel to the IP ranges data source test, sometimes, other tests are getting polluted with an instance of the provider with no API key.