### PR TITLE
feat(product_enablement): implement product enablement APIs

### DIFF
--- a/docs/resources/service_compute.md
+++ b/docs/resources/service_compute.md
@@ -104,6 +104,7 @@ $ terraform import fastly_service_compute.demo xxxxxxxxxxxxxxxxxxxx@2
 - `logging_splunk` (Block Set) (see [below for nested schema](#nestedblock--logging_splunk))
 - `logging_sumologic` (Block Set) (see [below for nested schema](#nestedblock--logging_sumologic))
 - `logging_syslog` (Block Set) (see [below for nested schema](#nestedblock--logging_syslog))
+- `product_enablement` (Block Set, Max: 1) (see [below for nested schema](#nestedblock--product_enablement))
 - `reuse` (Boolean) Services that are active cannot be destroyed. If set to `true` a service Terraform intends to destroy will instead be deactivated (allowing it to be reused by importing it into another Terraform project). If `false`, attempting to destroy an active service will cause an error. Default `false`
 - `version_comment` (String) Description field for the version
 
@@ -643,3 +644,16 @@ Optional:
 - `tls_hostname` (String) Used during the TLS handshake to validate the certificate
 - `token` (String) Whether to prepend each message with a specific token
 - `use_tls` (Boolean) Whether to use TLS for secure logging. Default `false`
+
+
+<a id="nestedblock--product_enablement"></a>
+### Nested Schema for `product_enablement`
+
+Optional:
+
+- `fanout` (Boolean) Enable Fanout support
+- `websockets` (Boolean) Enable WebSockets support
+
+Read-Only:
+
+- `name` (String) Internal property used to calculate plan diff

--- a/docs/resources/service_compute.md
+++ b/docs/resources/service_compute.md
@@ -656,4 +656,4 @@ Optional:
 
 Read-Only:
 
-- `name` (String) Internal property used to calculate plan diff
+- `name` (String) Used internally by the provider to identify modified settings

--- a/docs/resources/service_vcl.md
+++ b/docs/resources/service_vcl.md
@@ -281,6 +281,7 @@ $ terraform import fastly_service_vcl.demo xxxxxxxxxxxxxxxxxxxx@2
 - `logging_splunk` (Block Set) (see [below for nested schema](#nestedblock--logging_splunk))
 - `logging_sumologic` (Block Set) (see [below for nested schema](#nestedblock--logging_sumologic))
 - `logging_syslog` (Block Set) (see [below for nested schema](#nestedblock--logging_syslog))
+- `product_enablement` (Block Set, Max: 1) (see [below for nested schema](#nestedblock--product_enablement))
 - `request_setting` (Block Set) (see [below for nested schema](#nestedblock--request_setting))
 - `response_object` (Block Set) (see [below for nested schema](#nestedblock--response_object))
 - `reuse` (Boolean) Services that are active cannot be destroyed. If set to `true` a service Terraform intends to destroy will instead be deactivated (allowing it to be reused by importing it into another Terraform project). If `false`, attempting to destroy an active service will cause an error. Default `false`
@@ -1072,6 +1073,22 @@ Optional:
 - `tls_hostname` (String) Used during the TLS handshake to validate the certificate
 - `token` (String) Whether to prepend each message with a specific token
 - `use_tls` (Boolean) Whether to use TLS for secure logging. Default `false`
+
+
+<a id="nestedblock--product_enablement"></a>
+### Nested Schema for `product_enablement`
+
+Optional:
+
+- `brotli_compression` (Boolean) Enable Brotli Compression support
+- `domain_inspector` (Boolean) Enable Domain Inspector support
+- `image_optimizer` (Boolean) Enable Image Optimizer support
+- `origin_inspector` (Boolean) Enable Origin Inspector support
+- `websockets` (Boolean) Enable WebSockets support
+
+Read-Only:
+
+- `name` (String) Internal property used to calculate plan diff
 
 
 <a id="nestedblock--request_setting"></a>

--- a/docs/resources/service_vcl.md
+++ b/docs/resources/service_vcl.md
@@ -1082,13 +1082,13 @@ Optional:
 
 - `brotli_compression` (Boolean) Enable Brotli Compression support
 - `domain_inspector` (Boolean) Enable Domain Inspector support
-- `image_optimizer` (Boolean) Enable Image Optimizer support
+- `image_optimizer` (Boolean) Enable Image Optimizer support (requires at least one backend with a `shield` attribute)
 - `origin_inspector` (Boolean) Enable Origin Inspector support
 - `websockets` (Boolean) Enable WebSockets support
 
 Read-Only:
 
-- `name` (String) Internal property used to calculate plan diff
+- `name` (String) Used internally by the provider to identify modified settings
 
 
 <a id="nestedblock--request_setting"></a>

--- a/fastly/block_fastly_service_product_enablement.go
+++ b/fastly/block_fastly_service_product_enablement.go
@@ -34,7 +34,7 @@ func (h *ProductEnablementServiceAttributeHandler) GetSchema() *schema.Schema {
 		"name": {
 			Type:        schema.TypeString,
 			Computed:    true,
-			Description: "Internal property used to calculate plan diff",
+			Description: "Used internally by the provider to identify modified settings",
 		},
 	}
 
@@ -60,7 +60,7 @@ func (h *ProductEnablementServiceAttributeHandler) GetSchema() *schema.Schema {
 		blockAttributes["image_optimizer"] = &schema.Schema{
 			Type:        schema.TypeBool,
 			Optional:    true,
-			Description: "Enable Image Optimizer support",
+			Description: "Enable Image Optimizer support (requires at least one backend with a `shield` attribute)",
 		}
 		blockAttributes["origin_inspector"] = &schema.Schema{
 			Type:        schema.TypeBool,

--- a/fastly/block_fastly_service_product_enablement.go
+++ b/fastly/block_fastly_service_product_enablement.go
@@ -77,6 +77,7 @@ func (h *ProductEnablementServiceAttributeHandler) GetSchema() *schema.Schema {
 	}
 
 	// NOTE: Min/MaxItems: 1 (to enforce only one product_enablement per service).
+	// lintignore:S018
 	return &schema.Schema{
 		Type:     schema.TypeSet,
 		Optional: true,

--- a/fastly/block_fastly_service_product_enablement.go
+++ b/fastly/block_fastly_service_product_enablement.go
@@ -1,0 +1,475 @@
+package fastly
+
+import (
+	"context"
+	"log"
+
+	gofastly "github.com/fastly/go-fastly/v7/fastly"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// ProductEnablementServiceAttributeHandler provides a base implementation for ServiceAttributeDefinition.
+type ProductEnablementServiceAttributeHandler struct {
+	*DefaultServiceAttributeHandler
+}
+
+// NewServiceProductEnablement returns a new resource.
+func NewServiceProductEnablement(sa ServiceMetadata) ServiceAttributeDefinition {
+	return ToServiceAttributeDefinition(&ProductEnablementServiceAttributeHandler{
+		&DefaultServiceAttributeHandler{
+			key:             "product_enablement",
+			serviceMetadata: sa,
+		},
+	})
+}
+
+// Key returns the resource key.
+func (h *ProductEnablementServiceAttributeHandler) Key() string {
+	return h.key
+}
+
+// GetSchema returns the resource schema.
+func (h *ProductEnablementServiceAttributeHandler) GetSchema() *schema.Schema {
+	blockAttributes := map[string]*schema.Schema{
+		"name": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "Internal property used to calculate plan diff",
+		},
+	}
+
+	if h.GetServiceMetadata().serviceType == ServiceTypeCompute {
+		blockAttributes["fanout"] = &schema.Schema{
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "Enable Fanout support",
+		}
+	}
+
+	if h.GetServiceMetadata().serviceType == ServiceTypeVCL {
+		blockAttributes["brotli_compression"] = &schema.Schema{
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "Enable Brotli Compression support",
+		}
+		blockAttributes["domain_inspector"] = &schema.Schema{
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "Enable Domain Inspector support",
+		}
+		blockAttributes["image_optimizer"] = &schema.Schema{
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "Enable Image Optimizer support",
+		}
+		blockAttributes["origin_inspector"] = &schema.Schema{
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "Enable Origin Inspector support",
+		}
+	}
+
+	// websockets is supported for both Compute (wasm) and Deliver (vcl) services.
+	blockAttributes["websockets"] = &schema.Schema{
+		Type:        schema.TypeBool,
+		Optional:    true,
+		Description: "Enable WebSockets support",
+	}
+
+	// NOTE: Min/MaxItems: 1 (to enforce only one product_enablement per service).
+	return &schema.Schema{
+		Type:     schema.TypeSet,
+		Optional: true,
+		MaxItems: 1,
+		MinItems: 1,
+		Elem: &schema.Resource{
+			Schema: blockAttributes,
+		},
+	}
+}
+
+// Create creates the resource.
+func (h *ProductEnablementServiceAttributeHandler) Create(_ context.Context, d *schema.ResourceData, resource map[string]any, serviceVersion int, conn *gofastly.Client) error {
+	serviceID := d.Id()
+	log.Printf("[DEBUG] Service ID: %s\n", serviceID)
+
+	if h.GetServiceMetadata().serviceType == ServiceTypeCompute {
+		if resource["fanout"].(bool) {
+			log.Println("[DEBUG] fanout set")
+			_, err := conn.EnableProduct(&gofastly.ProductEnablementInput{
+				ProductID: gofastly.ProductFanout,
+				ServiceID: serviceID,
+			})
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	if h.GetServiceMetadata().serviceType == ServiceTypeVCL {
+		if resource["brotli_compression"].(bool) {
+			log.Println("[DEBUG] brotli_compression set")
+			_, err := conn.EnableProduct(&gofastly.ProductEnablementInput{
+				ProductID: gofastly.ProductBrotliCompression,
+				ServiceID: serviceID,
+			})
+			if err != nil {
+				return err
+			}
+		}
+
+		if resource["domain_inspector"].(bool) {
+			log.Println("[DEBUG] domain_inspector set")
+			_, err := conn.EnableProduct(&gofastly.ProductEnablementInput{
+				ProductID: gofastly.ProductDomainInspector,
+				ServiceID: serviceID,
+			})
+			if err != nil {
+				return err
+			}
+		}
+
+		if resource["image_optimizer"].(bool) {
+			log.Println("[DEBUG] image_optimizer set")
+			_, err := conn.EnableProduct(&gofastly.ProductEnablementInput{
+				ProductID: gofastly.ProductImageOptimizer,
+				ServiceID: serviceID,
+			})
+			if err != nil {
+				return err
+			}
+		}
+
+		if resource["origin_inspector"].(bool) {
+			log.Println("[DEBUG] origin_inspector set")
+			_, err := conn.EnableProduct(&gofastly.ProductEnablementInput{
+				ProductID: gofastly.ProductOriginInspector,
+				ServiceID: serviceID,
+			})
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	if resource["websockets"].(bool) {
+		log.Println("[DEBUG] websockets set")
+		_, err := conn.EnableProduct(&gofastly.ProductEnablementInput{
+			ProductID: gofastly.ProductWebSockets,
+			ServiceID: serviceID,
+		})
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Read refreshes the resource.
+func (h *ProductEnablementServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, _ map[string]any, serviceVersion int, conn *gofastly.Client) error {
+	localState := d.Get(h.Key()).(*schema.Set).List()
+
+	if len(localState) > 0 || d.Get("imported").(bool) || d.Get("force_refresh").(bool) {
+		log.Printf("[DEBUG] Refreshing Product Enablement Configuration for (%s)", d.Id())
+
+		// The API returns a 400 if a product is not enabled.
+		// The API client returns an error if a non-2xx is returned from the API.
+
+		var (
+			enabled bool
+			err     error
+		)
+
+		// NOTE: We must set name to a unique value for a plan diff to be calculated.
+		//
+		// This value can be static because (like with the 'package' block) there can
+		// only ever be one 'product_enablement' block per service resource.
+		// This is ensured via the schema where we set MinItems/MaxItems to 1.
+		//
+		// Unlike the 'package' block we use a structure copied from 'backend'.
+		// This is done so we can benefit from the 'modified' map data passed to the
+		// 'update' CRUD method.
+		result := map[string]any{
+			"name": "product_enablement",
+		}
+
+		if h.GetServiceMetadata().serviceType == ServiceTypeCompute {
+			enabled = false
+			_, err = conn.GetProduct(&gofastly.ProductEnablementInput{
+				ProductID: gofastly.ProductFanout,
+				ServiceID: d.Id(),
+			})
+			if err == nil {
+				enabled = true
+			}
+			result["fanout"] = enabled
+		}
+
+		if h.GetServiceMetadata().serviceType == ServiceTypeVCL {
+			enabled = false
+			_, err = conn.GetProduct(&gofastly.ProductEnablementInput{
+				ProductID: gofastly.ProductBrotliCompression,
+				ServiceID: d.Id(),
+			})
+			if err == nil {
+				enabled = true
+			}
+			result["brotli_compression"] = enabled
+
+			enabled = false
+			_, err = conn.GetProduct(&gofastly.ProductEnablementInput{
+				ProductID: gofastly.ProductDomainInspector,
+				ServiceID: d.Id(),
+			})
+			if err == nil {
+				enabled = true
+			}
+			result["domain_inspector"] = enabled
+
+			enabled = false
+			_, err = conn.GetProduct(&gofastly.ProductEnablementInput{
+				ProductID: gofastly.ProductImageOptimizer,
+				ServiceID: d.Id(),
+			})
+			if err == nil {
+				enabled = true
+			}
+			result["image_optimizer"] = enabled
+
+			enabled = false
+			_, err = conn.GetProduct(&gofastly.ProductEnablementInput{
+				ProductID: gofastly.ProductOriginInspector,
+				ServiceID: d.Id(),
+			})
+			if err == nil {
+				enabled = true
+			}
+			result["origin_inspector"] = enabled
+		}
+
+		enabled = false
+		_, err = conn.GetProduct(&gofastly.ProductEnablementInput{
+			ProductID: gofastly.ProductWebSockets,
+			ServiceID: d.Id(),
+		})
+		if err == nil {
+			enabled = true
+		}
+		result["websockets"] = enabled
+
+		results := []map[string]any{result}
+
+		if err := d.Set(h.Key(), results); err != nil {
+			log.Printf("[WARN] Error setting Product Enablement for (%s): %s", d.Id(), err)
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Update updates the resource.
+func (h *ProductEnablementServiceAttributeHandler) Update(_ context.Context, d *schema.ResourceData, resource, modified map[string]any, serviceVersion int, conn *gofastly.Client) error {
+	serviceID := d.Id()
+
+	log.Printf("[DEBUG] modified: %+v\n", modified)
+
+	if h.GetServiceMetadata().serviceType == ServiceTypeCompute {
+		if v, ok := modified["fanout"]; ok {
+			if v.(bool) {
+				log.Println("[DEBUG] fanout set")
+				_, err := conn.EnableProduct(&gofastly.ProductEnablementInput{
+					ProductID: gofastly.ProductFanout,
+					ServiceID: serviceID,
+				})
+				if err != nil {
+					return err
+				}
+			} else {
+				log.Println("[DEBUG] fanout not set")
+				err := conn.DisableProduct(&gofastly.ProductEnablementInput{
+					ProductID: gofastly.ProductFanout,
+					ServiceID: serviceID,
+				})
+				if err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	if h.GetServiceMetadata().serviceType == ServiceTypeVCL {
+		if v, ok := modified["brotli_compression"]; ok {
+			if v.(bool) {
+				log.Println("[DEBUG] brotli_compression set")
+				_, err := conn.EnableProduct(&gofastly.ProductEnablementInput{
+					ProductID: gofastly.ProductBrotliCompression,
+					ServiceID: serviceID,
+				})
+				if err != nil {
+					return err
+				}
+			} else {
+				log.Println("[DEBUG] brotli_compression not set")
+				err := conn.DisableProduct(&gofastly.ProductEnablementInput{
+					ProductID: gofastly.ProductBrotliCompression,
+					ServiceID: serviceID,
+				})
+				if err != nil {
+					return err
+				}
+			}
+		}
+
+		if v, ok := modified["domain_inspector"]; ok {
+			if v.(bool) {
+				log.Println("[DEBUG] domain_inspector set")
+				_, err := conn.EnableProduct(&gofastly.ProductEnablementInput{
+					ProductID: gofastly.ProductDomainInspector,
+					ServiceID: serviceID,
+				})
+				if err != nil {
+					return err
+				}
+			} else {
+				log.Println("[DEBUG] domain_inspector not set")
+				err := conn.DisableProduct(&gofastly.ProductEnablementInput{
+					ProductID: gofastly.ProductDomainInspector,
+					ServiceID: serviceID,
+				})
+				if err != nil {
+					return err
+				}
+			}
+		}
+
+		if v, ok := modified["image_optimizer"]; ok {
+			if v.(bool) {
+				log.Println("[DEBUG] image_optimizer set")
+				_, err := conn.EnableProduct(&gofastly.ProductEnablementInput{
+					ProductID: gofastly.ProductImageOptimizer,
+					ServiceID: serviceID,
+				})
+				if err != nil {
+					return err
+				}
+			} else {
+				log.Println("[DEBUG] image_optimizer not set")
+				err := conn.DisableProduct(&gofastly.ProductEnablementInput{
+					ProductID: gofastly.ProductImageOptimizer,
+					ServiceID: serviceID,
+				})
+				if err != nil {
+					return err
+				}
+			}
+		}
+
+		if v, ok := modified["origin_inspector"]; ok {
+			if v.(bool) {
+				log.Println("[DEBUG] origin_inspector set")
+				_, err := conn.EnableProduct(&gofastly.ProductEnablementInput{
+					ProductID: gofastly.ProductOriginInspector,
+					ServiceID: serviceID,
+				})
+				if err != nil {
+					return err
+				}
+			} else {
+				log.Println("[DEBUG] origin_inspector not set")
+				err := conn.DisableProduct(&gofastly.ProductEnablementInput{
+					ProductID: gofastly.ProductOriginInspector,
+					ServiceID: serviceID,
+				})
+				if err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	if v, ok := modified["websockets"]; ok {
+		if v.(bool) {
+			log.Println("[DEBUG] websockets set")
+			_, err := conn.EnableProduct(&gofastly.ProductEnablementInput{
+				ProductID: gofastly.ProductWebSockets,
+				ServiceID: serviceID,
+			})
+			if err != nil {
+				return err
+			}
+		} else {
+			log.Println("[DEBUG] websockets not set")
+			err := conn.DisableProduct(&gofastly.ProductEnablementInput{
+				ProductID: gofastly.ProductWebSockets,
+				ServiceID: serviceID,
+			})
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// Delete deletes the resource.
+//
+// FIXME: This implementation causes unnecessary API calls.
+// We should check if the specific 'products' have been disabled.
+func (h *ProductEnablementServiceAttributeHandler) Delete(_ context.Context, d *schema.ResourceData, resource map[string]any, serviceVersion int, conn *gofastly.Client) error {
+	if h.GetServiceMetadata().serviceType == ServiceTypeCompute {
+		err := conn.DisableProduct(&gofastly.ProductEnablementInput{
+			ProductID: gofastly.ProductFanout,
+			ServiceID: d.Id(),
+		})
+		if err != nil {
+			return err
+		}
+	}
+
+	if h.GetServiceMetadata().serviceType == ServiceTypeVCL {
+		err := conn.DisableProduct(&gofastly.ProductEnablementInput{
+			ProductID: gofastly.ProductBrotliCompression,
+			ServiceID: d.Id(),
+		})
+		if err != nil {
+			return err
+		}
+
+		err = conn.DisableProduct(&gofastly.ProductEnablementInput{
+			ProductID: gofastly.ProductDomainInspector,
+			ServiceID: d.Id(),
+		})
+		if err != nil {
+			return err
+		}
+
+		err = conn.DisableProduct(&gofastly.ProductEnablementInput{
+			ProductID: gofastly.ProductImageOptimizer,
+			ServiceID: d.Id(),
+		})
+		if err != nil {
+			return err
+		}
+
+		err = conn.DisableProduct(&gofastly.ProductEnablementInput{
+			ProductID: gofastly.ProductOriginInspector,
+			ServiceID: d.Id(),
+		})
+		if err != nil {
+			return err
+		}
+	}
+
+	err := conn.DisableProduct(&gofastly.ProductEnablementInput{
+		ProductID: gofastly.ProductWebSockets,
+		ServiceID: d.Id(),
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/fastly/block_fastly_service_product_enablement.go
+++ b/fastly/block_fastly_service_product_enablement.go
@@ -92,7 +92,6 @@ func (h *ProductEnablementServiceAttributeHandler) GetSchema() *schema.Schema {
 // Create creates the resource.
 func (h *ProductEnablementServiceAttributeHandler) Create(_ context.Context, d *schema.ResourceData, resource map[string]any, serviceVersion int, conn *gofastly.Client) error {
 	serviceID := d.Id()
-	log.Printf("[DEBUG] Service ID: %s\n", serviceID)
 
 	if h.GetServiceMetadata().serviceType == ServiceTypeCompute {
 		if resource["fanout"].(bool) {
@@ -273,8 +272,6 @@ func (h *ProductEnablementServiceAttributeHandler) Read(_ context.Context, d *sc
 // Update updates the resource.
 func (h *ProductEnablementServiceAttributeHandler) Update(_ context.Context, d *schema.ResourceData, resource, modified map[string]any, serviceVersion int, conn *gofastly.Client) error {
 	serviceID := d.Id()
-
-	log.Printf("[DEBUG] modified: %+v\n", modified)
 
 	if h.GetServiceMetadata().serviceType == ServiceTypeCompute {
 		if v, ok := modified["fanout"]; ok {

--- a/fastly/block_fastly_service_product_enablement_test.go
+++ b/fastly/block_fastly_service_product_enablement_test.go
@@ -1,0 +1,85 @@
+package fastly
+
+import (
+	"fmt"
+	"testing"
+
+	gofastly "github.com/fastly/go-fastly/v7/fastly"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccFastlyServiceVCLProductEnablement_basic(t *testing.T) {
+	var service gofastly.ServiceDetail
+	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	domainName := fmt.Sprintf("fastly-test.tf-%s.com", acctest.RandString(10))
+	backendName := fmt.Sprintf("backend-tf-%s", acctest.RandString(10))
+	backendAddress := "httpbin.org"
+
+	config := fmt.Sprintf(`
+  resource "fastly_service_vcl" "foo" {
+    name = "%s"
+
+    domain {
+      name    = "%s"
+      comment = "demo"
+    }
+
+    backend {
+      address = "%s"
+      name    = "%s"
+      port    = 443
+      shield  = "amsterdam-nl"
+    }
+
+    product_enablement {
+      brotli_compression = true
+      domain_inspector   = true
+      image_optimizer    = true
+      origin_inspector   = true
+      websockets         = true
+    }
+
+    force_destroy = true
+  }
+  `, serviceName, domainName, backendAddress, backendName)
+
+	// The following backends are what we expect to exist after all our Terraform
+	// configuration settings have been applied. We expect them to correlate to
+	// the specific backend definitions in the Terraform configuration.
+
+	b1 := gofastly.Backend{
+		Address: backendAddress,
+		Name:    backendName,
+		Port:    443,
+		Shield:  "amsterdam-nl", // required for image_optimizer
+
+		// NOTE: The following are defaults applied by the API.
+		BetweenBytesTimeout: 10000,
+		ConnectTimeout:      1000,
+		FirstByteTimeout:    15000,
+		Hostname:            backendAddress,
+		MaxConn:             200,
+		SSLCheckCert:        true,
+		Weight:              100,
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckServiceVCLDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceVCLExists("fastly_service_vcl.foo", &service),
+					resource.TestCheckResourceAttr("fastly_service_vcl.foo", "name", serviceName),
+					resource.TestCheckResourceAttr("fastly_service_vcl.foo", "backend.#", "1"),
+					testAccCheckFastlyServiceVCLBackendAttributes(&service, []*gofastly.Backend{&b1}),
+				),
+			},
+		},
+	})
+}

--- a/fastly/resource_fastly_service_compute.go
+++ b/fastly/resource_fastly_service_compute.go
@@ -14,6 +14,7 @@ var computeAttributes = ServiceMetadata{
 var computeService = &BaseServiceDefinition{
 	Type: computeAttributes.serviceType,
 	Attributes: []ServiceAttributeDefinition{
+		NewServiceProductEnablement(computeAttributes),
 		NewServiceDomain(computeAttributes),
 		NewServiceBackend(computeAttributes),
 		NewServiceLoggingS3(computeAttributes),

--- a/fastly/resource_fastly_service_compute.go
+++ b/fastly/resource_fastly_service_compute.go
@@ -14,9 +14,9 @@ var computeAttributes = ServiceMetadata{
 var computeService = &BaseServiceDefinition{
 	Type: computeAttributes.serviceType,
 	Attributes: []ServiceAttributeDefinition{
-		NewServiceProductEnablement(computeAttributes),
 		NewServiceDomain(computeAttributes),
 		NewServiceBackend(computeAttributes),
+		NewServiceProductEnablement(computeAttributes),
 		NewServiceLoggingS3(computeAttributes),
 		NewServiceLoggingPaperTrail(computeAttributes),
 		NewServiceLoggingSumologic(computeAttributes),

--- a/fastly/resource_fastly_service_compute_test.go
+++ b/fastly/resource_fastly_service_compute_test.go
@@ -26,20 +26,13 @@ func TestAccFastlyServiceCompute_basic(t *testing.T) {
 				Config: testAccServiceComputeConfig(name, domainName1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceVCLExists("fastly_service_compute.foo", &service),
-					resource.TestCheckResourceAttr(
-						"fastly_service_compute.foo", "name", name),
-					resource.TestCheckResourceAttr(
-						"fastly_service_compute.foo", "comment", "Managed by Terraform"),
-					resource.TestCheckResourceAttr(
-						"fastly_service_compute.foo", "version_comment", ""),
-					resource.TestCheckResourceAttr(
-						"fastly_service_compute.foo", "active_version", "0"),
-					resource.TestCheckResourceAttr(
-						"fastly_service_compute.foo", "domain.#", "1"),
-					resource.TestCheckResourceAttr(
-						"fastly_service_compute.foo", "backend.#", "1"),
-					resource.TestCheckResourceAttr(
-						"fastly_service_compute.foo", "package.#", "1"),
+					resource.TestCheckResourceAttr("fastly_service_compute.foo", "name", name),
+					resource.TestCheckResourceAttr("fastly_service_compute.foo", "comment", "Managed by Terraform"),
+					resource.TestCheckResourceAttr("fastly_service_compute.foo", "version_comment", ""),
+					resource.TestCheckResourceAttr("fastly_service_compute.foo", "active_version", "0"),
+					resource.TestCheckResourceAttr("fastly_service_compute.foo", "domain.#", "1"),
+					resource.TestCheckResourceAttr("fastly_service_compute.foo", "backend.#", "1"),
+					resource.TestCheckResourceAttr("fastly_service_compute.foo", "package.#", "1"),
 				),
 			},
 			{
@@ -47,7 +40,31 @@ func TestAccFastlyServiceCompute_basic(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				// These attributes are not stored on the Fastly API and must be ignored.
-				ImportStateVerifyIgnore: []string{"activate", "force_destroy", "package.0.filename", "imported"},
+				ImportStateVerifyIgnore: []string{"activate", "force_destroy", "package.0.filename", "imported", "product_enablement"},
+				// Validate product_enablement state after import.
+				// If nothing has been configured, which is the default, we expect the
+				// following state to be the result.
+				ImportStateCheck: func(s []*terraform.InstanceState) error {
+					if len(s) != 1 {
+						return fmt.Errorf("expected 1 state: %+v", s)
+					}
+					if s[0].Attributes["product_enablement.#"] != "1" {
+						return fmt.Errorf("expected product_enablement to be imported into state")
+					}
+					if s[0].Attributes["product_enablement.0.%"] != "3" {
+						return fmt.Errorf("expected product_enablement to contain 3 keys")
+					}
+					if s[0].Attributes["product_enablement.0.fanout"] != "false" {
+						return fmt.Errorf("expected brotli_compression to be false")
+					}
+					if s[0].Attributes["product_enablement.0.websockets"] != "false" {
+						return fmt.Errorf("expected websockets to be false")
+					}
+					if s[0].Attributes["product_enablement.0.name"] != "product_enablement" {
+						return fmt.Errorf("expected the generated 'name' key to be 'product_enablement'")
+					}
+					return nil
+				},
 			},
 		},
 	})

--- a/fastly/resource_fastly_service_vcl.go
+++ b/fastly/resource_fastly_service_vcl.go
@@ -19,6 +19,7 @@ var vclService = &BaseServiceDefinition{
 		NewServiceDomain(vclAttributes),
 		NewServiceHealthCheck(vclAttributes),
 		NewServiceBackend(vclAttributes),
+		NewServiceProductEnablement(vclAttributes),
 		NewServiceDirector(vclAttributes),
 		NewServiceHeader(vclAttributes),
 		NewServiceGzip(vclAttributes),

--- a/fastly/resource_fastly_service_vcl_test.go
+++ b/fastly/resource_fastly_service_vcl_test.go
@@ -345,9 +345,42 @@ func TestAccFastlyServiceVCL_basic(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				// These attributes are not stored on the Fastly API and must be ignored.
-				ImportStateVerifyIgnore: []string{"activate", "force_destroy", "imported"},
+				ImportStateVerifyIgnore: []string{"activate", "force_destroy", "imported", "product_enablement"},
 				ImportStateIdFunc: func(_ *terraform.State) (string, error) {
 					return fmt.Sprintf("%s@2", service.ID), nil
+				},
+				// Validate product_enablement state after import.
+				// If nothing has been configured, which is the default, we expect the
+				// following state to be the result.
+				ImportStateCheck: func(s []*terraform.InstanceState) error {
+					if len(s) != 1 {
+						return fmt.Errorf("expected 1 state: %+v", s)
+					}
+					if s[0].Attributes["product_enablement.#"] != "1" {
+						return fmt.Errorf("expected product_enablement to be imported into state")
+					}
+					if s[0].Attributes["product_enablement.0.%"] != "6" {
+						return fmt.Errorf("expected product_enablement to contain 6 keys")
+					}
+					if s[0].Attributes["product_enablement.0.brotli_compression"] != "false" {
+						return fmt.Errorf("expected brotli_compression to be false")
+					}
+					if s[0].Attributes["product_enablement.0.domain_inspector"] != "false" {
+						return fmt.Errorf("expected domain_inspector to be false")
+					}
+					if s[0].Attributes["product_enablement.0.image_optimizer"] != "false" {
+						return fmt.Errorf("expected image_optimizer to be false")
+					}
+					if s[0].Attributes["product_enablement.0.origin_inspector"] != "false" {
+						return fmt.Errorf("expected origin_inspector to be false")
+					}
+					if s[0].Attributes["product_enablement.0.websockets"] != "false" {
+						return fmt.Errorf("expected websockets to be false")
+					}
+					if s[0].Attributes["product_enablement.0.name"] != "product_enablement" {
+						return fmt.Errorf("expected the generated 'name' key to be 'product_enablement'")
+					}
+					return nil
 				},
 			},
 		},

--- a/go.mod
+++ b/go.mod
@@ -73,7 +73,6 @@ require (
 	golang.org/x/sys v0.0.0-20220627191245-f75cf1eec38b // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/tools v0.1.11-0.20220513221640-090b14e8501f // indirect
-	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	google.golang.org/appengine v1.6.6 // indirect
 	google.golang.org/genproto v0.0.0-20200904004341-0bd0a958aa1d // indirect
 	google.golang.org/grpc v1.48.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/bflad/tfproviderlint v0.28.1
-	github.com/fastly/go-fastly/v7 v7.2.0
+	github.com/fastly/go-fastly/v7 v7.3.0
 	github.com/google/go-cmp v0.5.9
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/terraform-plugin-docs v0.13.0

--- a/go.sum
+++ b/go.sum
@@ -99,7 +99,6 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dnaeon/go-vcr v1.2.0 h1:zHCHvJYTMh1N7xnV7zf1m1GPBF9Ad0Jk/whtQ1663qI=
-github.com/dnaeon/go-vcr v1.2.0/go.mod h1:R4UdLID7HZT3taECzJs4YgbbH6PIGXB6W/sc5OLb6RQ=
 github.com/emirpasic/gods v1.12.0 h1:QAUIPSaCu4G+POclxeqb3F+WPpdKqFGlw36+yOzGlrg=
 github.com/emirpasic/gods v1.12.0/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3ymbK86o=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
@@ -108,10 +107,8 @@ github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1m
 github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/go-control-plane v0.10.2-0.20220325020618-49ff273808a1/go.mod h1:KJwIaB5Mv44NWtYuAOFCVOjcI94vtpEz2JU/D2v6IjE=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
-github.com/fastly/go-fastly/v7 v7.0.0 h1:Qz6AHosQtSbp8u3aQyGruXNFF/yAqvvjaUCNvTM1XS4=
-github.com/fastly/go-fastly/v7 v7.0.0/go.mod h1:WdssHSSIe41/a5juIJagw8MCTA9m7xQ1TVLRcBQQuS8=
-github.com/fastly/go-fastly/v7 v7.2.0 h1:d2FlF2vwtXkCmp+hC5fmn6+wvrsZsC8ZhTfoaehQXzQ=
-github.com/fastly/go-fastly/v7 v7.2.0/go.mod h1:K32VeBzD+RJikDMUSKPpYfno8YBMXmNWjgGAn6I/OU8=
+github.com/fastly/go-fastly/v7 v7.3.0 h1:QG8rjm95DC2YLv8B64sHy2XhOfjfTRpx5dT/6uo/j8E=
+github.com/fastly/go-fastly/v7 v7.3.0/go.mod h1:K32VeBzD+RJikDMUSKPpYfno8YBMXmNWjgGAn6I/OU8=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.13.0 h1:8LOYc1KYPPmyKMuN8QV2DNRWNbLo6LZ0iLs8+mlH53w=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
@@ -352,14 +349,12 @@ github.com/mitchellh/go-wordwrap v0.0.0-20150314170334-ad45545899c7/go.mod h1:ZX
 github.com/mitchellh/go-wordwrap v1.0.0 h1:6GlHJ/LTGMrIJbwgdqdl2eEH8o+Exx/0m8ir9Gns0u4=
 github.com/mitchellh/go-wordwrap v1.0.0/go.mod h1:ZXFpozHsX6DPmq2I0TCekCxypsnAUbP2oI0UX1GXzOo=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
-github.com/mitchellh/mapstructure v1.4.3/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/reflectwalk v1.0.0/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/mitchellh/reflectwalk v1.0.1/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zxSIeXaQ=
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
-github.com/modocache/gover v0.0.0-20171022184752-b58185e213c5/go.mod h1:caMODM3PzxT8aQXRPkAt8xlV/e7d7w8GM5g0fa5F0D8=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k+Mg7cowZ8yv4Trqw9UsJby758=
 github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce/go.mod h1:uFMI8w+ref4v2r9jz+c9i1IfIttS/OkmLfrk1jne5hs=
@@ -427,7 +422,6 @@ github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
-github.com/yuin/goldmark v1.4.1/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/zclconf/go-cty v1.0.0/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=
 github.com/zclconf/go-cty v1.1.0/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=
 github.com/zclconf/go-cty v1.2.0/go.mod h1:hOPWgoHbaTUnI5k4D2ld+GRpFJSCe6bCM7m1q/N4PQ8=
@@ -527,7 +521,6 @@ golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwY
 golang.org/x/net v0.0.0-20210119194325-5f4716e94777/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210326060303-6b1517762897/go.mod h1:uSPa2vr4CLtc/ILN5odXGNXS6mhrKVzTaCXzk9m6W3k=
-golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2 h1:CIJ76btIcR3eFI5EgSo6k1qKw9KJexJuRLI9G7Hp5wE=
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -545,7 +538,6 @@ golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -585,12 +577,10 @@ golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210320140829-1e4c9ba3b0c4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210324051608-47abb6519492/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210502180810-71e4cd670f79/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20211019181941-9d821ace8654/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220627191245-f75cf1eec38b h1:2n253B2r0pYSmEV+UNCQoPfU/FiaizQEK5Gu4Bq4JE8=
 golang.org/x/sys v0.0.0-20220627191245-f75cf1eec38b/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
@@ -602,7 +592,6 @@ golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.5/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
-golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
 golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
@@ -660,7 +649,6 @@ golang.org/x/tools v0.1.11-0.20220513221640-090b14e8501f/go.mod h1:SgwaegtQh8clI
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=
 google.golang.org/api v0.7.0/go.mod h1:WtwebWUNSVBH/HAw79HIFXZNqEvBhG+Ra+ax0hx3E3M=
@@ -781,7 +769,6 @@ honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
-honnef.co/go/tools v0.2.2/go.mod h1:lPVVZ2BS5TfnjLyizF7o7hv7j9/L+8cZY2hLyjP9cGY=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=

--- a/go.sum
+++ b/go.sum
@@ -483,8 +483,6 @@ golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzB
 golang.org/x/mod v0.1.1-0.20191107180719-034126e5016b/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
-golang.org/x/mod v0.5.1 h1:OJxoQ/rynoF0dcCdI7cLPktw/hR2cueqYfjm43oqK38=
-golang.org/x/mod v0.5.1/go.mod h1:5OXOZSfqPIIbmVBIIKWRFfZjPR0E5r58TLhUjH0a2Ro=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 h1:6zppjxzCulZykYSLyVDYbneBfbaBIQPYMevg0bEwv2s=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
 golang.org/x/net v0.0.0-20180530234432-1e491301e022/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -641,9 +639,6 @@ golang.org/x/tools v0.0.0-20200804011535-6c149bb5ef0d/go.mod h1:njjCfa9FT2d7l9Bc
 golang.org/x/tools v0.0.0-20200825202427-b303f430e36d/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20200904185747-39188db58858/go.mod h1:Cj7w3i3Rnn0Xh82ur9kSqwfTHTeVxaDqrfMjpcNT6bE=
 golang.org/x/tools v0.0.0-20201028111035-eafbe7b904eb/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
-golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
-golang.org/x/tools v0.1.8 h1:P1HhGGuLW4aAclzjtmJdf0mJOjVUZUzOTqkAkWL+l6w=
-golang.org/x/tools v0.1.8/go.mod h1:nABZi5QlRsZVlzPpHl034qft6wpY4eDcsTt5AaioBiU=
 golang.org/x/tools v0.1.11-0.20220513221640-090b14e8501f h1:OKYpQQVE3DKSc3r3zHVzq46vq5YH7x8xpR3/k9ixmUg=
 golang.org/x/tools v0.1.11-0.20220513221640-090b14e8501f/go.mod h1:SgwaegtQh8clINPpECJMqnxLv9I09HLqnW3RMqW0CA4=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/vendor/github.com/fastly/go-fastly/v7/fastly/client.go
+++ b/vendor/github.com/fastly/go-fastly/v7/fastly/client.go
@@ -48,7 +48,7 @@ const DefaultRealtimeStatsEndpoint = "https://rt.fastly.com"
 var ProjectURL = "github.com/fastly/go-fastly"
 
 // ProjectVersion is the version of this library.
-var ProjectVersion = "7.2.0"
+var ProjectVersion = "7.3.0"
 
 // UserAgent is the user agent for this particular client.
 var UserAgent = fmt.Sprintf("FastlyGo/%s (+%s; %s)",
@@ -293,6 +293,7 @@ func (c *Client) Request(verb, p string, ro *RequestOptions) (*http.Response, er
 		c.updateLock.Lock()
 		defer c.updateLock.Unlock()
 	}
+	// nosemgrep: trailofbits.go.invalid-usage-of-modified-variable.invalid-usage-of-modified-variable
 	resp, err := checkResp(c.HTTPClient.Do(req))
 	if err != nil {
 		return resp, err

--- a/vendor/github.com/fastly/go-fastly/v7/fastly/errors.go
+++ b/vendor/github.com/fastly/go-fastly/v7/fastly/errors.go
@@ -291,6 +291,10 @@ var ErrManagedLoggingEnabled = errors.New("managed logging already enabled")
 // requires a "Token" key, but one was not set.
 var ErrMissingToken = NewFieldError("Token")
 
+// ErrMissingProductID is an error that is returned when an input struct
+// requires a "ProductID" key, but one was not set.
+var ErrMissingProductID = NewFieldError("ProductID")
+
 // Ensure HTTPError is, in fact, an error.
 var _ error = (*HTTPError)(nil)
 

--- a/vendor/github.com/fastly/go-fastly/v7/fastly/managed_logging.go
+++ b/vendor/github.com/fastly/go-fastly/v7/fastly/managed_logging.go
@@ -48,6 +48,7 @@ func (c *Client) CreateManagedLogging(i *CreateManagedLoggingInput) (*ManagedLog
 		return nil, ErrNotImplemented
 	}
 
+	// nosemgrep: trailofbits.go.invalid-usage-of-modified-variable.invalid-usage-of-modified-variable
 	resp, err := c.Post(path, nil)
 	// If the service already has managed logging enabled, it will respond
 	// with a 409. Handle this case specially so users can decide if this is

--- a/vendor/github.com/fastly/go-fastly/v7/fastly/product_enablement.go
+++ b/vendor/github.com/fastly/go-fastly/v7/fastly/product_enablement.go
@@ -1,0 +1,116 @@
+package fastly
+
+import (
+	"fmt"
+)
+
+// ProductEnablement represents a response from the Fastly API.
+type ProductEnablement struct {
+	Product ProductEnablementNested `mapstructure:"product"`
+	Service ProductEnablementNested `mapstructure:"service"`
+}
+
+type ProductEnablementNested struct {
+	ID     string `mapstructure:"id,omitempty"`
+	Object string `mapstructure:"object,omitempty"`
+}
+
+// Product is a base for the different product variants.
+type Product int64
+
+func (p Product) String() string {
+	switch p {
+	case ProductBrotliCompression:
+		return "brotli_compression"
+	case ProductDomainInspector:
+		return "domain_inspector"
+	case ProductFanout:
+		return "fanout"
+	case ProductImageOptimizer:
+		return "image_optimizer"
+	case ProductOriginInspector:
+		return "origin_inspector"
+	case ProductWebSockets:
+		return "websockets"
+	}
+	return "unknown"
+}
+
+const (
+	ProductUndefined Product = iota
+	ProductBrotliCompression
+	ProductDomainInspector
+	ProductFanout
+	ProductImageOptimizer
+	ProductOriginInspector
+	ProductWebSockets
+)
+
+// ProductEnablementInput is used as input to the various product API functions.
+type ProductEnablementInput struct {
+	// ProductID is the ID of the product and is constrained by the Product type (required).
+	ProductID Product
+	// ServiceID is the ID of the service (required).
+	ServiceID string
+}
+
+// GetProduct retrieves the details of the product enabled on the service.
+func (c *Client) GetProduct(i *ProductEnablementInput) (*ProductEnablement, error) {
+	if i.ProductID == ProductUndefined {
+		return nil, ErrMissingProductID
+	}
+	if i.ServiceID == "" {
+		return nil, ErrMissingServiceID
+	}
+
+	path := fmt.Sprintf("/enabled-products/%s/services/%s", i.ProductID, i.ServiceID)
+	resp, err := c.Get(path, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var h *ProductEnablement
+	if err := decodeBodyMap(resp.Body, &h); err != nil {
+		return nil, err
+	}
+
+	return h, nil
+}
+
+// EnableProduct enables the specified product on the service.
+func (c *Client) EnableProduct(i *ProductEnablementInput) (*ProductEnablement, error) {
+	if i.ProductID == ProductUndefined {
+		return nil, ErrMissingProductID
+	}
+	if i.ServiceID == "" {
+		return nil, ErrMissingServiceID
+	}
+
+	path := fmt.Sprintf("/enabled-products/%s/services/%s", i.ProductID, i.ServiceID)
+	resp, err := c.PutForm(path, i, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var http3 *ProductEnablement
+	if err := decodeBodyMap(resp.Body, &http3); err != nil {
+		return nil, err
+	}
+	return http3, nil
+}
+
+// DisableProduct disables the specified product on the service.
+func (c *Client) DisableProduct(i *ProductEnablementInput) error {
+	if i.ProductID == ProductUndefined {
+		return ErrMissingProductID
+	}
+	if i.ServiceID == "" {
+		return ErrMissingServiceID
+	}
+
+	path := fmt.Sprintf("/enabled-products/%s/services/%s", i.ProductID, i.ServiceID)
+	_, err := c.Delete(path, nil)
+	return err
+}

--- a/vendor/github.com/fastly/go-fastly/v7/fastly/purge.go
+++ b/vendor/github.com/fastly/go-fastly/v7/fastly/purge.go
@@ -38,6 +38,7 @@ func (c *Client) Purge(i *PurgeInput) (*Purge, error) {
 	}
 
 	var err error
+	// nosemgrep: trailofbits.go.questionable-assignment.questionable-assignment
 	ro.Params, err = constructRequestOptionsParam(i.URL)
 	if err != nil {
 		return nil, err

--- a/vendor/github.com/fastly/go-fastly/v7/fastly/request.go
+++ b/vendor/github.com/fastly/go-fastly/v7/fastly/request.go
@@ -95,6 +95,7 @@ func (c *Client) SimpleGet(target string) (*http.Response, error) {
 	}
 	request.Header.Set("User-Agent", UserAgent)
 
+	// nosemgrep: trailofbits.go.invalid-usage-of-modified-variable.invalid-usage-of-modified-variable
 	resp, err := checkResp(c.HTTPClient.Do(request))
 	if err != nil {
 		return resp, err

--- a/vendor/github.com/fastly/go-fastly/v7/fastly/waf_active_rule.go
+++ b/vendor/github.com/fastly/go-fastly/v7/fastly/waf_active_rule.go
@@ -165,7 +165,7 @@ func (c *Client) ListAllWAFActiveRules(i *ListAllWAFActiveRulesInput) (*WAFActiv
 			FilterMessage:    i.FilterMessage,
 		})
 		if err != nil {
-			return r, err
+			return nil, err
 		}
 
 		currentPage++

--- a/vendor/github.com/fastly/go-fastly/v7/fastly/waf_rule_exclusion.go
+++ b/vendor/github.com/fastly/go-fastly/v7/fastly/waf_rule_exclusion.go
@@ -212,7 +212,7 @@ func (c *Client) ListAllWAFRuleExclusions(i *ListAllWAFRuleExclusionsInput) (*WA
 			FilterExclusionType: i.FilterExclusionType,
 		})
 		if err != nil {
-			return r, err
+			return nil, err
 		}
 
 		currentPage++

--- a/vendor/github.com/fastly/go-fastly/v7/fastly/waf_rules.go
+++ b/vendor/github.com/fastly/go-fastly/v7/fastly/waf_rules.go
@@ -166,7 +166,7 @@ func (c *Client) ListAllWAFRules(i *ListAllWAFRulesInput) (*WAFRuleResponse, err
 			PageSize:         WAFPaginationPageSize,
 		})
 		if err != nil {
-			return r, err
+			return nil, err
 		}
 
 		currentPage++

--- a/vendor/github.com/fastly/go-fastly/v7/fastly/waf_version.go
+++ b/vendor/github.com/fastly/go-fastly/v7/fastly/waf_version.go
@@ -191,7 +191,7 @@ func (c *Client) ListAllWAFVersions(i *ListAllWAFVersionsInput) (*WAFVersionResp
 			PageSize:   WAFPaginationPageSize,
 		})
 		if err != nil {
-			return r, err
+			return nil, err
 		}
 
 		currentPage++

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -180,7 +180,7 @@ github.com/bgentry/speakeasy
 # github.com/davecgh/go-spew v1.1.1
 ## explicit
 github.com/davecgh/go-spew/spew
-# github.com/fastly/go-fastly/v7 v7.2.0
+# github.com/fastly/go-fastly/v7 v7.3.0
 ## explicit; go 1.18
 github.com/fastly/go-fastly/v7/fastly
 # github.com/fatih/color v1.13.0

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -500,8 +500,6 @@ golang.org/x/tools/internal/packagesinternal
 golang.org/x/tools/internal/span
 golang.org/x/tools/internal/typeparams
 golang.org/x/tools/internal/typesinternal
-# golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
-## explicit; go 1.11
 # google.golang.org/appengine v1.6.6
 ## explicit; go 1.11
 google.golang.org/appengine


### PR DESCRIPTION
✅ I've run the end-to-end test suite on this PR and it's passing.

**NOTE**:  
Enabling ImageOptimizer requires a backend with a 'shield' property configured.
The below example configuration demonstrates which products are available to each service type.

```terraform
resource "fastly_service_vcl" "demo" {
  name = "testing-prod-enablement"

  domain {
    name    = "testing-prod-enablement.integralist.co.uk"
    comment = "demo"
  }

  backend {
    address = "127.0.0.1"
    name    = "localhost"
    port    = 80
    shield  = "amsterdam-nl"
  }

  product_enablement {
    brotli_compression = true
    domain_inspector   = true
    image_optimizer    = true
    origin_inspector   = true
    websockets         = true
  }

  force_destroy = true
}

resource "fastly_service_compute" "demo" {
  name = "testing-prod-enablement-compute"

  domain {
    name    = "testing-prod-enablement-compute.integralist.co.uk"
    comment = "demo"
  }

  package {
    filename         = "package.tar.gz"
    source_code_hash = filesha512("package.tar.gz")
  }

  product_enablement {
    fanout     = true
    websockets = true
  }

  force_destroy = true
}
```