### PR TITLE
Correct typos

### DIFF
--- a/docs/resources/service_acl_entries_v1.md
+++ b/docs/resources/service_acl_entries_v1.md
@@ -56,7 +56,7 @@ resource "fastly_service_acl_entries_v1" "entries" {
     ip = "127.0.0.1"
     subnet = "24"
     negated = false
-    comment = "ALC Entry 1"
+    comment = "ACL Entry 1"
   }
 }
 ```
@@ -166,7 +166,7 @@ resource "fastly_service_acl_entries_v1" "entries" {
     ip = "127.0.0.1"
     subnet = "24"
     negated = false
-    comment = "ALC Entry 1"
+    comment = "ACL Entry 1"
   }
 }
 ```
@@ -189,7 +189,7 @@ resource "fastly_service_acl_entries_v1" "entries" {
     ip = "127.0.0.1"
     subnet = "24"
     negated = false
-    comment = "ALC Entry 1"
+    comment = "ACL Entry 1"
   }
   
   lifecycle {

--- a/fastly/resource_fastly_service_acl_entries_v1_test.go
+++ b/fastly/resource_fastly_service_acl_entries_v1_test.go
@@ -26,7 +26,7 @@ func TestResourceFastlyFlattenAclEntries(t *testing.T) {
 					IP:        "127.0.0.1",
 					Subnet:    24,
 					Negated:   false,
-					Comment:   "ALC Entry 1",
+					Comment:   "ACL Entry 1",
 				},
 				{
 					ServiceID: "service-id",
@@ -34,7 +34,7 @@ func TestResourceFastlyFlattenAclEntries(t *testing.T) {
 					IP:        "192.168.0.1",
 					Subnet:    16,
 					Negated:   true,
-					Comment:   "ALC Entry 2",
+					Comment:   "ACL Entry 2",
 				},
 			},
 			local: []map[string]interface{}{
@@ -42,13 +42,13 @@ func TestResourceFastlyFlattenAclEntries(t *testing.T) {
 					"ip":      "127.0.0.1",
 					"subnet":  "24",
 					"negated": false,
-					"comment": "ALC Entry 1",
+					"comment": "ACL Entry 1",
 				},
 				{
 					"ip":      "192.168.0.1",
 					"subnet":  "16",
 					"negated": true,
-					"comment": "ALC Entry 2",
+					"comment": "ACL Entry 2",
 				},
 			},
 		},
@@ -73,7 +73,7 @@ func TestAccFastlyServiceAclEntriesV1_create(t *testing.T) {
 			"ip":      "127.0.0.1",
 			"subnet":  "24",
 			"negated": false,
-			"comment": "ALC Entry 1",
+			"comment": "ACL Entry 1",
 		},
 	}
 
@@ -110,7 +110,7 @@ func TestAccFastlyServiceAclEntriesV1_update(t *testing.T) {
 			"ip":      "127.0.0.1",
 			"subnet":  "24",
 			"negated": false,
-			"comment": "ALC Entry 1",
+			"comment": "ACL Entry 1",
 		},
 	}
 
@@ -120,7 +120,7 @@ func TestAccFastlyServiceAclEntriesV1_update(t *testing.T) {
 			"ip":      "127.0.0.2",
 			"subnet":  "24",
 			"negated": false,
-			"comment": "ALC Entry 1",
+			"comment": "ACL Entry 1",
 		},
 	}
 
@@ -222,7 +222,7 @@ func TestAccFastlyServiceAclEntriesV1_delete(t *testing.T) {
 			"ip":      "127.0.0.1",
 			"subnet":  "24",
 			"negated": false,
-			"comment": "ALC Entry 1",
+			"comment": "ACL Entry 1",
 		},
 	}
 
