### PR TITLE
Prevent SSL related fields from being sent empty to the Fastly API.

### DIFF
--- a/fastly/block_fastly_service_backend.go
+++ b/fastly/block_fastly_service_backend.go
@@ -279,9 +279,7 @@ func (h *BackendServiceAttributeHandler) buildCreateBackendInput(service string,
 		MaxConn:             gofastly.Int(resource["max_conn"].(int)),
 		Name:                gofastly.String(resource["name"].(string)),
 		Port:                gofastly.Int(resource["port"].(int)),
-		SSLCertHostname:     gofastly.String(resource["ssl_cert_hostname"].(string)),
 		SSLCheckCert:        gofastly.CBool(resource["ssl_check_cert"].(bool)),
-		SSLSNIHostname:      gofastly.String(resource["ssl_sni_hostname"].(string)),
 		ServiceID:           service,
 		ServiceVersion:      latestVersion,
 		Shield:              gofastly.String(resource["shield"].(string)),
@@ -304,6 +302,9 @@ func (h *BackendServiceAttributeHandler) buildCreateBackendInput(service string,
 	if resource["ssl_ca_cert"].(string) != "" {
 		opts.SSLCACert = gofastly.String(resource["ssl_ca_cert"].(string))
 	}
+	if resource["ssl_cert_hostname"].(string) != "" {
+		opts.SSLCertHostname = gofastly.String(resource["ssl_cert_hostname"].(string))
+	}
 	if resource["ssl_ciphers"].(string) != "" {
 		opts.SSLCiphers = gofastly.String(resource["ssl_ciphers"].(string))
 	}
@@ -312,6 +313,9 @@ func (h *BackendServiceAttributeHandler) buildCreateBackendInput(service string,
 	}
 	if resource["ssl_client_key"].(string) != "" {
 		opts.SSLClientKey = gofastly.String(resource["ssl_client_key"].(string))
+	}
+	if resource["ssl_sni_hostname"].(string) != "" {
+		opts.SSLSNIHostname = gofastly.String(resource["ssl_sni_hostname"].(string))
 	}
 
 	if h.GetServiceMetadata().serviceType == ServiceTypeVCL {

--- a/fastly/block_fastly_service_backend_test.go
+++ b/fastly/block_fastly_service_backend_test.go
@@ -204,8 +204,13 @@ func TestAccFastlyServiceVCLBackend_basic(t *testing.T) {
 		Weight:              100,
 	}
 	b3 := gofastly.Backend{
-		Address:         backendAddress,
-		Name:            backendName + " new with use ssl",
+		Address: backendAddress,
+		Name:    backendName + " new with use ssl",
+		// NOTE: We don't set the port attribute in the Terraform configuration, and
+		// so the Terraform provider defaults to setting that to port 80. This test
+		// validates that the Fastly API currently accepts port 80 (although the
+		// setting of use_ssl would otherwise cause you to expect some kind of API
+		// validation to prevent port 80 from being used).
 		Port:            80,
 		SSLCertHostname: "httpbin.org",
 		UseSSL:          true,


### PR DESCRIPTION
**NOTE**: While updating all the SSL fields for a backend to not be sent empty to the API (unless the user explicitly set them to be empty) I noticed that setting `use_ssl` would cause an API error... 

```
Error: invalid configuration for Fastly Service (<REDACTED>): 
Mandatory SSL cert checks require specifying cert hostname
```

To fix this you have to also specify `ssl_cert_hostname`, so I've updated the tests to reflect this.