### PR TITLE
Add `use_tls` attribute for Splunk logging

### DIFF
--- a/docs/resources/service_compute.md
+++ b/docs/resources/service_compute.md
@@ -660,7 +660,7 @@ Optional:
 - **tls_client_key** (String, Sensitive) The client private key used to make authenticated requests. Must be in PEM format.
 - **tls_hostname** (String) The hostname used to verify the server's certificate. It can either be the Common Name or a Subject Alternative Name (SAN)
 - **token** (String, Sensitive) The Splunk token to be used for authentication
-- **use_tls** (Boolean) Whether to use TLS for secure logging. Defult: `false`
+- **use_tls** (Boolean) Whether to use TLS for secure logging. Default: `false`
 
 
 <a id="nestedblock--sumologic"></a>

--- a/docs/resources/service_compute.md
+++ b/docs/resources/service_compute.md
@@ -660,6 +660,7 @@ Optional:
 - **tls_client_key** (String, Sensitive) The client private key used to make authenticated requests. Must be in PEM format.
 - **tls_hostname** (String) The hostname used to verify the server's certificate. It can either be the Common Name or a Subject Alternative Name (SAN)
 - **token** (String, Sensitive) The Splunk token to be used for authentication
+- **use_tls** (Boolean) Whether to use TLS for secure logging. Defult: `false`
 
 
 <a id="nestedblock--sumologic"></a>

--- a/docs/resources/service_v1.md
+++ b/docs/resources/service_v1.md
@@ -1077,6 +1077,7 @@ Optional:
 - **tls_client_key** (String, Sensitive) The client private key used to make authenticated requests. Must be in PEM format.
 - **tls_hostname** (String) The hostname used to verify the server's certificate. It can either be the Common Name or a Subject Alternative Name (SAN)
 - **token** (String, Sensitive) The Splunk token to be used for authentication
+- **use_tls** (Boolean) Whether to use TLS for secure logging. Defult: `false`
 
 
 <a id="nestedblock--sumologic"></a>

--- a/docs/resources/service_v1.md
+++ b/docs/resources/service_v1.md
@@ -1077,7 +1077,7 @@ Optional:
 - **tls_client_key** (String, Sensitive) The client private key used to make authenticated requests. Must be in PEM format.
 - **tls_hostname** (String) The hostname used to verify the server's certificate. It can either be the Common Name or a Subject Alternative Name (SAN)
 - **token** (String, Sensitive) The Splunk token to be used for authentication
-- **use_tls** (Boolean) Whether to use TLS for secure logging. Defult: `false`
+- **use_tls** (Boolean) Whether to use TLS for secure logging. Default: `false`
 
 
 <a id="nestedblock--sumologic"></a>

--- a/fastly/block_fastly_service_v1_splunk.go
+++ b/fastly/block_fastly_service_v1_splunk.go
@@ -73,7 +73,7 @@ func (h *SplunkServiceAttributeHandler) GetSchema() *schema.Schema {
 			Type:        schema.TypeBool,
 			Optional:    true,
 			Default:     false,
-			Description: "Whether to use TLS for secure logging. Defult: `false`",
+			Description: "Whether to use TLS for secure logging. Default: `false`",
 		},
 	}
 

--- a/fastly/block_fastly_service_v1_splunk.go
+++ b/fastly/block_fastly_service_v1_splunk.go
@@ -69,6 +69,12 @@ func (h *SplunkServiceAttributeHandler) GetSchema() *schema.Schema {
 			Description: "The client private key used to make authenticated requests. Must be in PEM format.",
 			Sensitive:   true,
 		},
