### PR TITLE
Splunk token required

### DIFF
--- a/docs/resources/service_compute.md
+++ b/docs/resources/service_compute.md
@@ -595,6 +595,7 @@ Optional:
 Required:
 
 - **name** (String) A unique name to identify the Splunk endpoint. It is important to note that changing this attribute will delete and recreate the resource
+- **token** (String, Sensitive) The Splunk token to be used for authentication
 - **url** (String) The Splunk URL to stream logs to
 
 Optional:
@@ -603,7 +604,6 @@ Optional:
 - **tls_client_cert** (String) The client certificate used to make authenticated requests. Must be in PEM format.
 - **tls_client_key** (String, Sensitive) The client private key used to make authenticated requests. Must be in PEM format.
 - **tls_hostname** (String) The hostname used to verify the server's certificate. It can either be the Common Name or a Subject Alternative Name (SAN)
-- **token** (String, Sensitive) The Splunk token to be used for authentication
 - **use_tls** (Boolean) Whether to use TLS for secure logging. Default: `false`
 
 

--- a/docs/resources/service_vcl.md
+++ b/docs/resources/service_vcl.md
@@ -1009,6 +1009,7 @@ Optional:
 Required:
 
 - **name** (String) A unique name to identify the Splunk endpoint. It is important to note that changing this attribute will delete and recreate the resource
+- **token** (String, Sensitive) The Splunk token to be used for authentication
 - **url** (String) The Splunk URL to stream logs to
 
 Optional:
@@ -1021,7 +1022,6 @@ Optional:
 - **tls_client_cert** (String) The client certificate used to make authenticated requests. Must be in PEM format.
 - **tls_client_key** (String, Sensitive) The client private key used to make authenticated requests. Must be in PEM format.
 - **tls_hostname** (String) The hostname used to verify the server's certificate. It can either be the Common Name or a Subject Alternative Name (SAN)
-- **token** (String, Sensitive) The Splunk token to be used for authentication
 - **use_tls** (Boolean) Whether to use TLS for secure logging. Default: `false`
 
 

