### PR TITLE
Update VCL snippet type description

### DIFF
--- a/docs/resources/service_v1.md
+++ b/docs/resources/service_v1.md
@@ -473,7 +473,7 @@ Optional:
 Required:
 
 - **name** (String) A name that is unique across "regular" and "dynamic" VCL Snippet configuration blocks. It is important to note that changing this attribute will delete and recreate the resource
-- **type** (String) The location in generated VCL where the snippet should be placed (can be one of `init`, `recv`, `hit`, `miss`, `pass`, `fetch`, `error`, `deliver`, `log` or `none`)
+- **type** (String) The location in generated VCL where the snippet should be placed (can be one of `init`, `recv`, `hash`, `hit`, `miss`, `pass`, `fetch`, `error`, `deliver`, `log` or `none`)
 
 Optional:
 
@@ -1048,7 +1048,7 @@ Required:
 
 - **content** (String) The VCL code that specifies exactly what the snippet does
 - **name** (String) A name that is unique across "regular" and "dynamic" VCL Snippet configuration blocks. It is important to note that changing this attribute will delete and recreate the resource
-- **type** (String) The location in generated VCL where the snippet should be placed (can be one of `init`, `recv`, `hit`, `miss`, `pass`, `fetch`, `error`, `deliver`, `log` or `none`)
+- **type** (String) The location in generated VCL where the snippet should be placed (can be one of `init`, `recv`, `hash`, `hit`, `miss`, `pass`, `fetch`, `error`, `deliver`, `log` or `none`)
 
 Optional:
 

--- a/fastly/block_fastly_service_v1_dynamicsnippet.go
+++ b/fastly/block_fastly_service_v1_dynamicsnippet.go
@@ -39,7 +39,7 @@ func (h *DynamicSnippetServiceAttributeHandler) GetSchema() *schema.Schema {
 				"type": {
 					Type:             schema.TypeString,
 					Required:         true,
-					Description:      "The location in generated VCL where the snippet should be placed (can be one of `init`, `recv`, `hit`, `miss`, `pass`, `fetch`, `error`, `deliver`, `log` or `none`)",
+					Description:      SnippetTypeDescription,
 					ValidateDiagFunc: validateSnippetType(),
 				},
 				"priority": {

--- a/fastly/block_fastly_service_v1_snippet.go
+++ b/fastly/block_fastly_service_v1_snippet.go
@@ -39,7 +39,7 @@ func (h *SnippetServiceAttributeHandler) GetSchema() *schema.Schema {
 				"type": {
 					Type:             schema.TypeString,
 					Required:         true,
-					Description:      "The location in generated VCL where the snippet should be placed (can be one of `init`, `recv`, `hit`, `miss`, `pass`, `fetch`, `error`, `deliver`, `log` or `none`)",
+					Description:      SnippetTypeDescription,
 					ValidateDiagFunc: validateSnippetType(),
 				},
 				"content": {

--- a/fastly/constants.go
+++ b/fastly/constants.go
@@ -3,3 +3,4 @@ package fastly
 const MessageTypeDescription = "How the message should be formatted. Can be either `classic`, `loggly`, `logplex` or `blank`. Default is `classic`"
 const GzipLevelDescription = "Level of Gzip compression from `0-9`. `0` means no compression. `1` is the fastest and the least compressed version, `9` is the slowest and the most compressed version. Default `0`"
 const TimestampFormatDescription = "The `strftime` specified timestamp formatting (default `%Y-%m-%dT%H:%M:%S.000`)"
+const SnippetTypeDescription = "The location in generated VCL where the snippet should be placed (can be one of `init`, `recv`, `hash`, `hit`, `miss`, `pass`, `fetch`, `error`, `deliver`, `log` or `none`)"


### PR DESCRIPTION
to include `hash` type

https://github.com/fastly/go-fastly/blob/main/fastly/vcl_snippets.go#L17-L18