### PR TITLE
Add `activate` attribute support for `fastly_service_waf_configuration` resource

### DIFF
--- a/docs/resources/service_waf_configuration.md
+++ b/docs/resources/service_waf_configuration.md
@@ -581,6 +581,7 @@ $ terraform state rm fastly_service_waf_configuration.waf
 
 ### Optional
 
+- **activate** (Boolean) Conditionally prevents a new firewall version from being activated. The apply step will continue to create a new draft version but will not activate it if this is set to `false`. Default `true`
 - **allowed_http_versions** (String) Allowed HTTP versions
 - **allowed_methods** (String) A space-separated list of HTTP method names
 - **allowed_request_content_type** (String) Allowed request content types
@@ -612,6 +613,12 @@ $ terraform state rm fastly_service_waf_configuration.waf
 - **total_arg_length** (Number) The maximum size of argument names and values
 - **warning_anomaly_score** (Number) Score value to add for warning anomalies
 - **xss_score_threshold** (Number) XSS attack threshold
+
+### Read-Only
+
+- **active** (Boolean) Whether a specific firewall version is currently deployed
+- **cloned_version** (Number) The latest cloned firewall version by the provider
+- **number** (Number) The WAF firewall version
 
 <a id="nestedblock--rule"></a>
 ### Nested Schema for `rule`

--- a/fastly/block_fastly_waf_configuration_v1_active_rule_test.go
+++ b/fastly/block_fastly_waf_configuration_v1_active_rule_test.go
@@ -94,7 +94,7 @@ func TestAccFastlyServiceWAFVersionV1AddUpdateDeleteRules(t *testing.T) {
 			Revision: 2,
 		},
 	}
-	wafVerInput := testAccFastlyServiceWAFVersionV1BuildConfig(20)
+	wafVerInput := testAccFastlyServiceWAFVersionV1BuildConfig(20, true)
 	rulesTF1 := testAccCheckFastlyServiceWAFVersionV1ComposeWAFRules(rules1)
 	wafVer1 := testAccFastlyServiceWAFVersionV1ComposeConfiguration(wafVerInput, rulesTF1, "")
 

