### PR TITLE
deprecate geo_headers attribute

### DIFF
--- a/docs/resources/service_v1.md
+++ b/docs/resources/service_v1.md
@@ -985,7 +985,7 @@ Optional:
 - **default_host** (String) Sets the host header
 - **force_miss** (Boolean) Force a cache miss for the request. If specified, can be `true` or `false`
 - **force_ssl** (Boolean) Forces the request to use SSL (Redirects a non-SSL request to SSL)
-- **geo_headers** (Boolean) Injects Fastly-Geo-Country, Fastly-Geo-City, and Fastly-Geo-Region into the request headers
+- **geo_headers** (Boolean, Deprecated) Injects Fastly-Geo-Country, Fastly-Geo-City, and Fastly-Geo-Region into the request headers
 - **hash_keys** (String) Comma separated list of varnish request object fields that should be in the hash key
 - **max_stale_age** (Number) How old an object is allowed to be to serve `stale-if-error` or `stale-while-revalidate`, in seconds
 - **request_condition** (String) Name of already defined `condition` to determine if this request setting should be applied

--- a/fastly/block_fastly_service_v1_requestsetting.go
+++ b/fastly/block_fastly_service_v1_requestsetting.go
@@ -240,9 +240,12 @@ func (h *RequestSettingServiceAttributeHandler) Register(s *schema.Resource) err
 					Optional:    true,
 					Description: "Injects the X-Timer info into the request for viewing origin fetch durations",
 				},
+				// TODO: Although Fastly API has been exposing this parameter over years
+				// it turned out that setting this parameter does nothing. We should remove this attribute in v1.0.0
 				"geo_headers": {
 					Type:        schema.TypeBool,
 					Optional:    true,
+					Deprecated:  "'geo_headers' attribute has been deprecated and will be removed in the next major version release",
 					Description: "Injects Fastly-Geo-Country, Fastly-Geo-City, and Fastly-Geo-Region into the request headers",
 				},
 				"default_host": {


### PR DESCRIPTION
https://developer.fastly.com/reference/api/vcl-services/request-settings/

We've internally confirmed that the setting `geo_headers` parameter had been exposed without any actual implementation, and hence setting this parameter today basically does nothing. Deprecating this parameter.

<img width="739" alt="Screen Shot 2021-08-01 at 5 55 05" src="https://user-images.githubusercontent.com/11495867/127752212-be1d995e-5751-49bb-a4fd-43274740abbf.png">
