### PR TITLE
Bug: Backends send empty string to API

### DIFF
--- a/fastly/block_fastly_service_backend.go
+++ b/fastly/block_fastly_service_backend.go
@@ -277,16 +277,10 @@ func (h *BackendServiceAttributeHandler) buildCreateBackendInput(service string,
 		FirstByteTimeout:    gofastly.Int(resource["first_byte_timeout"].(int)),
 		HealthCheck:         gofastly.String(resource["healthcheck"].(string)),
 		MaxConn:             gofastly.Int(resource["max_conn"].(int)),
-		MaxTLSVersion:       gofastly.String(resource["max_tls_version"].(string)),
-		MinTLSVersion:       gofastly.String(resource["min_tls_version"].(string)),
 		Name:                gofastly.String(resource["name"].(string)),
 		Port:                gofastly.Int(resource["port"].(int)),
-		SSLCACert:           gofastly.String(resource["ssl_ca_cert"].(string)),
 		SSLCertHostname:     gofastly.String(resource["ssl_cert_hostname"].(string)),
 		SSLCheckCert:        gofastly.CBool(resource["ssl_check_cert"].(bool)),
-		SSLCiphers:          gofastly.String(resource["ssl_ciphers"].(string)),
-		SSLClientCert:       gofastly.String(resource["ssl_client_cert"].(string)),
-		SSLClientKey:        gofastly.String(resource["ssl_client_key"].(string)),
 		SSLSNIHostname:      gofastly.String(resource["ssl_sni_hostname"].(string)),
 		ServiceID:           service,
 		ServiceVersion:      latestVersion,
@@ -298,8 +292,26 @@ func (h *BackendServiceAttributeHandler) buildCreateBackendInput(service string,
 	// WARNING: The following fields shouldn't have an empty string passed.
 	// As it will cause the Fastly API to return an error.
 	// This is because go-fastly v7+ will not 'omitempty' due to pointer type.
+	if resource["min_tls_version"].(string) != "" {
+		opts.MinTLSVersion = gofastly.String(resource["min_tls_version"].(string))
+	}
+	if resource["max_tls_version"].(string) != "" {
+		opts.MaxTLSVersion = gofastly.String(resource["max_tls_version"].(string))
+	}
 	if resource["override_host"].(string) != "" {
 		opts.OverrideHost = gofastly.String(resource["override_host"].(string))
+	}
+	if resource["ssl_ca_cert"].(string) != "" {
+		opts.SSLCACert = gofastly.String(resource["ssl_ca_cert"].(string))
+	}
+	if resource["ssl_ciphers"].(string) != "" {
+		opts.SSLCiphers = gofastly.String(resource["ssl_ciphers"].(string))
+	}
+	if resource["ssl_client_cert"].(string) != "" {
+		opts.SSLClientCert = gofastly.String(resource["ssl_client_cert"].(string))
+	}
+	if resource["ssl_client_key"].(string) != "" {
+		opts.SSLClientKey = gofastly.String(resource["ssl_client_key"].(string))
 	}
 
 	if h.GetServiceMetadata().serviceType == ServiceTypeVCL {

--- a/fastly/block_fastly_service_backend_test.go
+++ b/fastly/block_fastly_service_backend_test.go
@@ -1,0 +1,318 @@
+package fastly
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	gofastly "github.com/fastly/go-fastly/v7/fastly"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestResourceFastlyFlattenBackend(t *testing.T) {
+	cases := []struct {
+		serviceMetadata ServiceMetadata
+		remote          []*gofastly.Backend
+		local           []map[string]any
+	}{
+		{
+			serviceMetadata: ServiceMetadata{
+				serviceType: ServiceTypeVCL,
+			},
+			remote: []*gofastly.Backend{
+				{
+					Name:                "test.notexample.com",
+					Address:             "www.notexample.com",
+					OverrideHost:        "origin.example.com",
+					Port:                80,
+					AutoLoadbalance:     false,
+					BetweenBytesTimeout: 10000,
+					ConnectTimeout:      1000,
+					ErrorThreshold:      0,
+					FirstByteTimeout:    15000,
+					MaxConn:             200,
+					RequestCondition:    "",
+					HealthCheck:         "",
+					UseSSL:              false,
+					SSLCheckCert:        true,
+					SSLCACert:           "",
+					SSLCertHostname:     "",
+					SSLSNIHostname:      "",
+					SSLClientKey:        "",
+					SSLClientCert:       "",
+					MaxTLSVersion:       "",
+					MinTLSVersion:       "",
+					SSLCiphers:          "foo:bar:baz",
+					Shield:              "lga-ny-us",
+					Weight:              100,
+				},
+			},
+			local: []map[string]any{
+				{
+					"name":                  "test.notexample.com",
+					"address":               "www.notexample.com",
+					"override_host":         "origin.example.com",
+					"port":                  80,
+					"auto_loadbalance":      false,
+					"between_bytes_timeout": 10000,
+					"connect_timeout":       1000,
+					"error_threshold":       0,
+					"first_byte_timeout":    15000,
+					"max_conn":              200,
+					"request_condition":     "",
+					"healthcheck":           "",
+					"use_ssl":               false,
+					"ssl_check_cert":        true,
+					"ssl_ca_cert":           "",
+					"ssl_cert_hostname":     "",
+					"ssl_sni_hostname":      "",
+					"ssl_client_key":        "",
+					"ssl_client_cert":       "",
+					"max_tls_version":       "",
+					"min_tls_version":       "",
+					"ssl_ciphers":           "foo:bar:baz",
+					"shield":                "lga-ny-us",
+					"weight":                100,
+				},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		out := flattenBackend(c.remote, c.serviceMetadata)
+		if !reflect.DeepEqual(out, c.local) {
+			t.Fatalf("Error matching:\nexpected: %#v\n     got: %#v", c.local, out)
+		}
+	}
+}
+
+func TestResourceFastlyFlattenBackendCompute(t *testing.T) {
+	cases := []struct {
+		serviceMetadata ServiceMetadata
+		remote          []*gofastly.Backend
+		local           []map[string]any
+	}{
+		{
+			serviceMetadata: ServiceMetadata{
+				serviceType: ServiceTypeCompute,
+			},
+			remote: []*gofastly.Backend{
+				{
+					Name:                "test.notexample.com",
+					Address:             "www.notexample.com",
+					OverrideHost:        "origin.example.com",
+					Port:                80,
+					AutoLoadbalance:     true,
+					BetweenBytesTimeout: 10000,
+					ConnectTimeout:      1000,
+					ErrorThreshold:      0,
+					FirstByteTimeout:    15000,
+					MaxConn:             200,
+					HealthCheck:         "",
+					UseSSL:              false,
+					SSLCheckCert:        true,
+					SSLHostname:         "",
+					SSLCACert:           "",
+					SSLCertHostname:     "",
+					SSLSNIHostname:      "",
+					SSLClientKey:        "",
+					SSLClientCert:       "",
+					MaxTLSVersion:       "",
+					MinTLSVersion:       "",
+					SSLCiphers:          "foo:bar:baz",
+					Shield:              "lga-ny-us",
+					Weight:              100,
+				},
+			},
+			local: []map[string]any{
+				{
+					"name":                  "test.notexample.com",
+					"address":               "www.notexample.com",
+					"override_host":         "origin.example.com",
+					"port":                  80,
+					"auto_loadbalance":      true,
+					"between_bytes_timeout": 10000,
+					"connect_timeout":       1000,
+					"error_threshold":       0,
+					"first_byte_timeout":    15000,
+					"max_conn":              200,
+					"healthcheck":           "",
+					"use_ssl":               false,
+					"ssl_check_cert":        true,
+					"ssl_ca_cert":           "",
+					"ssl_cert_hostname":     "",
+					"ssl_sni_hostname":      "",
+					"ssl_client_key":        "",
+					"ssl_client_cert":       "",
+					"max_tls_version":       "",
+					"min_tls_version":       "",
+					"ssl_ciphers":           "foo:bar:baz",
+					"shield":                "lga-ny-us",
+					"weight":                100,
+				},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		out := flattenBackend(c.remote, c.serviceMetadata)
+		if !reflect.DeepEqual(out, c.local) {
+			t.Fatalf("Error matching:\nexpected: %#v\n     got: %#v", c.local, out)
+		}
+	}
+}
+
+func TestAccFastlyServiceVCLBackend_basic(t *testing.T) {
+	var service gofastly.ServiceDetail
+	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	domainName := fmt.Sprintf("fastly-test.tf-%s.com", acctest.RandString(10))
+	backendName := fmt.Sprintf("backend-tf-%s", acctest.RandString(10))
+	backendAddress := "httpbin.org"
+
+	b1 := gofastly.Backend{
+		Address: backendAddress,
+		Name:    backendName,
+		Port:    80,
+
+		// NOTE: The following are defaults applied by the API.
+		BetweenBytesTimeout: 10000,
+		ConnectTimeout:      1000,
+		FirstByteTimeout:    15000,
+		Hostname:            backendAddress,
+		MaxConn:             200,
+		SSLCheckCert:        true,
+		Weight:              100,
+	}
+	b2 := gofastly.Backend{
+		Address: backendAddress,
+		Name:    backendName + " updated",
+		Port:    80,
+
+		// NOTE: The following are defaults applied by the API.
+		BetweenBytesTimeout: 10000,
+		ConnectTimeout:      1000,
+		FirstByteTimeout:    15000,
+		Hostname:            backendAddress,
+		MaxConn:             200,
+		SSLCheckCert:        true,
+		Weight:              100,
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckServiceVCLDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServiceVCLBackend(serviceName, domainName, backendAddress, backendName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceVCLExists("fastly_service_vcl.foo", &service),
+					resource.TestCheckResourceAttr("fastly_service_vcl.foo", "name", serviceName),
+					resource.TestCheckResourceAttr("fastly_service_vcl.foo", "backend.#", "1"),
+					testAccCheckFastlyServiceVCLBackendAttributes(&service, []*gofastly.Backend{&b1}),
+				),
+			},
+
+			{
+				Config: testAccServiceVCLBackendUpdate(serviceName, domainName, backendAddress, backendName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceVCLExists("fastly_service_vcl.foo", &service),
+					resource.TestCheckResourceAttr("fastly_service_vcl.foo", "backend.#", "2"),
+					testAccCheckFastlyServiceVCLBackendAttributes(&service, []*gofastly.Backend{&b1, &b2}),
+				),
+			},
+		},
+	})
+}
+
+func testAccServiceVCLBackend(serviceName, domainName, backendAddress, backendName string) string {
+	return fmt.Sprintf(`
+resource "fastly_service_vcl" "foo" {
+  name = "%s"
+
+  domain {
+    name    = "%s"
+    comment = "demo"
+  }
+
+  backend {
+    address = "%s"
+    name    = "%s"
+    port    = 80
+  }
+
+  force_destroy = true
+}`, serviceName, domainName, backendAddress, backendName)
+}
+
+func testAccServiceVCLBackendUpdate(serviceName, domainName, backendAddress, backendName string) string {
+	return fmt.Sprintf(`
+resource "fastly_service_vcl" "foo" {
+  name = "%s"
+
+  domain {
+    name    = "%s"
+    comment = "demo"
+  }
+
+  backend {
+    address = "%s"
+    name    = "%s"
+    port    = 80
+  }
+
+  backend {
+    address = "%s"
+    name    = "%s updated"
+    port    = 80
+  }
+
+  force_destroy = true
+}`, serviceName, domainName, backendAddress, backendName, backendAddress, backendName)
+}
+
+func testAccCheckFastlyServiceVCLBackendAttributes(service *gofastly.ServiceDetail, want []*gofastly.Backend) resource.TestCheckFunc {
+	return func(_ *terraform.State) error {
+		conn := testAccProvider.Meta().(*APIClient).conn
+		have, err := conn.ListBackends(&gofastly.ListBackendsInput{
+			ServiceID:      service.ID,
+			ServiceVersion: service.ActiveVersion.Number,
+		})
+		if err != nil {
+			return fmt.Errorf("error looking up Backends for (%s), version (%v): %s", service.Name, service.ActiveVersion.Number, err)
+		}
+
+		if len(have) != len(want) {
+			return fmt.Errorf("backend list count mismatch, expected (%d), got (%d)", len(want), len(have))
+		}
+
+		var found int
+		for _, w := range want {
+			for _, h := range have {
+				if w.Name == h.Name {
+					// we don't know these things ahead of time, so populate them now
+					w.ServiceID = service.ID
+					w.ServiceVersion = service.ActiveVersion.Number
+					// We don't track these, so clear them out because we also wont know
+					// these ahead of time
+					h.CreatedAt = nil
+					h.UpdatedAt = nil
+					if !reflect.DeepEqual(w, h) {
+						return fmt.Errorf("bad match Backend match, expected (%#v), got (%#v)", w, h)
+					}
+					found++
+				}
+			}
+		}
+
+		if found != len(want) {
+			return fmt.Errorf("error matching Backends (%d/%d)", found, len(want))
+		}
+
+		return nil
+	}
+}

--- a/fastly/block_fastly_service_backend_test.go
+++ b/fastly/block_fastly_service_backend_test.go
@@ -174,7 +174,7 @@ func TestAccFastlyServiceVCLBackend_basic(t *testing.T) {
 	b1 := gofastly.Backend{
 		Address: backendAddress,
 		Name:    backendName,
-		Port:    80,
+		Port:    443,
 
 		// NOTE: The following are defaults applied by the API.
 		BetweenBytesTimeout: 10000,
@@ -188,7 +188,7 @@ func TestAccFastlyServiceVCLBackend_basic(t *testing.T) {
 	b2 := gofastly.Backend{
 		Address: backendAddress,
 		Name:    backendName + " updated",
-		Port:    80,
+		Port:    443,
 
 		// NOTE: The following are defaults applied by the API.
 		BetweenBytesTimeout: 10000,
@@ -229,6 +229,8 @@ func TestAccFastlyServiceVCLBackend_basic(t *testing.T) {
 	})
 }
 
+// NOTE: We set the port to 443 so we can validate the API is expecting SSL/TLS
+// related attributes to not be accidentally sent with empty strings.
 func testAccServiceVCLBackend(serviceName, domainName, backendAddress, backendName string) string {
 	return fmt.Sprintf(`
 resource "fastly_service_vcl" "foo" {
@@ -242,13 +244,15 @@ resource "fastly_service_vcl" "foo" {
   backend {
     address = "%s"
     name    = "%s"
-    port    = 80
+    port    = 443
   }
 
   force_destroy = true
 }`, serviceName, domainName, backendAddress, backendName)
 }
 
+// NOTE: We set the port to 443 so we can validate the API is expecting SSL/TLS
+// related attributes to not be accidentally sent with empty strings.
 func testAccServiceVCLBackendUpdate(serviceName, domainName, backendAddress, backendName string) string {
 	return fmt.Sprintf(`
 resource "fastly_service_vcl" "foo" {
@@ -262,13 +266,13 @@ resource "fastly_service_vcl" "foo" {
   backend {
     address = "%s"
     name    = "%s"
-    port    = 80
+    port    = 443
   }
 
   backend {
     address = "%s"
     name    = "%s updated"
-    port    = 80
+    port    = 443
   }
 
   force_destroy = true

--- a/fastly/block_fastly_service_domain_test.go
+++ b/fastly/block_fastly_service_domain_test.go
@@ -1,0 +1,50 @@
+package fastly
+
+import (
+	"reflect"
+	"testing"
+
+	gofastly "github.com/fastly/go-fastly/v7/fastly"
+)
+
+func TestResourceFastlyFlattenDomains(t *testing.T) {
+	cases := []struct {
+		remote []*gofastly.Domain
+		local  []map[string]any
+	}{
+		{
+			remote: []*gofastly.Domain{
+				{
+					Name:    "test.notexample.com",
+					Comment: "not comment",
+				},
+			},
+			local: []map[string]any{
+				{
+					"name":    "test.notexample.com",
+					"comment": "not comment",
+				},
+			},
+		},
+		{
+			remote: []*gofastly.Domain{
+				{
+					Name: "test.notexample.com",
+				},
+			},
+			local: []map[string]any{
+				{
+					"name":    "test.notexample.com",
+					"comment": "",
+				},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		out := flattenDomains(c.remote)
+		if !reflect.DeepEqual(out, c.local) {
+			t.Fatalf("Error matching:\nexpected: %#v\ngot: %#v", c.local, out)
+		}
+	}
+}

--- a/fastly/resource_fastly_service_compute_test.go
+++ b/fastly/resource_fastly_service_compute_test.go
@@ -2,7 +2,6 @@ package fastly
 
 import (
 	"fmt"
-	"reflect"
 	"testing"
 
 	gofastly "github.com/fastly/go-fastly/v7/fastly"
@@ -10,82 +9,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
-
-func TestResourceFastlyFlattenBackendCompute(t *testing.T) {
-	cases := []struct {
-		serviceMetadata ServiceMetadata
-		remote          []*gofastly.Backend
-		local           []map[string]any
-	}{
-		{
-			serviceMetadata: ServiceMetadata{
-				serviceType: ServiceTypeCompute,
-			},
-			remote: []*gofastly.Backend{
-				{
-					Name:                "test.notexample.com",
-					Address:             "www.notexample.com",
-					OverrideHost:        "origin.example.com",
-					Port:                80,
-					AutoLoadbalance:     true,
-					BetweenBytesTimeout: 10000,
-					ConnectTimeout:      1000,
-					ErrorThreshold:      0,
-					FirstByteTimeout:    15000,
-					MaxConn:             200,
-					HealthCheck:         "",
-					UseSSL:              false,
-					SSLCheckCert:        true,
-					SSLHostname:         "",
-					SSLCACert:           "",
-					SSLCertHostname:     "",
-					SSLSNIHostname:      "",
-					SSLClientKey:        "",
-					SSLClientCert:       "",
-					MaxTLSVersion:       "",
-					MinTLSVersion:       "",
-					SSLCiphers:          "foo:bar:baz",
-					Shield:              "lga-ny-us",
-					Weight:              100,
-				},
-			},
-			local: []map[string]any{
-				{
-					"name":                  "test.notexample.com",
-					"address":               "www.notexample.com",
-					"override_host":         "origin.example.com",
-					"port":                  80,
-					"auto_loadbalance":      true,
-					"between_bytes_timeout": 10000,
-					"connect_timeout":       1000,
-					"error_threshold":       0,
-					"first_byte_timeout":    15000,
-					"max_conn":              200,
-					"healthcheck":           "",
-					"use_ssl":               false,
-					"ssl_check_cert":        true,
-					"ssl_ca_cert":           "",
-					"ssl_cert_hostname":     "",
-					"ssl_sni_hostname":      "",
-					"ssl_client_key":        "",
-					"ssl_client_cert":       "",
-					"max_tls_version":       "",
-					"min_tls_version":       "",
-					"ssl_ciphers":           "foo:bar:baz",
-					"shield":                "lga-ny-us",
-					"weight":                100,
-				},
-			},
-		},
-	}
-
-	for _, c := range cases {
-		out := flattenBackend(c.remote, c.serviceMetadata)
-		if !reflect.DeepEqual(out, c.local) {
-			t.Fatalf("Error matching:\nexpected: %#v\n     got: %#v", c.local, out)
-		}
-	}
-}
 
 func TestAccFastlyServiceCompute_basic(t *testing.T) {
 	var service gofastly.ServiceDetail

--- a/fastly/resource_fastly_service_vcl_test.go
+++ b/fastly/resource_fastly_service_vcl_test.go
@@ -2,7 +2,6 @@ package fastly
 
 import (
 	"fmt"
-	"reflect"
 	"regexp"
 	"strings"
 	"testing"
@@ -18,125 +17,6 @@ func init() {
 		Name: "fastly_service_vcl",
 		F:    testSweepServices,
 	})
-}
-
-func TestResourceFastlyFlattenDomains(t *testing.T) {
-	cases := []struct {
-		remote []*gofastly.Domain
-		local  []map[string]any
-	}{
-		{
-			remote: []*gofastly.Domain{
-				{
-					Name:    "test.notexample.com",
-					Comment: "not comment",
-				},
-			},
-			local: []map[string]any{
-				{
-					"name":    "test.notexample.com",
-					"comment": "not comment",
-				},
-			},
-		},
-		{
-			remote: []*gofastly.Domain{
-				{
-					Name: "test.notexample.com",
-				},
-			},
-			local: []map[string]any{
-				{
-					"name":    "test.notexample.com",
-					"comment": "",
-				},
-			},
-		},
-	}
-
-	for _, c := range cases {
-		out := flattenDomains(c.remote)
-		if !reflect.DeepEqual(out, c.local) {
-			t.Fatalf("Error matching:\nexpected: %#v\ngot: %#v", c.local, out)
-		}
-	}
-}
-
-func TestResourceFastlyFlattenBackend(t *testing.T) {
-	cases := []struct {
-		serviceMetadata ServiceMetadata
-		remote          []*gofastly.Backend
-		local           []map[string]any
-	}{
-		{
-			serviceMetadata: ServiceMetadata{
-				serviceType: ServiceTypeVCL,
-			},
-			remote: []*gofastly.Backend{
-				{
-					Name:                "test.notexample.com",
-					Address:             "www.notexample.com",
-					OverrideHost:        "origin.example.com",
-					Port:                80,
-					AutoLoadbalance:     false,
-					BetweenBytesTimeout: 10000,
-					ConnectTimeout:      1000,
-					ErrorThreshold:      0,
-					FirstByteTimeout:    15000,
-					MaxConn:             200,
-					RequestCondition:    "",
-					HealthCheck:         "",
-					UseSSL:              false,
-					SSLCheckCert:        true,
-					SSLCACert:           "",
-					SSLCertHostname:     "",
-					SSLSNIHostname:      "",
-					SSLClientKey:        "",
-					SSLClientCert:       "",
-					MaxTLSVersion:       "",
-					MinTLSVersion:       "",
-					SSLCiphers:          "foo:bar:baz",
-					Shield:              "lga-ny-us",
-					Weight:              100,
-				},
-			},
-			local: []map[string]any{
-				{
-					"name":                  "test.notexample.com",
-					"address":               "www.notexample.com",
-					"override_host":         "origin.example.com",
-					"port":                  80,
-					"auto_loadbalance":      false,
-					"between_bytes_timeout": 10000,
-					"connect_timeout":       1000,
-					"error_threshold":       0,
-					"first_byte_timeout":    15000,
-					"max_conn":              200,
-					"request_condition":     "",
-					"healthcheck":           "",
-					"use_ssl":               false,
-					"ssl_check_cert":        true,
-					"ssl_ca_cert":           "",
-					"ssl_cert_hostname":     "",
-					"ssl_sni_hostname":      "",
-					"ssl_client_key":        "",
-					"ssl_client_cert":       "",
-					"max_tls_version":       "",
-					"min_tls_version":       "",
-					"ssl_ciphers":           "foo:bar:baz",
-					"shield":                "lga-ny-us",
-					"weight":                100,
-				},
-			},
-		},
-	}
-
-	for _, c := range cases {
-		out := flattenBackend(c.remote, c.serviceMetadata)
-		if !reflect.DeepEqual(out, c.local) {
-			t.Fatalf("Error matching:\nexpected: %#v\n     got: %#v", c.local, out)
-		}
-	}
 }
 
 func TestAccFastlyServiceVCL_updateDomain(t *testing.T) {


### PR DESCRIPTION
**Problem**:
When creating a backend, if you set the port to 443 the API will expect SSL/TLS attributes to not be sent with an empty string, and that is what was happening in the latest Terraform v3 release. 

**Context** :
The Terraform provider wraps all values in a pointer (as that is what go-fastly v7+ expects), but the zero value for an attribute (e.g. `""` for the string type) is what will be wrapped inside the pointer and consequently sent to the API via go-fastly.

**Solution**:
As with other attributes, once we switched to port 443, we were able to use the integration/acceptance tests to identify which attributes would cause API errors and consequently avoid setting those fields on the go-fastly struct.