### PR TITLE
Correctly update `version_comment`

### DIFF
--- a/fastly/base_fastly_service_v1.go
+++ b/fastly/base_fastly_service_v1.go
@@ -361,7 +361,7 @@ func resourceServiceUpdate(ctx context.Context, d *schema.ResourceData, meta int
 	}
 
 	// Update the cloned version's comment. No new version is required for this.
-	if d.HasChange("version_comment") && !needsChange {
+	if d.HasChange("version_comment") && (!needsChange || isCreate) {
 		opts := gofastly.UpdateVersionInput{
 			ServiceID:      d.Id(),
 			ServiceVersion: d.Get("cloned_version").(int),
@@ -526,7 +526,7 @@ func resourceServiceRead(ctx context.Context, d *schema.ResourceData, meta inter
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	err = d.Set("version_comment", s.Version.Comment)
+	err = d.Set("version_comment", s.ActiveVersion.Comment)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/fastly/resource_fastly_service_v1_test.go
+++ b/fastly/resource_fastly_service_v1_test.go
@@ -404,7 +404,8 @@ func TestAccFastlyServiceV1_basic(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	comment := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
-	versionComment := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	versionComment1 := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	versionComment2 := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	domainName1 := fmt.Sprintf("fastly-test.tf-%s.com", acctest.RandString(10))
 	domainName2 := fmt.Sprintf("fastly-test.tf-%s.com", acctest.RandString(10))
 
@@ -414,7 +415,7 @@ func TestAccFastlyServiceV1_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckServiceV1Destroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccServiceV1Config(name, domainName1),
+				Config: testAccServiceV1Config_initWithVerstionComment(name, versionComment1, domainName1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
 					resource.TestCheckResourceAttr(
@@ -422,7 +423,7 @@ func TestAccFastlyServiceV1_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"fastly_service_v1.foo", "comment", "Managed by Terraform"),
 					resource.TestCheckResourceAttr(
-						"fastly_service_v1.foo", "version_comment", ""),
+						"fastly_service_v1.foo", "version_comment", versionComment1),
 					resource.TestCheckResourceAttr(
 						"fastly_service_v1.foo", "active_version", "1"),
 					resource.TestCheckResourceAttr(
@@ -432,7 +433,7 @@ func TestAccFastlyServiceV1_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccServiceV1Config_basicUpdate(name, comment, versionComment, domainName2),
+				Config: testAccServiceV1Config_basicUpdate(name, comment, versionComment2, domainName2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
 					resource.TestCheckResourceAttr(
@@ -440,7 +441,7 @@ func TestAccFastlyServiceV1_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"fastly_service_v1.foo", "comment", comment),
 					resource.TestCheckResourceAttr(
-						"fastly_service_v1.foo", "version_comment", versionComment),
+						"fastly_service_v1.foo", "version_comment", versionComment2),
 					resource.TestCheckResourceAttr(
 						"fastly_service_v1.foo", "active_version", "2"),
 					resource.TestCheckResourceAttr(
@@ -763,6 +764,26 @@ resource "fastly_service_v1" "foo" {
 
   force_destroy = true
 }`, name, domain)
+}
+
+func testAccServiceV1Config_initWithVerstionComment(name, versionComment, domain string) string {
+	return fmt.Sprintf(`
+resource "fastly_service_v1" "foo" {
+  name = "%s"
+  version_comment = "%s"
+
+  domain {
+    name    = "%s"
+    comment = "tf-testing-domain"
+  }
+
+  backend {
+    address = "aws.amazon.com"
+    name    = "amazon docs"
+  }
+
+  force_destroy = true
+}`, name, versionComment, domain)
 }
 
 func testAccServiceV1Config_default_host(name, domain, defaultHost string) string {


### PR DESCRIPTION
https://github.com/fastly/terraform-provider-fastly/issues/465

This PR fixes two issues.

1. `version_comment` attribute is ignored on service creation
2. `version_comment` value is wrongly assigned from `s.Version.Comment` as opposed to `s.ActiveVersion.Comment`
`s.Version` contains the last version object regardless of its state (draft/active), so we always should look at `s.ActiveVersion`