### PR TITLE
make backend block optional

### DIFF
--- a/docs/resources/service_compute.md
+++ b/docs/resources/service_compute.md
@@ -78,7 +78,6 @@ $ terraform import fastly_service_compute.demo xxxxxxxxxxxxxxxxxxxx@2
 
 ### Required
 
-- **backend** (Block Set, Min: 1) (see [below for nested schema](#nestedblock--backend))
 - **domain** (Block Set, Min: 1) A set of Domain names to serve as entry points for your Service (see [below for nested schema](#nestedblock--domain))
 - **name** (String) The unique name for the Service to create
 - **package** (Block List, Min: 1, Max: 1) The `package` block supports uploading or modifying Wasm packages for use in a Fastly Compute@Edge service. See Fastly's documentation on [Compute@Edge](https://developer.fastly.com/learning/compute/) (see [below for nested schema](#nestedblock--package))
@@ -86,6 +85,7 @@ $ terraform import fastly_service_compute.demo xxxxxxxxxxxxxxxxxxxx@2
 ### Optional
 
 - **activate** (Boolean) Conditionally prevents the Service from being activated. The apply step will continue to create a new draft version but will not activate it if this is set to `false`. Default `true`
+- **backend** (Block Set) (see [below for nested schema](#nestedblock--backend))
 - **bigquerylogging** (Block Set) (see [below for nested schema](#nestedblock--bigquerylogging))
 - **blobstoragelogging** (Block Set) (see [below for nested schema](#nestedblock--blobstoragelogging))
 - **comment** (String) Description field for the service. Default `Managed by Terraform`
@@ -125,6 +125,30 @@ $ terraform import fastly_service_compute.demo xxxxxxxxxxxxxxxxxxxx@2
 - **active_version** (Number) The currently active version of your Fastly Service
 - **cloned_version** (Number) The latest cloned version by the provider
 
+<a id="nestedblock--domain"></a>
+### Nested Schema for `domain`
+
+Required:
+
+- **name** (String) The domain that this Service will respond to. It is important to note that changing this attribute will delete and recreate the resource.
+
+Optional:
+
+- **comment** (String) An optional comment about the Domain.
+
+
+<a id="nestedblock--package"></a>
+### Nested Schema for `package`
+
+Required:
+
+- **filename** (String) The path to the Wasm deployment package within your local filesystem
+
+Optional:
+
+- **source_code_hash** (String) Used to trigger updates. Must be set to a SHA512 hash of the package file specified with the filename. The usual way to set this is filesha512("package.tar.gz") (Terraform 0.11.12 and later) or filesha512(file("package.tar.gz")) (Terraform 0.11.11 and earlier), where "package.tar.gz" is the local filename of the Wasm deployment package
+
+
 <a id="nestedblock--backend"></a>
 ### Nested Schema for `backend`
 
@@ -157,30 +181,6 @@ Optional:
 - **ssl_sni_hostname** (String) Overrides ssl_hostname, but only for SNI in the handshake. Does not affect cert validation at all
 - **use_ssl** (Boolean) Whether or not to use SSL to reach the Backend. Default `false`
 - **weight** (Number) The [portion of traffic](https://docs.fastly.com/en/guides/load-balancing-configuration#how-weight-affects-load-balancing) to send to this Backend. Each Backend receives weight / total of the traffic. Default `100`
-
-
-<a id="nestedblock--domain"></a>
-### Nested Schema for `domain`
-
-Required:
-
-- **name** (String) The domain that this Service will respond to. It is important to note that changing this attribute will delete and recreate the resource.
-
-Optional:
-
-- **comment** (String) An optional comment about the Domain.
-
-
-<a id="nestedblock--package"></a>
-### Nested Schema for `package`
-
-Required:
-
-- **filename** (String) The path to the Wasm deployment package within your local filesystem
-
-Optional:
-
-- **source_code_hash** (String) Used to trigger updates. Must be set to a SHA512 hash of the package file specified with the filename. The usual way to set this is filesha512("package.tar.gz") (Terraform 0.11.12 and later) or filesha512(file("package.tar.gz")) (Terraform 0.11.11 and earlier), where "package.tar.gz" is the local filename of the Wasm deployment package
 
 
 <a id="nestedblock--bigquerylogging"></a>

--- a/docs/resources/service_compute.md
+++ b/docs/resources/service_compute.md
@@ -78,6 +78,7 @@ $ terraform import fastly_service_compute.demo xxxxxxxxxxxxxxxxxxxx@2
 
 ### Required
 
+- **backend** (Block Set, Min: 1) (see [below for nested schema](#nestedblock--backend))
 - **domain** (Block Set, Min: 1) A set of Domain names to serve as entry points for your Service (see [below for nested schema](#nestedblock--domain))
 - **name** (String) The unique name for the Service to create
 - **package** (Block List, Min: 1, Max: 1) The `package` block supports uploading or modifying Wasm packages for use in a Fastly Compute@Edge service. See Fastly's documentation on [Compute@Edge](https://developer.fastly.com/learning/compute/) (see [below for nested schema](#nestedblock--package))
@@ -85,7 +86,6 @@ $ terraform import fastly_service_compute.demo xxxxxxxxxxxxxxxxxxxx@2
 ### Optional
 
 - **activate** (Boolean) Conditionally prevents the Service from being activated. The apply step will continue to create a new draft version but will not activate it if this is set to `false`. Default `true`
-- **backend** (Block Set) (see [below for nested schema](#nestedblock--backend))
 - **bigquerylogging** (Block Set) (see [below for nested schema](#nestedblock--bigquerylogging))
 - **blobstoragelogging** (Block Set) (see [below for nested schema](#nestedblock--blobstoragelogging))
 - **comment** (String) Description field for the service. Default `Managed by Terraform`
@@ -125,30 +125,6 @@ $ terraform import fastly_service_compute.demo xxxxxxxxxxxxxxxxxxxx@2
 - **active_version** (Number) The currently active version of your Fastly Service
 - **cloned_version** (Number) The latest cloned version by the provider
 
-<a id="nestedblock--domain"></a>
-### Nested Schema for `domain`
-
-Required:
-
-- **name** (String) The domain that this Service will respond to. It is important to note that changing this attribute will delete and recreate the resource.
-
-Optional:
-
-- **comment** (String) An optional comment about the Domain.
-
-
-<a id="nestedblock--package"></a>
-### Nested Schema for `package`
-
-Required:
-
-- **filename** (String) The path to the Wasm deployment package within your local filesystem
-
-Optional:
-
-- **source_code_hash** (String) Used to trigger updates. Must be set to a SHA512 hash of the package file specified with the filename. The usual way to set this is filesha512("package.tar.gz") (Terraform 0.11.12 and later) or filesha512(file("package.tar.gz")) (Terraform 0.11.11 and earlier), where "package.tar.gz" is the local filename of the Wasm deployment package
-
-
 <a id="nestedblock--backend"></a>
 ### Nested Schema for `backend`
 
@@ -181,6 +157,30 @@ Optional:
 - **ssl_sni_hostname** (String) Overrides ssl_hostname, but only for SNI in the handshake. Does not affect cert validation at all
 - **use_ssl** (Boolean) Whether or not to use SSL to reach the Backend. Default `false`
 - **weight** (Number) The [portion of traffic](https://docs.fastly.com/en/guides/load-balancing-configuration#how-weight-affects-load-balancing) to send to this Backend. Each Backend receives weight / total of the traffic. Default `100`
+
+
+<a id="nestedblock--domain"></a>
+### Nested Schema for `domain`
+
+Required:
+
+- **name** (String) The domain that this Service will respond to. It is important to note that changing this attribute will delete and recreate the resource.
+
+Optional:
+
+- **comment** (String) An optional comment about the Domain.
+
+
+<a id="nestedblock--package"></a>
+### Nested Schema for `package`
+
+Required:
+
+- **filename** (String) The path to the Wasm deployment package within your local filesystem
+
+Optional:
+
+- **source_code_hash** (String) Used to trigger updates. Must be set to a SHA512 hash of the package file specified with the filename. The usual way to set this is filesha512("package.tar.gz") (Terraform 0.11.12 and later) or filesha512(file("package.tar.gz")) (Terraform 0.11.11 and earlier), where "package.tar.gz" is the local filename of the Wasm deployment package
 
 
 <a id="nestedblock--bigquerylogging"></a>

--- a/docs/resources/service_v1.md
+++ b/docs/resources/service_v1.md
@@ -236,7 +236,6 @@ $ terraform import fastly_service_v1.demo xxxxxxxxxxxxxxxxxxxx@2
 
 ### Required
 
-- **backend** (Block Set, Min: 1) (see [below for nested schema](#nestedblock--backend))
 - **domain** (Block Set, Min: 1) A set of Domain names to serve as entry points for your Service (see [below for nested schema](#nestedblock--domain))
 - **name** (String) The unique name for the Service to create
 
@@ -244,6 +243,7 @@ $ terraform import fastly_service_v1.demo xxxxxxxxxxxxxxxxxxxx@2
 
 - **acl** (Block Set) (see [below for nested schema](#nestedblock--acl))
 - **activate** (Boolean) Conditionally prevents the Service from being activated. The apply step will continue to create a new draft version but will not activate it if this is set to `false`. Default `true`
+- **backend** (Block Set) (see [below for nested schema](#nestedblock--backend))
 - **bigquerylogging** (Block Set) (see [below for nested schema](#nestedblock--bigquerylogging))
 - **blobstoragelogging** (Block Set) (see [below for nested schema](#nestedblock--blobstoragelogging))
 - **cache_setting** (Block Set) (see [below for nested schema](#nestedblock--cache_setting))
@@ -295,6 +295,34 @@ $ terraform import fastly_service_v1.demo xxxxxxxxxxxxxxxxxxxx@2
 - **active_version** (Number) The currently active version of your Fastly Service
 - **cloned_version** (Number) The latest cloned version by the provider
 
+<a id="nestedblock--domain"></a>
+### Nested Schema for `domain`
+
+Required:
+
+- **name** (String) The domain that this Service will respond to. It is important to note that changing this attribute will delete and recreate the resource.
+
+Optional:
+
+- **comment** (String) An optional comment about the Domain.
+
+
+<a id="nestedblock--acl"></a>
+### Nested Schema for `acl`
+
+Required:
+
+- **name** (String) A unique name to identify this ACL. It is important to note that changing this attribute will delete and recreate the ACL, and discard the current items in the ACL
+
+Optional:
+
+- **force_destroy** (Boolean) Allow the ACL to be deleted, even if it contains entries. Defaults to false.
+
+Read-Only:
+
+- **acl_id** (String) The ID of the ACL
+
+
 <a id="nestedblock--backend"></a>
 ### Nested Schema for `backend`
 
@@ -328,34 +356,6 @@ Optional:
 - **ssl_sni_hostname** (String) Overrides ssl_hostname, but only for SNI in the handshake. Does not affect cert validation at all
 - **use_ssl** (Boolean) Whether or not to use SSL to reach the Backend. Default `false`
 - **weight** (Number) The [portion of traffic](https://docs.fastly.com/en/guides/load-balancing-configuration#how-weight-affects-load-balancing) to send to this Backend. Each Backend receives weight / total of the traffic. Default `100`
-
-
-<a id="nestedblock--domain"></a>
-### Nested Schema for `domain`
-
-Required:
-
-- **name** (String) The domain that this Service will respond to. It is important to note that changing this attribute will delete and recreate the resource.
-
-Optional:
-
-- **comment** (String) An optional comment about the Domain.
-
-
-<a id="nestedblock--acl"></a>
-### Nested Schema for `acl`
-
-Required:
-
-- **name** (String) A unique name to identify this ACL. It is important to note that changing this attribute will delete and recreate the ACL, and discard the current items in the ACL
-
-Optional:
-
-- **force_destroy** (Boolean) Allow the ACL to be deleted, even if it contains entries. Defaults to false.
-
-Read-Only:
-
-- **acl_id** (String) The ID of the ACL
 
 
 <a id="nestedblock--bigquerylogging"></a>

--- a/fastly/block_fastly_service_v1_backend.go
+++ b/fastly/block_fastly_service_v1_backend.go
@@ -404,19 +404,18 @@ func (h *BackendServiceAttributeHandler) Register(s *schema.Resource) error {
 		},
 	}
 
+	required := true
+
 	if h.GetServiceMetadata().serviceType == ServiceTypeVCL {
+		// backend is optional in VCL service
+		required = false
+
 		blockAttributes["request_condition"] = &schema.Schema{
 			Type:        schema.TypeString,
 			Optional:    true,
 			Default:     "",
 			Description: "Name of a condition, which if met, will select this backend during a request.",
 		}
-	}
-
-	// backend is optional in VCL service
-	required := true
-	if h.GetServiceMetadata().serviceType == ServiceTypeVCL {
-		required = false
 	}
 
 	s.Schema[h.GetKey()] = &schema.Schema{

--- a/fastly/block_fastly_service_v1_backend.go
+++ b/fastly/block_fastly_service_v1_backend.go
@@ -413,9 +413,18 @@ func (h *BackendServiceAttributeHandler) Register(s *schema.Resource) error {
 		}
 	}
 
+	required := true
+	optional := !required
+	// backend is optional in VCL service
+	if h.GetServiceMetadata().serviceType == ServiceTypeVCL {
+		required = false
+		optional = !required
+	}
+
 	s.Schema[h.GetKey()] = &schema.Schema{
 		Type:     schema.TypeSet,
-		Optional: true,
+		Required: required,
+		Optional: optional,
 		Elem: &schema.Resource{
 			Schema: blockAttributes,
 		},

--- a/fastly/block_fastly_service_v1_backend.go
+++ b/fastly/block_fastly_service_v1_backend.go
@@ -413,18 +413,16 @@ func (h *BackendServiceAttributeHandler) Register(s *schema.Resource) error {
 		}
 	}
 
-	required := true
-	optional := !required
 	// backend is optional in VCL service
+	required := true
 	if h.GetServiceMetadata().serviceType == ServiceTypeVCL {
 		required = false
-		optional = !required
 	}
 
 	s.Schema[h.GetKey()] = &schema.Schema{
 		Type:     schema.TypeSet,
 		Required: required,
-		Optional: optional,
+		Optional: !required,
 		Elem: &schema.Resource{
 			Schema: blockAttributes,
 		},

--- a/fastly/block_fastly_service_v1_backend.go
+++ b/fastly/block_fastly_service_v1_backend.go
@@ -415,7 +415,7 @@ func (h *BackendServiceAttributeHandler) Register(s *schema.Resource) error {
 
 	s.Schema[h.GetKey()] = &schema.Schema{
 		Type:     schema.TypeSet,
-		Required: true,
+		Optional: true,
 		Elem: &schema.Resource{
 			Schema: blockAttributes,
 		},


### PR DESCRIPTION
This addresses: https://github.com/fastly/terraform-provider-fastly/issues/454

Note: since this changes it from required to optional, this is NOT considered as a breaking change.