### PR TITLE
Fix integration tests

### DIFF
--- a/fastly/data_source_datacenters.go
+++ b/fastly/data_source_datacenters.go
@@ -51,16 +51,15 @@ func dataSourceFastlyDatacenters() *schema.Resource {
 }
 
 func dataSourceFastlyDatacentersRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-
 	conn := meta.(*FastlyClient).conn
 
 	log.Printf("[DEBUG] Reading datacenters")
 
 	datacenters, err := conn.AllDatacenters()
-
 	if err != nil {
 		return diag.Errorf("error fetching datacenters: %s", err)
 	}
+
 	hashBase, _ := json.Marshal(datacenters)
 	hashString := strconv.Itoa(hashcode.String(string(hashBase)))
 	d.SetId(hashString)
@@ -70,11 +69,9 @@ func dataSourceFastlyDatacentersRead(_ context.Context, d *schema.ResourceData, 
 	}
 
 	return nil
-
 }
 
 func flattenDatacenters(datacenters []gofastly.Datacenter) []map[string]interface{} {
-
 	pops := make([]map[string]interface{}, len(datacenters))
 	if len(datacenters) == 0 {
 		return pops

--- a/fastly/data_source_datacenters_test.go
+++ b/fastly/data_source_datacenters_test.go
@@ -23,7 +23,11 @@ func TestAccFastlyDataSourceDatacenters(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "pops.0.code"),
 					resource.TestCheckResourceAttrSet(resourceName, "pops.0.name"),
 					resource.TestCheckResourceAttrSet(resourceName, "pops.0.group"),
-					resource.TestCheckResourceAttrSet(resourceName, "pops.0.shield"),
+					// NOTE: we don't validate pops.0.shield as not all pops within the
+					// dataset has a shield value. We also can't rely on the data
+					// staying consistent (e.g. if either the order of the data changes
+					// or a pop that once reported a shield suddently stops reporting one,
+					// then the test becomes flaky.
 				),
 			},
 		},
@@ -32,7 +36,6 @@ func TestAccFastlyDataSourceDatacenters(t *testing.T) {
 
 func testAccFastlyDataSourceDatacenters(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-
 		r := s.RootModule().Resources[n]
 		a := r.Primary.Attributes
 

--- a/fastly/resource_fastly_service_versionless_test.go
+++ b/fastly/resource_fastly_service_versionless_test.go
@@ -25,7 +25,7 @@ func TestAccFastlyServiceVCL_creation_with_versionless_resources(t *testing.T) {
 		CheckDestroy:      testAccCheckServiceVCLDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccServiceVCLConfig_create_service_with_one_acl_dictionart_and_dynamic_snippet(serviceName, dictionaryName, aclName, dynamicSnippetName, domainName),
+				Config: testAccServiceVCLConfigCreateServiceWithOneACLDictionaryAndDynamicSnippet(serviceName, dictionaryName, aclName, dynamicSnippetName, domainName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceVCLExists("fastly_service_vcl.service", &service),
 					resource.TestCheckResourceAttr("fastly_service_acl_entries.entries", "entry.#", "1"),
@@ -37,7 +37,7 @@ func TestAccFastlyServiceVCL_creation_with_versionless_resources(t *testing.T) {
 	})
 }
 
-func testAccServiceVCLConfig_create_service_with_one_acl_dictionart_and_dynamic_snippet(serviceName, dictionaryName, aclName, dynamicSnippetName, domain string) string {
+func testAccServiceVCLConfigCreateServiceWithOneACLDictionaryAndDynamicSnippet(serviceName, dictionaryName, aclName, dynamicSnippetName, domain string) string {
 	return fmt.Sprintf(`
 locals {
   service_name         = "%s"
@@ -106,7 +106,7 @@ resource "fastly_service_dynamic_snippet_content" "dyn_content" {
 
   content = <<EOT
 if (!req.http.Accept-Language) {
-  set req.http.Accept-Language = table.lookup(${local.dictionary_name}, geoip.country_code, "en-US");
+  set req.http.Accept-Language = table.lookup(${local.dictionary_name}, client.geo.country_code, "en-US");
 }
 
 # block all requests to Admin pages from IP addresses not in office_ip_ranges


### PR DESCRIPTION
**Summary**:
- Replace `geoip.country_code` (deprecated; causes Varnish compiler error) with `client.geo.country_code`.
- Remove check for `shield` property on a POP (not every POP has a shield property).