### PR TITLE
Override `Transport` to enable keepalive and add new `force_http2` provider option

### DIFF
--- a/fastly/config.go
+++ b/fastly/config.go
@@ -47,8 +47,8 @@ func (c *Config) Client() (*FastlyClient, diag.Diagnostics) {
 	// 2 (minor). while http.Transport supports HTTP/2 by default, it does TLS-ALPN negotiation
 	// in order to support HTTP/1.x fallback. This means each new client connection initiated
 	// by each resource will start TLS handshake regardless of the existing connection pool status.
-	// explicitly assigning http2.Transport so there will be just one TLS-ALPN negotiation happens
-	// amoung all Fastly provider resources against the same api.fastly.com:443 destination.
+	// explicitly assigning http2.Transport so there will be just one TLS-ALPN negotiation happening
+	// (across all Fastly provider resources) against the same api.fastly.com:443 destination.
 	if c.ForceHttp2 {
 		fastlyClient.HTTPClient.Transport = &http2.Transport{}
 	} else {

--- a/fastly/config.go
+++ b/fastly/config.go
@@ -2,6 +2,7 @@ package fastly
 
 import (
 	"fmt"
+	"net/http"
 
 	gofastly "github.com/fastly/go-fastly/v5/fastly"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -10,10 +11,11 @@ import (
 )
 
 type Config struct {
-	ApiKey    string
-	BaseURL   string
-	UserAgent string
-	NoAuth    bool
+	ApiKey     string
+	BaseURL    string
+	UserAgent  string
+	NoAuth     bool
+	ForceHttp2 bool
 }
 
 type FastlyClient struct {
@@ -34,11 +36,25 @@ func (c *Config) Client() (*FastlyClient, diag.Diagnostics) {
 		return nil, diag.FromErr(err)
 	}
 
+	// NOTE: We're fixing two issues here.
+	// 1 (critical). go-fastly uses cleanhttp module that would disable keepalive connection:
+	// https://github.com/hashicorp/go-cleanhttp/blob/v0.5.2/cleanhttp.go#L14-L15
+	// this consumes local ports (source ports) more than necessary that could impact
+	// some of the clients under restricted NAT environments such as:
+	// https://github.com/fastly/terraform-provider-fastly/issues/484
+	// overriding it with the default (still non-shared transport) so we can enable keepalive
+	//
+	// 2 (minor). while http.Transport supports HTTP/2 by default, it does TLS-ALPN negotiation
+	// in order to support HTTP/1.x fallback. This means each new client connection initiated
+	// by each resource will start TLS handshake regardless of the existing connection pool status.
 	// explicitly assigning http2.Transport so there will be just one TLS-ALPN negotiation happens
 	// amoung all Fastly provider resources against the same api.fastly.com:443 destination.
-	// otherwise, each resource would consume a different source port due to TLS handshake.
-	// see also: https://github.com/fastly/terraform-provider-fastly/issues/484
-	fastlyClient.HTTPClient.Transport = &http2.Transport{}
+	if c.ForceHttp2 {
+		fastlyClient.HTTPClient.Transport = &http2.Transport{}
+	} else {
+		fastlyClient.HTTPClient.Transport = &http.Transport{}
+	}
+
 	fastlyClient.HTTPClient.Transport = logging.NewTransport("Fastly", fastlyClient.HTTPClient.Transport)
 
 	client.conn = fastlyClient

--- a/fastly/config_test.go
+++ b/fastly/config_test.go
@@ -32,12 +32,12 @@ func TestForceHttp2(t *testing.T) {
 	client2, _ := c2.Client()
 
 	tv1 := reflect.ValueOf(client1.conn.HTTPClient.Transport).Elem()
-	// <http.Transport Value>
-	ts1 := tv1.FieldByName("transport").Elem().Elem().String()
+	// http.Transport
+	ts1 := reflect.Indirect(tv1.FieldByName("transport").Elem()).Type().String()
 
 	tv2 := reflect.ValueOf(client2.conn.HTTPClient.Transport).Elem()
-	// <http2.Transport Value>
-	ts2 := tv2.FieldByName("transport").Elem().Elem().String()
+	// http2.Transport
+	ts2 := reflect.Indirect(tv2.FieldByName("transport").Elem()).Type().String()
 
 	if ts1 == ts2 {
 		t.Errorf("Failed to create client with force_http2: %#v, %#v", ts1, ts2)

--- a/fastly/config_test.go
+++ b/fastly/config_test.go
@@ -1,6 +1,7 @@
 package fastly
 
 import (
+	"reflect"
 	"testing"
 )
 
@@ -13,5 +14,32 @@ func TestUserAgentContainsProviderVersion(t *testing.T) {
 
 	if diagnostics.HasError() {
 		t.Errorf("Failed to create client: %s", diagToErr(diagnostics))
+	}
+}
+
+func TestForceHttp2(t *testing.T) {
+	c1 := Config{
+		ApiKey:  "someapikey",
+		BaseURL: "http://localhost",
+	}
+	client1, _ := c1.Client()
+
+	c2 := Config{
+		ApiKey:     "someapikey",
+		BaseURL:    "http://localhost",
+		ForceHttp2: true,
+	}
+	client2, _ := c2.Client()
+
+	tv1 := reflect.ValueOf(client1.conn.HTTPClient.Transport).Elem()
+	// <http.Transport Value>
+	ts1 := tv1.FieldByName("transport").Elem().Elem().String()
+
+	tv2 := reflect.ValueOf(client2.conn.HTTPClient.Transport).Elem()
+	// <http2.Transport Value>
+	ts2 := tv2.FieldByName("transport").Elem().Elem().String()
+
+	if ts1 == ts2 {
+		t.Errorf("Failed to create client with force_http2: %#v, %#v", ts1, ts2)
 	}
 }

--- a/fastly/provider.go
+++ b/fastly/provider.go
@@ -33,6 +33,12 @@ func Provider() *schema.Provider {
 				Default:     false,
 				Description: "Set this to `true` if you only need data source that does not require authentication such as `fastly_ip_ranges`",
 			},
+			"force_http2": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: "Set this to `true` to disable HTTP/1.x fallback mechanism that the underlying Go library will attempt upon connection to `api.fastly.com:443` by default. This may slightly improve the provider's performance and reduce unnecessary TLS handshakes. Default: `false`",
+			},
 		},
 		DataSourcesMap: map[string]*schema.Resource{
 			"fastly_ip_ranges":                    dataSourceFastlyIPRanges(),
@@ -70,10 +76,11 @@ func Provider() *schema.Provider {
 
 	provider.ConfigureContextFunc = func(_ context.Context, d *schema.ResourceData) (interface{}, diag.Diagnostics) {
 		config := Config{
-			ApiKey:    d.Get("api_key").(string),
-			BaseURL:   d.Get("base_url").(string),
-			NoAuth:    d.Get("no_auth").(bool),
-			UserAgent: provider.UserAgent(TerraformProviderProductUserAgent, version.ProviderVersion),
+			ApiKey:     d.Get("api_key").(string),
+			BaseURL:    d.Get("base_url").(string),
+			NoAuth:     d.Get("no_auth").(bool),
+			ForceHttp2: d.Get("force_http2").(bool),
+			UserAgent:  provider.UserAgent(TerraformProviderProductUserAgent, version.ProviderVersion),
 		}
 		return config.Client()
 	}

--- a/go.mod
+++ b/go.mod
@@ -11,4 +11,5 @@ require (
 	github.com/hashicorp/terraform-plugin-docs v0.5.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.7.1
 	github.com/stretchr/testify v1.7.0
+	golang.org/x/net v0.0.0-20210326060303-6b1517762897
 )

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -460,6 +460,7 @@ golang.org/x/lint/golint
 golang.org/x/mod/module
 golang.org/x/mod/semver
 # golang.org/x/net v0.0.0-20210326060303-6b1517762897
+## explicit
 golang.org/x/net/context
 golang.org/x/net/context/ctxhttp
 golang.org/x/net/http/httpguts


### PR DESCRIPTION
This is rather a very micro performance tuning.

The main motivation of this change is to (very slightly) help users in this situation:
https://github.com/fastly/terraform-provider-fastly/issues/484

This PR is not a fix nor a complete workaround for that issue at all and it can still happen, but we can at least reduce port consumption to 1/2 if they use more than one Fastly provider resource within the same plan/apply.

For instance, let's say if I have three Fastly resources defined in my .tf file, such as `fastly_service_v1`, `fastly_tls_subscription `, `fastly_ip_ranges`.

If I run `plan`, then this will consume at least 3 source ports because of the TLS handshake messages initiated by each resource:

<img width="839" alt="Screen Shot 2021-10-10 at 3 12 39" src="https://user-images.githubusercontent.com/11495867/136672838-ff1a8724-d454-4368-a40e-bafa9b8db7de.png">

Because each resource initializes its own client (@bengesoff correct me if I'm wrong), by default, `http.Transport` will start TLS handshake regardless of the existing established connection (pool) in order to verify if the destination supports HTTP/2 protocol by checking ALPN fields in the Server Hello message so that it can fallback to HTTP/1.x if needed.

But `http2.Transport` doesn't provide such fallback and always assumes the destination supports HTTP/2 so it can skip TLS handshake if there's a connection pool for that destination already. So in the above example, port consumption would be reduced from 3 to 1.

Since `api.fastly.com` supports HTTP/2, it should be fine to force HTTP/2.

---

[update 1]

For the safeness, we could introduce a new provider option something like `force_http2`:
https://github.com/fastly/terraform-provider-fastly/blob/main/fastly/provider.go#L15
(to be clear, HTTP/2 is enabled by default, but this option would disable a fallback to HTTP/1.x)

but my opinion is that we should still enable it by default and give users an option to opt it out if they see any issues dealing with HTTP/2 due to their local network (e.g., security proxies in the corp-network). Because otherwise, no one would notice this new option, I think.

[update 2]

As @bengesoff pointed out in his comment below, we're actually using [cleanhttp](https://github.com/hashicorp/go-cleanhttp) module via go-fastly.
https://github.com/fastly/go-fastly/blob/v5.1.0/fastly/client.go#L161-L163

This means we are effectively disabling keepalive connection as well as `MaxIdleConnsPerHost`:
https://github.com/hashicorp/go-cleanhttp/blob/v0.5.2/cleanhttp.go#L14-L15

This is consuming local ports (source ports) more than necessary that could impact some of the clients under the restricted NAT environment such as https://github.com/fastly/terraform-provider-fastly/issues/484
and it turned out to be the main cause of this port exhaustion issue.

Fortunately, this PR would fix this problem as well.

[update 3]

Since now we know the core problem is keepalive being disabled by cleanhttp, I'm introducing a new `force_http2` provider option but with the default value of `false`.