--- a/fastly/block_fastly_waf_configuration_v1_exclusion_test.go
+++ b/fastly/block_fastly_waf_configuration_v1_exclusion_test.go
@@ -132,7 +132,7 @@ func TestAccFastlyServiceWAFVersionV1Validation(t *testing.T) {
 
 	for _, c := range cases {
 
-		wafVerInput := testAccFastlyServiceWAFVersionV1BuildConfig(20)
+		wafVerInput := testAccFastlyServiceWAFVersionV1BuildConfig(20, true)
 		exclusionsTF1 := testAccCheckFastlyServiceWAFVersionV1ComposeWAFRuleExclusions(c.exclusions)
 
 		wafVer1 := testAccFastlyServiceWAFVersionV1ComposeConfiguration(wafVerInput, "", exclusionsTF1)
@@ -238,7 +238,7 @@ func TestAccFastlyServiceWAFVersionV1AddUpdateDeleteExclusions(t *testing.T) {
 		},
 	}
 
-	wafVerInput := testAccFastlyServiceWAFVersionV1BuildConfig(20)
+	wafVerInput := testAccFastlyServiceWAFVersionV1BuildConfig(20, true)
 	rulesTF := testAccCheckFastlyServiceWAFVersionV1ComposeWAFRules(rules)
 	exclusionsTF1 := testAccCheckFastlyServiceWAFVersionV1ComposeWAFRuleExclusions(exclusions1)
 	exclusionsTF2 := testAccCheckFastlyServiceWAFVersionV1ComposeWAFRuleExclusions(exclusions2)

--- a/fastly/resource_fastly_service_waf_configuration.go
+++ b/fastly/resource_fastly_service_waf_configuration.go
@@ -260,11 +260,11 @@ func resourceServiceWAFConfigurationV1Create(ctx context.Context, d *schema.Reso
 func resourceServiceWAFConfigurationV1Update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*FastlyClient).conn
 
-	// If any attributes other than Computed or "activate" have changed, clone a new firewall version.
+	// If any attributes other than Computed (unconfigurable) or "activate" have changed, clone a new firewall version.
 	// Otherwise, don't clone but activate a draft version that was previously created with "activate = false".
 	var needsChange bool
 	for k, v := range resourceServiceWAFConfigurationV1().Schema {
-		if v.Computed || k == "activate" {
+		if (v.Computed && !v.Optional) || k == "activate" {
 			continue
 		}
 		if d.HasChange(k) {

--- a/fastly/resource_fastly_service_waf_configuration.go
+++ b/fastly/resource_fastly_service_waf_configuration.go
@@ -39,6 +39,12 @@ func resourceServiceWAFConfigurationV1() *schema.Resource {
 			}),
 		),
 		Schema: map[string]*schema.Schema{
+			"waf_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The ID of the Web Application Firewall that the configuration belongs to",
+			},
 			"activate": {
 				Type:        schema.TypeBool,
 				Description: "Conditionally prevents a new firewall version from being activated. The apply step will continue to create a new draft version but will not activate it if this is set to `false`. Default `true`",
@@ -49,12 +55,6 @@ func resourceServiceWAFConfigurationV1() *schema.Resource {
 				Type:        schema.TypeInt,
 				Computed:    true,
 				Description: "The latest cloned firewall version by the provider",
-			},
-			"waf_id": {
-				Type:        schema.TypeString,
-				Required:    true,
-				ForceNew:    true,
-				Description: "The ID of the Web Application Firewall that the configuration belongs to",
 			},
 			"allowed_http_versions": {
 				Type:        schema.TypeString,
@@ -154,6 +154,11 @@ func resourceServiceWAFConfigurationV1() *schema.Resource {
 				Optional:    true,
 				Computed:    true,
 				Description: "The maximum number of arguments allowed",
+			},
+			"number": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "The WAF firewall version",
 			},
 			"notice_anomaly_score": {
 				Type:        schema.TypeInt,
@@ -583,6 +588,7 @@ func refreshWAFConfig(d *schema.ResourceData, version *gofastly.WAFVersion) {
 	d.Set("lfi_score_threshold", version.LFIScoreThreshold)
 	d.Set("max_file_size", version.MaxFileSize)
 	d.Set("max_num_args", version.MaxNumArgs)
+	d.Set("number", version.Number)
 	d.Set("notice_anomaly_score", version.NoticeAnomalyScore)
 	d.Set("paranoia_level", version.ParanoiaLevel)
 	d.Set("php_injection_score_threshold", version.PHPInjectionScoreThreshold)

--- a/fastly/resource_fastly_service_waf_configuration.go
+++ b/fastly/resource_fastly_service_waf_configuration.go
@@ -236,8 +236,7 @@ func resourceServiceWAFConfigurationV1Create(ctx context.Context, d *schema.Reso
 func resourceServiceWAFConfigurationV1Update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*FastlyClient).conn
 
-	// If attributes other than any computed or the "activate" attribute in this resource are changed
-	// we need to clone a new firewall version.
+	// If any attributes other than Computed or "activate" are changed, clone a new firewall version.
 	// Otherwise, don't clone but activate a draft version that was previously created with "activate = false".
 	var needsChange bool
 	for k, v := range resourceServiceWAFConfigurationV1().Schema {
@@ -595,7 +594,7 @@ func determineLatestVersion(versions []*gofastly.WAFVersion) (*gofastly.WAFVersi
 	})
 
 	// Find the current active firewall version
-	// or, pink the most recent version if there's no active version yet
+	// or, pick the most recent version if there's no active version yet
 	latest := versions[0]
 	for _, v := range versions {
 		if v.Active {

--- a/fastly/resource_fastly_service_waf_configuration.go
+++ b/fastly/resource_fastly_service_waf_configuration.go
@@ -51,6 +51,11 @@ func resourceServiceWAFConfigurationV1() *schema.Resource {
 				Default:     true,
 				Optional:    true,
 			},
+			"active": {
+				Type:        schema.TypeBool,
+				Description: "Whether a specific firewall version is currently deployed",
+				Computed:    true,
+			},
 			"cloned_version": {
 				Type:        schema.TypeInt,
 				Computed:    true,
@@ -572,6 +577,7 @@ func buildUpdateInput(d *schema.ResourceData, id string, number int) *gofastly.U
 }
 
 func refreshWAFConfig(d *schema.ResourceData, version *gofastly.WAFVersion) {
+	d.Set("active", version.Active)
 	d.Set("allowed_http_versions", version.AllowedHTTPVersions)
 	d.Set("allowed_methods", version.AllowedMethods)
 	d.Set("allowed_request_content_type", version.AllowedRequestContentType)

--- a/fastly/resource_fastly_service_waf_configuration.go
+++ b/fastly/resource_fastly_service_waf_configuration.go
@@ -633,6 +633,5 @@ func determineLatestVersion(versions []*gofastly.WAFVersion) (*gofastly.WAFVersi
 }
 
 func validateWAFConfigurationResource(_ context.Context, d *schema.ResourceDiff, _ interface{}) error {
-	err := validateWAFRuleExclusion(d)
-	return err
+	return validateWAFRuleExclusion(d)
 }


### PR DESCRIPTION
https://github.com/fastly/terraform-provider-fastly/issues/529

The overall implementation follows the almost same approach as [base_fastly_service_v1](https://github.com/fastly/terraform-provider-fastly/blob/main/fastly/base_fastly_service_v1.go)

```
% FASTLY_API_KEY=REDACTED make testacc TESTARGS='-run=TestAccFastlyServiceWAFVersionV1.*'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test -count=1 $(go list ./... |grep -v 'vendor') -v -run=TestAccFastlyServiceWAFVersionV1.* -parallel=4 -timeout 360m -ldflags="-X=github.com/fastly/terraform-provider-fastly/version.ProviderVersion=acc"
?   	github.com/fastly/terraform-provider-fastly	[no test files]
=== RUN   TestAccFastlyServiceWAFVersionV1FlattenWAFActiveRules
--- PASS: TestAccFastlyServiceWAFVersionV1FlattenWAFActiveRules (0.00s)
=== RUN   TestAccFastlyServiceWAFVersionV1AddUpdateDeleteRules
=== PAUSE TestAccFastlyServiceWAFVersionV1AddUpdateDeleteRules
=== RUN   TestAccFastlyServiceWAFVersionV1FlattenWAFRuleExclusions
--- PASS: TestAccFastlyServiceWAFVersionV1FlattenWAFRuleExclusions (0.00s)
=== RUN   TestAccFastlyServiceWAFVersionV1Validation
=== PAUSE TestAccFastlyServiceWAFVersionV1Validation
=== RUN   TestAccFastlyServiceWAFVersionV1AddUpdateDeleteExclusions
=== PAUSE TestAccFastlyServiceWAFVersionV1AddUpdateDeleteExclusions
=== RUN   TestAccFastlyServiceWAFVersionV1DetermineVersion
--- PASS: TestAccFastlyServiceWAFVersionV1DetermineVersion (0.00s)
=== RUN   TestAccFastlyServiceWAFVersionV1Add
=== PAUSE TestAccFastlyServiceWAFVersionV1Add
=== RUN   TestAccFastlyServiceWAFVersionV1AddExistingService
=== PAUSE TestAccFastlyServiceWAFVersionV1AddExistingService
=== RUN   TestAccFastlyServiceWAFVersionV1Update
=== PAUSE TestAccFastlyServiceWAFVersionV1Update
=== RUN   TestAccFastlyServiceWAFVersionV1Delete
=== PAUSE TestAccFastlyServiceWAFVersionV1Delete
=== RUN   TestAccFastlyServiceWAFVersionV1Import
=== PAUSE TestAccFastlyServiceWAFVersionV1Import
=== CONT  TestAccFastlyServiceWAFVersionV1AddUpdateDeleteRules
=== CONT  TestAccFastlyServiceWAFVersionV1AddExistingService
=== CONT  TestAccFastlyServiceWAFVersionV1Import
=== CONT  TestAccFastlyServiceWAFVersionV1Delete
--- PASS: TestAccFastlyServiceWAFVersionV1Import (126.39s)
=== CONT  TestAccFastlyServiceWAFVersionV1AddUpdateDeleteExclusions
--- PASS: TestAccFastlyServiceWAFVersionV1AddExistingService (143.18s)
=== CONT  TestAccFastlyServiceWAFVersionV1Add
--- PASS: TestAccFastlyServiceWAFVersionV1Delete (148.27s)
=== CONT  TestAccFastlyServiceWAFVersionV1Update
--- PASS: TestAccFastlyServiceWAFVersionV1AddUpdateDeleteRules (177.35s)
=== CONT  TestAccFastlyServiceWAFVersionV1Validation
--- PASS: TestAccFastlyServiceWAFVersionV1Validation (1.04s)
--- PASS: TestAccFastlyServiceWAFVersionV1Add (92.31s)
--- PASS: TestAccFastlyServiceWAFVersionV1AddUpdateDeleteExclusions (173.55s)
--- PASS: TestAccFastlyServiceWAFVersionV1Update (229.02s)
PASS
ok  	github.com/fastly/terraform-provider-fastly/fastly	378.177s
?   	github.com/fastly/terraform-provider-fastly/fastly/hashcode	[no test files]
?   	github.com/fastly/terraform-provider-fastly/version	[no test files]
```