### PR TITLE
fix(data_source_fastly_tls_configuration): listTLSConfigurations() pagination

### DIFF
--- a/fastly/data_source_fastly_tls_configuration.go
+++ b/fastly/data_source_fastly_tls_configuration.go
@@ -184,7 +184,7 @@ func getTLSConfigurationFilters(d *schema.ResourceData) []func(*fastly.CustomTLS
 
 func listTLSConfigurations(conn *fastly.Client, filters ...func(*fastly.CustomTLSConfiguration) bool) ([]*fastly.CustomTLSConfiguration, error) {
 	var configurations []*fastly.CustomTLSConfiguration
-	cursor := 0
+	cursor := 1
 	for {
 		list, err := conn.ListCustomTLSConfigurations(&fastly.ListCustomTLSConfigurationsInput{
 			PageNumber: cursor,
@@ -196,7 +196,7 @@ func listTLSConfigurations(conn *fastly.Client, filters ...func(*fastly.CustomTL
 		if len(list) == 0 {
 			break
 		}
-		cursor += len(list)
+		cursor += 1
 
 		for _, configuration := range list {
 			if filterTLSConfiguration(configuration, filters) {

--- a/fastly/data_source_fastly_tls_configuration.go
+++ b/fastly/data_source_fastly_tls_configuration.go
@@ -132,7 +132,7 @@ func dataSourceFastlyTLSConfigurationRead(_ context.Context, d *schema.ResourceD
 		}
 
 		if len(configurations) > 1 {
-			return diag.Errorf("Your query returned more than one result. Please change try a more specific search criteria and try again.")
+			return diag.Errorf("Your query returned more than one result. Please use a more specific search criteria and try again.")
 		}
 
 		configuration = configurations[0]


### PR DESCRIPTION
Fix TLS configuration pagination to iterate over result pages correctly.

Previously, if a list with only one TLS configuration was returned, the
result contained two duplicate configurations due to a pagination error.

When the same page is fetched twice, multiple entries for the same
configurations are added to the result array. This has the effect that
querying with a filter of `default = true` or on a specific unique name
will return multiple copies of the same result, causing an error in
dataSourceFastlyTLSConfigurationRead() where len(configurations) > 1.

The argument of PageNumber: 0 is dropped because of [0].
Page indexes start at 1, so PageNumber: 0 and PageNumber: 1 query the
same page.

cursor should increment one page at a time in order not to skip values,
and should start at 1 instead of 0 in order not to fetch the same page
twice.

Similarly, if /tls/configurations returned a result spanning multiple
pages containing N results (defaults to 100), the next queries would be
to pages N, 2*N, &c instead of pages 2, 3, ...

[0] https://github.com/fastly/go-fastly/blob/f1e3c717bfe88b473c08dd55aa0f9796fc932c71/fastly/custom_tls_configuration.go#L58

Fixes https://github.com/fastly/terraform-provider-fastly/issues/566