### PR TITLE
fix: force refresh when service version is reverted outside of Terraform

### DIFF
--- a/docs/resources/service_compute.md
+++ b/docs/resources/service_compute.md
@@ -111,6 +111,7 @@ $ terraform import fastly_service_compute.demo xxxxxxxxxxxxxxxxxxxx@2
 
 - `active_version` (Number) The currently active version of your Fastly Service
 - `cloned_version` (Number) The latest cloned version by the provider
+- `force_refresh` (Boolean) Used internally by the provider to temporarily indicate if all resources should call their associated API to update the local state. This is for scenarios where the service version has been reverted outside of Terraform (e.g. via the Fastly UI) and the provider needs to resync the state for a different active version (this is only if `activate` is `true`).
 - `id` (String) The ID of this resource.
 - `imported` (Boolean) Used internally by the provider to temporarily indicate if the service is being imported, and is reset to false once the import is finished
 

--- a/docs/resources/service_vcl.md
+++ b/docs/resources/service_vcl.md
@@ -294,6 +294,7 @@ $ terraform import fastly_service_vcl.demo xxxxxxxxxxxxxxxxxxxx@2
 
 - `active_version` (Number) The currently active version of your Fastly Service
 - `cloned_version` (Number) The latest cloned version by the provider
+- `force_refresh` (Boolean) Used internally by the provider to temporarily indicate if all resources should call their associated API to update the local state. This is for scenarios where the service version has been reverted outside of Terraform (e.g. via the Fastly UI) and the provider needs to resync the state for a different active version (this is only if `activate` is `true`).
 - `id` (String) The ID of this resource.
 - `imported` (Boolean) Used internally by the provider to temporarily indicate if the service is being imported, and is reset to false once the import is finished
 

