### PR TITLE
Reduce unnecessary API calls

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ TEST_PARALLELISM?=4
 
 default: build
 
-build:
+build: clean
 	go build -o bin/terraform-provider-$(PKG_NAME)_$(VERSION) -ldflags="-X $(FULL_PKG_NAME)/$(VERSION_PLACEHOLDER)=$(VERSION)"
 	@sh -c "'$(CURDIR)/scripts/generate-dev-overrides.sh'"
 

--- a/docs/resources/service_compute.md
+++ b/docs/resources/service_compute.md
@@ -112,6 +112,7 @@ $ terraform import fastly_service_compute.demo xxxxxxxxxxxxxxxxxxxx@2
 
 - **active_version** (Number) The currently active version of your Fastly Service
 - **cloned_version** (Number) The latest cloned version by the provider
+- **imported** (Boolean) Used internally by the provider to temporarily indicate if the service is being imported, and is reset to false once the import is finished
 
 <a id="nestedblock--domain"></a>
 ### Nested Schema for `domain`

--- a/docs/resources/service_vcl.md
+++ b/docs/resources/service_vcl.md
@@ -295,6 +295,7 @@ $ terraform import fastly_service_vcl.demo xxxxxxxxxxxxxxxxxxxx@2
 
 - **active_version** (Number) The currently active version of your Fastly Service
 - **cloned_version** (Number) The latest cloned version by the provider
+- **imported** (Boolean) Used internally by the provider to temporarily indicate if the service is being imported, and is reset to false once the import is finished
 
 <a id="nestedblock--domain"></a>
 ### Nested Schema for `domain`