@@ -275,7 +275,7 @@ func TestAccFastlyServiceAclEntriesV1_process_1001_entries(t *testing.T) {
 			"ip":      fmt.Sprintf("127.0.%d.%d", ipPart3, ipPart4),
 			"subnet":  "22",
 			"negated": false,
-			"comment": fmt.Sprintf("ALC Entry %d %d", ipPart3, ipPart4),
+			"comment": fmt.Sprintf("ACL Entry %d %d", ipPart3, ipPart4),
 		})
 
 		ipPart4++

--- a/templates/resources/service_acl_entries_v1.md.tmpl
+++ b/templates/resources/service_acl_entries_v1.md.tmpl
@@ -3,16 +3,16 @@ layout: "fastly"
 page_title: "Fastly: service_acl_entries_v1"
 sidebar_current: "docs-fastly-resource-service-acl-entries-v1"
 description: |-
-  Defines a set of Fastly ACL entries that can be used to populate a service ACL. 
+  Defines a set of Fastly ACL entries that can be used to populate a service ACL.
 ---
 
 # fastly_service_acl_entries_v1
 
 Defines a set of Fastly ACL entries that can be used to populate a service ACL.  This resource will populate an ACL with the entries and will track their state.
 
-~> **Warning:** Terraform will take precedence over any changes you make in the UI or API. Such changes are likely to be reversed if you run Terraform again.  
+~> **Warning:** Terraform will take precedence over any changes you make in the UI or API. Such changes are likely to be reversed if you run Terraform again.
 
-If Terraform is being used to populate the initial content of an ACL which you intend to manage via API or UI, then the lifecycle `ignore_changes` field can be used with the resource.  An example of this configuration is provided below.    
+If Terraform is being used to populate the initial content of an ACL which you intend to manage via API or UI, then the lifecycle `ignore_changes` field can be used with the resource.  An example of this configuration is provided below.
 
 
 ## Example Usage (Terraform >= 0.12.6)
@@ -56,7 +56,7 @@ resource "fastly_service_acl_entries_v1" "entries" {
     ip = "127.0.0.1"
     subnet = "24"
     negated = false
-    comment = "ALC Entry 1"
+    comment = "ACL Entry 1"
   }
 }
 ```
@@ -166,14 +166,14 @@ resource "fastly_service_acl_entries_v1" "entries" {
     ip = "127.0.0.1"
     subnet = "24"
     negated = false
-    comment = "ALC Entry 1"
+    comment = "ACL Entry 1"
   }
 }
 ```
 
 ### Supporting API and UI ACL updates with ignore_changes
 
-The following example demonstrates how the lifecycle `ignore_changes` field can be used to suppress updates against the 
+The following example demonstrates how the lifecycle `ignore_changes` field can be used to suppress updates against the
 entries in an ACL.  If, after your first deploy, the Fastly API or UI is to be used to manage entries in an ACL, then this will stop Terraform realigning the remote state with the initial set of ACL entries defined in your HCL.
 
 ```hcl
@@ -189,13 +189,13 @@ resource "fastly_service_acl_entries_v1" "entries" {
     ip = "127.0.0.1"
     subnet = "24"
     negated = false
-    comment = "ALC Entry 1"
+    comment = "ACL Entry 1"
   }
-  
+
   lifecycle {
     ignore_changes = [entry,]
   }
-  
+
 }
 ```
 
@@ -213,11 +213,11 @@ The resource ID is a combined value of the `service_id` and `acl_id` separated b
 $ terraform import fastly_service_acl_entries_v1.entries xxxxxxxxxxxxxxxxxxxx/xxxxxxxxxxxxxxxxxxxx
 ```
 
-If Terraform is already managing remote acl entries against a resource being imported then the user will be asked to remove it from the existing Terraform state.  
+If Terraform is already managing remote acl entries against a resource being imported then the user will be asked to remove it from the existing Terraform state.
 The following is an example of the Terraform state command to remove the resource named `fastly_service_acl_entries_v1.entries` from the Terraform state file.
 
 ```
 $ terraform state rm fastly_service_acl_entries_v1.entries
-``` 
+```
 
 {{end}}


### PR DESCRIPTION
- Replace `ALC` to `ACL` in the context of ACL resources.