### PR TITLE
Change to accept multi-pem blocks

### DIFF
--- a/docs/resources/tls_certificate.md
+++ b/docs/resources/tls_certificate.md
@@ -65,7 +65,7 @@ $ terraform import fastly_tls_certificate.demo xxxxxxxxxxx
 
 ### Required
 
-- **certificate_body** (String) PEM-formatted certificate.
+- **certificate_body** (String) PEM-formatted certificate, optionally including any intermediary certificates.
 
 ### Optional
 

--- a/fastly/resource_fastly_tls_certificate.go
+++ b/fastly/resource_fastly_tls_certificate.go
@@ -29,9 +29,9 @@ func resourceFastlyTLSCertificate() *schema.Resource {
 			},
 			"certificate_body": {
 				Type:             schema.TypeString,
-				Description:      "PEM-formatted certificate.",
+				Description:      "PEM-formatted certificate, optionally including any intermediary certificates.",
 				Required:         true,
-				ValidateDiagFunc: validatePEMBlock("CERTIFICATE"),
+				ValidateDiagFunc: validatePEMBlocks("CERTIFICATE"),
 			},
 			"created_at": {
 				Type:        schema.TypeString,


### PR DESCRIPTION
The API appears to accept the certificate as well as the intermediary certificates.

See #468 