### PR TITLE
Only update service `name` and `comment` if `activate` is true

### DIFF
--- a/fastly/base_fastly_service_v1.go
+++ b/fastly/base_fastly_service_v1.go
@@ -451,7 +451,7 @@ func resourceServiceRead(ctx context.Context, d *schema.ResourceData, meta inter
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Warning,
 			Summary:  "Some changes are ignored",
-			Detail:   "'name' and 'comment' attirbutes can only be updated with 'activate = true'",
+			Detail:   "'name' and 'comment' attributes can only be updated with 'activate = true'",
 		})
 	}
 

--- a/fastly/base_fastly_service_v1.go
+++ b/fastly/base_fastly_service_v1.go
@@ -443,6 +443,10 @@ func resourceServiceRead(ctx context.Context, d *schema.ResourceData, meta inter
 		return diag.FromErr(err)
 	}
 
+	// NOTE: service "name" and "comment" are versionless (mutable).
+	// Therefore, we only allow them to be updated if "activate = true".
+	// Unfortunately, with our current resource design, it's not easy to show
+	// a warning message upon plan, and so this warning will only appear upon applying.
 	if d.HasChanges("name", "comment") && !d.Get("activate").(bool) {
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Warning,


### PR DESCRIPTION
Service `name` and `comment` are versionless (mutable), so allowing them to be updated with `activate = false` is not an ideal behavior and should be ignored.

This is technically a (tiny) breaking change but I would be really surprised if anyone is updating those data with `activate = false` and impacted by this change, so I don't have much concerns including this change in the next release rather than waiting for v1, to be honest.