### PR TITLE
use d.SetNewComputed for TypeSet computed attributes

### DIFF
--- a/fastly/resource_fastly_tls_subscription.go
+++ b/fastly/resource_fastly_tls_subscription.go
@@ -332,7 +332,7 @@ func resourceFastlyTLSSubscriptionStateNotIssued(_ context.Context, d *schema.Re
 	return d.Get("state").(string) != "issued"
 }
 
-func resourceFastlyTLSSubscriptionSetNewComputed(_ context.Context, d *schema.ResourceDiff, meta interface{}) error {
+func resourceFastlyTLSSubscriptionSetNewComputed(_ context.Context, d *schema.ResourceDiff, _ interface{}) error {
 	// NOTE: This is a workaround for a bug in Terraform core
 	// where TypeSet computed attributes are not being updated with the new values upon applying (in an update action).
 	// This means that they will not be updated until the second "refresh" or "apply" after the first apply.

--- a/fastly/resource_fastly_tls_subscription.go
+++ b/fastly/resource_fastly_tls_subscription.go
@@ -333,7 +333,7 @@ func resourceFastlyTLSSubscriptionStateNotIssued(_ context.Context, d *schema.Re
 }
 
 func resourceFastlyTLSSubscriptionSetNewComputed(_ context.Context, d *schema.ResourceDiff, _ interface{}) error {
-	// NOTE: This is a workaround for a bug in Terraform core
+	// NOTE: This is a workaround for a bug in Terraform core (hashicorp/terraform-plugin-sdk#195)
 	// where TypeSet computed attributes are not being updated with the new values upon applying (in an update action).
 	// This means that they will not be updated until the second "refresh" or "apply" after the first apply.
 	// We should work around this and set the new values immediately upon applying so that other resources


### PR DESCRIPTION
This attempts to fix: https://github.com/fastly/terraform-provider-fastly/issues/451

TODO:
- [x] Update example https://registry.terraform.io/providers/fastly/fastly/latest/docs/resources/tls_subscription#example-usage

Note:
I'm not adding acceptance tests for this change because the update action only runs for "issued" state:
https://github.com/fastly/terraform-provider-fastly/blob/v0.33.0/fastly/resource_fastly_tls_subscription.go#L23

If we're about to add tests, that require tests to interact with DNS records as well as waiting for the subscription to be issued, which isn't ideal in my view.

Reference:
https://github.com/hashicorp/terraform-plugin-sdk/issues/195