### PR TITLE
gh: remove caching from lint job

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,13 +10,6 @@ jobs:
       uses: actions/setup-go@v2
       with:
         go-version: 1.16.x
-    - name: Restore cache
-      uses: actions/cache@v2
-      with:
-        path: ~/go/pkg/mod
-        key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-mod-
     - name: Fmt
       run: make fmt
     - name: Vet


### PR DESCRIPTION
When reviewing the workflow output for another PR (#479), I noticed that caching is broken in the workflow. In the `test` job, I spotted the following:

```
Unable to reserve cache with key Linux-go-mod-f1f14e721ac7d5ca194ab5bb35d4a0186149890a47da58c1d272a9d3187f71a7, another job may be creating this cache.
```

Turns out the conflicting job is `lint`, which prints:

```
Cache Size: ~0 MB (22 B)
Cache saved successfully
Cache saved with key: Linux-go-mod-f1f14e721ac7d5ca194ab5bb35d4a0186149890a47da58c1d272a9d3187f71a7
```

Since the lint job invokes `go fmt` and `go vet` and doesn't call `go mod download` or anything that implicitly downloads modules, there is no cache to persist. 