### PR TITLE
allow service to be reused

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,10 @@ $ make build
 
 Alongside the newly built binary a file called `developer_overrides.tfrc` will be created.  The `make build` target will communicate
 back details for setting the `TF_CLI_CONFIG_FILE` environment variable that will enable Terraform to use your locally built provider binary.
+
 * HashiCorp - [Development Overrides for Provider developers](https://www.terraform.io/docs/cli/config/config-file.html#development-overrides-for-provider-developers).
+
+> **NOTE**: If you have issues seeing any behaviours from code changes you've made to the provider, then it might be the terraform CLI is getting confused by which provider binary it should be using. Check inside the `./bin/` directory to see if there are multiple providers with different commit hashes (e.g. `terraform-provider-fastly_v2.2.0-5-gfdc37cee`) and delete them first before running `make build`. This should help the Terraform CLI resolve to the correct binary.
 
 ### Debugging the provider
 

--- a/docs/resources/service_compute.md
+++ b/docs/resources/service_compute.md
@@ -105,7 +105,7 @@ $ terraform import fastly_service_compute.demo xxxxxxxxxxxxxxxxxxxx@2
 - **logging_splunk** (Block Set) (see [below for nested schema](#nestedblock--logging_splunk))
 - **logging_sumologic** (Block Set) (see [below for nested schema](#nestedblock--logging_sumologic))
 - **logging_syslog** (Block Set) (see [below for nested schema](#nestedblock--logging_syslog))
-- **reuse** (Boolean) Services that are active cannot be destroyed. This will cause the service to be deactivated allowing it to be reused by importing it into another Terraform project. Default `false`
+- **reuse** (Boolean) Services that are active cannot be destroyed. If set to `true` a service Terraform intends to destroy will instead be deactivated (allowing it to be reused by importing it into another Terraform project). If `false`, attempting to destroy an active service will cause an error. Default `false`
 - **version_comment** (String) Description field for the version
 
 ### Read-Only

--- a/docs/resources/service_compute.md
+++ b/docs/resources/service_compute.md
@@ -105,6 +105,7 @@ $ terraform import fastly_service_compute.demo xxxxxxxxxxxxxxxxxxxx@2
 - **logging_splunk** (Block Set) (see [below for nested schema](#nestedblock--logging_splunk))
 - **logging_sumologic** (Block Set) (see [below for nested schema](#nestedblock--logging_sumologic))
 - **logging_syslog** (Block Set) (see [below for nested schema](#nestedblock--logging_syslog))
+- **reuse** (Boolean) Services that are active cannot be destroyed. This will cause the service to be deactivated allowing it to be reused by importing it into another Terraform project. Default `false`
 - **version_comment** (String) Description field for the version
 
 ### Read-Only

--- a/docs/resources/service_vcl.md
+++ b/docs/resources/service_vcl.md
@@ -283,6 +283,7 @@ $ terraform import fastly_service_vcl.demo xxxxxxxxxxxxxxxxxxxx@2
 - **logging_syslog** (Block Set) (see [below for nested schema](#nestedblock--logging_syslog))
 - **request_setting** (Block Set) (see [below for nested schema](#nestedblock--request_setting))
 - **response_object** (Block Set) (see [below for nested schema](#nestedblock--response_object))
+- **reuse** (Boolean) Services that are active cannot be destroyed. This will cause the service to be deactivated allowing it to be reused by importing it into another Terraform project. Default `false`
 - **snippet** (Block Set) (see [below for nested schema](#nestedblock--snippet))
 - **stale_if_error** (Boolean) Enables serving a stale object if there is an error
 - **stale_if_error_ttl** (Number) The default time-to-live (TTL) for serving the stale object for the version

--- a/docs/resources/service_vcl.md
+++ b/docs/resources/service_vcl.md
@@ -283,7 +283,7 @@ $ terraform import fastly_service_vcl.demo xxxxxxxxxxxxxxxxxxxx@2
 - **logging_syslog** (Block Set) (see [below for nested schema](#nestedblock--logging_syslog))
 - **request_setting** (Block Set) (see [below for nested schema](#nestedblock--request_setting))
 - **response_object** (Block Set) (see [below for nested schema](#nestedblock--response_object))
-- **reuse** (Boolean) Services that are active cannot be destroyed. This will cause the service to be deactivated allowing it to be reused by importing it into another Terraform project. Default `false`
+- **reuse** (Boolean) Services that are active cannot be destroyed. If set to `true` a service Terraform intends to destroy will instead be deactivated (allowing it to be reused by importing it into another Terraform project). If `false`, attempting to destroy an active service will cause an error. Default `false`
 - **snippet** (Block Set) (see [below for nested schema](#nestedblock--snippet))
 - **stale_if_error** (Boolean) Enables serving a stale object if there is an error
 - **stale_if_error_ttl** (Number) The default time-to-live (TTL) for serving the stale object for the version

--- a/fastly/base_fastly_service.go
+++ b/fastly/base_fastly_service.go
@@ -126,15 +126,17 @@ func resourceService(serviceDef ServiceDefinition) *schema.Resource {
 			},
 
 			"force_destroy": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Description: "Services that are active cannot be destroyed. In order to destroy the Service, set `force_destroy` to `true`. Default `false`",
+				Type:          schema.TypeBool,
+				Optional:      true,
+				Description:   "Services that are active cannot be destroyed. In order to destroy the Service, set `force_destroy` to `true`. Default `false`",
+				ConflictsWith: []string{"reuse"},
 			},
 
 			"reuse": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Description: "Services that are active cannot be destroyed. If set to `true` a service Terraform intends to destroy will instead be deactivated (allowing it to be reused by importing it into another Terraform project). If `false`, attempting to destroy an active service will cause an error. Default `false`",
+				Type:          schema.TypeBool,
+				Optional:      true,
+				Description:   "Services that are active cannot be destroyed. If set to `true` a service Terraform intends to destroy will instead be deactivated (allowing it to be reused by importing it into another Terraform project). If `false`, attempting to destroy an active service will cause an error. Default `false`",
+				ConflictsWith: []string{"force_destroy"},
 			},
 		},
 	}

--- a/fastly/base_fastly_service.go
+++ b/fastly/base_fastly_service.go
@@ -555,9 +555,6 @@ func resourceServiceDelete(_ context.Context, d *schema.ResourceData, meta inter
 		if err != nil {
 			return diag.FromErr(err)
 		}
-
-		d.SetId(d.Id())
-		return diag.FromErr(errors.New("don't delete the resource"))
 	}
 
 	return nil

--- a/fastly/base_fastly_service.go
+++ b/fastly/base_fastly_service.go
@@ -134,7 +134,7 @@ func resourceService(serviceDef ServiceDefinition) *schema.Resource {
 			"reuse": {
 				Type:        schema.TypeBool,
 				Optional:    true,
-				Description: "Services that are active cannot be destroyed. This will cause the service to be deactivated allowing it to be reused by importing it into another Terraform project. Default `false`",
+				Description: "Services that are active cannot be destroyed. If set to `true` a service Terraform intends to destroy will instead be deactivated (allowing it to be reused by importing it into another Terraform project). If `false`, attempting to destroy an active service will cause an error. Default `false`",
 			},
 		},
 	}
@@ -222,7 +222,6 @@ func resourceServiceCreate(ctx context.Context, d *schema.ResourceData, meta int
 		Comment: d.Get("comment").(string),
 		Type:    serviceDef.GetType(),
 	})
-
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -359,7 +358,6 @@ func resourceServiceUpdate(ctx context.Context, d *schema.ResourceData, meta int
 			ServiceID:      d.Id(),
 			ServiceVersion: latestVersion,
 		})
-
 		if err != nil {
 			return diag.Errorf("[ERR] Error checking validation: %s", err)
 		}
@@ -499,7 +497,6 @@ func resourceServiceRead(ctx context.Context, d *schema.ResourceData, meta inter
 	// have an empty ActiveService version (no version is active, so we can't
 	// query for information on it).
 	if s.ActiveVersion.Number != 0 {
-
 		// This delegates read to all the attribute handlers which can then manage reading state for
 		// their own attributes.
 		for _, a := range serviceDef.GetAttributeHandler() {


### PR DESCRIPTION
Fixes #515

**Summary**: add `reuse` attribute to `fastly_service_compute` and `fastly_service_vcl` that causes `terraform destroy` to not fully delete the service.

See my notes for the full details and my manual validation of this change set, and the various caveats:
https://github.com/fastly/terraform-provider-fastly/issues/515#issuecomment-1172187386

**NOTE**: I've manually tested this feature, and found it to work (see [comment](https://github.com/fastly/terraform-provider-fastly/issues/515#issuecomment-1172187386)) but there are no tests written because the Terraform test framework expects resources to be destroyed at the end of each e2e test, and this PR implements a feature that sits outside that scenario, and so any test we write would fail unless written in a really janky way and additionally we'd need to implement a post-test process to then clean-up the service resource that was set to persist being destroyed.

**Flow Examples**

- `terraform destroy`: service not activated
  - no attributes set == delete service API call (successful)
  - `force_destroy` == no deactivation service API call, delete service API call (successful)
  - `reuse` == no deactivation service API call, no delete service API call (basically a no-op)
- `terraform destroy`: service activated
  - no attributes set == delete service API call (fails -- as I can't delete an active service without deactivating first)
  - `force_destroy` == deactivate service API call (successful), delete service API call (successful)
  - `reuse` == deactivate service API call (successful)