### PR TITLE
dynamically generating provider version number to be added to docs index.md

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,8 @@ PKG_NAME=fastly
 FULL_PKG_NAME=github.com/fastly/terraform-provider-fastly
 VERSION_PLACEHOLDER=version.ProviderVersion
 VERSION=$(shell git describe --tags --always)
-DOCS_PROVIDER_VERSION=$(subst v,,$(VERSION))
+VERSION_SHORT=$(shell git describe --tags --always --abbrev=0)
+DOCS_PROVIDER_VERSION=$(subst v,,$(VERSION_SHORT))
 
 # Use a parallelism of 4 by default for tests, overriding whatever GOMAXPROCS is
 # set to. For the acceptance tests especially, the main bottleneck affecting the

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ PKG_NAME=fastly
 FULL_PKG_NAME=github.com/fastly/terraform-provider-fastly
 VERSION_PLACEHOLDER=version.ProviderVersion
 VERSION=$(shell git describe --tags --always)
+DOCS_PROVIDER_VERSION=$(subst v,,$(VERSION))
 
 # Use a parallelism of 4 by default for tests, overriding whatever GOMAXPROCS is
 # set to. For the acceptance tests especially, the main bottleneck affecting the
@@ -66,7 +67,9 @@ $(BIN)/%:
 	@cat tools/tools.go | grep _ | awk -F '"' '{print $$2}' | GOBIN=$(BIN) xargs -tI {} go install {}
 
 generate-docs: $(BIN)/tfplugindocs
+	$(shell sed -e "s/__VERSION__/$(DOCS_PROVIDER_VERSION)/g" examples/index-fastly-provider.tf.tmpl > examples/index-fastly-provider.tf)
 	$(BIN)/tfplugindocs generate
+	rm examples/index-fastly-provider.tf
 
 validate-docs: $(BIN)/tfplugindocs
 	$(BIN)/tfplugindocs validate

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,7 +25,7 @@ terraform {
   required_providers {
     fastly = {
       source = "fastly/fastly"
-      version >= "0.6.1"
+      version >= "0.38.0"
     }
   }
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,7 +25,7 @@ terraform {
   required_providers {
     fastly = {
       source = "fastly/fastly"
-      version >= "0.38.0"
+      version >= "0.6.1-848-ga3553a7c"
     }
   }
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,7 +25,7 @@ terraform {
   required_providers {
     fastly = {
       source = "fastly/fastly"
-      version >= "0.6.1-848-ga3553a7c"
+      version >= "0.6.1"
     }
   }
 }

--- a/examples/index-fastly-provider.tf.tmpl
+++ b/examples/index-fastly-provider.tf.tmpl
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     fastly = {
       source = "fastly/fastly"
-      version >= "0.38.0"
+      version >= "__VERSION__"
     }
   }
 }


### PR DESCRIPTION
I have updated the makefile to dynamically include the version number in the tf example which is loaded to index.md
In the fork I'm working on the current version number is 0.6.1, that's why it's generating that value.
Can anyone trigger the `make generate-docs` from this repo to update the version?