--- a/fastly/block_fastly_service_logging_splunk.go
+++ b/fastly/block_fastly_service_logging_splunk.go
@@ -25,7 +25,7 @@ func NewServiceLoggingSplunk(sa ServiceMetadata) ServiceAttributeDefinition {
 func (h *SplunkServiceAttributeHandler) Key() string { return h.key }
 
 func (h *SplunkServiceAttributeHandler) GetSchema() *schema.Schema {
-	var blockAttributes = map[string]*schema.Schema{
+	blockAttributes := map[string]*schema.Schema{
 		// Required fields
 		"name": {
 			Type:        schema.TypeString,
@@ -40,7 +40,7 @@ func (h *SplunkServiceAttributeHandler) GetSchema() *schema.Schema {
 		"token": {
 			Type:        schema.TypeString,
 			Required:    true,
-			DefaultFunc: schema.EnvDefaultFunc("FASTLY_SPLUNK_TOKEN", ""),
+			DefaultFunc: schema.EnvDefaultFunc("FASTLY_SPLUNK_TOKEN", nil),
 			Description: "The Splunk token to be used for authentication",
 			Sensitive:   true,
 		},
@@ -113,9 +113,8 @@ func (h *SplunkServiceAttributeHandler) GetSchema() *schema.Schema {
 	}
 }
 
-func (h *SplunkServiceAttributeHandler) Create(_ context.Context, d *schema.ResourceData, resource map[string]interface {
-}, serviceVersion int, conn *gofastly.Client) error {
-	var vla = h.getVCLLoggingAttributes(resource)
+func (h *SplunkServiceAttributeHandler) Create(_ context.Context, d *schema.ResourceData, resource map[string]interface{}, serviceVersion int, conn *gofastly.Client) error {
+	vla := h.getVCLLoggingAttributes(resource)
 	opts := gofastly.CreateSplunkInput{
 		ServiceID:         d.Id(),
 		ServiceVersion:    serviceVersion,
@@ -147,7 +146,6 @@ func (h *SplunkServiceAttributeHandler) Read(_ context.Context, d *schema.Resour
 		ServiceID:      d.Id(),
 		ServiceVersion: serviceVersion,
 	})
-
 	if err != nil {
 		return fmt.Errorf("[ERR] Error looking up Splunks for (%s), version (%v): %s", d.Id(), serviceVersion, err)
 	}
@@ -164,8 +162,7 @@ func (h *SplunkServiceAttributeHandler) Read(_ context.Context, d *schema.Resour
 	return nil
 }
 
-func (h *SplunkServiceAttributeHandler) Update(_ context.Context, d *schema.ResourceData, resource, modified map[string]interface {
-}, serviceVersion int, conn *gofastly.Client) error {
+func (h *SplunkServiceAttributeHandler) Update(_ context.Context, d *schema.ResourceData, resource, modified map[string]interface{}, serviceVersion int, conn *gofastly.Client) error {
 	opts := gofastly.UpdateSplunkInput{
 		ServiceID:      d.Id(),
 		ServiceVersion: serviceVersion,
@@ -225,8 +222,7 @@ func (h *SplunkServiceAttributeHandler) Update(_ context.Context, d *schema.Reso
 	return nil
 }
 
-func (h *SplunkServiceAttributeHandler) Delete(_ context.Context, d *schema.ResourceData, resource map[string]interface {
-}, serviceVersion int, conn *gofastly.Client) error {
+func (h *SplunkServiceAttributeHandler) Delete(_ context.Context, d *schema.ResourceData, resource map[string]interface{}, serviceVersion int, conn *gofastly.Client) error {
 	opts := gofastly.DeleteSplunkInput{
 		ServiceID:      d.Id(),
 		ServiceVersion: serviceVersion,

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 require (
 	github.com/bflad/tfproviderlint v0.27.1
-	github.com/fastly/go-fastly/v6 v6.4.0
+	github.com/fastly/go-fastly/v6 v6.4.3
 	github.com/google/go-cmp v0.5.6
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/terraform-plugin-docs v0.5.0

--- a/go.sum
+++ b/go.sum
@@ -103,8 +103,8 @@ github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymF
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
-github.com/fastly/go-fastly/v6 v6.4.0 h1:w3BO8QSpaVDIz/30/xgLdVwDS/sjr1L8nKwXzUuQUqQ=
-github.com/fastly/go-fastly/v6 v6.4.0/go.mod h1:NrIbx45etTFv35rgfRe+eQY+8kA47arWABIkOaQ+roY=
+github.com/fastly/go-fastly/v6 v6.4.3 h1:WjPfPuePYiFxIg6dZ6w1LdmZvKWhQEzOdAYzZ7f+41M=
+github.com/fastly/go-fastly/v6 v6.4.3/go.mod h1:NrIbx45etTFv35rgfRe+eQY+8kA47arWABIkOaQ+roY=
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=

--- a/vendor/github.com/fastly/go-fastly/v6/fastly/client.go
+++ b/vendor/github.com/fastly/go-fastly/v6/fastly/client.go
@@ -48,7 +48,7 @@ const DefaultRealtimeStatsEndpoint = "https://rt.fastly.com"
 var ProjectURL = "github.com/fastly/go-fastly"
 
 // ProjectVersion is the version of this library.
-var ProjectVersion = "6.4.0"
+var ProjectVersion = "6.4.3"
 
 // UserAgent is the user agent for this particular client.
 var UserAgent = fmt.Sprintf("FastlyGo/%s (+%s; %s)",

--- a/vendor/github.com/fastly/go-fastly/v6/fastly/datadog.go
+++ b/vendor/github.com/fastly/go-fastly/v6/fastly/datadog.go
@@ -94,6 +94,10 @@ func (c *Client) CreateDatadog(i *CreateDatadogInput) (*Datadog, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
+	if i.Token == "" {
+		return nil, ErrMissingToken
+	}
+
 	path := fmt.Sprintf("/service/%s/version/%d/logging/datadog", i.ServiceID, i.ServiceVersion)
 	resp, err := c.PostForm(path, i, nil)
 	if err != nil {
@@ -178,6 +182,10 @@ func (c *Client) UpdateDatadog(i *UpdateDatadogInput) (*Datadog, error) {
 
 	if i.Name == "" {
 		return nil, ErrMissingName
+	}
+
+	if i.Token != nil && *i.Token == "" {
+		return nil, ErrTokenEmpty
 	}
 
 	path := fmt.Sprintf("/service/%s/version/%d/logging/datadog/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))

--- a/vendor/github.com/fastly/go-fastly/v6/fastly/errors.go
+++ b/vendor/github.com/fastly/go-fastly/v6/fastly/errors.go
@@ -45,6 +45,12 @@ func NewFieldError(kind string) *FieldError {
 	}
 }
 
+const emptyTokenInvalid string = "the token value cannot be empty"
+
+// ErrTokenEmpty is an error that is returned when an input struct
+// specifies an "Token" key value which the user has set to an empty string.
+var ErrTokenEmpty = NewFieldError("Token").Message(emptyTokenInvalid)
+
 const batchModifyMaxExceeded string = "batch modify maximum operations exceeded"
 
 // ErrMaxExceededEntries is an error that is returned when an input struct
@@ -268,6 +274,10 @@ var ErrNotImplemented = errors.New("not implemented")
 // ErrManagedLoggingEnabled is an error that indicates that managed logging was
 // already enabled for a service.
 var ErrManagedLoggingEnabled = errors.New("managed logging already enabled")
+
+// ErrMissingToken is an error that is returned when an input struct
+// requires a "Token" key, but one was not set.
+var ErrMissingToken = NewFieldError("Token")
 
 // Ensure HTTPError is, in fact, an error.
 var _ error = (*HTTPError)(nil)

--- a/vendor/github.com/fastly/go-fastly/v6/fastly/honeycomb.go
+++ b/vendor/github.com/fastly/go-fastly/v6/fastly/honeycomb.go
@@ -94,6 +94,10 @@ func (c *Client) CreateHoneycomb(i *CreateHoneycombInput) (*Honeycomb, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
+	if i.Token == "" {
+		return nil, ErrMissingToken
+	}
+
 	path := fmt.Sprintf("/service/%s/version/%d/logging/honeycomb", i.ServiceID, i.ServiceVersion)
 	resp, err := c.PostForm(path, i, nil)
 	if err != nil {
@@ -178,6 +182,10 @@ func (c *Client) UpdateHoneycomb(i *UpdateHoneycombInput) (*Honeycomb, error) {
 
 	if i.Name == "" {
 		return nil, ErrMissingName
+	}
+
+	if i.Token != nil && *i.Token == "" {
+		return nil, ErrTokenEmpty
 	}
 
 	path := fmt.Sprintf("/service/%s/version/%d/logging/honeycomb/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))

--- a/vendor/github.com/fastly/go-fastly/v6/fastly/newrelic.go
+++ b/vendor/github.com/fastly/go-fastly/v6/fastly/newrelic.go
@@ -94,6 +94,10 @@ func (c *Client) CreateNewRelic(i *CreateNewRelicInput) (*NewRelic, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
+	if i.Token == "" {
+		return nil, ErrMissingToken
+	}
+
 	path := fmt.Sprintf("/service/%s/version/%d/logging/newrelic", i.ServiceID, i.ServiceVersion)
 	resp, err := c.PostForm(path, i, nil)
 	if err != nil {
@@ -178,6 +182,10 @@ func (c *Client) UpdateNewRelic(i *UpdateNewRelicInput) (*NewRelic, error) {
 
 	if i.Name == "" {
 		return nil, ErrMissingName
+	}
+
+	if i.Token != nil && *i.Token == "" {
+		return nil, ErrTokenEmpty
 	}
 
 	path := fmt.Sprintf("/service/%s/version/%d/logging/newrelic/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))

--- a/vendor/github.com/fastly/go-fastly/v6/fastly/scalyr.go
+++ b/vendor/github.com/fastly/go-fastly/v6/fastly/scalyr.go
@@ -94,6 +94,10 @@ func (c *Client) CreateScalyr(i *CreateScalyrInput) (*Scalyr, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
+	if i.Token == "" {
+		return nil, ErrMissingToken
+	}
+
 	path := fmt.Sprintf("/service/%s/version/%d/logging/scalyr", i.ServiceID, i.ServiceVersion)
 	resp, err := c.PostForm(path, i, nil)
 	if err != nil {
@@ -178,6 +182,10 @@ func (c *Client) UpdateScalyr(i *UpdateScalyrInput) (*Scalyr, error) {
 
 	if i.Name == "" {
 		return nil, ErrMissingName
+	}
+
+	if i.Token != nil && *i.Token == "" {
+		return nil, ErrTokenEmpty
 	}
 
 	path := fmt.Sprintf("/service/%s/version/%d/logging/scalyr/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))

--- a/vendor/github.com/fastly/go-fastly/v6/fastly/splunk.go
+++ b/vendor/github.com/fastly/go-fastly/v6/fastly/splunk.go
@@ -108,6 +108,10 @@ func (c *Client) CreateSplunk(i *CreateSplunkInput) (*Splunk, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
+	if i.Token == "" {
+		return nil, ErrMissingToken
+	}
+
 	path := fmt.Sprintf("/service/%s/version/%d/logging/splunk", i.ServiceID, i.ServiceVersion)
 	resp, err := c.PostForm(path, i, nil)
 	if err != nil {
@@ -199,6 +203,10 @@ func (c *Client) UpdateSplunk(i *UpdateSplunkInput) (*Splunk, error) {
 
 	if i.Name == "" {
 		return nil, ErrMissingName
+	}
+
+	if i.Token != nil && *i.Token == "" {
+		return nil, ErrTokenEmpty
 	}
 
 	path := fmt.Sprintf("/service/%s/version/%d/logging/splunk/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -249,7 +249,7 @@ github.com/bgentry/speakeasy
 # github.com/davecgh/go-spew v1.1.1
 ## explicit
 github.com/davecgh/go-spew/spew
-# github.com/fastly/go-fastly/v6 v6.4.0
+# github.com/fastly/go-fastly/v6 v6.4.3
 ## explicit; go 1.16
 github.com/fastly/go-fastly/v6/fastly
 # github.com/fatih/color v1.7.0


### PR DESCRIPTION
Fixes https://github.com/fastly/terraform-provider-fastly/issues/577

**NOTES**: The customer initially reported the Fastly API was returning an ambiguous error. The error messaging was intentional as the API internals are sharing an implementation across multiple types, which means the error had to be generic in wording. 

To help avoid confusion a new version of go-fastly was released (v6.4.3) with additional checks for the `Token` field. This PR bumps the go-fastly dependency to the new version.

I then also noticed a bug in the Terraform provider where the use of `schema.EnvDefaultFunc` meant that if no environment variable (i.e. `FASTLY_SPLUNK_TOKEN`) had been set, then an empty string would be used. Returning an empty string causes Terraform to use the value as the fallback and sends the empty string to go-fastly. 

Instead of an empty string, if the helper function returned `nil`, then Terraform would enforce the 'required field' behaviour on the `Token` attribute and would prompt the user to add a value to their HCL configuration. Thus avoiding having to even call out to go-fastly (only for go-fastly's new check for a token value to fail).