### PR TITLE
Allow `certainly` as a certificate authority

### DIFF
--- a/docs/resources/tls_subscription.md
+++ b/docs/resources/tls_subscription.md
@@ -178,7 +178,7 @@ $ terraform import fastly_tls_subscription.demo xxxxxxxxxxx
 
 ### Required
 
-- `certificate_authority` (String) The entity that issues and certifies the TLS certificates for your subscription. Valid values are `lets-encrypt` or `globalsign`.
+- `certificate_authority` (String) The entity that issues and certifies the TLS certificates for your subscription. Valid values are `lets-encrypt`, `globalsign` or `certainly`.
 - `domains` (Set of String) List of domains on which to enable TLS.
 
 ### Optional

--- a/docs/resources/tls_subscription.md
+++ b/docs/resources/tls_subscription.md
@@ -178,7 +178,7 @@ $ terraform import fastly_tls_subscription.demo xxxxxxxxxxx
 
 ### Required
 
-- `certificate_authority` (String) The entity that issues and certifies the TLS certificates for your subscription. Valid values are `lets-encrypt`, `globalsign` or `certainly`.
+- `certificate_authority` (String) The entity that issues and certifies the TLS certificates for your subscription. Valid values are `lets-encrypt`, `globalsign` or `certainly` (beta).
 - `domains` (Set of String) List of domains on which to enable TLS.
 
 ### Optional

--- a/fastly/resource_fastly_tls_subscription.go
+++ b/fastly/resource_fastly_tls_subscription.go
@@ -36,7 +36,7 @@ func resourceFastlyTLSSubscription() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"certificate_authority": {
 				Type:         schema.TypeString,
-				Description:  "The entity that issues and certifies the TLS certificates for your subscription. Valid values are `lets-encrypt`, `globalsign` or `certainly`.",
+				Description:  "The entity that issues and certifies the TLS certificates for your subscription. Valid values are `lets-encrypt`, `globalsign` or `certainly` (beta).",
 				Required:     true,
 				ForceNew:     true,
 				ValidateFunc: validation.StringInSlice([]string{"lets-encrypt", "globalsign", "certainly"}, false),

--- a/fastly/resource_fastly_tls_subscription.go
+++ b/fastly/resource_fastly_tls_subscription.go
@@ -36,10 +36,10 @@ func resourceFastlyTLSSubscription() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"certificate_authority": {
 				Type:         schema.TypeString,
-				Description:  "The entity that issues and certifies the TLS certificates for your subscription. Valid values are `lets-encrypt` or `globalsign`.",
+				Description:  "The entity that issues and certifies the TLS certificates for your subscription. Valid values are `lets-encrypt`, `globalsign` or `certainly`.",
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validation.StringInSlice([]string{"lets-encrypt", "globalsign"}, false),
+				ValidateFunc: validation.StringInSlice([]string{"lets-encrypt", "globalsign", "certainly"}, false),
 			},
 			"certificate_id": {
 				Type:        schema.TypeString,


### PR DESCRIPTION
As the product has been announced in https://www.fastly.com/blog/announcing-certainly-fastlys-own-tls-certification-authority, it'd be great to support it in this Terraform provider.