### PR TITLE
Avoid N backend API calls with new data exposed by `Director` type.

### DIFF
--- a/fastly/block_fastly_service_director.go
+++ b/fastly/block_fastly_service_director.go
@@ -10,10 +10,12 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
+// DirectorServiceAttributeHandler implements ServiceAttributeDefinition.
 type DirectorServiceAttributeHandler struct {
 	*DefaultServiceAttributeHandler
 }
 
+// NewServiceDirector constructs a service attribute.
 func NewServiceDirector(sa ServiceMetadata) ServiceAttributeDefinition {
 	return ToServiceAttributeDefinition(&DirectorServiceAttributeHandler{
 		&DefaultServiceAttributeHandler{
@@ -23,8 +25,10 @@ func NewServiceDirector(sa ServiceMetadata) ServiceAttributeDefinition {
 	})
 }
 
+// Key returns the resource key.
 func (h *DirectorServiceAttributeHandler) Key() string { return h.key }
 
+// GetSchema returns the resource schema.
 func (h *DirectorServiceAttributeHandler) GetSchema() *schema.Schema {
 	return &schema.Schema{
 		Type:     schema.TypeSet,
@@ -79,8 +83,8 @@ func (h *DirectorServiceAttributeHandler) GetSchema() *schema.Schema {
 	}
 }
 
-func (h *DirectorServiceAttributeHandler) Create(_ context.Context, d *schema.ResourceData, resource map[string]interface {
-}, serviceVersion int, conn *gofastly.Client) error {
+// Create creates a new resource instance.
+func (h *DirectorServiceAttributeHandler) Create(_ context.Context, d *schema.ResourceData, resource map[string]interface{}, serviceVersion int, conn *gofastly.Client) error {
 	opts := gofastly.CreateDirectorInput{
 		ServiceID:      d.Id(),
 		ServiceVersion: serviceVersion,
@@ -130,13 +134,13 @@ func (h *DirectorServiceAttributeHandler) Create(_ context.Context, d *schema.Re
 	return nil
 }
 
+// Read refreshes the resource state.
 func (h *DirectorServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, _ map[string]interface{}, serviceVersion int, conn *gofastly.Client) error {
 	log.Printf("[DEBUG] Refreshing Directors for (%s)", d.Id())
 	directorList, err := conn.ListDirectors(&gofastly.ListDirectorsInput{
 		ServiceID:      d.Id(),
 		ServiceVersion: serviceVersion,
 	})
-
 	if err != nil {
 		return fmt.Errorf("[ERR] Error looking up Directors for (%s), version (%v): %s", d.Id(), serviceVersion, err)
 	}
@@ -177,8 +181,8 @@ func (h *DirectorServiceAttributeHandler) Read(_ context.Context, d *schema.Reso
 	return nil
 }
 
-func (h *DirectorServiceAttributeHandler) Update(_ context.Context, d *schema.ResourceData, resource, modified map[string]interface {
-}, serviceVersion int, conn *gofastly.Client) error {
+// Update updates the resource instance.
+func (h *DirectorServiceAttributeHandler) Update(_ context.Context, d *schema.ResourceData, resource, modified map[string]interface{}, serviceVersion int, conn *gofastly.Client) error {
 	opts := gofastly.UpdateDirectorInput{
 		ServiceID:      d.Id(),
 		ServiceVersion: serviceVersion,
@@ -234,7 +238,6 @@ func (h *DirectorServiceAttributeHandler) Update(_ context.Context, d *schema.Re
 			}
 			log.Printf("[DEBUG] Director Backend Update opts: %#v", opts)
 			err := conn.DeleteDirectorBackend(&opts)
-
 			if err != nil {
 				// If we end up trying to remove a backend that no longer exists, then the
 				// API will return a '404 Not Found'. We don't want to return those errors
@@ -255,7 +258,6 @@ func (h *DirectorServiceAttributeHandler) Update(_ context.Context, d *schema.Re
 			}
 			log.Printf("[DEBUG] Director Backend Update opts: %#v", opts)
 			_, err := conn.CreateDirectorBackend(&opts)
-
 			if err != nil {
 				return err
 			}
@@ -264,8 +266,8 @@ func (h *DirectorServiceAttributeHandler) Update(_ context.Context, d *schema.Re
 	return nil
 }
 
-func (h *DirectorServiceAttributeHandler) Delete(_ context.Context, d *schema.ResourceData, resource map[string]interface {
-}, serviceVersion int, conn *gofastly.Client) error {
+// Delete deletes the resource instance.
+func (h *DirectorServiceAttributeHandler) Delete(_ context.Context, d *schema.ResourceData, resource map[string]interface{}, serviceVersion int, conn *gofastly.Client) error {
 	opts := gofastly.DeleteDirectorInput{
 		ServiceID:      d.Id(),
 		ServiceVersion: serviceVersion,

--- a/fastly/block_fastly_service_director_test.go
+++ b/fastly/block_fastly_service_director_test.go
@@ -14,10 +14,8 @@ import (
 
 func TestResourceFastlyFlattenDirectors(t *testing.T) {
 	cases := []struct {
-		remoteDirector        []*gofastly.Director
-		remoteDirectorBackend []*gofastly.DirectorBackend
-
-		local []map[string]interface{}
+		remoteDirector []*gofastly.Director
+		local          []map[string]interface{}
 	}{
 		{
 			remoteDirector: []*gofastly.Director{
@@ -26,12 +24,9 @@ func TestResourceFastlyFlattenDirectors(t *testing.T) {
 					Type:    3,
 					Quorum:  75,
 					Retries: 10,
-				},
-			},
-			remoteDirectorBackend: []*gofastly.DirectorBackend{
-				{
-					Director: "somedirector",
-					Backend:  "somebackend",
+					Backends: []string{
+						"somebackend",
+					},
 				},
 			},
 			local: []map[string]interface{}{
@@ -48,27 +43,17 @@ func TestResourceFastlyFlattenDirectors(t *testing.T) {
 			remoteDirector: []*gofastly.Director{
 				{
 					Name: "somedirector",
+					Backends: []string{
+						"somebackend",
+						"someotherbackend",
+					},
 				},
 				{
 					Name: "someotherdirector",
-				},
-			},
-			remoteDirectorBackend: []*gofastly.DirectorBackend{
-				{
-					Director: "somedirector",
-					Backend:  "somebackend",
-				},
-				{
-					Director: "somedirector",
-					Backend:  "someotherbackend",
-				},
-				{
-					Director: "someotherdirector",
-					Backend:  "somebackend",
-				},
-				{
-					Director: "someotherdirector",
-					Backend:  "someotherbackend",
+					Backends: []string{
+						"somebackend",
+						"someotherbackend",
+					},
 				},
 			},
 			local: []map[string]interface{}{

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/bflad/tfproviderlint v0.27.1
-	github.com/fastly/go-fastly/v6 v6.0.0
+	github.com/fastly/go-fastly/v6 v6.3.2
 	github.com/google/go-cmp v0.5.6
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/terraform-plugin-docs v0.5.0

--- a/go.sum
+++ b/go.sum
@@ -103,8 +103,8 @@ github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymF
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
-github.com/fastly/go-fastly/v6 v6.0.0 h1:T9bRQ4rQKUmhi3DbLWMx020kzJxu57kWCirW/IELwxg=
-github.com/fastly/go-fastly/v6 v6.0.0/go.mod h1:MsNmaK4Ent7khsgA91rC7TcTEsCDU2m7wi4ZnOX4Dn0=
+github.com/fastly/go-fastly/v6 v6.3.2 h1:MQawBCmIy/m9rs3aI0V+0N8P8UODJs1EfJPHJVBwEqI=
+github.com/fastly/go-fastly/v6 v6.3.2/go.mod h1:NrIbx45etTFv35rgfRe+eQY+8kA47arWABIkOaQ+roY=
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=

--- a/vendor/github.com/fastly/go-fastly/v6/fastly/acl_entry.go
+++ b/vendor/github.com/fastly/go-fastly/v6/fastly/acl_entry.go
@@ -125,10 +125,16 @@ func (c *Client) listACLEntriesWithPage(i *ListACLEntriesInput, p *ListAclEntrie
 		perPage = i.PerPage
 	}
 
+	// page is not specified, fetch from the beginning
 	if i.Page <= 0 && p.CurrentPage == 0 {
 		p.CurrentPage = 1
 	} else {
-		p.CurrentPage = p.CurrentPage + 1
+		// page is specified, fetch from a given page
+		if !p.consumed {
+			p.CurrentPage = i.Page
+		} else {
+			p.CurrentPage = p.CurrentPage + 1
+		}
 	}
 
 	path := fmt.Sprintf("/service/%s/acl/%s/entries", i.ServiceID, i.ACLID)

--- a/vendor/github.com/fastly/go-fastly/v6/fastly/client.go
+++ b/vendor/github.com/fastly/go-fastly/v6/fastly/client.go
@@ -11,8 +11,10 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/google/go-querystring/query"
 	"github.com/google/jsonapi"
@@ -46,7 +48,7 @@ const DefaultRealtimeStatsEndpoint = "https://rt.fastly.com"
 var ProjectURL = "github.com/fastly/go-fastly"
 
 // ProjectVersion is the version of this library.
-var ProjectVersion = "6.0.0"
+var ProjectVersion = "6.3.2"
 
 // UserAgent is the user agent for this particular client.
 var UserAgent = fmt.Sprintf("FastlyGo/%s (+%s; %s)",
@@ -70,6 +72,12 @@ type Client struct {
 
 	// url is the parsed URL from Address
 	url *url.URL
+
+	// remaining is last observed value of http header Fastly-RateLimit-Remaining
+	remaining int
+
+	// reset is last observed value of http header Fastly-RateLimit-Reset
+	reset int64
 }
 
 // RTSClient is the entrypoint to the Fastly's Realtime Stats API.
@@ -140,6 +148,11 @@ func NewRealtimeStatsClientForEndpoint(token, endpoint string) (*RTSClient, erro
 }
 
 func (c *Client) init() (*Client, error) {
+	// Until we do a request, we don't know how many are left.
+	// Use the default limit as a first guess:
+	// https://developer.fastly.com/reference/api/#rate-limiting
+	c.remaining = 1000
+
 	u, err := url.Parse(c.Address)
 	if err != nil {
 		return nil, err
@@ -151,6 +164,18 @@ func (c *Client) init() (*Client, error) {
 	}
 
 	return c, nil
+}
+
+// RateLimitRemaining returns the number of non-read requests left before
+// rate limiting causes a 429 Too Many Requests error.
+func (c *Client) RateLimitRemaining() int {
+	return c.remaining
+}
+
+// RateLimitReset returns the next time the rate limiter's counter will be
+// reset.
+func (c *Client) RateLimitReset() time.Time {
+	return time.Unix(c.reset, 0)
 }
 
 // Get issues an HTTP GET request.
@@ -270,9 +295,23 @@ func (c *Client) Request(verb, p string, ro *RequestOptions) (*http.Response, er
 
 	}
 	resp, err := checkResp(c.HTTPClient.Do(req))
-
 	if err != nil {
 		return resp, err
+	}
+
+	if verb != "GET" && verb != "HEAD" {
+		remaining := resp.Header.Get("Fastly-RateLimit-Remaining")
+		if remaining != "" {
+			if val, err := strconv.Atoi(remaining); err == nil {
+				c.remaining = val
+			}
+		}
+		reset := resp.Header.Get("Fastly-RateLimit-Reset")
+		if reset != "" {
+			if val, err := strconv.ParseInt(reset, 10, 64); err == nil {
+				c.reset = val
+			}
+		}
 	}
 
 	return resp, nil

--- a/vendor/github.com/fastly/go-fastly/v6/fastly/custom_tls_domain.go
+++ b/vendor/github.com/fastly/go-fastly/v6/fastly/custom_tls_domain.go
@@ -31,7 +31,7 @@ func (l *ListTLSDomainsInput) formatFilters() map[string]string {
 	result := map[string]string{}
 	pairings := map[string]interface{}{
 		"filter[in_use]":               l.FilterInUse,
-		"filter[tls_certificate.id]":   l.FilterTLSCertificateID,
+		"filter[tls_certificates.id]":  l.FilterTLSCertificateID,
 		"filter[tls_subscriptions.id]": l.FilterTLSSubscriptionID,
 		"include":                      l.Include,
 		"page[number]":                 l.PageNumber,

--- a/vendor/github.com/fastly/go-fastly/v6/fastly/dictionary_item.go
+++ b/vendor/github.com/fastly/go-fastly/v6/fastly/dictionary_item.go
@@ -122,10 +122,16 @@ func (c *Client) listDictionaryItemsWithPage(i *ListDictionaryItemsInput, p *Lis
 		perPage = i.PerPage
 	}
 
+	// page is not specified, fetch from the beginning
 	if i.Page <= 0 && p.CurrentPage == 0 {
 		p.CurrentPage = 1
 	} else {
-		p.CurrentPage = p.CurrentPage + 1
+		// page is specified, fetch from a given page
+		if !p.consumed {
+			p.CurrentPage = i.Page
+		} else {
+			p.CurrentPage = p.CurrentPage + 1
+		}
 	}
 
 	path := fmt.Sprintf("/service/%s/dictionary/%s/items", i.ServiceID, i.DictionaryID)

--- a/vendor/github.com/fastly/go-fastly/v6/fastly/director.go
+++ b/vendor/github.com/fastly/go-fastly/v6/fastly/director.go
@@ -30,6 +30,7 @@ type Director struct {
 	ServiceVersion int    `mapstructure:"version"`
 
 	Name      string       `mapstructure:"name"`
+	Backends  []string     `mapstructure:"backends"`
 	Comment   string       `mapstructure:"comment"`
 	Shield    string       `mapstructure:"shield"`
 	Quorum    uint         `mapstructure:"quorum"`

--- a/vendor/github.com/fastly/go-fastly/v6/fastly/erl.go
+++ b/vendor/github.com/fastly/go-fastly/v6/fastly/erl.go
@@ -1,0 +1,282 @@
+//
+// API reference:
+// https://developer.fastly.com/reference/api/vcl-services/rate-limiter/
+// NB: ERL is an optional feature that must be enabled before use
+package fastly
+
+import (
+	"fmt"
+	"sort"
+	"time"
+)
+
+// ERL models the response from the Fastly API.
+type ERL struct {
+	Action             ERLAction        `mapstructure:"action"`
+	ClientKey          []string         `mapstructure:"client_key"`
+	CreatedAt          *time.Time       `mapstructure:"created_at"`
+	DeletedAt          *time.Time       `mapstructure:"deleted_at"`
+	FeatureRevision    int              `mapstructure:"feature_revision"` // 1..
+	HttpMethods        []string         `mapstructure:"http_methods"`
+	ID                 string           `mapstructure:"id"`
+	LoggerType         ERLLogger        `mapstructure:"logger_type"`
+	Name               string           `mapstructure:"name"`
+	PenaltyBoxDuration int              `mapstructure:"penalty_box_duration"` // 1..60
+	Response           *ERLResponseType `mapstructure:"response"`             // required if Action != Log
+	ResponseObjectName string           `mapstructure:"response_object_name"`
+	RpsLimit           int              `mapstructure:"rps_limit"` // 10..10000
+	ServiceId          string           `mapstructure:"service_id"`
+	UpdatedAt          *time.Time       `mapstructure:"updated_at"`
+	UriDictionaryName  string           `mapstructure:"uri_dictionary_name"`
+	Version            int              `mapstructure:"version"` // 1..
+	WindowSize         ERLWindowSize    `mapstructure:"window_size"`
+}
+
+// ERLResponseType models the response from the Fastly API.
+type ERLResponseType struct {
+	ERLStatus      int    `url:"status,omitempty"`
+	ERLContentType string `url:"content_type,omitempty"`
+	ERLContent     string `url:"content,omitempty"`
+}
+
+// ERLAction represents the action variants for when a rate limiter
+// violation is detected.
+type ERLAction string
+
+const (
+	ERLActionLogOnly        ERLAction = "log_only"
+	ERLActionResponse       ERLAction = "response"
+	ERLActionResponseObject ERLAction = "response_object"
+)
+
+// ERLLogger represents the supported log provider variants.
+type ERLLogger string
+
+const (
+	ERLLogAzureBlob       ERLLogger = "azureblob"
+	ERLLogBigQuery        ERLLogger = "bigquery"
+	ERLLogCloudFiles      ERLLogger = "cloudfiles"
+	ERLLogDataDog         ERLLogger = "datadog"
+	ERLLogDigitalOcean    ERLLogger = "digitalocean"
+	ERLLogElasticSearch   ERLLogger = "elasticsearch"
+	ERLLogFtp             ERLLogger = "ftp"
+	ERLLogGcs             ERLLogger = "gcs"
+	ERLLogGoogleAnalytics ERLLogger = "googleanalytics"
+	ERLLogHeroku          ERLLogger = "heroku"
+	ERLLogHoneycomb       ERLLogger = "honeycomb"
+	ERLLogHttp            ERLLogger = "http"
+	ERLLogHttps           ERLLogger = "https"
+	ERLLogKafta           ERLLogger = "kafka"
+	ERLLogKinesis         ERLLogger = "kinesis"
+	ERLLogLogEntries      ERLLogger = "logentries"
+	ERLLogLoggly          ERLLogger = "loggly"
+	ERLLogLogShuttle      ERLLogger = "logshuttle"
+	ERLLogNewRelic        ERLLogger = "newrelic"
+	ERLLogOpenStack       ERLLogger = "openstack"
+	ERLLogPaperTrail      ERLLogger = "papertrail"
+	ERLLogPubSub          ERLLogger = "pubsub"
+	ERLLogS3              ERLLogger = "s3"
+	ERLLogScalyr          ERLLogger = "scalyr"
+	ERLLogSftp            ERLLogger = "sftp"
+	ERLLogSplunk          ERLLogger = "splunk"
+	ERLLogStackDriver     ERLLogger = "stackdriver"
+	ERLLogSumoLogiuc      ERLLogger = "sumologic"
+	ERLLogSysLog          ERLLogger = "syslog"
+)
+
+// ERLWindowSize represents the duration variants for when the RPS limit is
+// exceeded.
+type ERLWindowSize int
+
+const (
+	ERLSize1  ERLWindowSize = 1
+	ERLSize10 ERLWindowSize = 10
+	ERLSize60 ERLWindowSize = 60
+)
+
+// ERLsByName is a sortable list of ERLs
+type ERLsByName []*ERL
+
+// Len, Swap, and Less implement the sortable interface
+func (s ERLsByName) Len() int      { return len(s) }
+func (s ERLsByName) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
+func (s ERLsByName) Less(i, j int) bool {
+	return s[i].Name < s[j].Name
+}
+
+// ListERLsInput is used as input to the ListERLs function.
+type ListERLsInput struct {
+	ServiceID      string // required
+	ServiceVersion int    // required
+}
+
+// ListERLs returns the list of ERLs for the specified service version.
+func (c *Client) ListERLs(i *ListERLsInput) ([]*ERL, error) {
+	if i.ServiceID == "" {
+		return nil, ErrMissingServiceID
+	}
+	if i.ServiceVersion == 0 {
+		return nil, ErrMissingServiceVersion
+	}
+
+	path := fmt.Sprintf("/service/%s/version/%d/rate-limiters", i.ServiceID, i.ServiceVersion)
+	resp, err := c.Get(path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var erls []*ERL
+	if err := decodeBodyMap(resp.Body, &erls); err != nil {
+		return nil, err
+	}
+
+	sort.Stable(ERLsByName(erls))
+	return erls, nil
+}
+
+// CreateERLInput is used as input to the CreateERL function.
+type CreateERLInput struct {
+	Action             ERLAction        `url:"action"`
+	ClientKey          []string         `url:"client_key,brackets"`
+	HttpMethods        []string         `url:"http_methods,brackets"`
+	Name               string           `url:"name"`
+	PenaltyBoxDuration int              `url:"penalty_box_duration"`
+	Response           *ERLResponseType `url:"response,omitempty"`
+	RpsLimit           int              `url:"rps_limit"`
+	ServiceID          string           `url:"-"`
+	ServiceVersion     int              `url:"-"`
+	WindowSize         ERLWindowSize    `url:"window_size"`
+}
+
+// CreateERL returns a new ERL.
+func (c *Client) CreateERL(i *CreateERLInput) (*ERL, error) {
+	if i.ServiceID == "" {
+		return nil, ErrMissingServiceID
+	}
+	if i.ServiceVersion == 0 {
+		return nil, ErrMissingServiceVersion
+	}
+
+	path := fmt.Sprintf("/service/%s/version/%d/rate-limiters", i.ServiceID, i.ServiceVersion)
+	resp, err := c.PostForm(path, i, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var erl *ERL
+	if err := decodeBodyMap(resp.Body, &erl); err != nil {
+		return nil, err
+	}
+
+	return erl, nil
+}
+
+// DeleteERLInput is used as input to the DeleteERL function.
+type DeleteERLInput struct {
+	ServiceID      string `form:"service_id"`
+	ServiceVersion int    `form:"version"`
+	ERLID          string `form:"id"`
+}
+
+// DeleteERL deletes the specified ERL.
+func (c *Client) DeleteERL(i *DeleteERLInput) error {
+	if i.ServiceID == "" {
+		return ErrMissingServiceID
+	}
+	if i.ServiceVersion == 0 {
+		return ErrMissingServiceVersion
+	}
+	if i.ERLID == "" {
+		return ErrMissingID
+	}
+
+	path := fmt.Sprintf("/rate-limiters/%s", i.ERLID)
+	resp, err := c.Delete(path, nil)
+	if err != nil {
+		return err
+	}
+
+	var r *statusResp
+	if err := decodeBodyMap(resp.Body, &r); err != nil {
+		return err
+	}
+	if !r.Ok() {
+		return fmt.Errorf("not ok")
+	}
+
+	return nil
+}
+
+// GetERLInput is used as input to the GetERL function.
+type GetERLInput struct {
+	ServiceID      string `form:"service_id"`
+	ServiceVersion int    `form:"version"`
+	ERLID          string `form:"id"`
+}
+
+// GetERL returns the specified ERL.
+func (c *Client) GetERL(i *GetERLInput) (*ERL, error) {
+	if i.ServiceID == "" {
+		return nil, ErrMissingServiceID
+	}
+	if i.ServiceVersion == 0 {
+		return nil, ErrMissingServiceVersion
+	}
+	if i.ERLID == "" {
+		return nil, ErrMissingID
+	}
+
+	path := fmt.Sprintf("/rate-limiters/%s", i.ERLID)
+	resp, err := c.Get(path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var erl *ERL
+	if err := decodeBodyMap(resp.Body, &erl); err != nil {
+		return nil, err
+	}
+
+	return erl, nil
+}
+
+// UpdateERLInput is used as input to the UpdateERL function.
+type UpdateERLInput struct {
+	Action             ERLAction        `url:"action,omitempty"`
+	ClientKey          []string         `url:"client_key,omitempty,brackets"`
+	HttpMethods        []string         `url:"http_methods,omitempty,brackets"`
+	ID                 string           `url:"id"`
+	Name               string           `url:"name,omitempty"`
+	PenaltyBoxDuration int              `url:"penalty_box_duration,omitempty"`
+	Response           *ERLResponseType `url:"response,omitempty"`
+	RpsLimit           int              `url:"rps_limit,omitempty"`
+	ServiceID          string           `url:"-"`
+	ServiceVersion     int              `url:"-"`
+	WindowSize         ERLWindowSize    `url:"window_size,omitempty"`
+}
+
+// UpdateERLInput updates the specified ERL.
+func (c *Client) UpdateERL(i *UpdateERLInput) (*ERL, error) {
+	if i.ServiceID == "" {
+		return nil, ErrMissingServiceID
+	}
+	if i.ServiceVersion == 0 {
+		return nil, ErrMissingServiceVersion
+	}
+	if i.ID == "" {
+		return nil, ErrMissingID
+	}
+
+	path := fmt.Sprintf("/rate-limiters/%s", i.ID)
+	resp, err := c.PutForm(path, i, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var erl *ERL
+	if err := decodeBodyMap(resp.Body, &erl); err != nil {
+		return nil, err
+	}
+
+	return erl, nil
+}

--- a/vendor/github.com/fastly/go-fastly/v6/fastly/origin_inspector.go
+++ b/vendor/github.com/fastly/go-fastly/v6/fastly/origin_inspector.go
@@ -1,0 +1,146 @@
+package fastly
+
+import (
+	"encoding/json"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// OriginInspector represents the response format returned for a request to
+// the historical Origin Inspector metrics endpoint.
+type OriginInspector struct {
+	Data   []OriginData `mapstructure:"data"`
+	Meta   OriginMeta   `mapstructure:"meta"`
+	Status string       `mapstructure:"status"`
+}
+
+// OriginData represents the series of values over time for a single
+// dimension combination.
+type OriginData struct {
+	Dimensions map[string]string `mapstructure:"dimensions"`
+	Values     []OriginMetrics   `mapstructure:"values"`
+}
+
+// OriginMetrics represents the possible metrics that can be returned by a call
+// to the Origin Inspector endpoints.
+type OriginMetrics struct {
+	Latency0to1ms         uint64 `mapstructure:"latency_0_to_1ms"`
+	Latency1to5ms         uint64 `mapstructure:"latency_1_to_5ms"`
+	Latency5to10ms        uint64 `mapstructure:"latency_5_to_10ms"`
+	Latency10to50ms       uint64 `mapstructure:"latency_10_to_50ms"`
+	Latency50to100ms      uint64 `mapstructure:"latency_50_to_100ms"`
+	Latency100to250ms     uint64 `mapstructure:"latency_100_to_250ms"`
+	Latency250to500ms     uint64 `mapstructure:"latency_250_to_500ms"`
+	Latency500to1000ms    uint64 `mapstructure:"latency_500_to_1000ms"`
+	Latency1000to5000ms   uint64 `mapstructure:"latency_1000_to_5000ms"`
+	Latency5000to10000ms  uint64 `mapstructure:"latency_5000_to_10000ms"`
+	Latency10000to60000ms uint64 `mapstructure:"latency_10000_to_60000ms"`
+	Latency60000ms        uint64 `mapstructure:"latency_60000ms"`
+	RespBodyBytes         uint64 `mapstructure:"resp_body_bytes"`
+	RespHeaderBytes       uint64 `mapstructure:"resp_header_bytes"`
+	Responses             uint64 `mapstructure:"responses"`
+	Status1xx             uint64 `mapstructure:"status_1xx"`
+	Status200             uint64 `mapstructure:"status_200"`
+	Status204             uint64 `mapstructure:"status_204"`
+	Status206             uint64 `mapstructure:"status_206"`
+	Status2xx             uint64 `mapstructure:"status_2xx"`
+	Status301             uint64 `mapstructure:"status_301"`
+	Status302             uint64 `mapstructure:"status_302"`
+	Status304             uint64 `mapstructure:"status_304"`
+	Status3xx             uint64 `mapstructure:"status_3xx"`
+	Status400             uint64 `mapstructure:"status_400"`
+	Status401             uint64 `mapstructure:"status_401"`
+	Status403             uint64 `mapstructure:"status_403"`
+	Status404             uint64 `mapstructure:"status_404"`
+	Status416             uint64 `mapstructure:"status_416"`
+	Status429             uint64 `mapstructure:"status_429"`
+	Status4xx             uint64 `mapstructure:"status_4xx"`
+	Status500             uint64 `mapstructure:"status_500"`
+	Status501             uint64 `mapstructure:"status_501"`
+	Status502             uint64 `mapstructure:"status_502"`
+	Status503             uint64 `mapstructure:"status_503"`
+	Status504             uint64 `mapstructure:"status_504"`
+	Status505             uint64 `mapstructure:"status_505"`
+	Status5xx             uint64 `mapstructure:"status_5xx"`
+	Timestamp             uint64 `mapstructure:"timestamp"`
+}
+
+// OriginMeta is the meta section returned for /metrics/origins responses
+type OriginMeta struct {
+	Start      string            `mapstructure:"start"`
+	End        string            `mapstructure:"end"`
+	Downsample string            `mapstructure:"downsample"`
+	Metric     string            `mapstructure:"metric"`
+	Limit      int               `mapstructure:"limit"`
+	NextCursor string            `mapstructure:"next_cursor"`
+	Sort       string            `mapstructure:"sort"`
+	GroupBy    string            `mapstructure:"group_by"`
+	Filters    map[string]string `mapstructure:"filters"`
+}
+
+// GetOriginMetricsInput is the input to an OriginMetrics request.
+type GetOriginMetricsInput struct {
+	ServiceID   string
+	Start       time.Time
+	End         time.Time
+	Metrics     []string
+	GroupBy     []string
+	Downsample  string
+	Hosts       []string
+	Datacenters []string
+	Regions     []string
+	Cursor      string
+}
+
+// GetOriginMetricsForService returns stats data based on GetOriginMetricsInput
+func (c *Client) GetOriginMetricsForService(i *GetOriginMetricsInput) (*OriginInspector, error) {
+	var resp interface{}
+	if err := c.GetOriginMetricsForServiceJSON(i, &resp); err != nil {
+		return nil, err
+	}
+
+	var or *OriginInspector
+	if err := decodeMap(resp, &or); err != nil {
+		return nil, err
+	}
+	return or, nil
+}
+
+// GetOriginMetricsForServiceJSON fetches Origin Inspector metrics for a single service and decodes the response
+// directly to the JSON struct dst.
+func (c *Client) GetOriginMetricsForServiceJSON(i *GetOriginMetricsInput, dst interface{}) error {
+	if i.ServiceID == "" {
+		return ErrMissingServiceID
+	}
+
+	p := "/metrics/origins/services/" + i.ServiceID
+
+	start := ""
+	if !i.Start.IsZero() {
+		start = strconv.FormatInt(i.Start.Unix(), 10)
+	}
+	end := ""
+	if !i.End.IsZero() {
+		end = strconv.FormatInt(i.End.Unix(), 10)
+	}
+
+	r, err := c.Get(p, &RequestOptions{
+		Params: map[string]string{
+			"start":      start,
+			"end":        end,
+			"downsample": i.Downsample,
+			"metric":     strings.Join(i.Metrics, ","),
+			"host":       strings.Join(i.Hosts, ","),
+			"datacenter": strings.Join(i.Datacenters, ","),
+			"region":     strings.Join(i.Regions, ","),
+			"cursor":     i.Cursor,
+		},
+	})
+	if err != nil {
+		return err
+	}
+	defer r.Body.Close()
+
+	return json.NewDecoder(r.Body).Decode(dst)
+}

--- a/vendor/github.com/fastly/go-fastly/v6/fastly/service.go
+++ b/vendor/github.com/fastly/go-fastly/v6/fastly/service.go
@@ -128,10 +128,16 @@ func (c *Client) listServicesWithPage(i *ListServicesInput, p *ListServicesPagin
 		perPage = i.PerPage
 	}
 
+	// page is not specified, fetch from the beginning
 	if i.Page <= 0 && p.CurrentPage == 0 {
 		p.CurrentPage = 1
 	} else {
-		p.CurrentPage = p.CurrentPage + 1
+		// page is specified, fetch from a given page
+		if !p.consumed {
+			p.CurrentPage = i.Page
+		} else {
+			p.CurrentPage = p.CurrentPage + 1
+		}
 	}
 
 	requestOptions := &RequestOptions{

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -234,7 +234,7 @@ github.com/bgentry/go-netrc/netrc
 github.com/bgentry/speakeasy
 # github.com/davecgh/go-spew v1.1.1
 github.com/davecgh/go-spew/spew
-# github.com/fastly/go-fastly/v6 v6.0.0
+# github.com/fastly/go-fastly/v6 v6.3.2
 ## explicit
 github.com/fastly/go-fastly/v6/fastly
 # github.com/fatih/color v1.7.0


### PR DESCRIPTION
This PR relates to the recent go-fastly API client update:
https://github.com/fastly/go-fastly/pull/347