### PR TITLE
docs: fix fastly-s3 hyperlinks

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -25,7 +25,7 @@ terraform {
   required_providers {
     fastly = {
       source  = "fastly/fastly"
-      version = ">= 0.41.0"
+      version = ">= 1.0.0"
     }
   }
 }

--- a/docs/resources/service_vcl.md
+++ b/docs/resources/service_vcl.md
@@ -208,6 +208,7 @@ resource "fastly_service_vcl" "demo" {
 should be set to `<bucket_name>.s3-website-<region>.amazonaws.com` in the `backend` block. See the
 Fastly documentation on [Amazon S3][fastly-s3].
 
+[fastly-s3]: https://docs.fastly.com/en/guides/amazon-s3
 [fastly-cname]: https://docs.fastly.com/en/guides/adding-cname-records
 [fastly-conditionals]: https://docs.fastly.com/en/guides/using-conditions
 [fastly-sumologic]: https://developer.fastly.com/reference/api/logging/sumologic/

--- a/templates/resources/service_vcl.md.tmpl
+++ b/templates/resources/service_vcl.md.tmpl
@@ -46,6 +46,7 @@ Basic usage with [Web Application Firewall](https://developer.fastly.com/referen
 should be set to `<bucket_name>.s3-website-<region>.amazonaws.com` in the `backend` block. See the
 Fastly documentation on [Amazon S3][fastly-s3].
 
+[fastly-s3]: https://docs.fastly.com/en/guides/amazon-s3
 [fastly-cname]: https://docs.fastly.com/en/guides/adding-cname-records
 [fastly-conditionals]: https://docs.fastly.com/en/guides/using-conditions
 [fastly-sumologic]: https://developer.fastly.com/reference/api/logging/sumologic/


### PR DESCRIPTION
Fix the hyperlinks in the docs page, below is what is looks like right now.
![image](https://user-images.githubusercontent.com/1580956/154165604-b38383c2-1766-45a2-b953-a90dc2dd593e.png)
