### PR TITLE
fix(backend): remove auto_loadbalance from compute service

### DIFF
--- a/docs/resources/service_compute.md
+++ b/docs/resources/service_compute.md
@@ -150,7 +150,6 @@ Required:
 
 Optional:
 
-- `auto_loadbalance` (Boolean) Denotes if this Backend should be included in the pool of backends that requests are load balanced against. Default `false`
 - `between_bytes_timeout` (Number) How long to wait between bytes in milliseconds. Default `10000`
 - `connect_timeout` (Number) How long to wait for a timeout in milliseconds. Default `1000`
 - `error_threshold` (Number) Number of errors to allow before the Backend is marked as down. Default `0`

--- a/fastly/block_fastly_service_backend.go
+++ b/fastly/block_fastly_service_backend.go
@@ -37,12 +37,6 @@ func (h *BackendServiceAttributeHandler) GetSchema() *schema.Schema {
 			Required:    true,
 			Description: "An IPv4, hostname, or IPv6 address for the Backend",
 		},
-		"auto_loadbalance": {
-			Type:        schema.TypeBool,
-			Optional:    true,
-			Default:     false,
-			Description: "Denotes if this Backend should be included in the pool of backends that requests are load balanced against. Default `false`",
-		},
 		"between_bytes_timeout": {
 			Type:        schema.TypeInt,
 			Optional:    true,
@@ -176,6 +170,12 @@ func (h *BackendServiceAttributeHandler) GetSchema() *schema.Schema {
 	required := false
 
 	if h.GetServiceMetadata().serviceType == ServiceTypeVCL {
+		blockAttributes["auto_loadbalance"] = &schema.Schema{
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Default:     false,
+			Description: "Denotes if this Backend should be included in the pool of backends that requests are load balanced against. Default `false`",
+		}
 		blockAttributes["request_condition"] = &schema.Schema{
 			Type:        schema.TypeString,
 			Optional:    true,
@@ -270,7 +270,6 @@ func (h *BackendServiceAttributeHandler) createDeleteBackendInput(service string
 func (h *BackendServiceAttributeHandler) buildCreateBackendInput(service string, latestVersion int, resource map[string]any) gofastly.CreateBackendInput {
 	opts := gofastly.CreateBackendInput{
 		Address:             gofastly.String(resource["address"].(string)),
-		AutoLoadbalance:     gofastly.CBool(resource["auto_loadbalance"].(bool)),
 		BetweenBytesTimeout: gofastly.Int(resource["between_bytes_timeout"].(int)),
 		ConnectTimeout:      gofastly.Int(resource["connect_timeout"].(int)),
 		ErrorThreshold:      gofastly.Int(resource["error_threshold"].(int)),
@@ -319,6 +318,7 @@ func (h *BackendServiceAttributeHandler) buildCreateBackendInput(service string,
 	}
 
 	if h.GetServiceMetadata().serviceType == ServiceTypeVCL {
+		opts.AutoLoadbalance = gofastly.CBool(resource["auto_loadbalance"].(bool))
 		opts.RequestCondition = gofastly.String(resource["request_condition"].(string))
 	}
 	return opts
@@ -358,7 +358,9 @@ func (h *BackendServiceAttributeHandler) buildUpdateBackendInput(serviceID strin
 		opts.BetweenBytesTimeout = gofastly.Int(v.(int))
 	}
 	if v, ok := modified["auto_loadbalance"]; ok {
-		opts.AutoLoadbalance = gofastly.CBool(v.(bool))
+		if h.GetServiceMetadata().serviceType == ServiceTypeVCL {
+			opts.AutoLoadbalance = gofastly.CBool(v.(bool))
+		}
 	}
 	if v, ok := modified["weight"]; ok {
 		opts.Weight = gofastly.Int(v.(int))
@@ -415,7 +417,6 @@ func flattenBackend(remoteState []*gofastly.Backend, sa ServiceMetadata) []map[s
 	for _, resource := range remoteState {
 		data := map[string]any{
 			"address":               resource.Address,
-			"auto_loadbalance":      resource.AutoLoadbalance,
 			"between_bytes_timeout": int(resource.BetweenBytesTimeout),
 			"connect_timeout":       int(resource.ConnectTimeout),
 			"error_threshold":       int(resource.ErrorThreshold),
@@ -440,6 +441,7 @@ func flattenBackend(remoteState []*gofastly.Backend, sa ServiceMetadata) []map[s
 		}
 
 		if sa.serviceType == ServiceTypeVCL {
+			data["auto_loadbalance"] = resource.AutoLoadbalance
 			data["request_condition"] = resource.RequestCondition
 		}
 

--- a/fastly/block_fastly_service_backend_test.go
+++ b/fastly/block_fastly_service_backend_test.go
@@ -104,7 +104,6 @@ func TestResourceFastlyFlattenBackendCompute(t *testing.T) {
 					Address:             "www.notexample.com",
 					OverrideHost:        "origin.example.com",
 					Port:                80,
-					AutoLoadbalance:     true,
 					BetweenBytesTimeout: 10000,
 					ConnectTimeout:      1000,
 					ErrorThreshold:      0,
@@ -132,7 +131,6 @@ func TestResourceFastlyFlattenBackendCompute(t *testing.T) {
 					"address":               "www.notexample.com",
 					"override_host":         "origin.example.com",
 					"port":                  80,
-					"auto_loadbalance":      true,
 					"between_bytes_timeout": 10000,
 					"connect_timeout":       1000,
 					"error_threshold":       0,
@@ -333,7 +331,7 @@ func testAccCheckFastlyServiceVCLBackendAttributes(service *gofastly.ServiceDeta
 					// we don't know these things ahead of time, so populate them now
 					w.ServiceID = service.ID
 					w.ServiceVersion = service.ActiveVersion.Number
-					// We don't track these, so clear them out because we also wont know
+					// We don't track these, so clear them out because we also won't know
 					// these ahead of time
 					h.CreatedAt = nil
 					h.UpdatedAt = nil


### PR DESCRIPTION
Although the `auto_loadbalance` feature was never officially supported by the Compute service type, our removal of the attribute is still considered a break in the exposed user interface; meaning we'll need to treat this as a BREAKING change and include it in a new major version release.

> **NOTE:** I've run the full integration test suite, and it's passing.