### PR TITLE
Publish 1.0.0 Migration Guide as part of docs

### DIFF
--- a/docs/guides/1.0.0-migration-guide.md
+++ b/docs/guides/1.0.0-migration-guide.md
@@ -1,0 +1,58 @@
+---
+page_title: "Fastly Terraform 1.0.0 Migration Guide"
+---
+
+## Fastly Terraform 1.0.0 Migration Guide
+
+**Resources omit `_v1` suffix**:
+
+All resources now have a consistent naming convention which omit the previous v1 suffix.
+
+- `fastly_service_v1` -> `fastly_service_vcl` (renamed with `_vcl` suffix)
+- `fastly_service_acl_entries_v1` -> `fastly_service_acl_entries`
+- `fastly_service_dictionary_items_v1` -> `fastly_service_dictionary_items`
+- `fastly_service_dynamic_snippet_content_v1` -> `fastly_service_dynamic_snippet_content`
+- `fastly_user_v1` -> `fastly_user`
+
+**Logging resources have consistent naming format**:
+
+All logging resources now have a consistent naming convention with the provider prefixed with `logging_`.
+
+- `bigquerylogging` -> `logging_bigquery`
+- `blobstoragelogging` -> `logging_blobstorage`
+- `gcslogging` -> `logging_gcs`
+- `httpslogging` -> `logging_https`
+- `logentries` -> `logging_logentries`
+- `papertrail` -> `logging_papertrail`
+- `s3logging` -> `logging_s3`
+- `splunk` -> `logging_splunk`
+- `sumologic` -> `logging_sumologic`
+- `syslog` -> `logging_syslog`
+
+**Director `capacity` removed**:
+
+The Fastly API never supported the `capacity` field for a `director` resource (this was added to the Terraform provider by mistake). Load balancing of director backends is managed by the `weight` field on each associated `backend` resource.
+
+**GCS Logging field `email` renamed**:
+
+The Fastly API was updated with a new [`user`](https://developer.fastly.com/reference/api/logging/gcs/) field to replace `email`.
+
+**Logging `format` and `format_version` defaults changed**:
+
+Pre-1.0.0 the default values for `format` and `format_version` were incorrectly set to an older version `1`. All new logging endpoints use the version `2` custom log format by default.
+
+**Backend `auto_loadbalance` default changed**:
+
+The Fastly web interface defaults "Auto load balance" to "No". The most common reason for having multiple backends in a single service is to route different paths to different backends, rather than load balance between different origins. The provider pre-1.0.0 defaulted `auto_loadbalance` to `true`, which was considered unexpected behaviour. The default is now `false`.
+
+**Gzip `content_types` and `extensions` type changed**:
+
+The `content_types` and `extensions` fields for a `gzip` resource, pre-1.0.0, were implemented as a [`TypeSet`](https://www.terraform.io/plugin/sdkv2/schemas/schema-types#typeset) (an **unordered** collection of items whose state index is calculated by the hash of the attributes of the set). This would result in confusing and unexpected diffs. Now they are implemented as a [`TypeList`](https://www.terraform.io/plugin/sdkv2/schemas/schema-types#typelist) (an **ordered** collection of items).
+
+**Automatically opt-in to `ignore_changes` behaviour for versionless resources**:
+
+The versionless resources (ACL entries, Dictionary items and Dynamic VCL Snippets) are sometimes used in a way whereby they are "seeded" via Terraform and then updated/managed externally via the API or UI console. For this, the documentation suggests using `ignore_changes`, a built-in Terraform meta-argument, that allows the user to specify fields to ignore and from which to allow the state to drift.
+
+However, sometimes this isn't obvious or the user doesn't understand this suggestion until it is too late, and data ends up getting lost. This happens because the user makes changes elsewhere and doesn't use `ignore_changes`, so Terraform takes action to remove the state drift and deletes their changes. This data is then unrecoverable.
+
+In 1.0.0 the default behaviour of these resources has changed. Terraform now ignores any changes, and only allows the "dangerous" behaviour by explicitly opting in with a `manage_*` option (e.g. `manage_entries`, `manage_items`, `manage_snippets` depending on the versionless resource).


### PR DESCRIPTION
Starting from https://registry.terraform.io/providers/fastly/fastly/latest/docs and trying to find upgrade information, I had to jump to this repo, find the the changelog, follow the link from there to #534, and then find the link there to the migration guide. I'd like to help make that a bit more obvious for folks in the future. 😀

This imports the 1.0.0 migration guide from https://gist.github.com/Integralist/b4c3231f0c95d59cf977c2911125a0a4 into `/docs/guides` for publication on the Terraform registry with the rest of the docs.

(I'm hoping that this is the most up-to-date version of the migration guide, but the fact that the gist is tagged with `#delete` has me questioning that…)