### PR TITLE
Remove TLS subscriptions that 404 from state

### DIFF
--- a/fastly/resource_fastly_tls_subscription.go
+++ b/fastly/resource_fastly_tls_subscription.go
@@ -3,10 +3,12 @@ package fastly
 import (
 	"context"
 	"fmt"
+	"log"
 	"strings"
 	"time"
 
 	"github.com/fastly/go-fastly/v5/fastly"
+	gofastly "github.com/fastly/go-fastly/v5/fastly"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -193,6 +195,12 @@ func resourceFastlyTLSSubscriptionRead(_ context.Context, d *schema.ResourceData
 		Include: &include,
 	})
 	if err != nil {
+		if err, ok := err.(*gofastly.HTTPError); ok && err.IsNotFound() {
+			log.Printf("[WARN] No TLS subscription found for ID (%s)", d.Id())
+			d.SetId("")
+			return nil
+		}
+
 		return diag.FromErr(err)
 	}
 

--- a/fastly/resource_fastly_tls_subscription_validation.go
+++ b/fastly/resource_fastly_tls_subscription_validation.go
@@ -3,11 +3,14 @@ package fastly
 import (
 	"context"
 	"fmt"
+	"log"
+	"time"
+
 	"github.com/fastly/go-fastly/v5/fastly"
+	gofastly "github.com/fastly/go-fastly/v5/fastly"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"time"
 )
 
 func resourceFastlyTLSSubscriptionValidation() *schema.Resource {
@@ -71,6 +74,12 @@ func resourceFastlyTLSSubscriptionValidationRead(_ context.Context, d *schema.Re
 		ID: subscriptionID,
 	})
 	if err != nil {
+		if err, ok := err.(*gofastly.HTTPError); ok && err.IsNotFound() {
+			log.Printf("[WARN] No TLS subscription found for ID (%s)", d.Id())
+			d.SetId("")
+			return nil
+		}
+
 		return diag.FromErr(err)
 	}
 


### PR DESCRIPTION
When a TLS subscription is removed outside of Terraform, currently it causes refreshes to fail

```
╷
│ Error: 404 - Not Found:
│ 
│     Title:  Not found
│     Detail: The subscription you requested was not found
```

Instead, the provider should remove these resources from state. This is handled in other resources but the exact implementation differs a bit by resource. 