### PR TITLE
Fix fastly_service_waf_configuration not updating rule attributes correctly

### DIFF
--- a/fastly/block_fastly_waf_configuration_v1_active_rule.go
+++ b/fastly/block_fastly_waf_configuration_v1_active_rule.go
@@ -200,25 +200,3 @@ func flattenWAFActiveRules(rules []*gofastly.WAFActiveRule) []map[string]interfa
 	}
 	return rl
 }
-
-// deleteByModSecID returns a copy of the argument "remove" with all common (with the same modsec_rule_id) elements with argument "add" removed.
-func deleteByModSecID(remove *schema.Set, add []interface{}) *schema.Set {
-
-	modSecIDs := make(map[int]interface{}, remove.Len())
-	result := schema.CopySet(remove)
-
-	for _, rv := range remove.List() {
-		r := rv.(map[string]interface{})
-		modSecIDs[r["modsec_rule_id"].(int)] = r
-	}
-
-	if len(modSecIDs) > 0 {
-		for _, av := range add {
-			a := av.(map[string]interface{})
-			if v, ok := modSecIDs[a["modsec_rule_id"].(int)]; ok {
-				result.Remove(v)
-			}
-		}
-	}
-	return result
-}

--- a/fastly/block_fastly_waf_configuration_v1_active_rule.go
+++ b/fastly/block_fastly_waf_configuration_v1_active_rule.go
@@ -63,11 +63,11 @@ func updateRules(d *schema.ResourceData, meta interface{}, wafID string, Number 
 		return err
 	}
 
-	// NOTE: Fastly WAF (WAF 2020) API doesn't have a proper "bulk" upsert endpoint.
+	// NOTE: Fastly WAF (WAF 2020) API doesn't have a proper batch update endpoint.
 	// go-fastly uses the below endpoint for UpsertBatchOperation:
 	// "POST /waf/firewalls/:firewall_id/versions/:version_id/active-rules"
-	// but this endpoint only updates "status" when it comes to upsert and "revision" field is ignored.
-	// Therefore, when one of the rule attributes changes we must delete it first and create it as a new rule.
+	// but this endpoint only updates "status" when it comes to upsert operation and "revision" field is ignored.
+	// Therefore, when one of the rule attributes is changed we must delete it first and create it as a new rule.
 
 	log.Print("[INFO] WAF rules update")
 	// DELETE removed rules

--- a/fastly/block_fastly_waf_configuration_v1_active_rule_test.go
+++ b/fastly/block_fastly_waf_configuration_v1_active_rule_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/fastly/terraform-provider-fastly/fastly/hashcode"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
@@ -41,55 +40,6 @@ func TestAccFastlyServiceWAFVersionV1FlattenWAFActiveRules(t *testing.T) {
 		out := flattenWAFActiveRules(c.remote)
 		if !reflect.DeepEqual(out, c.local) {
 			t.Fatalf("Error matching:\nexpected: %#v\n     got: %#v", c.local, out)
-		}
-	}
-}
-
-func TestAccFastlyServiceWAFVersionV1FlattenWAFDeleteByModSecID(t *testing.T) {
-
-	addInput := []map[string]interface{}{{"modsec_rule_id": 1}, {"modsec_rule_id": 12}, {"modsec_rule_id": 123}}
-	add := make([]interface{}, len(addInput), len(addInput))
-	for i := range addInput {
-		add[i] = addInput[i]
-	}
-
-	deleteInput := []map[string]interface{}{{"modsec_rule_id": 12}, {"modsec_rule_id": 123}, {"modsec_rule_id": 1234}}
-	remove := make([]interface{}, len(deleteInput), len(deleteInput))
-	for i := range deleteInput {
-		remove[i] = deleteInput[i]
-	}
-
-	expectedInput := []map[string]interface{}{{"modsec_rule_id": 1234}}
-	expected := make([]interface{}, len(expectedInput), len(expectedInput))
-	for i := range expectedInput {
-		expected[i] = expectedInput[i]
-	}
-
-	cases := []struct {
-		add      []interface{}
-		remove   *schema.Set
-		expected *schema.Set
-	}{
-		{
-			add:      []interface{}{},
-			remove:   schema.NewSet(testHashFunc, []interface{}{}),
-			expected: schema.NewSet(testHashFunc, []interface{}{}),
-		},
-		{
-			add:      add,
-			remove:   schema.NewSet(testHashFunc, []interface{}{}),
-			expected: schema.NewSet(testHashFunc, []interface{}{}),
-		},
-		{
-			add:      add,
-			remove:   schema.NewSet(testHashFunc, remove),
-			expected: schema.NewSet(testHashFunc, expected),
-		},
-	}
-	for _, c := range cases {
-		out := deleteByModSecID(c.remove, c.add)
-		if !c.expected.Equal(out) {
-			t.Fatalf("Error matching:\nexpected: %#v\n     got: %#v", c.expected, c.remove)
 		}
 	}
 }

--- a/fastly/block_fastly_waf_configuration_v1_active_rule_test.go
+++ b/fastly/block_fastly_waf_configuration_v1_active_rule_test.go
@@ -114,8 +114,14 @@ func TestAccFastlyServiceWAFVersionV1AddUpdateDeleteRules(t *testing.T) {
 			Status:   "log",
 			Revision: 1,
 		},
+		{
+			ModSecID: 910100,
+			Status:   "score",
+			Revision: 1,
+		},
 	}
 	rules2 := []gofastly.WAFActiveRule{
+		// update status
 		{
 			ModSecID: 1010080,
 			Status:   "block",
@@ -130,6 +136,12 @@ func TestAccFastlyServiceWAFVersionV1AddUpdateDeleteRules(t *testing.T) {
 			ModSecID: 2037405,
 			Status:   "block",
 			Revision: 1,
+		},
+		// update revision
+		{
+			ModSecID: 910100,
+			Status:   "score",
+			Revision: 2,
 		},
 	}
 	wafVerInput := testAccFastlyServiceWAFVersionV1BuildConfig(20)
@@ -204,6 +216,9 @@ func testAccCheckFastlyServiceWAFVersionV1CheckRules(service *gofastly.ServiceDe
 			}
 			if expected[i].Status != actual[i].Status {
 				return fmt.Errorf("Error matching:\nexpected: %#v\ngot: %#v", expected[i].Status, actual[i].Status)
+			}
+			if expected[i].Revision != actual[i].Revision {
+				return fmt.Errorf("Error matching:\nexpected: %#v\ngot: %#v", expected[i].Revision, actual[i].Revision)
 			}
 		}
 		return nil


### PR DESCRIPTION
from code comment:

> // NOTE: Fastly WAF (WAF 2020) API doesn't have a proper batch update endpoint.
> // go-fastly uses the below endpoint for UpsertBatchOperation:
> // "POST /waf/firewalls/:firewall_id/versions/:version_id/active-rules"
> // but this endpoint only updates "status" when it comes to upsert and "revision" field is ignored.
> // Therefore, when one of the rule attributes is changed we must delete it first and create it as a new rule.