--- a/fastly/block_fastly_service_acl.go
+++ b/fastly/block_fastly_service_acl.go
@@ -75,7 +75,7 @@ func (h *ACLServiceAttributeHandler) Create(_ context.Context, d *schema.Resourc
 func (h *ACLServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, _ map[string]any, latestVersion int, conn *gofastly.Client) error {
 	localState := d.Get(h.Key()).(*schema.Set).List()
 
-	if len(localState) > 0 || d.Get("imported").(bool) {
+	if len(localState) > 0 || d.Get("imported").(bool) || d.Get("force_refresh").(bool) {
 		log.Printf("[DEBUG] Refreshing ACLs for (%s)", d.Id())
 		remoteState, err := conn.ListACLs(&gofastly.ListACLsInput{
 			ServiceID:      d.Id(),

--- a/fastly/block_fastly_service_backend.go
+++ b/fastly/block_fastly_service_backend.go
@@ -211,7 +211,7 @@ func (h *BackendServiceAttributeHandler) Create(_ context.Context, d *schema.Res
 func (h *BackendServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, _ map[string]any, serviceVersion int, conn *gofastly.Client) error {
 	localState := d.Get(h.GetKey()).(*schema.Set).List()
 
-	if len(localState) > 0 || d.Get("imported").(bool) {
+	if len(localState) > 0 || d.Get("imported").(bool) || d.Get("force_refresh").(bool) {
 		log.Printf("[DEBUG] Refreshing Backends for (%s)", d.Id())
 		remoteState, err := conn.ListBackends(&gofastly.ListBackendsInput{
 			ServiceID:      d.Id(),

--- a/fastly/block_fastly_service_cachesetting.go
+++ b/fastly/block_fastly_service_cachesetting.go
@@ -90,7 +90,7 @@ func (h *CacheSettingServiceAttributeHandler) Create(_ context.Context, d *schem
 func (h *CacheSettingServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, _ map[string]any, serviceVersion int, conn *gofastly.Client) error {
 	localState := d.Get(h.GetKey()).(*schema.Set).List()
 
-	if len(localState) > 0 || d.Get("imported").(bool) {
+	if len(localState) > 0 || d.Get("imported").(bool) || d.Get("force_refresh").(bool) {
 		log.Printf("[DEBUG] Refreshing Cache Settings for (%s)", d.Id())
 		remoteState, err := conn.ListCacheSettings(&gofastly.ListCacheSettingsInput{
 			ServiceID:      d.Id(),

--- a/fastly/block_fastly_service_condition.go
+++ b/fastly/block_fastly_service_condition.go
@@ -89,7 +89,7 @@ func (h *ConditionServiceAttributeHandler) Create(_ context.Context, d *schema.R
 func (h *ConditionServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, _ map[string]any, serviceVersion int, conn *gofastly.Client) error {
 	localState := d.Get(h.GetKey()).(*schema.Set).List()
 
-	if len(localState) > 0 || d.Get("imported").(bool) {
+	if len(localState) > 0 || d.Get("imported").(bool) || d.Get("force_refresh").(bool) {
 		log.Printf("[DEBUG] Refreshing Conditions for (%s)", d.Id())
 		remoteState, err := conn.ListConditions(&gofastly.ListConditionsInput{
 			ServiceID:      d.Id(),

--- a/fastly/block_fastly_service_dictionary.go
+++ b/fastly/block_fastly_service_dictionary.go
@@ -85,7 +85,7 @@ func (h *DictionaryServiceAttributeHandler) Create(_ context.Context, d *schema.
 func (h *DictionaryServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, _ map[string]any, serviceVersion int, conn *gofastly.Client) error {
 	localState := d.Get(h.GetKey()).(*schema.Set).List()
 
-	if len(localState) > 0 || d.Get("imported").(bool) {
+	if len(localState) > 0 || d.Get("imported").(bool) || d.Get("force_refresh").(bool) {
 		log.Printf("[DEBUG] Refreshing Dictionaries for (%s)", d.Id())
 		remoteState, err := conn.ListDictionaries(&gofastly.ListDictionariesInput{
 			ServiceID:      d.Id(),

--- a/fastly/block_fastly_service_director.go
+++ b/fastly/block_fastly_service_director.go
@@ -140,7 +140,7 @@ func (h *DirectorServiceAttributeHandler) Create(_ context.Context, d *schema.Re
 func (h *DirectorServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, _ map[string]any, serviceVersion int, conn *gofastly.Client) error {
 	localState := d.Get(h.GetKey()).(*schema.Set).List()
 
-	if len(localState) > 0 || d.Get("imported").(bool) {
+	if len(localState) > 0 || d.Get("imported").(bool) || d.Get("force_refresh").(bool) {
 		log.Printf("[DEBUG] Refreshing Directors for (%s)", d.Id())
 		remoteState, err := conn.ListDirectors(&gofastly.ListDirectorsInput{
 			ServiceID:      d.Id(),

--- a/fastly/block_fastly_service_domain.go
+++ b/fastly/block_fastly_service_domain.go
@@ -76,7 +76,7 @@ func (h *DomainServiceAttributeHandler) Create(_ context.Context, d *schema.Reso
 func (h *DomainServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, _ map[string]any, serviceVersion int, conn *gofastly.Client) error {
 	localState := d.Get(h.GetKey()).(*schema.Set).List()
 
-	if len(localState) > 0 || d.Get("imported").(bool) {
+	if len(localState) > 0 || d.Get("imported").(bool) || d.Get("force_refresh").(bool) {
 		// TODO: update go-fastly to support an ActiveVersion struct, which contains
 		// domain and backend info in the response. Here we do 2 additional queries
 		// to find out that info

--- a/fastly/block_fastly_service_dynamicsnippet.go
+++ b/fastly/block_fastly_service_dynamicsnippet.go
@@ -92,7 +92,7 @@ func (h *DynamicSnippetServiceAttributeHandler) Create(_ context.Context, d *sch
 func (h *DynamicSnippetServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, _ map[string]any, serviceVersion int, conn *gofastly.Client) error {
 	localState := d.Get(h.GetKey()).(*schema.Set).List()
 
-	if len(localState) > 0 || d.Get("imported").(bool) {
+	if len(localState) > 0 || d.Get("imported").(bool) || d.Get("force_refresh").(bool) {
 		log.Printf("[DEBUG] Refreshing VCL Snippets for (%s)", d.Id())
 		remoteState, err := conn.ListSnippets(&gofastly.ListSnippetsInput{
 			ServiceID:      d.Id(),

--- a/fastly/block_fastly_service_gzip.go
+++ b/fastly/block_fastly_service_gzip.go
@@ -94,7 +94,7 @@ func (h *GzipServiceAttributeHandler) Create(_ context.Context, d *schema.Resour
 func (h *GzipServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, _ map[string]any, serviceVersion int, conn *gofastly.Client) error {
 	localState := d.Get(h.GetKey()).(*schema.Set).List()
 
-	if len(localState) > 0 || d.Get("imported").(bool) {
+	if len(localState) > 0 || d.Get("imported").(bool) || d.Get("force_refresh").(bool) {
 		log.Printf("[DEBUG] Refreshing Gzips for (%s)", d.Id())
 		remoteState, err := conn.ListGzips(&gofastly.ListGzipsInput{
 			ServiceID:      d.Id(),

--- a/fastly/block_fastly_service_header.go
+++ b/fastly/block_fastly_service_header.go
@@ -134,7 +134,7 @@ func (h *HeaderServiceAttributeHandler) Create(_ context.Context, d *schema.Reso
 func (h *HeaderServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, _ map[string]any, serviceVersion int, conn *gofastly.Client) error {
 	localState := d.Get(h.GetKey()).(*schema.Set).List()
 
-	if len(localState) > 0 || d.Get("imported").(bool) {
+	if len(localState) > 0 || d.Get("imported").(bool) || d.Get("force_refresh").(bool) {
 		log.Printf("[DEBUG] Refreshing Headers for (%s)", d.Id())
 		remoteState, err := conn.ListHeaders(&gofastly.ListHeadersInput{
 			ServiceID:      d.Id(),

--- a/fastly/block_fastly_service_healthcheck.go
+++ b/fastly/block_fastly_service_healthcheck.go
@@ -159,7 +159,7 @@ func (h *HealthCheckServiceAttributeHandler) Create(_ context.Context, d *schema
 func (h *HealthCheckServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, _ map[string]any, serviceVersion int, conn *gofastly.Client) error {
 	localState := d.Get(h.GetKey()).(*schema.Set).List()
 
-	if len(localState) > 0 || d.Get("imported").(bool) {
+	if len(localState) > 0 || d.Get("imported").(bool) || d.Get("force_refresh").(bool) {
 		log.Printf("[DEBUG] Refreshing Healthcheck for (%s)", d.Id())
 		remoteState, err := conn.ListHealthChecks(&gofastly.ListHealthChecksInput{
 			ServiceID:      d.Id(),

--- a/fastly/block_fastly_service_logging_bigquery.go
+++ b/fastly/block_fastly_service_logging_bigquery.go
@@ -155,7 +155,7 @@ func (h *BigQueryLoggingServiceAttributeHandler) Create(_ context.Context, d *sc
 func (h *BigQueryLoggingServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, _ map[string]any, serviceVersion int, conn *gofastly.Client) error {
 	localState := d.Get(h.GetKey()).(*schema.Set).List()
 
-	if len(localState) > 0 || d.Get("imported").(bool) {
+	if len(localState) > 0 || d.Get("imported").(bool) || d.Get("force_refresh").(bool) {
 		log.Printf("[DEBUG] Refreshing BigQuery for (%s)", d.Id())
 		remoteState, err := conn.ListBigQueries(&gofastly.ListBigQueriesInput{
 			ServiceID:      d.Id(),

--- a/fastly/block_fastly_service_logging_blobstorage.go
+++ b/fastly/block_fastly_service_logging_blobstorage.go
@@ -194,7 +194,7 @@ func (h *BlobStorageLoggingServiceAttributeHandler) Create(_ context.Context, d 
 func (h *BlobStorageLoggingServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, _ map[string]any, serviceVersion int, conn *gofastly.Client) error {
 	localState := d.Get(h.GetKey()).(*schema.Set).List()
 
-	if len(localState) > 0 || d.Get("imported").(bool) {
+	if len(localState) > 0 || d.Get("imported").(bool) || d.Get("force_refresh").(bool) {
 		log.Printf("[DEBUG] Refreshing Blob Storages for (%s)", d.Id())
 		remoteState, err := conn.ListBlobStorages(&gofastly.ListBlobStoragesInput{
 			ServiceID:      d.Id(),

--- a/fastly/block_fastly_service_logging_cloudfiles.go
+++ b/fastly/block_fastly_service_logging_cloudfiles.go
@@ -154,7 +154,7 @@ func (h *CloudfilesServiceAttributeHandler) Create(_ context.Context, d *schema.
 func (h *CloudfilesServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, _ map[string]any, serviceVersion int, conn *gofastly.Client) error {
 	localState := d.Get(h.GetKey()).(*schema.Set).List()
 
-	if len(localState) > 0 || d.Get("imported").(bool) {
+	if len(localState) > 0 || d.Get("imported").(bool) || d.Get("force_refresh").(bool) {
 		// Refresh Cloud Files.
 		log.Printf("[DEBUG] Refreshing Cloud Files logging endpoints for (%s)", d.Id())
 		remoteState, err := conn.ListCloudfiles(&gofastly.ListCloudfilesInput{

--- a/fastly/block_fastly_service_logging_datadog.go
+++ b/fastly/block_fastly_service_logging_datadog.go
@@ -99,7 +99,7 @@ func (h *DatadogServiceAttributeHandler) Create(_ context.Context, d *schema.Res
 func (h *DatadogServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, _ map[string]any, serviceVersion int, conn *gofastly.Client) error {
 	localState := d.Get(h.GetKey()).(*schema.Set).List()
 
-	if len(localState) > 0 || d.Get("imported").(bool) {
+	if len(localState) > 0 || d.Get("imported").(bool) || d.Get("force_refresh").(bool) {
 		log.Printf("[DEBUG] Refreshing Datadog logging endpoints for (%s)", d.Id())
 		remoteState, err := conn.ListDatadog(&gofastly.ListDatadogInput{
 			ServiceID:      d.Id(),

--- a/fastly/block_fastly_service_logging_digitalocean.go
+++ b/fastly/block_fastly_service_logging_digitalocean.go
@@ -154,7 +154,7 @@ func (h *DigitalOceanServiceAttributeHandler) Create(_ context.Context, d *schem
 func (h *DigitalOceanServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, _ map[string]any, serviceVersion int, conn *gofastly.Client) error {
 	localState := d.Get(h.GetKey()).(*schema.Set).List()
 
-	if len(localState) > 0 || d.Get("imported").(bool) {
+	if len(localState) > 0 || d.Get("imported").(bool) || d.Get("force_refresh").(bool) {
 		log.Printf("[DEBUG] Refreshing DigitalOcean Spaces logging endpoints for (%s)", d.Id())
 		remoteState, err := conn.ListDigitalOceans(&gofastly.ListDigitalOceansInput{
 			ServiceID:      d.Id(),

--- a/fastly/block_fastly_service_logging_elasticsearch.go
+++ b/fastly/block_fastly_service_logging_elasticsearch.go
@@ -150,7 +150,7 @@ func (h *ElasticSearchServiceAttributeHandler) Create(_ context.Context, d *sche
 func (h *ElasticSearchServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, _ map[string]any, serviceVersion int, conn *gofastly.Client) error {
 	localState := d.Get(h.GetKey()).(*schema.Set).List()
 
-	if len(localState) > 0 || d.Get("imported").(bool) {
+	if len(localState) > 0 || d.Get("imported").(bool) || d.Get("force_refresh").(bool) {
 		log.Printf("[DEBUG] Refreshing Elasticsearch logging endpoints for (%s)", d.Id())
 		remoteState, err := conn.ListElasticsearch(&gofastly.ListElasticsearchInput{
 			ServiceID:      d.Id(),

--- a/fastly/block_fastly_service_logging_ftp.go
+++ b/fastly/block_fastly_service_logging_ftp.go
@@ -155,7 +155,7 @@ func (h *FTPServiceAttributeHandler) Create(_ context.Context, d *schema.Resourc
 func (h *FTPServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, _ map[string]any, serviceVersion int, conn *gofastly.Client) error {
 	localState := d.Get(h.GetKey()).(*schema.Set).List()
 
-	if len(localState) > 0 || d.Get("imported").(bool) {
+	if len(localState) > 0 || d.Get("imported").(bool) || d.Get("force_refresh").(bool) {
 		log.Printf("[DEBUG] Refreshing FTP logging endpoints for (%s)", d.Id())
 		remoteState, err := conn.ListFTPs(&gofastly.ListFTPsInput{
 			ServiceID:      d.Id(),

--- a/fastly/block_fastly_service_logging_gcs.go
+++ b/fastly/block_fastly_service_logging_gcs.go
@@ -191,7 +191,7 @@ func (h *GCSLoggingServiceAttributeHandler) Create(_ context.Context, d *schema.
 func (h *GCSLoggingServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, _ map[string]any, serviceVersion int, conn *gofastly.Client) error {
 	localState := d.Get(h.GetKey()).(*schema.Set).List()
 
-	if len(localState) > 0 || d.Get("imported").(bool) {
+	if len(localState) > 0 || d.Get("imported").(bool) || d.Get("force_refresh").(bool) {
 		log.Printf("[DEBUG] Refreshing GCS for (%s)", d.Id())
 		remoteState, err := conn.ListGCSs(&gofastly.ListGCSsInput{
 			ServiceID:      d.Id(),

--- a/fastly/block_fastly_service_logging_googlepubsub.go
+++ b/fastly/block_fastly_service_logging_googlepubsub.go
@@ -116,7 +116,7 @@ func (h *GooglePubSubServiceAttributeHandler) Create(_ context.Context, d *schem
 func (h *GooglePubSubServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, _ map[string]any, serviceVersion int, conn *gofastly.Client) error {
 	localState := d.Get(h.GetKey()).(*schema.Set).List()
 
-	if len(localState) > 0 || d.Get("imported").(bool) {
+	if len(localState) > 0 || d.Get("imported").(bool) || d.Get("force_refresh").(bool) {
 		log.Printf("[DEBUG] Refreshing Google Cloud Pub/Sub logging endpoints for (%s)", d.Id())
 		remoteState, err := conn.ListPubsubs(&gofastly.ListPubsubsInput{
 			ServiceID:      d.Id(),

--- a/fastly/block_fastly_service_logging_heroku.go
+++ b/fastly/block_fastly_service_logging_heroku.go
@@ -101,7 +101,7 @@ func (h *HerokuServiceAttributeHandler) Create(_ context.Context, d *schema.Reso
 func (h *HerokuServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, _ map[string]any, serviceVersion int, conn *gofastly.Client) error {
 	localState := d.Get(h.GetKey()).(*schema.Set).List()
 
-	if len(localState) > 0 || d.Get("imported").(bool) {
+	if len(localState) > 0 || d.Get("imported").(bool) || d.Get("force_refresh").(bool) {
 		log.Printf("[DEBUG] Refreshing Heroku logging endpoints for (%s)", d.Id())
 		remoteState, err := conn.ListHerokus(&gofastly.ListHerokusInput{
 			ServiceID:      d.Id(),

--- a/fastly/block_fastly_service_logging_honeycomb.go
+++ b/fastly/block_fastly_service_logging_honeycomb.go
@@ -98,7 +98,7 @@ func (h *HoneycombServiceAttributeHandler) Create(_ context.Context, d *schema.R
 func (h *HoneycombServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, _ map[string]any, serviceVersion int, conn *gofastly.Client) error {
 	localState := d.Get(h.GetKey()).(*schema.Set).List()
 
-	if len(localState) > 0 || d.Get("imported").(bool) {
+	if len(localState) > 0 || d.Get("imported").(bool) || d.Get("force_refresh").(bool) {
 		log.Printf("[DEBUG] Refreshing Honeycomb logging endpoints for (%s)", d.Id())
 		remoteState, err := conn.ListHoneycombs(&gofastly.ListHoneycombsInput{
 			ServiceID:      d.Id(),

--- a/fastly/block_fastly_service_logging_https.go
+++ b/fastly/block_fastly_service_logging_https.go
@@ -165,7 +165,7 @@ func (h *HTTPSLoggingServiceAttributeHandler) Create(_ context.Context, d *schem
 func (h *HTTPSLoggingServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, _ map[string]any, serviceVersion int, conn *gofastly.Client) error {
 	localState := d.Get(h.GetKey()).(*schema.Set).List()
 
-	if len(localState) > 0 || d.Get("imported").(bool) {
+	if len(localState) > 0 || d.Get("imported").(bool) || d.Get("force_refresh").(bool) {
 		log.Printf("[DEBUG] Refreshing HTTPS logging endpoints for (%s)", d.Id())
 		remoteState, err := conn.ListHTTPS(&gofastly.ListHTTPSInput{
 			ServiceID:      d.Id(),

--- a/fastly/block_fastly_service_logging_kafka.go
+++ b/fastly/block_fastly_service_logging_kafka.go
@@ -164,7 +164,7 @@ func (h *KafkaServiceAttributeHandler) Create(_ context.Context, d *schema.Resou
 func (h *KafkaServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, _ map[string]any, serviceVersion int, conn *gofastly.Client) error {
 	localState := d.Get(h.GetKey()).(*schema.Set).List()
 
-	if len(localState) > 0 || d.Get("imported").(bool) {
+	if len(localState) > 0 || d.Get("imported").(bool) || d.Get("force_refresh").(bool) {
 		log.Printf("[DEBUG] Refreshing Kafka logging endpoints for (%s)", d.Id())
 		remoteState, err := conn.ListKafkas(&gofastly.ListKafkasInput{
 			ServiceID:      d.Id(),

--- a/fastly/block_fastly_service_logging_kinesis.go
+++ b/fastly/block_fastly_service_logging_kinesis.go
@@ -116,7 +116,7 @@ func (h *KinesisServiceAttributeHandler) Create(_ context.Context, d *schema.Res
 func (h *KinesisServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, _ map[string]any, serviceVersion int, conn *gofastly.Client) error {
 	localState := d.Get(h.GetKey()).(*schema.Set).List()
 
-	if len(localState) > 0 || d.Get("imported").(bool) {
+	if len(localState) > 0 || d.Get("imported").(bool) || d.Get("force_refresh").(bool) {
 		log.Printf("[DEBUG] Refreshing Kinesis logging endpoints for (%s)", d.Id())
 		remoteState, err := conn.ListKinesis(&gofastly.ListKinesisInput{
 			ServiceID:      d.Id(),

--- a/fastly/block_fastly_service_logging_logentries.go
+++ b/fastly/block_fastly_service_logging_logentries.go
@@ -129,7 +129,7 @@ func (h *LogentriesServiceAttributeHandler) Create(_ context.Context, d *schema.
 func (h *LogentriesServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, _ map[string]any, serviceVersion int, conn *gofastly.Client) error {
 	localState := d.Get(h.GetKey()).(*schema.Set).List()
 
-	if len(localState) > 0 || d.Get("imported").(bool) {
+	if len(localState) > 0 || d.Get("imported").(bool) || d.Get("force_refresh").(bool) {
 		log.Printf("[DEBUG] Refreshing Logentries for (%s)", d.Id())
 		remoteState, err := conn.ListLogentries(&gofastly.ListLogentriesInput{
 			ServiceID:      d.Id(),

--- a/fastly/block_fastly_service_logging_loggly.go
+++ b/fastly/block_fastly_service_logging_loggly.go
@@ -95,7 +95,7 @@ func (h *LogglyServiceAttributeHandler) Create(_ context.Context, d *schema.Reso
 func (h *LogglyServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, _ map[string]any, serviceVersion int, conn *gofastly.Client) error {
 	localState := d.Get(h.GetKey()).(*schema.Set).List()
 
-	if len(localState) > 0 || d.Get("imported").(bool) {
+	if len(localState) > 0 || d.Get("imported").(bool) || d.Get("force_refresh").(bool) {
 		log.Printf("[DEBUG] Refreshing Loggly logging endpoints for (%s)", d.Id())
 		remoteState, err := conn.ListLoggly(&gofastly.ListLogglyInput{
 			ServiceID:      d.Id(),

--- a/fastly/block_fastly_service_logging_logshuttle.go
+++ b/fastly/block_fastly_service_logging_logshuttle.go
@@ -99,7 +99,7 @@ func (h *LogshuttleServiceAttributeHandler) Create(_ context.Context, d *schema.
 func (h *LogshuttleServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, _ map[string]any, serviceVersion int, conn *gofastly.Client) error {
 	localState := d.Get(h.GetKey()).(*schema.Set).List()
 
-	if len(localState) > 0 || d.Get("imported").(bool) {
+	if len(localState) > 0 || d.Get("imported").(bool) || d.Get("force_refresh").(bool) {
 		log.Printf("[DEBUG] Refreshing Log Shuttle logging endpoints for (%s)", d.Id())
 		remoteState, err := conn.ListLogshuttles(&gofastly.ListLogshuttlesInput{
 			ServiceID:      d.Id(),

--- a/fastly/block_fastly_service_logging_newrelic.go
+++ b/fastly/block_fastly_service_logging_newrelic.go
@@ -99,7 +99,7 @@ func (h *NewRelicServiceAttributeHandler) Create(_ context.Context, d *schema.Re
 func (h *NewRelicServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, _ map[string]any, serviceVersion int, conn *gofastly.Client) error {
 	localState := d.Get(h.GetKey()).(*schema.Set).List()
 
-	if len(localState) > 0 || d.Get("imported").(bool) {
+	if len(localState) > 0 || d.Get("imported").(bool) || d.Get("force_refresh").(bool) {
 		log.Printf("[DEBUG] Refreshing New Relic logging endpoints for (%s)", d.Id())
 		remoteState, err := conn.ListNewRelic(&gofastly.ListNewRelicInput{
 			ServiceID:      d.Id(),

--- a/fastly/block_fastly_service_logging_openstack.go
+++ b/fastly/block_fastly_service_logging_openstack.go
@@ -154,7 +154,7 @@ func (h *OpenstackServiceAttributeHandler) Create(_ context.Context, d *schema.R
 func (h *OpenstackServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, _ map[string]any, serviceVersion int, conn *gofastly.Client) error {
 	localState := d.Get(h.GetKey()).(*schema.Set).List()
 
-	if len(localState) > 0 || d.Get("imported").(bool) {
+	if len(localState) > 0 || d.Get("imported").(bool) || d.Get("force_refresh").(bool) {
 		log.Printf("[DEBUG] Refreshing OpenStack logging endpoints for (%s)", d.Id())
 		remoteState, err := conn.ListOpenstack(&gofastly.ListOpenstackInput{
 			ServiceID:      d.Id(),

--- a/fastly/block_fastly_service_logging_papertrail.go
+++ b/fastly/block_fastly_service_logging_papertrail.go
@@ -122,7 +122,7 @@ func (h *PaperTrailServiceAttributeHandler) Create(_ context.Context, d *schema.
 func (h *PaperTrailServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, _ map[string]any, serviceVersion int, conn *gofastly.Client) error {
 	localState := d.Get(h.GetKey()).(*schema.Set).List()
 
-	if len(localState) > 0 || d.Get("imported").(bool) {
+	if len(localState) > 0 || d.Get("imported").(bool) || d.Get("force_refresh").(bool) {
 		log.Printf("[DEBUG] Refreshing Papertrail for (%s)", d.Id())
 		remoteState, err := conn.ListPapertrails(&gofastly.ListPapertrailsInput{
 			ServiceID:      d.Id(),

--- a/fastly/block_fastly_service_logging_s3.go
+++ b/fastly/block_fastly_service_logging_s3.go
@@ -235,7 +235,7 @@ func (h *S3LoggingServiceAttributeHandler) Create(_ context.Context, d *schema.R
 func (h *S3LoggingServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, _ map[string]any, serviceVersion int, conn *gofastly.Client) error {
 	localState := d.Get(h.GetKey()).(*schema.Set).List()
 
-	if len(localState) > 0 || d.Get("imported").(bool) {
+	if len(localState) > 0 || d.Get("imported").(bool) || d.Get("force_refresh").(bool) {
 		log.Printf("[DEBUG] Refreshing S3 Logging for (%s)", d.Id())
 		remoteState, err := conn.ListS3s(&gofastly.ListS3sInput{
 			ServiceID:      d.Id(),

--- a/fastly/block_fastly_service_logging_scalyr.go
+++ b/fastly/block_fastly_service_logging_scalyr.go
@@ -99,7 +99,7 @@ func (h *ScalyrServiceAttributeHandler) Create(_ context.Context, d *schema.Reso
 func (h *ScalyrServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, _ map[string]any, serviceVersion int, conn *gofastly.Client) error {
 	localState := d.Get(h.GetKey()).(*schema.Set).List()
 
-	if len(localState) > 0 || d.Get("imported").(bool) {
+	if len(localState) > 0 || d.Get("imported").(bool) || d.Get("force_refresh").(bool) {
 		log.Printf("[DEBUG] Refreshing Scalyr logging endpoints for (%s)", d.Id())
 		remoteState, err := conn.ListScalyrs(&gofastly.ListScalyrsInput{
 			ServiceID:      d.Id(),

--- a/fastly/block_fastly_service_logging_sftp.go
+++ b/fastly/block_fastly_service_logging_sftp.go
@@ -172,7 +172,7 @@ func (h *SFTPServiceAttributeHandler) Create(_ context.Context, d *schema.Resour
 func (h *SFTPServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, _ map[string]any, serviceVersion int, conn *gofastly.Client) error {
 	localState := d.Get(h.GetKey()).(*schema.Set).List()
 
-	if len(localState) > 0 || d.Get("imported").(bool) {
+	if len(localState) > 0 || d.Get("imported").(bool) || d.Get("force_refresh").(bool) {
 		log.Printf("[DEBUG] Refreshing SFTP logging endpoints for (%s)", d.Id())
 		remoteState, err := conn.ListSFTPs(&gofastly.ListSFTPsInput{
 			ServiceID:      d.Id(),

--- a/fastly/block_fastly_service_logging_splunk.go
+++ b/fastly/block_fastly_service_logging_splunk.go
@@ -157,7 +157,7 @@ func (h *SplunkServiceAttributeHandler) Create(_ context.Context, d *schema.Reso
 func (h *SplunkServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, _ map[string]any, serviceVersion int, conn *gofastly.Client) error {
 	localState := d.Get(h.GetKey()).(*schema.Set).List()
 
-	if len(localState) > 0 || d.Get("imported").(bool) {
+	if len(localState) > 0 || d.Get("imported").(bool) || d.Get("force_refresh").(bool) {
 		log.Printf("[DEBUG] Refreshing Splunks for (%s)", d.Id())
 		remoteState, err := conn.ListSplunks(&gofastly.ListSplunksInput{
 			ServiceID:      d.Id(),

--- a/fastly/block_fastly_service_logging_sumologic.go
+++ b/fastly/block_fastly_service_logging_sumologic.go
@@ -123,7 +123,7 @@ func (h *SumologicServiceAttributeHandler) Create(_ context.Context, d *schema.R
 func (h *SumologicServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, _ map[string]any, serviceVersion int, conn *gofastly.Client) error {
 	localState := d.Get(h.GetKey()).(*schema.Set).List()
 
-	if len(localState) > 0 || d.Get("imported").(bool) {
+	if len(localState) > 0 || d.Get("imported").(bool) || d.Get("force_refresh").(bool) {
 		log.Printf("[DEBUG] Refreshing Sumologic for (%s)", d.Id())
 		remoteState, err := conn.ListSumologics(&gofastly.ListSumologicsInput{
 			ServiceID:      d.Id(),

--- a/fastly/block_fastly_service_logging_syslog.go
+++ b/fastly/block_fastly_service_logging_syslog.go
@@ -173,7 +173,7 @@ func (h *SyslogServiceAttributeHandler) Create(_ context.Context, d *schema.Reso
 func (h *SyslogServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, _ map[string]any, serviceVersion int, conn *gofastly.Client) error {
 	localState := d.Get(h.GetKey()).(*schema.Set).List()
 
-	if len(localState) > 0 || d.Get("imported").(bool) {
+	if len(localState) > 0 || d.Get("imported").(bool) || d.Get("force_refresh").(bool) {
 		log.Printf("[DEBUG] Refreshing Syslog for (%s)", d.Id())
 		remoteState, err := conn.ListSyslogs(&gofastly.ListSyslogsInput{
 			ServiceID:      d.Id(),

--- a/fastly/block_fastly_service_package.go
+++ b/fastly/block_fastly_service_package.go
@@ -76,7 +76,7 @@ func (h *PackageServiceAttributeHandler) Process(_ context.Context, d *schema.Re
 func (h *PackageServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, s *gofastly.ServiceDetail, conn *gofastly.Client) error {
 	localState := d.Get(h.key).([]any)
 
-	if len(localState) > 0 || d.Get("imported").(bool) {
+	if len(localState) > 0 || d.Get("imported").(bool) || d.Get("force_refresh").(bool) {
 		log.Printf("[DEBUG] Refreshing package for (%s)", d.Id())
 		remoteState, err := conn.GetPackage(&gofastly.GetPackageInput{
 			ServiceID:      d.Id(),

--- a/fastly/block_fastly_service_requestsetting.go
+++ b/fastly/block_fastly_service_requestsetting.go
@@ -129,7 +129,7 @@ func (h *RequestSettingServiceAttributeHandler) Create(_ context.Context, d *sch
 func (h *RequestSettingServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, _ map[string]any, serviceVersion int, conn *gofastly.Client) error {
 	localState := d.Get(h.GetKey()).(*schema.Set).List()
 
-	if len(localState) > 0 || d.Get("imported").(bool) {
+	if len(localState) > 0 || d.Get("imported").(bool) || d.Get("force_refresh").(bool) {
 		log.Printf("[DEBUG] Refreshing Request Settings for (%s)", d.Id())
 		remoteState, err := conn.ListRequestSettings(&gofastly.ListRequestSettingsInput{
 			ServiceID:      d.Id(),

--- a/fastly/block_fastly_service_responseobject.go
+++ b/fastly/block_fastly_service_responseobject.go
@@ -108,7 +108,7 @@ func (h *ResponseObjectServiceAttributeHandler) Create(_ context.Context, d *sch
 func (h *ResponseObjectServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, _ map[string]any, serviceVersion int, conn *gofastly.Client) error {
 	localState := d.Get(h.GetKey()).(*schema.Set).List()
 
-	if len(localState) > 0 || d.Get("imported").(bool) {
+	if len(localState) > 0 || d.Get("imported").(bool) || d.Get("force_refresh").(bool) {
 		log.Printf("[DEBUG] Refreshing Response Object for (%s)", d.Id())
 		remoteState, err := conn.ListResponseObjects(&gofastly.ListResponseObjectsInput{
 			ServiceID:      d.Id(),

--- a/fastly/block_fastly_service_snippet.go
+++ b/fastly/block_fastly_service_snippet.go
@@ -86,7 +86,7 @@ func (h *SnippetServiceAttributeHandler) Create(_ context.Context, d *schema.Res
 func (h *SnippetServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, _ map[string]any, serviceVersion int, conn *gofastly.Client) error {
 	localState := d.Get(h.Key()).(*schema.Set).List()
 
-	if len(localState) > 0 || d.Get("imported").(bool) {
+	if len(localState) > 0 || d.Get("imported").(bool) || d.Get("force_refresh").(bool) {
 		log.Printf("[DEBUG] Refreshing VCL Snippets for (%s)", d.Id())
 		remoteState, err := conn.ListSnippets(&gofastly.ListSnippetsInput{
 			ServiceID:      d.Id(),

--- a/fastly/block_fastly_service_vcl.go
+++ b/fastly/block_fastly_service_vcl.go
@@ -80,7 +80,7 @@ func (h *VCLServiceAttributeHandler) Create(_ context.Context, d *schema.Resourc
 func (h *VCLServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, _ map[string]any, serviceVersion int, conn *gofastly.Client) error {
 	localState := d.Get(h.Key()).(*schema.Set).List()
 
-	if len(localState) > 0 || d.Get("imported").(bool) {
+	if len(localState) > 0 || d.Get("imported").(bool) || d.Get("force_refresh").(bool) {
 		log.Printf("[DEBUG] Refreshing VCLs for (%s)", d.Id())
 		remoteState, err := conn.ListVCLs(&gofastly.ListVCLsInput{
 			ServiceID:      d.Id(),

--- a/fastly/block_fastly_service_waf.go
+++ b/fastly/block_fastly_service_waf.go
@@ -102,7 +102,7 @@ func (h *WAFServiceAttributeHandler) Process(_ context.Context, d *schema.Resour
 func (h *WAFServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, s *gofastly.ServiceDetail, conn *gofastly.Client) error {
 	localState := d.Get(h.GetKey()).([]any)
 
-	if len(localState) > 0 || d.Get("imported").(bool) {
+	if len(localState) > 0 || d.Get("imported").(bool) || d.Get("force_refresh").(bool) {
 		log.Printf("[DEBUG] Refreshing WAFs for (%s)", d.Id())
 		remoteState, err := conn.ListWAFs(&gofastly.ListWAFsInput{
 			FilterService: d.Id(),


### PR DESCRIPTION
Fixes #629

**NOTE:** I tested this locally by building the provider and following the following steps...

1. Create a new fastly_service_vcl service with two domains.
2. Delete one of the domains and plan/apply the change (creating service version 2).
3. Rollback the service to version 1 via the Fastly UI.
4. Run terraform plan and it should display the same plan as step 2.
5. Once plan is applied, then `terraform show` reveals service is now at version 3 and has the correct resources.