### PR TITLE
Expose `certificate_id` read-only attribute from `fastly_tls_subscription` resource

### DIFF
--- a/docs/resources/tls_subscription.md
+++ b/docs/resources/tls_subscription.md
@@ -169,6 +169,7 @@ $ terraform import fastly_tls_subscription.demo xxxxxxxxxxx
 
 ### Read-Only
 
+- **certificate_id** (String) The certificate ID associated with the subscription.
 - **created_at** (String) Timestamp (GMT) when the subscription was created.
 - **managed_dns_challenge** (Map of String, Deprecated) The details required to configure DNS to respond to ACME DNS challenge in order to verify domain ownership.
 - **managed_dns_challenges** (Set of Object) A list of options for configuring DNS to respond to ACME DNS challenge in order to verify domain ownership. (see [below for nested schema](#nestedatt--managed_dns_challenges))

--- a/fastly/resource_fastly_tls_subscription.go
+++ b/fastly/resource_fastly_tls_subscription.go
@@ -60,6 +60,11 @@ func resourceFastlyTLSSubscription() *schema.Resource {
 				Optional:    true,
 				Computed:    true,
 			},
+			"certificate_id": {
+				Type:        schema.TypeString,
+				Description: "The certificate ID associated with the subscription.",
+				Computed:    true,
+			},
 			"created_at": {
 				Type:        schema.TypeString,
 				Description: "Timestamp (GMT) when the subscription was created.",
@@ -213,6 +218,9 @@ func resourceFastlyTLSSubscriptionRead(_ context.Context, d *schema.ResourceData
 		domains = append(domains, domain.ID)
 	}
 
+	// NOTE: there must be only one certificate id included per subscription
+	var certificateId = subscription.Certificates[len(subscription.Certificates)-1].ID
+
 	var managedHTTPChallenges []map[string]interface{}
 	var managedDNSChallenges []map[string]interface{}
 	for _, domain := range subscription.Authorizations {
@@ -269,6 +277,10 @@ func resourceFastlyTLSSubscriptionRead(_ context.Context, d *schema.ResourceData
 		return diag.FromErr(err)
 	}
 	err = d.Set("common_name", subscription.CommonName.ID)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	err = d.Set("certificate_id", certificateId)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/fastly/resource_fastly_tls_subscription.go
+++ b/fastly/resource_fastly_tls_subscription.go
@@ -219,7 +219,7 @@ func resourceFastlyTLSSubscriptionRead(_ context.Context, d *schema.ResourceData
 	}
 
 	// NOTE: there must be only one certificate id included per subscription
-	var certificateId = subscription.Certificates[len(subscription.Certificates)-1].ID
+	var certificateId = subscription.Certificates[0].ID
 
 	var managedHTTPChallenges []map[string]interface{}
 	var managedDNSChallenges []map[string]interface{}

--- a/fastly/resource_fastly_tls_subscription.go
+++ b/fastly/resource_fastly_tls_subscription.go
@@ -219,7 +219,11 @@ func resourceFastlyTLSSubscriptionRead(_ context.Context, d *schema.ResourceData
 	}
 
 	// NOTE: there must be only one certificate id included per subscription
-	var certificateId = subscription.Certificates[0].ID
+	// "pending" and "processing" state may not include the id (for new subsctiptions)
+	var certificateId = ""
+	if len(subscription.Certificates) > 0 {
+		certificateId = subscription.Certificates[0].ID
+	}
 
 	var managedHTTPChallenges []map[string]interface{}
 	var managedDNSChallenges []map[string]interface{}

--- a/fastly/resource_fastly_tls_subscription.go
+++ b/fastly/resource_fastly_tls_subscription.go
@@ -219,7 +219,7 @@ func resourceFastlyTLSSubscriptionRead(_ context.Context, d *schema.ResourceData
 	}
 
 	// NOTE: there must be only one certificate id included per subscription
-	// "pending" and "processing" state may not include the id (for new subsctiptions)
+	// "pending" and "processing" state may not include the id (for new subscriptions)
 	var certificateId = ""
 	if len(subscription.Certificates) > 0 {
 		certificateId = subscription.Certificates[0].ID


### PR DESCRIPTION
Use case:
https://registry.terraform.io/providers/fastly/fastly/latest/docs/resources/tls_activation

`fastly_tls_certificate` resource isn't used for Fastly managed certs, but BYO certs. Therefore, if adding TLS configuration for a given `certificate_id` that is a Fastly managed cert, there isn't a way to obtain the required `certificate_id` for that `fastly_tls_activation` resource unless exposing it via the `fastly_tls_subscription` resource or specifying the id manually.