### PR TITLE
allow TF_LOG=debug in the non-deterministic test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ build:
 test:
 	go test -i $(TEST) || exit 1
 	echo $(TEST) | \
-		xargs -t -n4 go test $(TESTARGS) -timeout=30s -parallel=$(TEST_PARALLELISM)
+		xargs -t -n4 go test -v $(TESTARGS) -timeout=90s -parallel=$(TEST_PARALLELISM)
 
 # prefix `go test` with TF_LOG=debug or 'trace' for additional terraform output
 # such as all the requests and responses it handles.

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ build:
 test:
 	go test -i $(TEST) || exit 1
 	echo $(TEST) | \
-		xargs -t -n4 go test -v $(TESTARGS) -timeout=90s -parallel=$(TEST_PARALLELISM)
+		xargs -t -n4 go test $(TESTARGS) -timeout=30s -parallel=$(TEST_PARALLELISM)
 
 # prefix `go test` with TF_LOG=debug or 'trace' for additional terraform output
 # such as all the requests and responses it handles.

--- a/fastly/block_fastly_service_v1_s3logging_test.go
+++ b/fastly/block_fastly_service_v1_s3logging_test.go
@@ -134,6 +134,11 @@ func TestResourceFastlyFlattenS3(t *testing.T) {
 }
 
 func TestAccFastlyServiceV1_s3logging_basic(t *testing.T) {
+	err := os.Setenv("TF_LOG", "debug")
+	if err != nil {
+		panic(fmt.Sprintf("Failed to set TF_LOG: %v", err))
+	}
+
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	domainName1 := fmt.Sprintf("fastly-test.tf-%s.com", acctest.RandString(10))

--- a/fastly/block_fastly_service_v1_s3logging_test.go
+++ b/fastly/block_fastly_service_v1_s3logging_test.go
@@ -134,6 +134,7 @@ func TestResourceFastlyFlattenS3(t *testing.T) {
 }
 
 func TestAccFastlyServiceV1_s3logging_basic(t *testing.T) {
+	// We set TF_LOG to analyse logs and have more context on an error that seems to be caused by a race condition
 	err := os.Setenv("TF_LOG", "debug")
 	if err != nil {
 		panic(fmt.Sprintf("Failed to set TF_LOG: %v", err))


### PR DESCRIPTION
In this PR, we've set TF_LOG=debug only for estAccFastlyServiceV1_s3logging_basic. 
The aim is to have more context on the error that is probably caused by a race condition.
The logs coming from that test will be visible in the acceptance tests suite. 