+		"use_tls": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Default:     false,
+			Description: "Whether to use TLS for secure logging. Defult: `false`",
+		},
 	}
 
 	if h.GetServiceMetadata().serviceType == ServiceTypeVCL {
@@ -120,6 +126,7 @@ func (h *SplunkServiceAttributeHandler) Create(_ context.Context, d *schema.Reso
 		TLSCACert:         resource["tls_ca_cert"].(string),
 		TLSClientCert:     resource["tls_client_cert"].(string),
 		TLSClientKey:      resource["tls_client_key"].(string),
+		UseTLS:            gofastly.Compatibool(resource["use_tls"].(bool)),
 		Format:            vla.format,
 		FormatVersion:     uintOrDefault(vla.formatVersion),
 		ResponseCondition: vla.responseCondition,
@@ -206,6 +213,9 @@ func (h *SplunkServiceAttributeHandler) Update(_ context.Context, d *schema.Reso
 	if v, ok := modified["tls_client_key"]; ok {
 		opts.TLSClientKey = gofastly.String(v.(string))
 	}
+	if v, ok := modified["use_tls"]; ok {
+		opts.UseTLS = gofastly.CBool(v.(bool))
+	}
 
 	log.Printf("[DEBUG] Update Splunk Opts: %#v", opts)
 	_, err := conn.UpdateSplunk(&opts)
@@ -247,6 +257,7 @@ func flattenSplunks(splunkList []*gofastly.Splunk) []map[string]interface{} {
 			"response_condition": s.ResponseCondition,
 			"placement":          s.Placement,
 			"token":              s.Token,
+			"use_tls":            s.UseTLS,
 			"tls_hostname":       s.TLSHostname,
 			"tls_ca_cert":        s.TLSCACert,
 			"tls_client_cert":    s.TLSClientCert,

--- a/fastly/block_fastly_service_v1_splunk_test.go
+++ b/fastly/block_fastly_service_v1_splunk_test.go
@@ -61,6 +61,7 @@ func TestResourceFastlyFlattenSplunk(t *testing.T) {
 					"tls_ca_cert":     cert,
 					"tls_client_cert": cert,
 					"tls_client_key":  key,
+					"use_tls":         false,
 				},
 			},
 		},
@@ -86,6 +87,7 @@ func TestAccFastlyServiceV1_splunk_basic(t *testing.T) {
 		FormatVersion:     1,
 		Placement:         "waf_debug",
 		ResponseCondition: "error_response_5XX",
+		UseTLS:            true,
 	}
 
 	splunkLogOneUpdated := gofastly.Splunk{
@@ -96,6 +98,7 @@ func TestAccFastlyServiceV1_splunk_basic(t *testing.T) {
 		FormatVersion:     2,
 		Placement:         "waf_debug",
 		ResponseCondition: "error_response_5XX",
+		UseTLS:            false,
 	}
 
 	splunkLogTwo := gofastly.Splunk{
@@ -106,6 +109,7 @@ func TestAccFastlyServiceV1_splunk_basic(t *testing.T) {
 		FormatVersion:     2,
 		Placement:         "waf_debug",
 		ResponseCondition: "ok_response_2XX",
+		UseTLS:            false,
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -464,6 +468,7 @@ resource "fastly_service_v1" "foo" {
     format_version     = 1
     placement          = "waf_debug"
     response_condition = "error_response_5XX"
+	use_tls            = true
   }
 
   force_destroy = true

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.16
 require (
 	github.com/ajg/form v0.0.0-20160822230020-523a5da1a92f // indirect
 	github.com/bflad/tfproviderlint v0.27.1
-	github.com/fastly/go-fastly/v5 v5.0.0
+	github.com/fastly/go-fastly/v5 v5.1.0
 	github.com/google/go-cmp v0.5.6
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/terraform-plugin-docs v0.5.0

--- a/go.sum
+++ b/go.sum
@@ -106,8 +106,8 @@ github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymF
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
-github.com/fastly/go-fastly/v5 v5.0.0 h1:SyYmAARhDQ4GFpcKZ404kumH473nsF8EgBBdY83igQs=
-github.com/fastly/go-fastly/v5 v5.0.0/go.mod h1:Hr7UTc2laOUk+jnocgJFIjpE/jqoxR0Oftt0AIeLSzo=
+github.com/fastly/go-fastly/v5 v5.1.0 h1:BrIfBDdrg8JxAH+Uvq2ml/ro7gORYdWLmodlvyOr+5k=
+github.com/fastly/go-fastly/v5 v5.1.0/go.mod h1:Hr7UTc2laOUk+jnocgJFIjpE/jqoxR0Oftt0AIeLSzo=
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=

--- a/vendor/github.com/fastly/go-fastly/v5/fastly/client.go
+++ b/vendor/github.com/fastly/go-fastly/v5/fastly/client.go
@@ -47,7 +47,7 @@ const DefaultRealtimeStatsEndpoint = "https://rt.fastly.com"
 var ProjectURL = "github.com/fastly/go-fastly"
 
 // ProjectVersion is the version of this library.
-var ProjectVersion = "4.0.0"
+var ProjectVersion = "5.1.0"
 
 // UserAgent is the user agent for this particular client.
 var UserAgent = fmt.Sprintf("FastlyGo/%s (+%s; %s)",

--- a/vendor/github.com/fastly/go-fastly/v5/fastly/splunk.go
+++ b/vendor/github.com/fastly/go-fastly/v5/fastly/splunk.go
@@ -21,6 +21,7 @@ type Splunk struct {
 	ResponseCondition string     `mapstructure:"response_condition"`
 	Placement         string     `mapstructure:"placement"`
 	Token             string     `mapstructure:"token"`
+	UseTLS            bool       `mapstructure:"use_tls"`
 	TLSCACert         string     `mapstructure:"tls_ca_cert"`
 	TLSHostname       string     `mapstructure:"tls_hostname"`
 	TLSClientCert     string     `mapstructure:"tls_client_cert"`
@@ -81,19 +82,20 @@ type CreateSplunkInput struct {
 	// ServiceVersion is the specific configuration version (required).
 	ServiceVersion int
 
-	Name              string `form:"name,omitempty"`
-	URL               string `form:"url,omitempty"`
-	RequestMaxEntries uint   `form:"request_max_entries,omitempty"`
-	RequestMaxBytes   uint   `form:"request_max_bytes,omitempty"`
-	Format            string `form:"format,omitempty"`
-	FormatVersion     uint   `form:"format_version,omitempty"`
-	ResponseCondition string `form:"response_condition,omitempty"`
-	Placement         string `form:"placement,omitempty"`
-	Token             string `form:"token,omitempty"`
-	TLSCACert         string `form:"tls_ca_cert,omitempty"`
-	TLSHostname       string `form:"tls_hostname,omitempty"`
-	TLSClientCert     string `form:"tls_client_cert,omitempty"`
-	TLSClientKey      string `form:"tls_client_key,omitempty"`
+	Name              string      `form:"name,omitempty"`
+	URL               string      `form:"url,omitempty"`
+	RequestMaxEntries uint        `form:"request_max_entries,omitempty"`
+	RequestMaxBytes   uint        `form:"request_max_bytes,omitempty"`
+	Format            string      `form:"format,omitempty"`
+	FormatVersion     uint        `form:"format_version,omitempty"`
+	ResponseCondition string      `form:"response_condition,omitempty"`
+	Placement         string      `form:"placement,omitempty"`
+	Token             string      `form:"token,omitempty"`
+	UseTLS            Compatibool `form:"use_tls,omitempty"`
+	TLSCACert         string      `form:"tls_ca_cert,omitempty"`
+	TLSHostname       string      `form:"tls_hostname,omitempty"`
+	TLSClientCert     string      `form:"tls_client_cert,omitempty"`
+	TLSClientKey      string      `form:"tls_client_key,omitempty"`
 }
 
 // CreateSplunk creates a new Fastly splunk.
@@ -169,19 +171,20 @@ type UpdateSplunkInput struct {
 	// Name is the name of the splunk to update.
 	Name string
 
-	NewName           *string `form:"name,omitempty"`
-	URL               *string `form:"url,omitempty"`
-	RequestMaxEntries *uint   `form:"request_max_entries,omitempty"`
-	RequestMaxBytes   *uint   `form:"request_max_bytes,omitempty"`
-	Format            *string `form:"format,omitempty"`
-	FormatVersion     *uint   `form:"format_version,omitempty"`
-	ResponseCondition *string `form:"response_condition,omitempty"`
-	Placement         *string `form:"placement,omitempty"`
-	Token             *string `form:"token,omitempty"`
-	TLSCACert         *string `form:"tls_ca_cert,omitempty"`
-	TLSHostname       *string `form:"tls_hostname,omitempty"`
-	TLSClientCert     *string `form:"tls_client_cert,omitempty"`
-	TLSClientKey      *string `form:"tls_client_key,omitempty"`
+	NewName           *string      `form:"name,omitempty"`
+	URL               *string      `form:"url,omitempty"`
+	RequestMaxEntries *uint        `form:"request_max_entries,omitempty"`
+	RequestMaxBytes   *uint        `form:"request_max_bytes,omitempty"`
+	Format            *string      `form:"format,omitempty"`
+	FormatVersion     *uint        `form:"format_version,omitempty"`
+	ResponseCondition *string      `form:"response_condition,omitempty"`
+	Placement         *string      `form:"placement,omitempty"`
+	Token             *string      `form:"token,omitempty"`
+	UseTLS            *Compatibool `form:"use_tls,omitempty"`
+	TLSCACert         *string      `form:"tls_ca_cert,omitempty"`
+	TLSHostname       *string      `form:"tls_hostname,omitempty"`
+	TLSClientCert     *string      `form:"tls_client_cert,omitempty"`
+	TLSClientKey      *string      `form:"tls_client_key,omitempty"`
 }
 
 // UpdateSplunk updates a specific splunk.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -237,7 +237,7 @@ github.com/bgentry/go-netrc/netrc
 github.com/bgentry/speakeasy
 # github.com/davecgh/go-spew v1.1.1
 github.com/davecgh/go-spew/spew
-# github.com/fastly/go-fastly/v5 v5.0.0
+# github.com/fastly/go-fastly/v5 v5.1.0
 ## explicit
 github.com/fastly/go-fastly/v5/fastly
 # github.com/fatih/color v1.7.0


### PR DESCRIPTION
ref. https://developer.fastly.com/reference/api/logging/splunk/

^^ the default `use_tls` value is `false` so this addition is not considered as breaking change.

Also bumping go-fastly version to v5.1.0 to support this new struct field:
https://github.com/fastly/go-fastly/blob/main/CHANGELOG.md