--- a/fastly/base_fastly_service.go
+++ b/fastly/base_fastly_service.go
@@ -406,6 +406,8 @@ func resourceServiceUpdate(ctx context.Context, d *schema.ResourceData, meta int
 
 // resourceServiceRead provides service resource Read functionality.
 func resourceServiceRead(ctx context.Context, d *schema.ResourceData, meta interface{}, serviceDef ServiceDefinition) diag.Diagnostics {
+	log.Printf("[DEBUG] Refreshing Service Configuration for (%s)", d.Id())
+
 	conn := meta.(*APIClient).conn
 
 	var diags diag.Diagnostics

--- a/fastly/block_fastly_service_acl.go
+++ b/fastly/block_fastly_service_acl.go
@@ -77,7 +77,7 @@ func (h *ACLServiceAttributeHandler) Create(_ context.Context, d *schema.Resourc
 func (h *ACLServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, _ map[string]interface{}, latestVersion int, conn *gofastly.Client) error {
 	resources := d.Get(h.Key()).(*schema.Set).List()
 
-	if len(resources) > 0 {
+	if len(resources) > 0 || d.Get("imported").(bool) {
 		log.Printf("[DEBUG] Refreshing ACLs for (%s)", d.Id())
 		aclList, err := conn.ListACLs(&gofastly.ListACLsInput{
 			ServiceID:      d.Id(),

--- a/fastly/block_fastly_service_backend.go
+++ b/fastly/block_fastly_service_backend.go
@@ -220,7 +220,7 @@ func (h *BackendServiceAttributeHandler) Create(_ context.Context, d *schema.Res
 func (h *BackendServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, _ map[string]interface{}, serviceVersion int, conn *gofastly.Client) error {
 	resources := d.Get(h.GetKey()).(*schema.Set).List()
 
-	if len(resources) > 0 {
+	if len(resources) > 0 || d.Get("imported").(bool) {
 		log.Printf("[DEBUG] Refreshing Backends for (%s)", d.Id())
 		backendList, err := conn.ListBackends(&gofastly.ListBackendsInput{
 			ServiceID:      d.Id(),

--- a/fastly/block_fastly_service_cachesetting.go
+++ b/fastly/block_fastly_service_cachesetting.go
@@ -92,7 +92,7 @@ func (h *CacheSettingServiceAttributeHandler) Create(_ context.Context, d *schem
 func (h *CacheSettingServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, _ map[string]interface{}, serviceVersion int, conn *gofastly.Client) error {
 	resources := d.Get(h.GetKey()).(*schema.Set).List()
 
-	if len(resources) > 0 {
+	if len(resources) > 0 || d.Get("imported").(bool) {
 		log.Printf("[DEBUG] Refreshing Cache Settings for (%s)", d.Id())
 		cslList, err := conn.ListCacheSettings(&gofastly.ListCacheSettingsInput{
 			ServiceID:      d.Id(),

--- a/fastly/block_fastly_service_condition.go
+++ b/fastly/block_fastly_service_condition.go
@@ -89,7 +89,7 @@ func (h *ConditionServiceAttributeHandler) Create(_ context.Context, d *schema.R
 func (h *ConditionServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, _ map[string]interface{}, serviceVersion int, conn *gofastly.Client) error {
 	resources := d.Get(h.GetKey()).(*schema.Set).List()
 
-	if len(resources) > 0 {
+	if len(resources) > 0 || d.Get("imported").(bool) {
 		log.Printf("[DEBUG] Refreshing Conditions for (%s)", d.Id())
 		conditionList, err := conn.ListConditions(&gofastly.ListConditionsInput{
 			ServiceID:      d.Id(),

--- a/fastly/block_fastly_service_condition.go
+++ b/fastly/block_fastly_service_condition.go
@@ -87,20 +87,25 @@ func (h *ConditionServiceAttributeHandler) Create(_ context.Context, d *schema.R
 
 // Read refreshes the resource.
 func (h *ConditionServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, _ map[string]interface{}, serviceVersion int, conn *gofastly.Client) error {
-	log.Printf("[DEBUG] Refreshing Conditions for (%s)", d.Id())
-	conditionList, err := conn.ListConditions(&gofastly.ListConditionsInput{
-		ServiceID:      d.Id(),
-		ServiceVersion: serviceVersion,
-	})
-	if err != nil {
-		return fmt.Errorf("error looking up Conditions for (%s), version (%v): %s", d.Id(), serviceVersion, err)
+	resources := d.Get(h.GetKey()).(*schema.Set).List()
+
+	if len(resources) > 0 {
+		log.Printf("[DEBUG] Refreshing Conditions for (%s)", d.Id())
+		conditionList, err := conn.ListConditions(&gofastly.ListConditionsInput{
+			ServiceID:      d.Id(),
+			ServiceVersion: serviceVersion,
+		})
+		if err != nil {
+			return fmt.Errorf("error looking up Conditions for (%s), version (%v): %s", d.Id(), serviceVersion, err)
+		}
+
+		cl := flattenConditions(conditionList)
+
+		if err := d.Set(h.GetKey(), cl); err != nil {
+			log.Printf("[WARN] Error setting Conditions for (%s): %s", d.Id(), err)
+		}
 	}
 
-	cl := flattenConditions(conditionList)
-
-	if err := d.Set(h.GetKey(), cl); err != nil {
-		log.Printf("[WARN] Error setting Conditions for (%s): %s", d.Id(), err)
-	}
 	return nil
 }
 

--- a/fastly/block_fastly_service_dictionary.go
+++ b/fastly/block_fastly_service_dictionary.go
@@ -87,7 +87,7 @@ func (h *DictionaryServiceAttributeHandler) Create(_ context.Context, d *schema.
 func (h *DictionaryServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, _ map[string]interface{}, serviceVersion int, conn *gofastly.Client) error {
 	resources := d.Get(h.GetKey()).(*schema.Set).List()
 
-	if len(resources) > 0 {
+	if len(resources) > 0 || d.Get("imported").(bool) {
 		log.Printf("[DEBUG] Refreshing Dictionaries for (%s)", d.Id())
 		dictList, err := conn.ListDictionaries(&gofastly.ListDictionariesInput{
 			ServiceID:      d.Id(),

--- a/fastly/block_fastly_service_director.go
+++ b/fastly/block_fastly_service_director.go
@@ -140,7 +140,7 @@ func (h *DirectorServiceAttributeHandler) Create(_ context.Context, d *schema.Re
 func (h *DirectorServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, _ map[string]interface{}, serviceVersion int, conn *gofastly.Client) error {
 	resources := d.Get(h.GetKey()).(*schema.Set).List()
 
-	if len(resources) > 0 {
+	if len(resources) > 0 || d.Get("imported").(bool) {
 		log.Printf("[DEBUG] Refreshing Directors for (%s)", d.Id())
 		directorList, err := conn.ListDirectors(&gofastly.ListDirectorsInput{
 			ServiceID:      d.Id(),

--- a/fastly/block_fastly_service_director.go
+++ b/fastly/block_fastly_service_director.go
@@ -138,19 +138,23 @@ func (h *DirectorServiceAttributeHandler) Create(_ context.Context, d *schema.Re
 
 // Read refreshes the resource state.
 func (h *DirectorServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, _ map[string]interface{}, serviceVersion int, conn *gofastly.Client) error {
-	log.Printf("[DEBUG] Refreshing Directors for (%s)", d.Id())
-	directorList, err := conn.ListDirectors(&gofastly.ListDirectorsInput{
-		ServiceID:      d.Id(),
-		ServiceVersion: serviceVersion,
-	})
-	if err != nil {
-		return fmt.Errorf("error looking up Directors for (%s), version (%v): %s", d.Id(), serviceVersion, err)
-	}
+	resources := d.Get(h.GetKey()).(*schema.Set).List()
 
-	dirl := flattenDirectors(directorList)
+	if len(resources) > 0 {
+		log.Printf("[DEBUG] Refreshing Directors for (%s)", d.Id())
+		directorList, err := conn.ListDirectors(&gofastly.ListDirectorsInput{
+			ServiceID:      d.Id(),
+			ServiceVersion: serviceVersion,
+		})
+		if err != nil {
+			return fmt.Errorf("error looking up Directors for (%s), version (%v): %s", d.Id(), serviceVersion, err)
+		}
 
-	if err := d.Set(h.GetKey(), dirl); err != nil {
-		log.Printf("[WARN] Error setting Directors for (%s): %s", d.Id(), err)
+		dirl := flattenDirectors(directorList)
+
+		if err := d.Set(h.GetKey(), dirl); err != nil {
+			log.Printf("[WARN] Error setting Directors for (%s): %s", d.Id(), err)
+		}
 	}
 
 	return nil

--- a/fastly/block_fastly_service_domain.go
+++ b/fastly/block_fastly_service_domain.go
@@ -77,7 +77,7 @@ func (h *DomainServiceAttributeHandler) Create(_ context.Context, d *schema.Reso
 func (h *DomainServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, _ map[string]interface{}, serviceVersion int, conn *gofastly.Client) error {
 	resources := d.Get(h.GetKey()).(*schema.Set).List()
 
-	if len(resources) > 0 {
+	if len(resources) > 0 || d.Get("imported").(bool) {
 		// TODO: update go-fastly to support an ActiveVersion struct, which contains
 		// domain and backend info in the response. Here we do 2 additional queries
 		// to find out that info

--- a/fastly/block_fastly_service_domain.go
+++ b/fastly/block_fastly_service_domain.go
@@ -75,24 +75,29 @@ func (h *DomainServiceAttributeHandler) Create(_ context.Context, d *schema.Reso
 
 // Read refreshes the resource.
 func (h *DomainServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, _ map[string]interface{}, serviceVersion int, conn *gofastly.Client) error {
-	// TODO: update go-fastly to support an ActiveVersion struct, which contains
-	// domain and backend info in the response. Here we do 2 additional queries
-	// to find out that info
-	log.Printf("[DEBUG] Refreshing Domains for (%s)", d.Id())
-	domainList, err := conn.ListDomains(&gofastly.ListDomainsInput{
-		ServiceID:      d.Id(),
-		ServiceVersion: serviceVersion,
-	})
-	if err != nil {
-		return fmt.Errorf("error looking up Domains for (%s), version (%v): %s", d.Id(), serviceVersion, err)
+	resources := d.Get(h.GetKey()).(*schema.Set).List()
+
+	if len(resources) > 0 {
+		// TODO: update go-fastly to support an ActiveVersion struct, which contains
+		// domain and backend info in the response. Here we do 2 additional queries
+		// to find out that info
+		log.Printf("[DEBUG] Refreshing Domains for (%s)", d.Id())
+		domainList, err := conn.ListDomains(&gofastly.ListDomainsInput{
+			ServiceID:      d.Id(),
+			ServiceVersion: serviceVersion,
+		})
+		if err != nil {
+			return fmt.Errorf("error looking up Domains for (%s), version (%v): %s", d.Id(), serviceVersion, err)
+		}
+
+		// Refresh Domains
+		dl := flattenDomains(domainList)
+
+		if err := d.Set(h.GetKey(), dl); err != nil {
+			log.Printf("[WARN] Error setting Domains for (%s): %s", d.Id(), err)
+		}
 	}
 
-	// Refresh Domains
-	dl := flattenDomains(domainList)
-
-	if err := d.Set(h.GetKey(), dl); err != nil {
-		log.Printf("[WARN] Error setting Domains for (%s): %s", d.Id(), err)
-	}
 	return nil
 }
 

--- a/fastly/block_fastly_service_dynamicsnippet.go
+++ b/fastly/block_fastly_service_dynamicsnippet.go
@@ -86,7 +86,7 @@ func (h *DynamicSnippetServiceAttributeHandler) Create(_ context.Context, d *sch
 func (h *DynamicSnippetServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, _ map[string]interface{}, serviceVersion int, conn *gofastly.Client) error {
 	resources := d.Get(h.GetKey()).(*schema.Set).List()
 
-	if len(resources) > 0 {
+	if len(resources) > 0 || d.Get("imported").(bool) {
 		log.Printf("[DEBUG] Refreshing VCL Snippets for (%s)", d.Id())
 		snippetList, err := conn.ListSnippets(&gofastly.ListSnippetsInput{
 			ServiceID:      d.Id(),

--- a/fastly/block_fastly_service_dynamicsnippet.go
+++ b/fastly/block_fastly_service_dynamicsnippet.go
@@ -84,18 +84,22 @@ func (h *DynamicSnippetServiceAttributeHandler) Create(_ context.Context, d *sch
 
 // Read refreshes the resource.
 func (h *DynamicSnippetServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, _ map[string]interface{}, serviceVersion int, conn *gofastly.Client) error {
-	log.Printf("[DEBUG] Refreshing VCL Snippets for (%s)", d.Id())
-	snippetList, err := conn.ListSnippets(&gofastly.ListSnippetsInput{
-		ServiceID:      d.Id(),
-		ServiceVersion: serviceVersion,
-	})
-	if err != nil {
-		return fmt.Errorf("error looking up VCL Snippets for (%s), version (%v): %s", d.Id(), serviceVersion, err)
-	}
+	resources := d.Get(h.GetKey()).(*schema.Set).List()
 
-	dynamicSnippets := flattenDynamicSnippets(snippetList)
-	if err := d.Set(h.GetKey(), dynamicSnippets); err != nil {
-		log.Printf("[WARN] Error setting VCL Dynamic Snippets for (%s): %s", d.Id(), err)
+	if len(resources) > 0 {
+		log.Printf("[DEBUG] Refreshing VCL Snippets for (%s)", d.Id())
+		snippetList, err := conn.ListSnippets(&gofastly.ListSnippetsInput{
+			ServiceID:      d.Id(),
+			ServiceVersion: serviceVersion,
+		})
+		if err != nil {
+			return fmt.Errorf("error looking up VCL Snippets for (%s), version (%v): %s", d.Id(), serviceVersion, err)
+		}
+
+		dynamicSnippets := flattenDynamicSnippets(snippetList)
+		if err := d.Set(h.GetKey(), dynamicSnippets); err != nil {
+			log.Printf("[WARN] Error setting VCL Dynamic Snippets for (%s): %s", d.Id(), err)
+		}
 	}
 
 	return nil

--- a/fastly/block_fastly_service_gzip.go
+++ b/fastly/block_fastly_service_gzip.go
@@ -96,7 +96,7 @@ func (h *GzipServiceAttributeHandler) Create(_ context.Context, d *schema.Resour
 func (h *GzipServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, _ map[string]interface{}, serviceVersion int, conn *gofastly.Client) error {
 	resources := d.Get(h.GetKey()).(*schema.Set).List()
 
-	if len(resources) > 0 {
+	if len(resources) > 0 || d.Get("imported").(bool) {
 		log.Printf("[DEBUG] Refreshing Gzips for (%s)", d.Id())
 		gzipsList, err := conn.ListGzips(&gofastly.ListGzipsInput{
 			ServiceID:      d.Id(),

--- a/fastly/block_fastly_service_gzip.go
+++ b/fastly/block_fastly_service_gzip.go
@@ -94,49 +94,53 @@ func (h *GzipServiceAttributeHandler) Create(_ context.Context, d *schema.Resour
 
 // Read refreshes the resource.
 func (h *GzipServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, _ map[string]interface{}, serviceVersion int, conn *gofastly.Client) error {
-	log.Printf("[DEBUG] Refreshing Gzips for (%s)", d.Id())
-	gzipsList, err := conn.ListGzips(&gofastly.ListGzipsInput{
-		ServiceID:      d.Id(),
-		ServiceVersion: serviceVersion,
-	})
-	if err != nil {
-		return fmt.Errorf("error looking up Gzips for (%s), version (%v): %s", d.Id(), serviceVersion, err)
-	}
+	resources := d.Get(h.GetKey()).(*schema.Set).List()
 
-	gl := flattenGzips(gzipsList)
-
-	// NOTE: Although "content_types" and "extensions" fields are optional in spec,
-	// Fastly API will actually set the default value silently when these fields are not sent
-	// or an empty field value is sent. This will cause unexpected diff.
-	// We need to ignore these fields in the API response unless field values are explicitly set.
-	{
-		type IgnoreFields struct {
-			Name string
-		}
-		ignoreList := map[string][]IgnoreFields{}
-
-		for _, elem := range d.Get("gzip").(*schema.Set).List() {
-			m := elem.(map[string]interface{})
-			name := m["name"].(string)
-			if len(m["content_types"].([]interface{})) == 0 {
-				ignoreList[name] = append(ignoreList[name], IgnoreFields{Name: "content_types"})
-			}
-			if len(m["extensions"].([]interface{})) == 0 {
-				ignoreList[name] = append(ignoreList[name], IgnoreFields{Name: "extensions"})
-			}
+	if len(resources) > 0 {
+		log.Printf("[DEBUG] Refreshing Gzips for (%s)", d.Id())
+		gzipsList, err := conn.ListGzips(&gofastly.ListGzipsInput{
+			ServiceID:      d.Id(),
+			ServiceVersion: serviceVersion,
+		})
+		if err != nil {
+			return fmt.Errorf("error looking up Gzips for (%s), version (%v): %s", d.Id(), serviceVersion, err)
 		}
 
-		for i, g := range gl {
-			if v, ok := ignoreList[g["name"].(string)]; ok && len(v) > 0 {
-				for _, sl := range v {
-					gl[i][sl.Name] = nil
+		gl := flattenGzips(gzipsList)
+
+		// NOTE: Although "content_types" and "extensions" fields are optional in spec,
+		// Fastly API will actually set the default value silently when these fields are not sent
+		// or an empty field value is sent. This will cause unexpected diff.
+		// We need to ignore these fields in the API response unless field values are explicitly set.
+		{
+			type IgnoreFields struct {
+				Name string
+			}
+			ignoreList := map[string][]IgnoreFields{}
+
+			for _, elem := range d.Get("gzip").(*schema.Set).List() {
+				m := elem.(map[string]interface{})
+				name := m["name"].(string)
+				if len(m["content_types"].([]interface{})) == 0 {
+					ignoreList[name] = append(ignoreList[name], IgnoreFields{Name: "content_types"})
+				}
+				if len(m["extensions"].([]interface{})) == 0 {
+					ignoreList[name] = append(ignoreList[name], IgnoreFields{Name: "extensions"})
+				}
+			}
+
+			for i, g := range gl {
+				if v, ok := ignoreList[g["name"].(string)]; ok && len(v) > 0 {
+					for _, sl := range v {
+						gl[i][sl.Name] = nil
+					}
 				}
 			}
 		}
-	}
 
-	if err := d.Set(h.GetKey(), gl); err != nil {
-		log.Printf("[WARN] Error setting Gzips for (%s): %s", d.Id(), err)
+		if err := d.Set(h.GetKey(), gl); err != nil {
+			log.Printf("[WARN] Error setting Gzips for (%s): %s", d.Id(), err)
+		}
 	}
 
 	return nil

--- a/fastly/block_fastly_service_header.go
+++ b/fastly/block_fastly_service_header.go
@@ -134,19 +134,23 @@ func (h *HeaderServiceAttributeHandler) Create(_ context.Context, d *schema.Reso
 
 // Read refreshes the resource.
 func (h *HeaderServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, _ map[string]interface{}, serviceVersion int, conn *gofastly.Client) error {
-	log.Printf("[DEBUG] Refreshing Headers for (%s)", d.Id())
-	headerList, err := conn.ListHeaders(&gofastly.ListHeadersInput{
-		ServiceID:      d.Id(),
-		ServiceVersion: serviceVersion,
-	})
-	if err != nil {
-		return fmt.Errorf("error looking up Headers for (%s), version (%v): %s", d.Id(), serviceVersion, err)
-	}
+	resources := d.Get(h.GetKey()).(*schema.Set).List()
 
-	hl := flattenHeaders(headerList)
+	if len(resources) > 0 {
+		log.Printf("[DEBUG] Refreshing Headers for (%s)", d.Id())
+		headerList, err := conn.ListHeaders(&gofastly.ListHeadersInput{
+			ServiceID:      d.Id(),
+			ServiceVersion: serviceVersion,
+		})
+		if err != nil {
+			return fmt.Errorf("error looking up Headers for (%s), version (%v): %s", d.Id(), serviceVersion, err)
+		}
 
-	if err := d.Set(h.GetKey(), hl); err != nil {
-		log.Printf("[WARN] Error setting Headers for (%s): %s", d.Id(), err)
+		hl := flattenHeaders(headerList)
+
+		if err := d.Set(h.GetKey(), hl); err != nil {
+			log.Printf("[WARN] Error setting Headers for (%s): %s", d.Id(), err)
+		}
 	}
 
 	return nil

--- a/fastly/block_fastly_service_header.go
+++ b/fastly/block_fastly_service_header.go
@@ -136,7 +136,7 @@ func (h *HeaderServiceAttributeHandler) Create(_ context.Context, d *schema.Reso
 func (h *HeaderServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, _ map[string]interface{}, serviceVersion int, conn *gofastly.Client) error {
 	resources := d.Get(h.GetKey()).(*schema.Set).List()
 
-	if len(resources) > 0 {
+	if len(resources) > 0 || d.Get("imported").(bool) {
 		log.Printf("[DEBUG] Refreshing Headers for (%s)", d.Id())
 		headerList, err := conn.ListHeaders(&gofastly.ListHeadersInput{
 			ServiceID:      d.Id(),

--- a/fastly/block_fastly_service_healthcheck.go
+++ b/fastly/block_fastly_service_healthcheck.go
@@ -136,7 +136,7 @@ func (h *HealthCheckServiceAttributeHandler) Create(_ context.Context, d *schema
 func (h *HealthCheckServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, _ map[string]interface{}, serviceVersion int, conn *gofastly.Client) error {
 	resources := d.Get(h.GetKey()).(*schema.Set).List()
 
-	if len(resources) > 0 {
+	if len(resources) > 0 || d.Get("imported").(bool) {
 		log.Printf("[DEBUG] Refreshing Healthcheck for (%s)", d.Id())
 		healthcheckList, err := conn.ListHealthChecks(&gofastly.ListHealthChecksInput{
 			ServiceID:      d.Id(),

--- a/fastly/block_fastly_service_logging_bigquery.go
+++ b/fastly/block_fastly_service_logging_bigquery.go
@@ -139,23 +139,27 @@ func (h *BigQueryLoggingServiceAttributeHandler) Create(_ context.Context, d *sc
 
 // Read refreshes the resource.
 func (h *BigQueryLoggingServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, _ map[string]interface{}, serviceVersion int, conn *gofastly.Client) error {
-	log.Printf("[DEBUG] Refreshing BigQuery for (%s)", d.Id())
-	bqs, err := conn.ListBigQueries(&gofastly.ListBigQueriesInput{
-		ServiceID:      d.Id(),
-		ServiceVersion: serviceVersion,
-	})
-	if err != nil {
-		return fmt.Errorf("error looking up BigQuery logging for (%s), version (%v): %s", d.Id(), serviceVersion, err)
-	}
+	resources := d.Get(h.GetKey()).(*schema.Set).List()
 
-	bql := flattenBigQuery(bqs)
+	if len(resources) > 0 {
+		log.Printf("[DEBUG] Refreshing BigQuery for (%s)", d.Id())
+		bqs, err := conn.ListBigQueries(&gofastly.ListBigQueriesInput{
+			ServiceID:      d.Id(),
+			ServiceVersion: serviceVersion,
+		})
+		if err != nil {
+			return fmt.Errorf("error looking up BigQuery logging for (%s), version (%v): %s", d.Id(), serviceVersion, err)
+		}
 
-	for _, element := range bql {
-		h.pruneVCLLoggingAttributes(element)
-	}
+		bql := flattenBigQuery(bqs)
 
-	if err := d.Set(h.GetKey(), bql); err != nil {
-		log.Printf("[WARN] Error setting BigQuery for (%s): %s", d.Id(), err)
+		for _, element := range bql {
+			h.pruneVCLLoggingAttributes(element)
+		}
+
+		if err := d.Set(h.GetKey(), bql); err != nil {
+			log.Printf("[WARN] Error setting BigQuery for (%s): %s", d.Id(), err)
+		}
 	}
 
 	return nil

--- a/fastly/block_fastly_service_logging_bigquery.go
+++ b/fastly/block_fastly_service_logging_bigquery.go
@@ -141,7 +141,7 @@ func (h *BigQueryLoggingServiceAttributeHandler) Create(_ context.Context, d *sc
 func (h *BigQueryLoggingServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, _ map[string]interface{}, serviceVersion int, conn *gofastly.Client) error {
 	resources := d.Get(h.GetKey()).(*schema.Set).List()
 
-	if len(resources) > 0 {
+	if len(resources) > 0 || d.Get("imported").(bool) {
 		log.Printf("[DEBUG] Refreshing BigQuery for (%s)", d.Id())
 		bqs, err := conn.ListBigQueries(&gofastly.ListBigQueriesInput{
 			ServiceID:      d.Id(),

--- a/fastly/block_fastly_service_logging_blobstorage.go
+++ b/fastly/block_fastly_service_logging_blobstorage.go
@@ -175,24 +175,29 @@ func (h *BlobStorageLoggingServiceAttributeHandler) Create(_ context.Context, d 
 
 // Read refreshes the resource.
 func (h *BlobStorageLoggingServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, _ map[string]interface{}, serviceVersion int, conn *gofastly.Client) error {
-	log.Printf("[DEBUG] Refreshing Blob Storages for (%s)", d.Id())
-	blobStorageList, err := conn.ListBlobStorages(&gofastly.ListBlobStoragesInput{
-		ServiceID:      d.Id(),
-		ServiceVersion: serviceVersion,
-	})
-	if err != nil {
-		return fmt.Errorf("error looking up Blob Storages for (%s), version (%v): %s", d.Id(), serviceVersion, err)
+	resources := d.Get(h.GetKey()).(*schema.Set).List()
+
+	if len(resources) > 0 {
+		log.Printf("[DEBUG] Refreshing Blob Storages for (%s)", d.Id())
+		blobStorageList, err := conn.ListBlobStorages(&gofastly.ListBlobStoragesInput{
+			ServiceID:      d.Id(),
+			ServiceVersion: serviceVersion,
+		})
+		if err != nil {
+			return fmt.Errorf("error looking up Blob Storages for (%s), version (%v): %s", d.Id(), serviceVersion, err)
+		}
+
+		bsl := flattenBlobStorages(blobStorageList)
+
+		for _, element := range bsl {
+			h.pruneVCLLoggingAttributes(element)
+		}
+
+		if err := d.Set(h.GetKey(), bsl); err != nil {
+			log.Printf("[WARN] Error setting Blob Storages for (%s): %s", d.Id(), err)
+		}
 	}
 
-	bsl := flattenBlobStorages(blobStorageList)
-
-	for _, element := range bsl {
-		h.pruneVCLLoggingAttributes(element)
-	}
-
-	if err := d.Set(h.GetKey(), bsl); err != nil {
-		log.Printf("[WARN] Error setting Blob Storages for (%s): %s", d.Id(), err)
-	}
 	return nil
 }
 

--- a/fastly/block_fastly_service_logging_blobstorage.go
+++ b/fastly/block_fastly_service_logging_blobstorage.go
@@ -177,7 +177,7 @@ func (h *BlobStorageLoggingServiceAttributeHandler) Create(_ context.Context, d 
 func (h *BlobStorageLoggingServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, _ map[string]interface{}, serviceVersion int, conn *gofastly.Client) error {
 	resources := d.Get(h.GetKey()).(*schema.Set).List()
 
-	if len(resources) > 0 {
+	if len(resources) > 0 || d.Get("imported").(bool) {
 		log.Printf("[DEBUG] Refreshing Blob Storages for (%s)", d.Id())
 		blobStorageList, err := conn.ListBlobStorages(&gofastly.ListBlobStoragesInput{
 			ServiceID:      d.Id(),

--- a/fastly/block_fastly_service_logging_cloudfiles.go
+++ b/fastly/block_fastly_service_logging_cloudfiles.go
@@ -160,24 +160,28 @@ func (h *CloudfilesServiceAttributeHandler) Create(_ context.Context, d *schema.
 
 // Read refreshes the resource.
 func (h *CloudfilesServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, _ map[string]interface{}, serviceVersion int, conn *gofastly.Client) error {
-	// Refresh Cloud Files.
-	log.Printf("[DEBUG] Refreshing Cloud Files logging endpoints for (%s)", d.Id())
-	cloudfilesList, err := conn.ListCloudfiles(&gofastly.ListCloudfilesInput{
-		ServiceID:      d.Id(),
-		ServiceVersion: serviceVersion,
-	})
-	if err != nil {
-		return fmt.Errorf("error looking up Cloud Files logging endpoints for (%s), version (%v): %s", d.Id(), serviceVersion, err)
-	}
+	resources := d.Get(h.GetKey()).(*schema.Set).List()
 
-	ell := flattenCloudfiles(cloudfilesList)
+	if len(resources) > 0 {
+		// Refresh Cloud Files.
+		log.Printf("[DEBUG] Refreshing Cloud Files logging endpoints for (%s)", d.Id())
+		cloudfilesList, err := conn.ListCloudfiles(&gofastly.ListCloudfilesInput{
+			ServiceID:      d.Id(),
+			ServiceVersion: serviceVersion,
+		})
+		if err != nil {
+			return fmt.Errorf("error looking up Cloud Files logging endpoints for (%s), version (%v): %s", d.Id(), serviceVersion, err)
+		}
 
-	for _, element := range ell {
-		h.pruneVCLLoggingAttributes(element)
-	}
+		ell := flattenCloudfiles(cloudfilesList)
 
-	if err := d.Set(h.GetKey(), ell); err != nil {
-		log.Printf("[WARN] Error setting Cloud Files logging endpoints for (%s): %s", d.Id(), err)
+		for _, element := range ell {
+			h.pruneVCLLoggingAttributes(element)
+		}
+
+		if err := d.Set(h.GetKey(), ell); err != nil {
+			log.Printf("[WARN] Error setting Cloud Files logging endpoints for (%s): %s", d.Id(), err)
+		}
 	}
 
 	return nil

--- a/fastly/block_fastly_service_logging_cloudfiles.go
+++ b/fastly/block_fastly_service_logging_cloudfiles.go
@@ -162,7 +162,7 @@ func (h *CloudfilesServiceAttributeHandler) Create(_ context.Context, d *schema.
 func (h *CloudfilesServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, _ map[string]interface{}, serviceVersion int, conn *gofastly.Client) error {
 	resources := d.Get(h.GetKey()).(*schema.Set).List()
 
-	if len(resources) > 0 {
+	if len(resources) > 0 || d.Get("imported").(bool) {
 		// Refresh Cloud Files.
 		log.Printf("[DEBUG] Refreshing Cloud Files logging endpoints for (%s)", d.Id())
 		cloudfilesList, err := conn.ListCloudfiles(&gofastly.ListCloudfilesInput{

--- a/fastly/block_fastly_service_logging_datadog.go
+++ b/fastly/block_fastly_service_logging_datadog.go
@@ -103,7 +103,7 @@ func (h *DatadogServiceAttributeHandler) Create(_ context.Context, d *schema.Res
 func (h *DatadogServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, _ map[string]interface{}, serviceVersion int, conn *gofastly.Client) error {
 	resources := d.Get(h.GetKey()).(*schema.Set).List()
 
-	if len(resources) > 0 {
+	if len(resources) > 0 || d.Get("imported").(bool) {
 		log.Printf("[DEBUG] Refreshing Datadog logging endpoints for (%s)", d.Id())
 		datadogList, err := conn.ListDatadog(&gofastly.ListDatadogInput{
 			ServiceID:      d.Id(),

--- a/fastly/block_fastly_service_logging_datadog.go
+++ b/fastly/block_fastly_service_logging_datadog.go
@@ -101,24 +101,27 @@ func (h *DatadogServiceAttributeHandler) Create(_ context.Context, d *schema.Res
 
 // Read refreshes the resource.
 func (h *DatadogServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, _ map[string]interface{}, serviceVersion int, conn *gofastly.Client) error {
-	// Refresh Datadog.
-	log.Printf("[DEBUG] Refreshing Datadog logging endpoints for (%s)", d.Id())
-	datadogList, err := conn.ListDatadog(&gofastly.ListDatadogInput{
-		ServiceID:      d.Id(),
-		ServiceVersion: serviceVersion,
-	})
-	if err != nil {
-		return fmt.Errorf("error looking up Datadog logging endpoints for (%s), version (%v): %s", d.Id(), serviceVersion, err)
-	}
+	resources := d.Get(h.GetKey()).(*schema.Set).List()
 
-	dll := flattenDatadog(datadogList)
+	if len(resources) > 0 {
+		log.Printf("[DEBUG] Refreshing Datadog logging endpoints for (%s)", d.Id())
+		datadogList, err := conn.ListDatadog(&gofastly.ListDatadogInput{
+			ServiceID:      d.Id(),
+			ServiceVersion: serviceVersion,
+		})
+		if err != nil {
+			return fmt.Errorf("error looking up Datadog logging endpoints for (%s), version (%v): %s", d.Id(), serviceVersion, err)
+		}
 
-	for _, element := range dll {
-		h.pruneVCLLoggingAttributes(element)
-	}
+		dll := flattenDatadog(datadogList)
 
-	if err := d.Set(h.GetKey(), dll); err != nil {
-		log.Printf("[WARN] Error setting Datadog logging endpoints for (%s): %s", d.Id(), err)
+		for _, element := range dll {
+			h.pruneVCLLoggingAttributes(element)
+		}
+
+		if err := d.Set(h.GetKey(), dll); err != nil {
+			log.Printf("[WARN] Error setting Datadog logging endpoints for (%s): %s", d.Id(), err)
+		}
 	}
 
 	return nil

--- a/fastly/block_fastly_service_logging_digitalocean.go
+++ b/fastly/block_fastly_service_logging_digitalocean.go
@@ -161,7 +161,7 @@ func (h *DigitalOceanServiceAttributeHandler) Create(_ context.Context, d *schem
 func (h *DigitalOceanServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, _ map[string]interface{}, serviceVersion int, conn *gofastly.Client) error {
 	resources := d.Get(h.GetKey()).(*schema.Set).List()
 
-	if len(resources) > 0 {
+	if len(resources) > 0 || d.Get("imported").(bool) {
 		log.Printf("[DEBUG] Refreshing DigitalOcean Spaces logging endpoints for (%s)", d.Id())
 		digitaloceanList, err := conn.ListDigitalOceans(&gofastly.ListDigitalOceansInput{
 			ServiceID:      d.Id(),

--- a/fastly/block_fastly_service_logging_digitalocean.go
+++ b/fastly/block_fastly_service_logging_digitalocean.go
@@ -159,24 +159,27 @@ func (h *DigitalOceanServiceAttributeHandler) Create(_ context.Context, d *schem
 
 // Read refreshes the resource.
 func (h *DigitalOceanServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, _ map[string]interface{}, serviceVersion int, conn *gofastly.Client) error {
-	// Refresh DigitalOcean Spaces.
-	log.Printf("[DEBUG] Refreshing DigitalOcean Spaces logging endpoints for (%s)", d.Id())
-	digitaloceanList, err := conn.ListDigitalOceans(&gofastly.ListDigitalOceansInput{
-		ServiceID:      d.Id(),
-		ServiceVersion: serviceVersion,
-	})
-	if err != nil {
-		return fmt.Errorf("error looking up DigitalOcean Spaces logging endpoints for (%s), version (%v): %s", d.Id(), serviceVersion, err)
-	}
+	resources := d.Get(h.GetKey()).(*schema.Set).List()
 
-	ell := flattenDigitalOcean(digitaloceanList)
+	if len(resources) > 0 {
+		log.Printf("[DEBUG] Refreshing DigitalOcean Spaces logging endpoints for (%s)", d.Id())
+		digitaloceanList, err := conn.ListDigitalOceans(&gofastly.ListDigitalOceansInput{
+			ServiceID:      d.Id(),
+			ServiceVersion: serviceVersion,
+		})
+		if err != nil {
+			return fmt.Errorf("error looking up DigitalOcean Spaces logging endpoints for (%s), version (%v): %s", d.Id(), serviceVersion, err)
+		}
 
-	for _, element := range ell {
-		h.pruneVCLLoggingAttributes(element)
-	}
+		ell := flattenDigitalOcean(digitaloceanList)
 
-	if err := d.Set(h.GetKey(), ell); err != nil {
-		log.Printf("[WARN] Error setting DigitalOcean Spaces logging endpoints for (%s): %s", d.Id(), err)
+		for _, element := range ell {
+			h.pruneVCLLoggingAttributes(element)
+		}
+
+		if err := d.Set(h.GetKey(), ell); err != nil {
+			log.Printf("[WARN] Error setting DigitalOcean Spaces logging endpoints for (%s): %s", d.Id(), err)
+		}
 	}
 
 	return nil

--- a/fastly/block_fastly_service_logging_elasticsearch.go
+++ b/fastly/block_fastly_service_logging_elasticsearch.go
@@ -163,7 +163,7 @@ func (h *ElasticSearchServiceAttributeHandler) Create(_ context.Context, d *sche
 func (h *ElasticSearchServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, _ map[string]interface{}, serviceVersion int, conn *gofastly.Client) error {
 	resources := d.Get(h.GetKey()).(*schema.Set).List()
 
-	if len(resources) > 0 {
+	if len(resources) > 0 || d.Get("imported").(bool) {
 		log.Printf("[DEBUG] Refreshing Elasticsearch logging endpoints for (%s)", d.Id())
 		elasticsearchList, err := conn.ListElasticsearch(&gofastly.ListElasticsearchInput{
 			ServiceID:      d.Id(),

--- a/fastly/block_fastly_service_logging_ftp.go
+++ b/fastly/block_fastly_service_logging_ftp.go
@@ -163,7 +163,7 @@ func (h *FTPServiceAttributeHandler) Create(_ context.Context, d *schema.Resourc
 func (h *FTPServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, _ map[string]interface{}, serviceVersion int, conn *gofastly.Client) error {
 	resources := d.Get(h.GetKey()).(*schema.Set).List()
 
-	if len(resources) > 0 {
+	if len(resources) > 0 || d.Get("imported").(bool) {
 		log.Printf("[DEBUG] Refreshing FTP logging endpoints for (%s)", d.Id())
 		ftpList, err := conn.ListFTPs(&gofastly.ListFTPsInput{
 			ServiceID:      d.Id(),

--- a/fastly/block_fastly_service_logging_gcs.go
+++ b/fastly/block_fastly_service_logging_gcs.go
@@ -163,23 +163,27 @@ func (h *GCSLoggingServiceAttributeHandler) Create(_ context.Context, d *schema.
 
 // Read refreshes the resource.
 func (h *GCSLoggingServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, _ map[string]interface{}, serviceVersion int, conn *gofastly.Client) error {
-	log.Printf("[DEBUG] Refreshing GCS for (%s)", d.Id())
-	gs, err := conn.ListGCSs(&gofastly.ListGCSsInput{
-		ServiceID:      d.Id(),
-		ServiceVersion: serviceVersion,
-	})
-	if err != nil {
-		return fmt.Errorf("error looking up GCS for (%s), version (%v): %s", d.Id(), serviceVersion, err)
-	}
+	resources := d.Get(h.GetKey()).(*schema.Set).List()
 
-	gcsl := flattenGCS(gs)
+	if len(resources) > 0 {
+		log.Printf("[DEBUG] Refreshing GCS for (%s)", d.Id())
+		gs, err := conn.ListGCSs(&gofastly.ListGCSsInput{
+			ServiceID:      d.Id(),
+			ServiceVersion: serviceVersion,
+		})
+		if err != nil {
+			return fmt.Errorf("error looking up GCS for (%s), version (%v): %s", d.Id(), serviceVersion, err)
+		}
 
-	for _, element := range gcsl {
-		h.pruneVCLLoggingAttributes(element)
-	}
+		gcsl := flattenGCS(gs)
 
-	if err := d.Set(h.GetKey(), gcsl); err != nil {
-		log.Printf("[WARN] Error setting gcs for (%s): %s", d.Id(), err)
+		for _, element := range gcsl {
+			h.pruneVCLLoggingAttributes(element)
+		}
+
+		if err := d.Set(h.GetKey(), gcsl); err != nil {
+			log.Printf("[WARN] Error setting gcs for (%s): %s", d.Id(), err)
+		}
 	}
 
 	return nil

--- a/fastly/block_fastly_service_logging_gcs.go
+++ b/fastly/block_fastly_service_logging_gcs.go
@@ -165,7 +165,7 @@ func (h *GCSLoggingServiceAttributeHandler) Create(_ context.Context, d *schema.
 func (h *GCSLoggingServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, _ map[string]interface{}, serviceVersion int, conn *gofastly.Client) error {
 	resources := d.Get(h.GetKey()).(*schema.Set).List()
 
-	if len(resources) > 0 {
+	if len(resources) > 0 || d.Get("imported").(bool) {
 		log.Printf("[DEBUG] Refreshing GCS for (%s)", d.Id())
 		gs, err := conn.ListGCSs(&gofastly.ListGCSsInput{
 			ServiceID:      d.Id(),

--- a/fastly/block_fastly_service_logging_googlepubsub.go
+++ b/fastly/block_fastly_service_logging_googlepubsub.go
@@ -115,7 +115,7 @@ func (h *GooglePubSubServiceAttributeHandler) Create(_ context.Context, d *schem
 func (h *GooglePubSubServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, _ map[string]interface{}, serviceVersion int, conn *gofastly.Client) error {
 	resources := d.Get(h.GetKey()).(*schema.Set).List()
 
-	if len(resources) > 0 {
+	if len(resources) > 0 || d.Get("imported").(bool) {
 		log.Printf("[DEBUG] Refreshing Google Cloud Pub/Sub logging endpoints for (%s)", d.Id())
 		googlepubsubList, err := conn.ListPubsubs(&gofastly.ListPubsubsInput{
 			ServiceID:      d.Id(),

--- a/fastly/block_fastly_service_logging_googlepubsub.go
+++ b/fastly/block_fastly_service_logging_googlepubsub.go
@@ -113,24 +113,27 @@ func (h *GooglePubSubServiceAttributeHandler) Create(_ context.Context, d *schem
 
 // Read refreshes the resource.
 func (h *GooglePubSubServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, _ map[string]interface{}, serviceVersion int, conn *gofastly.Client) error {
-	// Refresh Google Cloud Pub/Sub logging endpoints.
-	log.Printf("[DEBUG] Refreshing Google Cloud Pub/Sub logging endpoints for (%s)", d.Id())
-	googlepubsubList, err := conn.ListPubsubs(&gofastly.ListPubsubsInput{
-		ServiceID:      d.Id(),
-		ServiceVersion: serviceVersion,
-	})
-	if err != nil {
-		return fmt.Errorf("error looking up Google Cloud Pub/Sub logging endpoints for (%s), version (%v): %s", d.Id(), serviceVersion, err)
-	}
+	resources := d.Get(h.GetKey()).(*schema.Set).List()
 
-	googlepubsubLogList := flattenGooglePubSub(googlepubsubList)
+	if len(resources) > 0 {
+		log.Printf("[DEBUG] Refreshing Google Cloud Pub/Sub logging endpoints for (%s)", d.Id())
+		googlepubsubList, err := conn.ListPubsubs(&gofastly.ListPubsubsInput{
+			ServiceID:      d.Id(),
+			ServiceVersion: serviceVersion,
+		})
+		if err != nil {
+			return fmt.Errorf("error looking up Google Cloud Pub/Sub logging endpoints for (%s), version (%v): %s", d.Id(), serviceVersion, err)
+		}
 
-	for _, element := range googlepubsubLogList {
-		h.pruneVCLLoggingAttributes(element)
-	}
+		googlepubsubLogList := flattenGooglePubSub(googlepubsubList)
 
-	if err := d.Set(h.GetKey(), googlepubsubLogList); err != nil {
-		log.Printf("[WARN] Error setting Google Cloud Pub/Sublogging endpoints for (%s): %s", d.Id(), err)
+		for _, element := range googlepubsubLogList {
+			h.pruneVCLLoggingAttributes(element)
+		}
+
+		if err := d.Set(h.GetKey(), googlepubsubLogList); err != nil {
+			log.Printf("[WARN] Error setting Google Cloud Pub/Sublogging endpoints for (%s): %s", d.Id(), err)
+		}
 	}
 
 	return nil

--- a/fastly/block_fastly_service_logging_heroku.go
+++ b/fastly/block_fastly_service_logging_heroku.go
@@ -101,7 +101,7 @@ func (h *HerokuServiceAttributeHandler) Create(_ context.Context, d *schema.Reso
 func (h *HerokuServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, _ map[string]interface{}, serviceVersion int, conn *gofastly.Client) error {
 	resources := d.Get(h.GetKey()).(*schema.Set).List()
 
-	if len(resources) > 0 {
+	if len(resources) > 0 || d.Get("imported").(bool) {
 		log.Printf("[DEBUG] Refreshing Heroku logging endpoints for (%s)", d.Id())
 		herokuList, err := conn.ListHerokus(&gofastly.ListHerokusInput{
 			ServiceID:      d.Id(),

--- a/fastly/block_fastly_service_logging_honeycomb.go
+++ b/fastly/block_fastly_service_logging_honeycomb.go
@@ -101,7 +101,7 @@ func (h *HoneycombServiceAttributeHandler) Create(_ context.Context, d *schema.R
 func (h *HoneycombServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, _ map[string]interface{}, serviceVersion int, conn *gofastly.Client) error {
 	resources := d.Get(h.GetKey()).(*schema.Set).List()
 
-	if len(resources) > 0 {
+	if len(resources) > 0 || d.Get("imported").(bool) {
 		log.Printf("[DEBUG] Refreshing Honeycomb logging endpoints for (%s)", d.Id())
 		honeycombList, err := conn.ListHoneycombs(&gofastly.ListHoneycombsInput{
 			ServiceID:      d.Id(),

--- a/fastly/block_fastly_service_logging_https.go
+++ b/fastly/block_fastly_service_logging_https.go
@@ -179,7 +179,7 @@ func (h *HTTPSLoggingServiceAttributeHandler) Create(_ context.Context, d *schem
 func (h *HTTPSLoggingServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, _ map[string]interface{}, serviceVersion int, conn *gofastly.Client) error {
 	resources := d.Get(h.GetKey()).(*schema.Set).List()
 
-	if len(resources) > 0 {
+	if len(resources) > 0 || d.Get("imported").(bool) {
 		log.Printf("[DEBUG] Refreshing HTTPS logging endpoints for (%s)", d.Id())
 		httpsList, err := conn.ListHTTPS(&gofastly.ListHTTPSInput{
 			ServiceID:      d.Id(),

--- a/fastly/block_fastly_service_logging_kafka.go
+++ b/fastly/block_fastly_service_logging_kafka.go
@@ -180,7 +180,7 @@ func (h *KafkaServiceAttributeHandler) Create(_ context.Context, d *schema.Resou
 func (h *KafkaServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, _ map[string]interface{}, serviceVersion int, conn *gofastly.Client) error {
 	resources := d.Get(h.GetKey()).(*schema.Set).List()
 
-	if len(resources) > 0 {
+	if len(resources) > 0 || d.Get("imported").(bool) {
 		log.Printf("[DEBUG] Refreshing Kafka logging endpoints for (%s)", d.Id())
 		kafkaList, err := conn.ListKafkas(&gofastly.ListKafkasInput{
 			ServiceID:      d.Id(),

--- a/fastly/block_fastly_service_logging_kinesis.go
+++ b/fastly/block_fastly_service_logging_kinesis.go
@@ -122,7 +122,7 @@ func (h *KinesisServiceAttributeHandler) Create(_ context.Context, d *schema.Res
 func (h *KinesisServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, _ map[string]interface{}, serviceVersion int, conn *gofastly.Client) error {
 	resources := d.Get(h.GetKey()).(*schema.Set).List()
 
-	if len(resources) > 0 {
+	if len(resources) > 0 || d.Get("imported").(bool) {
 		log.Printf("[DEBUG] Refreshing Kinesis logging endpoints for (%s)", d.Id())
 		kinesisList, err := conn.ListKinesis(&gofastly.ListKinesisInput{
 			ServiceID:      d.Id(),

--- a/fastly/block_fastly_service_logging_logentries.go
+++ b/fastly/block_fastly_service_logging_logentries.go
@@ -123,7 +123,7 @@ func (h *LogentriesServiceAttributeHandler) Create(_ context.Context, d *schema.
 func (h *LogentriesServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, _ map[string]interface{}, serviceVersion int, conn *gofastly.Client) error {
 	resources := d.Get(h.GetKey()).(*schema.Set).List()
 
-	if len(resources) > 0 {
+	if len(resources) > 0 || d.Get("imported").(bool) {
 		log.Printf("[DEBUG] Refreshing Logentries for (%s)", d.Id())
 		logentriesList, err := conn.ListLogentries(&gofastly.ListLogentriesInput{
 			ServiceID:      d.Id(),

--- a/fastly/block_fastly_service_logging_loggly.go
+++ b/fastly/block_fastly_service_logging_loggly.go
@@ -93,24 +93,27 @@ func (h *LogglyServiceAttributeHandler) Create(_ context.Context, d *schema.Reso
 
 // Read refreshes the resource.
 func (h *LogglyServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, _ map[string]interface{}, serviceVersion int, conn *gofastly.Client) error {
-	// Refresh Loggly.
-	log.Printf("[DEBUG] Refreshing Loggly logging endpoints for (%s)", d.Id())
-	logglyList, err := conn.ListLoggly(&gofastly.ListLogglyInput{
-		ServiceID:      d.Id(),
-		ServiceVersion: serviceVersion,
-	})
-	if err != nil {
-		return fmt.Errorf("error looking up Loggly logging endpoints for (%s), version (%v): %s", d.Id(), serviceVersion, err)
-	}
+	resources := d.Get(h.GetKey()).(*schema.Set).List()
 
-	ell := flattenLoggly(logglyList)
+	if len(resources) > 0 {
+		log.Printf("[DEBUG] Refreshing Loggly logging endpoints for (%s)", d.Id())
+		logglyList, err := conn.ListLoggly(&gofastly.ListLogglyInput{
+			ServiceID:      d.Id(),
+			ServiceVersion: serviceVersion,
+		})
+		if err != nil {
+			return fmt.Errorf("error looking up Loggly logging endpoints for (%s), version (%v): %s", d.Id(), serviceVersion, err)
+		}
 
-	for _, element := range ell {
-		h.pruneVCLLoggingAttributes(element)
-	}
+		ell := flattenLoggly(logglyList)
 
-	if err := d.Set(h.GetKey(), ell); err != nil {
-		log.Printf("[WARN] Error setting Loggly logging endpoints for (%s): %s", d.Id(), err)
+		for _, element := range ell {
+			h.pruneVCLLoggingAttributes(element)
+		}
+
+		if err := d.Set(h.GetKey(), ell); err != nil {
+			log.Printf("[WARN] Error setting Loggly logging endpoints for (%s): %s", d.Id(), err)
+		}
 	}
 
 	return nil

--- a/fastly/block_fastly_service_logging_loggly.go
+++ b/fastly/block_fastly_service_logging_loggly.go
@@ -95,7 +95,7 @@ func (h *LogglyServiceAttributeHandler) Create(_ context.Context, d *schema.Reso
 func (h *LogglyServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, _ map[string]interface{}, serviceVersion int, conn *gofastly.Client) error {
 	resources := d.Get(h.GetKey()).(*schema.Set).List()
 
-	if len(resources) > 0 {
+	if len(resources) > 0 || d.Get("imported").(bool) {
 		log.Printf("[DEBUG] Refreshing Loggly logging endpoints for (%s)", d.Id())
 		logglyList, err := conn.ListLoggly(&gofastly.ListLogglyInput{
 			ServiceID:      d.Id(),

--- a/fastly/block_fastly_service_logging_logshuttle.go
+++ b/fastly/block_fastly_service_logging_logshuttle.go
@@ -101,7 +101,7 @@ func (h *LogshuttleServiceAttributeHandler) Create(_ context.Context, d *schema.
 func (h *LogshuttleServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, _ map[string]interface{}, serviceVersion int, conn *gofastly.Client) error {
 	resources := d.Get(h.GetKey()).(*schema.Set).List()
 
-	if len(resources) > 0 {
+	if len(resources) > 0 || d.Get("imported").(bool) {
 		log.Printf("[DEBUG] Refreshing Log Shuttle logging endpoints for (%s)", d.Id())
 		logshuttleList, err := conn.ListLogshuttles(&gofastly.ListLogshuttlesInput{
 			ServiceID:      d.Id(),

--- a/fastly/block_fastly_service_logging_newrelic.go
+++ b/fastly/block_fastly_service_logging_newrelic.go
@@ -101,7 +101,7 @@ func (h *NewRelicServiceAttributeHandler) Create(_ context.Context, d *schema.Re
 func (h *NewRelicServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, _ map[string]interface{}, serviceVersion int, conn *gofastly.Client) error {
 	resources := d.Get(h.GetKey()).(*schema.Set).List()
 
-	if len(resources) > 0 {
+	if len(resources) > 0 || d.Get("imported").(bool) {
 		log.Printf("[DEBUG] Refreshing New Relic logging endpoints for (%s)", d.Id())
 		newrelicList, err := conn.ListNewRelic(&gofastly.ListNewRelicInput{
 			ServiceID:      d.Id(),

--- a/fastly/block_fastly_service_logging_openstack.go
+++ b/fastly/block_fastly_service_logging_openstack.go
@@ -160,24 +160,27 @@ func (h *OpenstackServiceAttributeHandler) Create(_ context.Context, d *schema.R
 
 // Read refreshes the resource.
 func (h *OpenstackServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, _ map[string]interface{}, serviceVersion int, conn *gofastly.Client) error {
-	// Refresh OpenStack.
-	log.Printf("[DEBUG] Refreshing OpenStack logging endpoints for (%s)", d.Id())
-	openstackList, err := conn.ListOpenstack(&gofastly.ListOpenstackInput{
-		ServiceID:      d.Id(),
-		ServiceVersion: serviceVersion,
-	})
-	if err != nil {
-		return fmt.Errorf("error looking up OpenStack logging endpoints for (%s), version (%v): %s", d.Id(), serviceVersion, err)
-	}
+	resources := d.Get(h.GetKey()).(*schema.Set).List()
 
-	ell := flattenOpenstack(openstackList)
+	if len(resources) > 0 {
+		log.Printf("[DEBUG] Refreshing OpenStack logging endpoints for (%s)", d.Id())
+		openstackList, err := conn.ListOpenstack(&gofastly.ListOpenstackInput{
+			ServiceID:      d.Id(),
+			ServiceVersion: serviceVersion,
+		})
+		if err != nil {
+			return fmt.Errorf("error looking up OpenStack logging endpoints for (%s), version (%v): %s", d.Id(), serviceVersion, err)
+		}
 
-	for _, element := range ell {
-		h.pruneVCLLoggingAttributes(element)
-	}
+		ell := flattenOpenstack(openstackList)
 
-	if err := d.Set(h.GetKey(), ell); err != nil {
-		log.Printf("[WARN] Error setting OpenStack logging endpoints for (%s): %s", d.Id(), err)
+		for _, element := range ell {
+			h.pruneVCLLoggingAttributes(element)
+		}
+
+		if err := d.Set(h.GetKey(), ell); err != nil {
+			log.Printf("[WARN] Error setting OpenStack logging endpoints for (%s): %s", d.Id(), err)
+		}
 	}
 
 	return nil

--- a/fastly/block_fastly_service_logging_openstack.go
+++ b/fastly/block_fastly_service_logging_openstack.go
@@ -162,7 +162,7 @@ func (h *OpenstackServiceAttributeHandler) Create(_ context.Context, d *schema.R
 func (h *OpenstackServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, _ map[string]interface{}, serviceVersion int, conn *gofastly.Client) error {
 	resources := d.Get(h.GetKey()).(*schema.Set).List()
 
-	if len(resources) > 0 {
+	if len(resources) > 0 || d.Get("imported").(bool) {
 		log.Printf("[DEBUG] Refreshing OpenStack logging endpoints for (%s)", d.Id())
 		openstackList, err := conn.ListOpenstack(&gofastly.ListOpenstackInput{
 			ServiceID:      d.Id(),

--- a/fastly/block_fastly_service_logging_papertrail.go
+++ b/fastly/block_fastly_service_logging_papertrail.go
@@ -115,7 +115,7 @@ func (h *PaperTrailServiceAttributeHandler) Create(_ context.Context, d *schema.
 func (h *PaperTrailServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, _ map[string]interface{}, serviceVersion int, conn *gofastly.Client) error {
 	resources := d.Get(h.GetKey()).(*schema.Set).List()
 
-	if len(resources) > 0 {
+	if len(resources) > 0 || d.Get("imported").(bool) {
 		log.Printf("[DEBUG] Refreshing Papertrail for (%s)", d.Id())
 		papertrailList, err := conn.ListPapertrails(&gofastly.ListPapertrailsInput{
 			ServiceID:      d.Id(),

--- a/fastly/block_fastly_service_logging_papertrail.go
+++ b/fastly/block_fastly_service_logging_papertrail.go
@@ -113,23 +113,27 @@ func (h *PaperTrailServiceAttributeHandler) Create(_ context.Context, d *schema.
 
 // Read refreshes the resource.
 func (h *PaperTrailServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, _ map[string]interface{}, serviceVersion int, conn *gofastly.Client) error {
-	log.Printf("[DEBUG] Refreshing Papertrail for (%s)", d.Id())
-	papertrailList, err := conn.ListPapertrails(&gofastly.ListPapertrailsInput{
-		ServiceID:      d.Id(),
-		ServiceVersion: serviceVersion,
-	})
-	if err != nil {
-		return fmt.Errorf("error looking up Papertrail for (%s), version (%v): %s", d.Id(), serviceVersion, err)
-	}
+	resources := d.Get(h.GetKey()).(*schema.Set).List()
 
-	pl := flattenPapertrails(papertrailList)
+	if len(resources) > 0 {
+		log.Printf("[DEBUG] Refreshing Papertrail for (%s)", d.Id())
+		papertrailList, err := conn.ListPapertrails(&gofastly.ListPapertrailsInput{
+			ServiceID:      d.Id(),
+			ServiceVersion: serviceVersion,
+		})
+		if err != nil {
+			return fmt.Errorf("error looking up Papertrail for (%s), version (%v): %s", d.Id(), serviceVersion, err)
+		}
 
-	for _, element := range pl {
-		h.pruneVCLLoggingAttributes(element)
-	}
+		pl := flattenPapertrails(papertrailList)
 
-	if err := d.Set(h.GetKey(), pl); err != nil {
-		log.Printf("[WARN] Error setting Papertrail for (%s): %s", d.Id(), err)
+		for _, element := range pl {
+			h.pruneVCLLoggingAttributes(element)
+		}
+
+		if err := d.Set(h.GetKey(), pl); err != nil {
+			log.Printf("[WARN] Error setting Papertrail for (%s): %s", d.Id(), err)
+		}
 	}
 
 	return nil

--- a/fastly/block_fastly_service_logging_s3.go
+++ b/fastly/block_fastly_service_logging_s3.go
@@ -233,7 +233,7 @@ func (h *S3LoggingServiceAttributeHandler) Create(_ context.Context, d *schema.R
 func (h *S3LoggingServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, _ map[string]interface{}, serviceVersion int, conn *gofastly.Client) error {
 	resources := d.Get(h.GetKey()).(*schema.Set).List()
 
-	if len(resources) > 0 {
+	if len(resources) > 0 || d.Get("imported").(bool) {
 		log.Printf("[DEBUG] Refreshing S3 Logging for (%s)", d.Id())
 		s3List, err := conn.ListS3s(&gofastly.ListS3sInput{
 			ServiceID:      d.Id(),

--- a/fastly/block_fastly_service_logging_scalyr.go
+++ b/fastly/block_fastly_service_logging_scalyr.go
@@ -101,24 +101,27 @@ func (h *ScalyrServiceAttributeHandler) Create(_ context.Context, d *schema.Reso
 
 // Read refreshes the resource.
 func (h *ScalyrServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, _ map[string]interface{}, serviceVersion int, conn *gofastly.Client) error {
-	// Refresh Scalyr.
-	log.Printf("[DEBUG] Refreshing Scalyr logging endpoints for (%s)", d.Id())
-	scalyrList, err := conn.ListScalyrs(&gofastly.ListScalyrsInput{
-		ServiceID:      d.Id(),
-		ServiceVersion: serviceVersion,
-	})
-	if err != nil {
-		return fmt.Errorf("error looking up Scalyr logging endpoints for (%s), version (%v): %s", d.Id(), serviceVersion, err)
-	}
+	resources := d.Get(h.GetKey()).(*schema.Set).List()
 
-	scalyrLogList := flattenScalyr(scalyrList)
+	if len(resources) > 0 {
+		log.Printf("[DEBUG] Refreshing Scalyr logging endpoints for (%s)", d.Id())
+		scalyrList, err := conn.ListScalyrs(&gofastly.ListScalyrsInput{
+			ServiceID:      d.Id(),
+			ServiceVersion: serviceVersion,
+		})
+		if err != nil {
+			return fmt.Errorf("error looking up Scalyr logging endpoints for (%s), version (%v): %s", d.Id(), serviceVersion, err)
+		}
 
-	for _, element := range scalyrLogList {
-		h.pruneVCLLoggingAttributes(element)
-	}
+		scalyrLogList := flattenScalyr(scalyrList)
 
-	if err := d.Set(h.GetKey(), scalyrLogList); err != nil {
-		log.Printf("[WARN] Error setting Scalyr logging endpoints for (%s): %s", d.Id(), err)
+		for _, element := range scalyrLogList {
+			h.pruneVCLLoggingAttributes(element)
+		}
+
+		if err := d.Set(h.GetKey(), scalyrLogList); err != nil {
+			log.Printf("[WARN] Error setting Scalyr logging endpoints for (%s): %s", d.Id(), err)
+		}
 	}
 
 	return nil

--- a/fastly/block_fastly_service_logging_scalyr.go
+++ b/fastly/block_fastly_service_logging_scalyr.go
@@ -103,7 +103,7 @@ func (h *ScalyrServiceAttributeHandler) Create(_ context.Context, d *schema.Reso
 func (h *ScalyrServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, _ map[string]interface{}, serviceVersion int, conn *gofastly.Client) error {
 	resources := d.Get(h.GetKey()).(*schema.Set).List()
 
-	if len(resources) > 0 {
+	if len(resources) > 0 || d.Get("imported").(bool) {
 		log.Printf("[DEBUG] Refreshing Scalyr logging endpoints for (%s)", d.Id())
 		scalyrList, err := conn.ListScalyrs(&gofastly.ListScalyrsInput{
 			ServiceID:      d.Id(),

--- a/fastly/block_fastly_service_logging_sftp.go
+++ b/fastly/block_fastly_service_logging_sftp.go
@@ -182,7 +182,7 @@ func (h *SFTPServiceAttributeHandler) Create(_ context.Context, d *schema.Resour
 func (h *SFTPServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, _ map[string]interface{}, serviceVersion int, conn *gofastly.Client) error {
 	resources := d.Get(h.GetKey()).(*schema.Set).List()
 
-	if len(resources) > 0 {
+	if len(resources) > 0 || d.Get("imported").(bool) {
 		log.Printf("[DEBUG] Refreshing SFTP logging endpoints for (%s)", d.Id())
 		sftpList, err := conn.ListSFTPs(&gofastly.ListSFTPsInput{
 			ServiceID:      d.Id(),

--- a/fastly/block_fastly_service_logging_sftp.go
+++ b/fastly/block_fastly_service_logging_sftp.go
@@ -180,24 +180,27 @@ func (h *SFTPServiceAttributeHandler) Create(_ context.Context, d *schema.Resour
 
 // Read refreshes the resource.
 func (h *SFTPServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, _ map[string]interface{}, serviceVersion int, conn *gofastly.Client) error {
-	// Refresh SFTP.
-	log.Printf("[DEBUG] Refreshing SFTP logging endpoints for (%s)", d.Id())
-	sftpList, err := conn.ListSFTPs(&gofastly.ListSFTPsInput{
-		ServiceID:      d.Id(),
-		ServiceVersion: serviceVersion,
-	})
-	if err != nil {
-		return fmt.Errorf("error looking up SFTP logging endpoints for (%s), version (%v): %s", d.Id(), serviceVersion, err)
-	}
+	resources := d.Get(h.GetKey()).(*schema.Set).List()
 
-	ell := flattenSFTP(sftpList)
+	if len(resources) > 0 {
+		log.Printf("[DEBUG] Refreshing SFTP logging endpoints for (%s)", d.Id())
+		sftpList, err := conn.ListSFTPs(&gofastly.ListSFTPsInput{
+			ServiceID:      d.Id(),
+			ServiceVersion: serviceVersion,
+		})
+		if err != nil {
+			return fmt.Errorf("error looking up SFTP logging endpoints for (%s), version (%v): %s", d.Id(), serviceVersion, err)
+		}
 
-	for _, element := range ell {
-		h.pruneVCLLoggingAttributes(element)
-	}
+		ell := flattenSFTP(sftpList)
 
-	if err := d.Set(h.GetKey(), ell); err != nil {
-		log.Printf("[WARN] Error setting SFTP logging endpoints for (%s): %s", d.Id(), err)
+		for _, element := range ell {
+			h.pruneVCLLoggingAttributes(element)
+		}
+
+		if err := d.Set(h.GetKey(), ell); err != nil {
+			log.Printf("[WARN] Error setting SFTP logging endpoints for (%s): %s", d.Id(), err)
+		}
 	}
 
 	return nil

--- a/fastly/block_fastly_service_logging_splunk.go
+++ b/fastly/block_fastly_service_logging_splunk.go
@@ -151,7 +151,7 @@ func (h *SplunkServiceAttributeHandler) Create(_ context.Context, d *schema.Reso
 func (h *SplunkServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, _ map[string]interface{}, serviceVersion int, conn *gofastly.Client) error {
 	resources := d.Get(h.GetKey()).(*schema.Set).List()
 
-	if len(resources) > 0 {
+	if len(resources) > 0 || d.Get("imported").(bool) {
 		log.Printf("[DEBUG] Refreshing Splunks for (%s)", d.Id())
 		splunkList, err := conn.ListSplunks(&gofastly.ListSplunksInput{
 			ServiceID:      d.Id(),

--- a/fastly/block_fastly_service_logging_splunk.go
+++ b/fastly/block_fastly_service_logging_splunk.go
@@ -149,24 +149,29 @@ func (h *SplunkServiceAttributeHandler) Create(_ context.Context, d *schema.Reso
 
 // Read refreshes the resource.
 func (h *SplunkServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, _ map[string]interface{}, serviceVersion int, conn *gofastly.Client) error {
-	log.Printf("[DEBUG] Refreshing Splunks for (%s)", d.Id())
-	splunkList, err := conn.ListSplunks(&gofastly.ListSplunksInput{
-		ServiceID:      d.Id(),
-		ServiceVersion: serviceVersion,
-	})
-	if err != nil {
-		return fmt.Errorf("error looking up Splunks for (%s), version (%v): %s", d.Id(), serviceVersion, err)
+	resources := d.Get(h.GetKey()).(*schema.Set).List()
+
+	if len(resources) > 0 {
+		log.Printf("[DEBUG] Refreshing Splunks for (%s)", d.Id())
+		splunkList, err := conn.ListSplunks(&gofastly.ListSplunksInput{
+			ServiceID:      d.Id(),
+			ServiceVersion: serviceVersion,
+		})
+		if err != nil {
+			return fmt.Errorf("error looking up Splunks for (%s), version (%v): %s", d.Id(), serviceVersion, err)
+		}
+
+		spl := flattenSplunks(splunkList)
+
+		for _, element := range spl {
+			h.pruneVCLLoggingAttributes(element)
+		}
+
+		if err := d.Set(h.GetKey(), spl); err != nil {
+			log.Printf("[WARN] Error setting Splunks for (%s): %s", d.Id(), err)
+		}
 	}
 
-	spl := flattenSplunks(splunkList)
-
-	for _, element := range spl {
-		h.pruneVCLLoggingAttributes(element)
-	}
-
-	if err := d.Set(h.GetKey(), spl); err != nil {
-		log.Printf("[WARN] Error setting Splunks for (%s): %s", d.Id(), err)
-	}
 	return nil
 }
 

--- a/fastly/block_fastly_service_logging_sumologic.go
+++ b/fastly/block_fastly_service_logging_sumologic.go
@@ -115,24 +115,29 @@ func (h *SumologicServiceAttributeHandler) Create(_ context.Context, d *schema.R
 
 // Read refreshes the resource.
 func (h *SumologicServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, _ map[string]interface{}, serviceVersion int, conn *gofastly.Client) error {
-	log.Printf("[DEBUG] Refreshing Sumologic for (%s)", d.Id())
-	sumologicList, err := conn.ListSumologics(&gofastly.ListSumologicsInput{
-		ServiceID:      d.Id(),
-		ServiceVersion: serviceVersion,
-	})
-	if err != nil {
-		return fmt.Errorf("error looking up Sumologic for (%s), version (%v): %s", d.Id(), serviceVersion, err)
+	resources := d.Get(h.GetKey()).(*schema.Set).List()
+
+	if len(resources) > 0 {
+		log.Printf("[DEBUG] Refreshing Sumologic for (%s)", d.Id())
+		sumologicList, err := conn.ListSumologics(&gofastly.ListSumologicsInput{
+			ServiceID:      d.Id(),
+			ServiceVersion: serviceVersion,
+		})
+		if err != nil {
+			return fmt.Errorf("error looking up Sumologic for (%s), version (%v): %s", d.Id(), serviceVersion, err)
+		}
+
+		sul := flattenSumologics(sumologicList)
+
+		for _, element := range sul {
+			h.pruneVCLLoggingAttributes(element)
+		}
+
+		if err := d.Set(h.GetKey(), sul); err != nil {
+			log.Printf("[WARN] Error setting Sumologic for (%s): %s", d.Id(), err)
+		}
 	}
 
-	sul := flattenSumologics(sumologicList)
-
-	for _, element := range sul {
-		h.pruneVCLLoggingAttributes(element)
-	}
-
-	if err := d.Set(h.GetKey(), sul); err != nil {
-		log.Printf("[WARN] Error setting Sumologic for (%s): %s", d.Id(), err)
-	}
 	return nil
 }
 

--- a/fastly/block_fastly_service_logging_sumologic.go
+++ b/fastly/block_fastly_service_logging_sumologic.go
@@ -117,7 +117,7 @@ func (h *SumologicServiceAttributeHandler) Create(_ context.Context, d *schema.R
 func (h *SumologicServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, _ map[string]interface{}, serviceVersion int, conn *gofastly.Client) error {
 	resources := d.Get(h.GetKey()).(*schema.Set).List()
 
-	if len(resources) > 0 {
+	if len(resources) > 0 || d.Get("imported").(bool) {
 		log.Printf("[DEBUG] Refreshing Sumologic for (%s)", d.Id())
 		sumologicList, err := conn.ListSumologics(&gofastly.ListSumologicsInput{
 			ServiceID:      d.Id(),

--- a/fastly/block_fastly_service_logging_syslog.go
+++ b/fastly/block_fastly_service_logging_syslog.go
@@ -167,7 +167,7 @@ func (h *SyslogServiceAttributeHandler) Create(_ context.Context, d *schema.Reso
 func (h *SyslogServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, _ map[string]interface{}, serviceVersion int, conn *gofastly.Client) error {
 	resources := d.Get(h.GetKey()).(*schema.Set).List()
 
-	if len(resources) > 0 {
+	if len(resources) > 0 || d.Get("imported").(bool) {
 		log.Printf("[DEBUG] Refreshing Syslog for (%s)", d.Id())
 		syslogList, err := conn.ListSyslogs(&gofastly.ListSyslogsInput{
 			ServiceID:      d.Id(),

--- a/fastly/block_fastly_service_package.go
+++ b/fastly/block_fastly_service_package.go
@@ -93,7 +93,6 @@ func (h *PackageServiceAttributeHandler) Read(_ context.Context, d *schema.Resou
 
 		filename := d.Get("package.0.filename").(string)
 		wp := flattenPackage(pkg, filename)
-		log.Printf("[WARN] Package state: %+v", wp)
 		if err := d.Set(h.GetKey(), wp); err != nil {
 			log.Printf("[WARN] Error setting Package for (%s): %s", d.Id(), err)
 		}

--- a/fastly/block_fastly_service_package.go
+++ b/fastly/block_fastly_service_package.go
@@ -74,9 +74,6 @@ func (h *PackageServiceAttributeHandler) Process(_ context.Context, d *schema.Re
 
 // Read refreshes the attribute state against the Fastly API.
 func (h *PackageServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, s *gofastly.ServiceDetail, conn *gofastly.Client) error {
-	log.Printf("[DEBUG] Refreshing %s", h.key)
-	log.Printf("[DEBUG] Refreshing %s", h.GetKey())
-	log.Printf("[DEBUG] Refreshing %T", d.Get(h.key))
 	resources := d.Get(h.key).([]interface{})
 
 	if len(resources) > 0 {

--- a/fastly/block_fastly_service_package.go
+++ b/fastly/block_fastly_service_package.go
@@ -76,7 +76,7 @@ func (h *PackageServiceAttributeHandler) Process(_ context.Context, d *schema.Re
 func (h *PackageServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, s *gofastly.ServiceDetail, conn *gofastly.Client) error {
 	resources := d.Get(h.key).([]interface{})
 
-	if len(resources) > 0 {
+	if len(resources) > 0 || d.Get("imported").(bool) {
 		log.Printf("[DEBUG] Refreshing package for (%s)", d.Id())
 		pkg, err := conn.GetPackage(&gofastly.GetPackageInput{
 			ServiceID:      d.Id(),

--- a/fastly/block_fastly_service_requestsetting.go
+++ b/fastly/block_fastly_service_requestsetting.go
@@ -131,7 +131,7 @@ func (h *RequestSettingServiceAttributeHandler) Create(_ context.Context, d *sch
 func (h *RequestSettingServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, _ map[string]interface{}, serviceVersion int, conn *gofastly.Client) error {
 	resources := d.Get(h.GetKey()).(*schema.Set).List()
 
-	if len(resources) > 0 {
+	if len(resources) > 0 || d.Get("imported").(bool) {
 		log.Printf("[DEBUG] Refreshing Request Settings for (%s)", d.Id())
 		rsList, err := conn.ListRequestSettings(&gofastly.ListRequestSettingsInput{
 			ServiceID:      d.Id(),

--- a/fastly/block_fastly_service_responseobject.go
+++ b/fastly/block_fastly_service_responseobject.go
@@ -110,7 +110,7 @@ func (h *ResponseObjectServiceAttributeHandler) Create(_ context.Context, d *sch
 func (h *ResponseObjectServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, _ map[string]interface{}, serviceVersion int, conn *gofastly.Client) error {
 	resources := d.Get(h.GetKey()).(*schema.Set).List()
 
-	if len(resources) > 0 {
+	if len(resources) > 0 || d.Get("imported").(bool) {
 		log.Printf("[DEBUG] Refreshing Response Object for (%s)", d.Id())
 		responseObjectList, err := conn.ListResponseObjects(&gofastly.ListResponseObjectsInput{
 			ServiceID:      d.Id(),

--- a/fastly/block_fastly_service_snippet.go
+++ b/fastly/block_fastly_service_snippet.go
@@ -86,7 +86,7 @@ func (h *SnippetServiceAttributeHandler) Create(_ context.Context, d *schema.Res
 func (h *SnippetServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, _ map[string]interface{}, serviceVersion int, conn *gofastly.Client) error {
 	resources := d.Get(h.Key()).(*schema.Set).List()
 
-	if len(resources) > 0 {
+	if len(resources) > 0 || d.Get("imported").(bool) {
 		log.Printf("[DEBUG] Refreshing VCL Snippets for (%s)", d.Id())
 		snippetList, err := conn.ListSnippets(&gofastly.ListSnippetsInput{
 			ServiceID:      d.Id(),

--- a/fastly/block_fastly_service_vcl.go
+++ b/fastly/block_fastly_service_vcl.go
@@ -80,7 +80,7 @@ func (h *VCLServiceAttributeHandler) Create(_ context.Context, d *schema.Resourc
 func (h *VCLServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, _ map[string]interface{}, serviceVersion int, conn *gofastly.Client) error {
 	resources := d.Get(h.Key()).(*schema.Set).List()
 
-	if len(resources) > 0 {
+	if len(resources) > 0 || d.Get("imported").(bool) {
 		log.Printf("[DEBUG] Refreshing VCLs for (%s)", d.Id())
 		vclList, err := conn.ListVCLs(&gofastly.ListVCLsInput{
 			ServiceID:      d.Id(),

--- a/fastly/block_fastly_service_vcl.go
+++ b/fastly/block_fastly_service_vcl.go
@@ -78,20 +78,25 @@ func (h *VCLServiceAttributeHandler) Create(_ context.Context, d *schema.Resourc
 
 // Read refreshes the resource.
 func (h *VCLServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, _ map[string]interface{}, serviceVersion int, conn *gofastly.Client) error {
-	log.Printf("[DEBUG] Refreshing VCLs for (%s)", d.Id())
-	vclList, err := conn.ListVCLs(&gofastly.ListVCLsInput{
-		ServiceID:      d.Id(),
-		ServiceVersion: serviceVersion,
-	})
-	if err != nil {
-		return fmt.Errorf("error looking up VCLs for (%s), version (%v): %s", d.Id(), serviceVersion, err)
+	resources := d.Get(h.Key()).(*schema.Set).List()
+
+	if len(resources) > 0 {
+		log.Printf("[DEBUG] Refreshing VCLs for (%s)", d.Id())
+		vclList, err := conn.ListVCLs(&gofastly.ListVCLsInput{
+			ServiceID:      d.Id(),
+			ServiceVersion: serviceVersion,
+		})
+		if err != nil {
+			return fmt.Errorf("error looking up VCLs for (%s), version (%v): %s", d.Id(), serviceVersion, err)
+		}
+
+		vl := flattenVCLs(vclList)
+
+		if err := d.Set(h.GetKey(), vl); err != nil {
+			log.Printf("[WARN] Error setting VCLs for (%s): %s", d.Id(), err)
+		}
 	}
 
-	vl := flattenVCLs(vclList)
-
-	if err := d.Set(h.GetKey(), vl); err != nil {
-		log.Printf("[WARN] Error setting VCLs for (%s): %s", d.Id(), err)
-	}
 	return nil
 }
 

--- a/fastly/block_fastly_service_waf.go
+++ b/fastly/block_fastly_service_waf.go
@@ -102,7 +102,7 @@ func (h *WAFServiceAttributeHandler) Process(_ context.Context, d *schema.Resour
 func (h *WAFServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, s *gofastly.ServiceDetail, conn *gofastly.Client) error {
 	resources := d.Get(h.GetKey()).([]interface{})
 
-	if len(resources) > 0 {
+	if len(resources) > 0 || d.Get("imported").(bool) {
 		log.Printf("[DEBUG] Refreshing WAFs for (%s)", d.Id())
 		wafList, err := conn.ListWAFs(&gofastly.ListWAFsInput{
 			FilterService: d.Id(),

--- a/fastly/block_fastly_service_waf.go
+++ b/fastly/block_fastly_service_waf.go
@@ -100,21 +100,25 @@ func (h *WAFServiceAttributeHandler) Process(_ context.Context, d *schema.Resour
 }
 
 func (h *WAFServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, s *gofastly.ServiceDetail, conn *gofastly.Client) error {
-	// refresh WAFs
-	log.Printf("[DEBUG] Refreshing WAFs for (%s)", d.Id())
-	wafList, err := conn.ListWAFs(&gofastly.ListWAFsInput{
-		FilterService: d.Id(),
-		FilterVersion: s.ActiveVersion.Number,
-	})
-	if err != nil {
-		return fmt.Errorf("error looking up WAFs for (%s), version (%v): %s", d.Id(), s.ActiveVersion.Number, err)
+	resources := d.Get(h.GetKey()).(*schema.Set).List()
+
+	if len(resources) > 0 {
+		log.Printf("[DEBUG] Refreshing WAFs for (%s)", d.Id())
+		wafList, err := conn.ListWAFs(&gofastly.ListWAFsInput{
+			FilterService: d.Id(),
+			FilterVersion: s.ActiveVersion.Number,
+		})
+		if err != nil {
+			return fmt.Errorf("error looking up WAFs for (%s), version (%v): %s", d.Id(), s.ActiveVersion.Number, err)
+		}
+
+		waf := flattenWAFs(wafList.Items)
+
+		if err := d.Set("waf", waf); err != nil {
+			log.Printf("[WARN] Error setting waf for (%s): %s", d.Id(), err)
+		}
 	}
 
-	waf := flattenWAFs(wafList.Items)
-
-	if err := d.Set("waf", waf); err != nil {
-		log.Printf("[WARN] Error setting waf for (%s): %s", d.Id(), err)
-	}
 	return nil
 }
 

--- a/fastly/resource_fastly_service_acl_entries.go
+++ b/fastly/resource_fastly_service_acl_entries.go
@@ -3,6 +3,7 @@ package fastly
 import (
 	"context"
 	"fmt"
+	"log"
 	"strconv"
 	"strings"
 
@@ -112,6 +113,8 @@ func resourceServiceACLEntriesCreate(ctx context.Context, d *schema.ResourceData
 }
 
 func resourceServiceACLEntriesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	log.Print("[DEBUG] Refreshing ACL Entries Configuration")
+
 	conn := meta.(*APIClient).conn
 
 	serviceID := d.Get("service_id").(string)

--- a/fastly/resource_fastly_service_authorization.go
+++ b/fastly/resource_fastly_service_authorization.go
@@ -2,6 +2,7 @@ package fastly
 
 import (
 	"context"
+	"log"
 
 	gofastly "github.com/fastly/go-fastly/v6/fastly"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -65,6 +66,8 @@ func resourceServiceAuthorizationCreate(_ context.Context, d *schema.ResourceDat
 }
 
 func resourceServiceAuthorizationRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	log.Printf("[DEBUG] Refreshing Service Authorization Configuration for (%s)", d.Id())
+
 	conn := meta.(*APIClient).conn
 
 	sa, err := conn.GetServiceAuthorization(&gofastly.GetServiceAuthorizationInput{

--- a/fastly/resource_fastly_service_compute_test.go
+++ b/fastly/resource_fastly_service_compute_test.go
@@ -125,7 +125,7 @@ func TestAccFastlyServiceCompute_basic(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				// These attributes are not stored on the Fastly API and must be ignored.
-				ImportStateVerifyIgnore: []string{"activate", "force_destroy", "package.0.filename"},
+				ImportStateVerifyIgnore: []string{"activate", "force_destroy", "package.0.filename", "imported"},
 			},
 		},
 	})

--- a/fastly/resource_fastly_service_dictionary_items.go
+++ b/fastly/resource_fastly_service_dictionary_items.go
@@ -3,6 +3,7 @@ package fastly
 import (
 	"context"
 	"fmt"
+	"log"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -138,6 +139,8 @@ func resourceServiceDictionaryItemsUpdate(ctx context.Context, d *schema.Resourc
 }
 
 func resourceServiceDictionaryItemsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	log.Print("[DEBUG] Refreshing Dictionary Items Configuration")
+
 	conn := meta.(*APIClient).conn
 
 	serviceID := d.Get("service_id").(string)

--- a/fastly/resource_fastly_service_dynamic_snippet_content.go
+++ b/fastly/resource_fastly_service_dynamic_snippet_content.go
@@ -3,6 +3,7 @@ package fastly
 import (
 	"context"
 	"fmt"
+	"log"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -98,6 +99,8 @@ func resourceServiceDynamicSnippetUpdate(ctx context.Context, d *schema.Resource
 }
 
 func resourceServiceDynamicSnippetRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	log.Print("[DEBUG] Refreshing Dynamic Snippet Configuration")
+
 	conn := meta.(*APIClient).conn
 
 	serviceID := d.Get("service_id").(string)

--- a/fastly/resource_fastly_service_vcl_test.go
+++ b/fastly/resource_fastly_service_vcl_test.go
@@ -430,18 +430,12 @@ func TestAccFastlyServiceVCL_basic(t *testing.T) {
 				Config: testAccServiceVCLConfigInitWithVersionComment(name, versionComment1, domainName1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceVCLExists("fastly_service_vcl.foo", &service),
-					resource.TestCheckResourceAttr(
-						"fastly_service_vcl.foo", "name", name),
-					resource.TestCheckResourceAttr(
-						"fastly_service_vcl.foo", "comment", "Managed by Terraform"),
-					resource.TestCheckResourceAttr(
-						"fastly_service_vcl.foo", "version_comment", versionComment1),
-					resource.TestCheckResourceAttr(
-						"fastly_service_vcl.foo", "active_version", "1"),
-					resource.TestCheckResourceAttr(
-						"fastly_service_vcl.foo", "domain.#", "1"),
-					resource.TestCheckResourceAttr(
-						"fastly_service_vcl.foo", "backend.#", "1"),
+					resource.TestCheckResourceAttr("fastly_service_vcl.foo", "name", name),
+					resource.TestCheckResourceAttr("fastly_service_vcl.foo", "comment", "Managed by Terraform"),
+					resource.TestCheckResourceAttr("fastly_service_vcl.foo", "version_comment", versionComment1),
+					resource.TestCheckResourceAttr("fastly_service_vcl.foo", "active_version", "1"),
+					resource.TestCheckResourceAttr("fastly_service_vcl.foo", "domain.#", "1"),
+					resource.TestCheckResourceAttr("fastly_service_vcl.foo", "backend.#", "1"),
 				),
 			},
 			{
@@ -449,10 +443,8 @@ func TestAccFastlyServiceVCL_basic(t *testing.T) {
 				Config: testAccServiceVCLConfigUpdateServiceComment(name, "new service comment", domainName1, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceVCLExists("fastly_service_vcl.foo", &service),
-					resource.TestCheckResourceAttr(
-						"fastly_service_vcl.foo", "active_version", "1"),
-					resource.TestCheckResourceAttr(
-						"fastly_service_vcl.foo", "comment", "Managed by Terraform"),
+					resource.TestCheckResourceAttr("fastly_service_vcl.foo", "active_version", "1"),
+					resource.TestCheckResourceAttr("fastly_service_vcl.foo", "comment", "Managed by Terraform"),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -460,18 +452,12 @@ func TestAccFastlyServiceVCL_basic(t *testing.T) {
 				Config: testAccServiceVCLConfigBasicUpdate(name, comment, versionComment2, domainName2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceVCLExists("fastly_service_vcl.foo", &service),
-					resource.TestCheckResourceAttr(
-						"fastly_service_vcl.foo", "name", name),
-					resource.TestCheckResourceAttr(
-						"fastly_service_vcl.foo", "comment", comment),
-					resource.TestCheckResourceAttr(
-						"fastly_service_vcl.foo", "version_comment", versionComment2),
-					resource.TestCheckResourceAttr(
-						"fastly_service_vcl.foo", "active_version", "2"),
-					resource.TestCheckResourceAttr(
-						"fastly_service_vcl.foo", "domain.#", "1"),
-					resource.TestCheckResourceAttr(
-						"fastly_service_vcl.foo", "backend.#", "1"),
+					resource.TestCheckResourceAttr("fastly_service_vcl.foo", "name", name),
+					resource.TestCheckResourceAttr("fastly_service_vcl.foo", "comment", comment),
+					resource.TestCheckResourceAttr("fastly_service_vcl.foo", "version_comment", versionComment2),
+					resource.TestCheckResourceAttr("fastly_service_vcl.foo", "active_version", "2"),
+					resource.TestCheckResourceAttr("fastly_service_vcl.foo", "domain.#", "1"),
+					resource.TestCheckResourceAttr("fastly_service_vcl.foo", "backend.#", "1"),
 				),
 			},
 			{
@@ -479,7 +465,7 @@ func TestAccFastlyServiceVCL_basic(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				// These attributes are not stored on the Fastly API and must be ignored.
-				ImportStateVerifyIgnore: []string{"activate", "force_destroy"},
+				ImportStateVerifyIgnore: []string{"activate", "force_destroy", "imported"},
 				ImportStateIdFunc: func(_ *terraform.State) (string, error) {
 					return fmt.Sprintf("%s@2", service.ID), nil
 				},

--- a/fastly/resource_fastly_service_waf_configuration.go
+++ b/fastly/resource_fastly_service_waf_configuration.go
@@ -356,6 +356,8 @@ func resourceServiceWAFConfigurationUpdate(ctx context.Context, d *schema.Resour
 }
 
 func resourceServiceWAFConfigurationRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	log.Printf("[DEBUG] Refreshing WAF Configuration for (%s)", d.Id())
+
 	latestVersion, err := getLatestVersion(d, meta)
 	if err != nil {
 		if errRes, ok := err.(*gofastly.HTTPError); ok {

--- a/fastly/resource_fastly_tls_activation.go
+++ b/fastly/resource_fastly_tls_activation.go
@@ -71,6 +71,8 @@ func resourceFastlyTLSActivationCreate(ctx context.Context, d *schema.ResourceDa
 }
 
 func resourceFastlyTLSActivationRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	log.Printf("[DEBUG] Refreshing TLS Activation Configuration for (%s)", d.Id())
+
 	conn := meta.(*APIClient).conn
 
 	activation, err := conn.GetTLSActivation(&fastly.GetTLSActivationInput{

--- a/fastly/resource_fastly_tls_certificate.go
+++ b/fastly/resource_fastly_tls_certificate.go
@@ -3,6 +3,7 @@ package fastly
 import (
 	"context"
 	"fmt"
+	"log"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -101,6 +102,8 @@ func resourceFastlyTLSCertificateCreate(ctx context.Context, d *schema.ResourceD
 }
 
 func resourceFastlyTLSCertificateRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	log.Printf("[DEBUG] Refreshing TLS Certificate Configuration for (%s)", d.Id())
+
 	conn := meta.(*APIClient).conn
 
 	var diags diag.Diagnostics

--- a/fastly/resource_fastly_tls_platform_certificate.go
+++ b/fastly/resource_fastly_tls_platform_certificate.go
@@ -3,6 +3,7 @@ package fastly
 import (
 	"context"
 	"fmt"
+	"log"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -103,6 +104,8 @@ func resourceFastlyTLSPlatformCertificateCreate(ctx context.Context, d *schema.R
 }
 
 func resourceFastlyTLSPlatformCertificateRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	log.Printf("[DEBUG] Refreshing TLS Platform Certificate Configuration for (%s)", d.Id())
+
 	conn := meta.(*APIClient).conn
 
 	var diags diag.Diagnostics

--- a/fastly/resource_fastly_tls_private_key.go
+++ b/fastly/resource_fastly_tls_private_key.go
@@ -3,6 +3,7 @@ package fastly
 import (
 	"context"
 	"fmt"
+	"log"
 	"time"
 
 	gofastly "github.com/fastly/go-fastly/v6/fastly"
@@ -78,6 +79,8 @@ func resourceFastlyTLSPrivateKeyCreate(ctx context.Context, d *schema.ResourceDa
 }
 
 func resourceFastlyTLSPrivateKeyRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	log.Printf("[DEBUG] Refreshing TLS Private Key Configuration for (%s)", d.Id())
+
 	conn := meta.(*APIClient).conn
 
 	var diags diag.Diagnostics

--- a/fastly/resource_fastly_tls_subscription.go
+++ b/fastly/resource_fastly_tls_subscription.go
@@ -3,6 +3,7 @@ package fastly
 import (
 	"context"
 	"fmt"
+	"log"
 	"strings"
 	"time"
 
@@ -191,6 +192,8 @@ func resourceFastlyTLSSubscriptionCreate(ctx context.Context, d *schema.Resource
 }
 
 func resourceFastlyTLSSubscriptionRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	log.Printf("[DEBUG] Refreshing TLS Subscription Configuration for (%s)", d.Id())
+
 	conn := meta.(*APIClient).conn
 
 	include := "tls_authorizations"

--- a/fastly/resource_fastly_tls_subscription_validation.go
+++ b/fastly/resource_fastly_tls_subscription_validation.go
@@ -3,6 +3,7 @@ package fastly
 import (
 	"context"
 	"fmt"
+	"log"
 	"time"
 
 	gofastly "github.com/fastly/go-fastly/v6/fastly"
@@ -65,6 +66,8 @@ func resourceFastlyTLSSubscriptionValidationCreate(ctx context.Context, d *schem
 }
 
 func resourceFastlyTLSSubscriptionValidationRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	log.Printf("[DEBUG] Refreshing TLS Subscription Validation Configuration for (%s)", d.Id())
+
 	conn := meta.(*APIClient).conn
 
 	subscriptionID := d.Get("subscription_id").(string)

--- a/fastly/resource_fastly_user.go
+++ b/fastly/resource_fastly_user.go
@@ -2,6 +2,7 @@ package fastly
 
 import (
 	"context"
+	"log"
 
 	gofastly "github.com/fastly/go-fastly/v6/fastly"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -61,6 +62,7 @@ func resourceUserCreate(_ context.Context, d *schema.ResourceData, meta interfac
 }
 
 func resourceUserRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	log.Printf("[DEBUG] Refreshing User Configuration for (%s)", d.Id())
 	conn := meta.(*APIClient).conn
 
 	u, err := conn.GetUser(&gofastly.GetUserInput{


### PR DESCRIPTION
**Problem**: The top-level resources (e.g. fastly_service_vcl, fastly_service_compute, etc) only call the resource's associated 'Read' method (to update the internal Terraform state) if the resources were actually defined in the TF configuration, whereas nested block resources within a top-level resource (e.g. backend, domain, dictionary etc) have a `Read` method that will make GET API calls to update the data for that nested resource regardless of whether they were defined in the TF configuration.

**Solution**: Wrap each relevant section of code (in the nested block resource's 'Read' method) in a conditional statement that checks the length of available resources that exist within the state file.

Additionally, I discovered this implementation broke the provider's ability to import a service, and so I added a new computed attribute called `imported` that is temporarily set to `true` while an import is happening, and then reset it to `false` once the import is complete. This allows each nested resource's 'Read' method to not accidentally skip calling the API when an import is the intended behaviour.

**Results**:
This PR has caused the time it takes to run the end-to-end integration tests (as well as user `terraform plan`s) to be reduced by **~70%**!

**Notes**: There appears to be an inconsistency in how the resource 'key' is looked up. Most files use `GetKey()` while a couple of files use `Key()`. The former looks to be inherited by a base structure. I've not tried to clean this up, but I'm aware this might not be obvious to a code reviewer.

I've tested this code locally and can see that if I don't define a resource, then we don't try to refresh the state by calling the associated API endpoint. Then I define a new resource in the user Terraform configuration and I see that when running a `terraform plan` that the associated API endpoint is called for a refresh of state.

---

The review is easier with whitespace changes disabled...
https://github.com/fastly/terraform-provider-fastly/pull/593/files?w=1 
