### PR TITLE
Update service_dictionary_items.md

### DIFF
--- a/docs/resources/service_dictionary_items.md
+++ b/docs/resources/service_dictionary_items.md
@@ -230,6 +230,8 @@ resource "fastly_service_dictionary_items" "items" {
 
 ## Import
 
+~> **Note:** The dictionary resouce should be empty before importing
+
 This is an example of the import command being applied to the resource named `fastly_service_dictionary_items.items`
 The resource ID is a combined value of the `service_id` and `dictionary_id` separated by a forward slash.
 


### PR DESCRIPTION
Fixed previous note to use the proper markdown for a note. Note is for importing an edge dictionary and ensuring it's empty before importing. If the dictionary resource is not empty  the import fails silently.