### PR TITLE
Bug: Some logging providers were sending an empty `placement` to the Fastly API

### DIFF
--- a/fastly/block_fastly_service_logging_bigquery.go
+++ b/fastly/block_fastly_service_logging_bigquery.go
@@ -124,7 +124,6 @@ func (h *BigQueryLoggingServiceAttributeHandler) Create(_ context.Context, d *sc
 		User:           gofastly.String(resource["email"].(string)),
 		SecretKey:      gofastly.String(resource["secret_key"].(string)),
 		Template:       gofastly.String(resource["template"].(string)),
-		Placement:      gofastly.String(vla.placement),
 	}
 
 	// WARNING: The following fields shouldn't have an empty string passed.
@@ -132,6 +131,9 @@ func (h *BigQueryLoggingServiceAttributeHandler) Create(_ context.Context, d *sc
 	// This is because go-fastly v7+ will not 'omitempty' due to pointer type.
 	if vla.format != "" {
 		opts.Format = gofastly.String(vla.format)
+	}
+	if vla.placement != "" {
+		opts.Placement = gofastly.String(vla.placement)
 	}
 	if vla.responseCondition != "" {
 		opts.ResponseCondition = gofastly.String(vla.responseCondition)

--- a/fastly/block_fastly_service_logging_bigquery_test.go
+++ b/fastly/block_fastly_service_logging_bigquery_test.go
@@ -189,8 +189,7 @@ resource "fastly_service_vcl" "foo" {
     project_id = "example-gcp-project"
     dataset    = "example_bq_dataset"
     table      = "example_bq_table"
-	format     = "%%h %%l %%u %%t %%r %%>s"
-	placement  = "waf_debug"
+    format     = "%%h %%l %%u %%t %%r %%>s"
   }
 
   force_destroy = true

--- a/fastly/block_fastly_service_logging_cloudfiles.go
+++ b/fastly/block_fastly_service_logging_cloudfiles.go
@@ -344,7 +344,6 @@ func (h *CloudfilesServiceAttributeHandler) buildCreate(cloudfilesMap any, servi
 		Name:             gofastly.String(resource["name"].(string)),
 		Path:             gofastly.String(resource["path"].(string)),
 		Period:           gofastly.Int(resource["period"].(int)),
-		Placement:        gofastly.String(vla.placement),
 		PublicKey:        gofastly.String(resource["public_key"].(string)),
 		Region:           gofastly.String(resource["region"].(string)),
 		ServiceID:        serviceID,
@@ -364,6 +363,9 @@ func (h *CloudfilesServiceAttributeHandler) buildCreate(cloudfilesMap any, servi
 	// WARNING: The following fields shouldn't have an empty string passed.
 	// As it will cause the Fastly API to return an error.
 	// This is because go-fastly v7+ will not 'omitempty' due to pointer type.
+	if vla.placement != "" {
+		opts.Placement = gofastly.String(vla.placement)
+	}
 	if vla.responseCondition != "" {
 		opts.ResponseCondition = gofastly.String(vla.responseCondition)
 	}

--- a/fastly/block_fastly_service_logging_digitalocean.go
+++ b/fastly/block_fastly_service_logging_digitalocean.go
@@ -344,7 +344,6 @@ func (h *DigitalOceanServiceAttributeHandler) buildCreate(digitaloceanMap any, s
 		Name:             gofastly.String(resource["name"].(string)),
 		Path:             gofastly.String(resource["path"].(string)),
 		Period:           gofastly.Int(resource["period"].(int)),
-		Placement:        gofastly.String(vla.placement),
 		PublicKey:        gofastly.String(resource["public_key"].(string)),
 		SecretKey:        gofastly.String(resource["secret_key"].(string)),
 		ServiceID:        serviceID,
@@ -363,6 +362,9 @@ func (h *DigitalOceanServiceAttributeHandler) buildCreate(digitaloceanMap any, s
 	// WARNING: The following fields shouldn't have an empty string passed.
 	// As it will cause the Fastly API to return an error.
 	// This is because go-fastly v7+ will not 'omitempty' due to pointer type.
+	if vla.placement != "" {
+		opts.Placement = gofastly.String(vla.placement)
+	}
 	if vla.responseCondition != "" {
 		opts.ResponseCondition = gofastly.String(vla.responseCondition)
 	}

--- a/fastly/block_fastly_service_logging_elasticsearch.go
+++ b/fastly/block_fastly_service_logging_elasticsearch.go
@@ -312,7 +312,6 @@ func (h *ElasticSearchServiceAttributeHandler) buildCreate(elasticsearchMap any,
 		Name:              gofastly.String(resource["name"].(string)),
 		Password:          gofastly.String(resource["password"].(string)),
 		Pipeline:          gofastly.String(resource["pipeline"].(string)),
-		Placement:         gofastly.String(vla.placement),
 		RequestMaxBytes:   gofastly.Int(resource["request_max_bytes"].(int)),
 		RequestMaxEntries: gofastly.Int(resource["request_max_entries"].(int)),
 		ServiceID:         serviceID,
@@ -328,9 +327,9 @@ func (h *ElasticSearchServiceAttributeHandler) buildCreate(elasticsearchMap any,
 	// WARNING: The following fields shouldn't have an empty string passed.
 	// As it will cause the Fastly API to return an error.
 	// This is because go-fastly v7+ will not 'omitempty' due to pointer type.
-	// if vla.placement != "" {
-	// 	opts.Placement = gofastly.String(vla.placement)
-	// }
+	if vla.placement != "" {
+		opts.Placement = gofastly.String(vla.placement)
+	}
 	if vla.responseCondition != "" {
 		opts.ResponseCondition = gofastly.String(vla.responseCondition)
 	}

--- a/fastly/block_fastly_service_logging_ftp.go
+++ b/fastly/block_fastly_service_logging_ftp.go
@@ -346,7 +346,6 @@ func (h *FTPServiceAttributeHandler) buildCreate(ftpMap any, serviceID string, s
 		Password:         gofastly.String(resource["password"].(string)),
 		Path:             gofastly.String(resource["path"].(string)),
 		Period:           gofastly.Int(resource["period"].(int)),
-		Placement:        gofastly.String(vla.placement),
 		Port:             gofastly.Int(resource["port"].(int)),
 		PublicKey:        gofastly.String(resource["public_key"].(string)),
 		ServiceID:        serviceID,
@@ -366,6 +365,9 @@ func (h *FTPServiceAttributeHandler) buildCreate(ftpMap any, serviceID string, s
 	// WARNING: The following fields shouldn't have an empty string passed.
 	// As it will cause the Fastly API to return an error.
 	// This is because go-fastly v7+ will not 'omitempty' due to pointer type.
+	if vla.placement != "" {
+		opts.Placement = gofastly.String(vla.placement)
+	}
 	if vla.responseCondition != "" {
 		opts.ResponseCondition = gofastly.String(vla.responseCondition)
 	}

--- a/fastly/block_fastly_service_logging_googlepubsub.go
+++ b/fastly/block_fastly_service_logging_googlepubsub.go
@@ -255,7 +255,6 @@ func (h *GooglePubSubServiceAttributeHandler) buildCreate(googlepubsubMap any, s
 		Format:         gofastly.String(vla.format),
 		FormatVersion:  vla.formatVersion,
 		Name:           gofastly.String(resource["name"].(string)),
-		Placement:      gofastly.String(vla.placement),
 		ProjectID:      gofastly.String(resource["project_id"].(string)),
 		SecretKey:      gofastly.String(resource["secret_key"].(string)),
 		ServiceID:      serviceID,
@@ -267,6 +266,9 @@ func (h *GooglePubSubServiceAttributeHandler) buildCreate(googlepubsubMap any, s
 	// WARNING: The following fields shouldn't have an empty string passed.
 	// As it will cause the Fastly API to return an error.
 	// This is because go-fastly v7+ will not 'omitempty' due to pointer type.
+	if vla.placement != "" {
+		opts.Placement = gofastly.String(vla.placement)
+	}
 	if vla.responseCondition != "" {
 		opts.ResponseCondition = gofastly.String(vla.responseCondition)
 	}

--- a/fastly/block_fastly_service_logging_kafka.go
+++ b/fastly/block_fastly_service_logging_kafka.go
@@ -341,7 +341,6 @@ func (h *KafkaServiceAttributeHandler) buildCreate(kafkaMap any, serviceID strin
 		Name:             gofastly.String(resource["name"].(string)),
 		ParseLogKeyvals:  gofastly.CBool(resource["parse_log_keyvals"].(bool)),
 		Password:         gofastly.String(resource["password"].(string)),
-		Placement:        gofastly.String(vla.placement),
 		RequestMaxBytes:  gofastly.Int(resource["request_max_bytes"].(int)),
 		RequiredACKs:     gofastly.String(resource["required_acks"].(string)),
 		ServiceID:        serviceID,
@@ -358,6 +357,9 @@ func (h *KafkaServiceAttributeHandler) buildCreate(kafkaMap any, serviceID strin
 	// WARNING: The following fields shouldn't have an empty string passed.
 	// As it will cause the Fastly API to return an error.
 	// This is because go-fastly v7+ will not 'omitempty' due to pointer type.
+	if vla.placement != "" {
+		opts.Placement = gofastly.String(vla.placement)
+	}
 	if vla.responseCondition != "" {
 		opts.ResponseCondition = gofastly.String(vla.responseCondition)
 	}

--- a/fastly/block_fastly_service_logging_openstack.go
+++ b/fastly/block_fastly_service_logging_openstack.go
@@ -346,7 +346,6 @@ func (h *OpenstackServiceAttributeHandler) buildCreate(openstackMap any, service
 		Name:             gofastly.String(resource["name"].(string)),
 		Path:             gofastly.String(resource["path"].(string)),
 		Period:           gofastly.Int(resource["period"].(int)),
-		Placement:        gofastly.String(vla.placement),
 		PublicKey:        gofastly.String(resource["public_key"].(string)),
 		ServiceID:        serviceID,
 		ServiceVersion:   serviceVersion,
@@ -366,6 +365,9 @@ func (h *OpenstackServiceAttributeHandler) buildCreate(openstackMap any, service
 	// WARNING: The following fields shouldn't have an empty string passed.
 	// As it will cause the Fastly API to return an error.
 	// This is because go-fastly v7+ will not 'omitempty' due to pointer type.
+	if vla.placement != "" {
+		opts.Placement = gofastly.String(vla.placement)
+	}
 	if vla.responseCondition != "" {
 		opts.ResponseCondition = gofastly.String(vla.responseCondition)
 	}

--- a/fastly/block_fastly_service_logging_scalyr.go
+++ b/fastly/block_fastly_service_logging_scalyr.go
@@ -221,7 +221,6 @@ func (h *ScalyrServiceAttributeHandler) buildCreate(scalyrMap any, serviceID str
 		Format:         gofastly.String(vla.format),
 		FormatVersion:  vla.formatVersion,
 		Name:           gofastly.String(resource["name"].(string)),
-		Placement:      gofastly.String(vla.placement),
 		Region:         gofastly.String(resource["region"].(string)),
 		ServiceID:      serviceID,
 		ServiceVersion: serviceVersion,
@@ -234,6 +233,9 @@ func (h *ScalyrServiceAttributeHandler) buildCreate(scalyrMap any, serviceID str
 	// if vla.placement != "" {
 	// 	opts.Placement = gofastly.String(vla.placement)
 	// }
+	if vla.placement != "" {
+		opts.Placement = gofastly.String(vla.placement)
+	}
 	if vla.responseCondition != "" {
 		opts.ResponseCondition = gofastly.String(vla.responseCondition)
 	}

--- a/fastly/block_fastly_service_logging_sftp.go
+++ b/fastly/block_fastly_service_logging_sftp.go
@@ -371,7 +371,6 @@ func (h *SFTPServiceAttributeHandler) buildCreate(sftpMap any, serviceID string,
 		Name:             gofastly.String(resource["name"].(string)),
 		Password:         gofastly.String(resource["password"].(string)),
 		Path:             gofastly.String(resource["path"].(string)),
-		Placement:        gofastly.String(vla.placement),
 		Port:             gofastly.Int(resource["port"].(int)),
 		PublicKey:        gofastly.String(resource["public_key"].(string)),
 		SSHKnownHosts:    gofastly.String(resource["ssh_known_hosts"].(string)),
@@ -393,6 +392,9 @@ func (h *SFTPServiceAttributeHandler) buildCreate(sftpMap any, serviceID string,
 	// WARNING: The following fields shouldn't have an empty string passed.
 	// As it will cause the Fastly API to return an error.
 	// This is because go-fastly v7+ will not 'omitempty' due to pointer type.
+	if vla.placement != "" {
+		opts.Placement = gofastly.String(vla.placement)
+	}
 	if vla.responseCondition != "" {
 		opts.ResponseCondition = gofastly.String(vla.responseCondition)
 	}


### PR DESCRIPTION
**Problem**:
When creating a logging provider the `placement` attribute is optional and the API will expect it to not be sent with an empty value, but that is what was happening in the latest Terraform v3 release. 

**Context** :
The Terraform provider wraps all values in a pointer (as that is what go-fastly v7+ expects), but the zero value for an attribute (e.g. `""` for the string type) is what will be wrapped inside the pointer and consequently sent to the API via go-fastly. Previously we had used the integration/acceptance tests to identify which attributes would cause API errors but what happened in this instance was that the tests were setting a value for that field and so no error was reported.

**Solution**:
Do as we have already done with the other logging providers and avoid setting the `placement` field on the go-fastly struct.