### PR TITLE
Make it possible to remove backend from director

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -25,7 +25,7 @@ terraform {
   required_providers {
     fastly = {
       source  = "fastly/fastly"
-      version = ">= 0.41.0"
+      version = ">= 1.0.0"
     }
   }
 }

--- a/fastly/block_fastly_service_director.go
+++ b/fastly/block_fastly_service_director.go
@@ -320,7 +320,6 @@ func flattenDirectors(directorList []*gofastly.Director, directorBackendList []*
 }
 
 func getDirectorBackendChange(d *schema.ResourceData, resource map[string]interface{}) (odb *schema.Set, ndb *schema.Set) {
-	name := resource["name"]
 	od, nd := d.GetChange("director")
 
 	if od == nil {
@@ -341,6 +340,7 @@ func getDirectorBackendChange(d *schema.ResourceData, resource map[string]interf
 		return new(schema.Set)
 	}
 
+	name := resource["name"]
 	odb = get(name.(string), od.(*schema.Set))
 	ndb = get(name.(string), nd.(*schema.Set))
 


### PR DESCRIPTION
Fixes https://github.com/fastly/terraform-provider-fastly/issues/545
Fixes https://github.com/fastly/terraform-provider-fastly/issues/546

Make it possible to remove backends from a director.

This is a proposed fix for #545
If the backend in a director block changes, get the changes from `*schema.ResourceData` and compute backends to be removed/added using Set's `Difference` method.

Removing a director backend can result in a 404 error if the backend is removed from the service. I'm just ignoring the error in this fix since they don't mean anything useful to users.

I've also fixed an unrelated issue (#546) with the comment field in the director block which was causing the acceptance tests to fail.