### PR TITLE
feat(fastly_service_compute): support new `content` attribute

### DIFF
--- a/docs/resources/service_compute.md
+++ b/docs/resources/service_compute.md
@@ -131,12 +131,10 @@ Optional:
 <a id="nestedblock--package"></a>
 ### Nested Schema for `package`
 
-Required:
-
-- `filename` (String) The path to the Wasm deployment package within your local filesystem
-
 Optional:
 
+- `content` (String) The contents of the Wasm deployment package (e.g. could be provided using an input variable or via external data source output variable). Conflicts with `filename`. Exactly one of these two arguments must be specified
+- `filename` (String) The path to the Wasm deployment package within your local filesystem. Conflicts with `content`. Exactly one of these two arguments must be specified
 - `source_code_hash` (String) Used to trigger updates. Must be set to a SHA512 hash of the package file specified with the filename. The usual way to set this is filesha512("package.tar.gz") (Terraform 0.11.12 and later) or filesha512(file("package.tar.gz")) (Terraform 0.11.11 and earlier), where "package.tar.gz" is the local filename of the Wasm deployment package
 
 

--- a/docs/resources/service_compute.md
+++ b/docs/resources/service_compute.md
@@ -133,7 +133,7 @@ Optional:
 
 Optional:
 
-- `content` (String) The contents of the Wasm deployment package (e.g. could be provided using an input variable or via external data source output variable). Conflicts with `filename`. Exactly one of these two arguments must be specified
+- `content` (String) The contents of the Wasm deployment package as a base64 encoded string (e.g. could be provided using an input variable or via external data source output variable). Conflicts with `filename`. Exactly one of these two arguments must be specified
 - `filename` (String) The path to the Wasm deployment package within your local filesystem. Conflicts with `content`. Exactly one of these two arguments must be specified
 - `source_code_hash` (String) Used to trigger updates. Must be set to a SHA512 hash of the package file specified with the filename. The usual way to set this is filesha512("package.tar.gz") (Terraform 0.11.12 and later) or filesha512(file("package.tar.gz")) (Terraform 0.11.11 and earlier), where "package.tar.gz" is the local filename of the Wasm deployment package
 

--- a/fastly/block_fastly_service_package.go
+++ b/fastly/block_fastly_service_package.go
@@ -47,7 +47,6 @@ func (h *PackageServiceAttributeHandler) Register(s *schema.Resource) error {
 					Description:   "The path to the Wasm deployment package within your local filesystem. Conflicts with `content`. Exactly one of these two arguments must be specified",
 					ConflictsWith: []string{"package.0.content"},
 				},
-				// sha512 hash of the file
 				"source_code_hash": {
 					Type:          schema.TypeString,
 					Optional:      true,

--- a/fastly/block_fastly_service_package.go
+++ b/fastly/block_fastly_service_package.go
@@ -35,16 +35,14 @@ func (h *PackageServiceAttributeHandler) Register(s *schema.Resource) error {
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
 				"content": {
-					Type:          schema.TypeString,
-					Optional:      true,
-					Description:   "The contents of the Wasm deployment package (e.g. could be provided using an input variable or via external data source output variable). Conflicts with `filename`. Exactly one of these two arguments must be specified",
-					ConflictsWith: []string{"filename"},
+					Type:        schema.TypeString,
+					Optional:    true,
+					Description: "The contents of the Wasm deployment package (e.g. could be provided using an input variable or via external data source output variable). Conflicts with `filename`. Exactly one of these two arguments must be specified",
 				},
 				"filename": {
-					Type:          schema.TypeString,
-					Optional:      true,
-					Description:   "The path to the Wasm deployment package within your local filesystem. Conflicts with `content`. Exactly one of these two arguments must be specified",
-					ConflictsWith: []string{"content"},
+					Type:        schema.TypeString,
+					Optional:    true,
+					Description: "The path to the Wasm deployment package within your local filesystem. Conflicts with `content`. Exactly one of these two arguments must be specified",
 				},
 				// sha512 hash of the file
 				"source_code_hash": {

--- a/fastly/block_fastly_service_package.go
+++ b/fastly/block_fastly_service_package.go
@@ -121,7 +121,6 @@ func (h *PackageServiceAttributeHandler) Read(_ context.Context, d *schema.Resou
 			pkgType PkgType
 		)
 
-		// We extract data from the state and reuse it when updating the state.
 		// The value is provided by the user's config as the API doesn't return it.
 		if v := d.Get("package.0.content").(string); v != "" {
 			pkgData = v

--- a/fastly/block_fastly_service_package.go
+++ b/fastly/block_fastly_service_package.go
@@ -94,7 +94,7 @@ func (h *PackageServiceAttributeHandler) Process(_ context.Context, d *schema.Re
 type PkgType int64
 
 const (
-	PkgUndefined PkgType = iota
+	_ PkgType = iota
 	PkgContent
 	PkgFilename
 )

--- a/fastly/block_fastly_service_package.go
+++ b/fastly/block_fastly_service_package.go
@@ -36,21 +36,24 @@ func (h *PackageServiceAttributeHandler) Register(s *schema.Resource) error {
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
 				"content": {
-					Type:        schema.TypeString,
-					Optional:    true,
-					Description: "The contents of the Wasm deployment package as a base64 encoded string (e.g. could be provided using an input variable or via external data source output variable). Conflicts with `filename`. Exactly one of these two arguments must be specified",
+					Type:          schema.TypeString,
+					Optional:      true,
+					Description:   "The contents of the Wasm deployment package as a base64 encoded string (e.g. could be provided using an input variable or via external data source output variable). Conflicts with `filename`. Exactly one of these two arguments must be specified",
+					ConflictsWith: []string{"package.0.filename"},
 				},
 				"filename": {
-					Type:        schema.TypeString,
-					Optional:    true,
-					Description: "The path to the Wasm deployment package within your local filesystem. Conflicts with `content`. Exactly one of these two arguments must be specified",
+					Type:          schema.TypeString,
+					Optional:      true,
+					Description:   "The path to the Wasm deployment package within your local filesystem. Conflicts with `content`. Exactly one of these two arguments must be specified",
+					ConflictsWith: []string{"package.0.content"},
 				},
 				// sha512 hash of the file
 				"source_code_hash": {
-					Type:        schema.TypeString,
-					Optional:    true,
-					Computed:    true,
-					Description: `Used to trigger updates. Must be set to a SHA512 hash of the package file specified with the filename. The usual way to set this is filesha512("package.tar.gz") (Terraform 0.11.12 and later) or filesha512(file("package.tar.gz")) (Terraform 0.11.11 and earlier), where "package.tar.gz" is the local filename of the Wasm deployment package`,
+					Type:          schema.TypeString,
+					Optional:      true,
+					Computed:      true,
+					Description:   `Used to trigger updates. Must be set to a SHA512 hash of the package file specified with the filename. The usual way to set this is filesha512("package.tar.gz") (Terraform 0.11.12 and later) or filesha512(file("package.tar.gz")) (Terraform 0.11.11 and earlier), where "package.tar.gz" is the local filename of the Wasm deployment package`,
+					ConflictsWith: []string{"package.0.content"},
 				},
 			},
 		},

--- a/fastly/block_fastly_service_package.go
+++ b/fastly/block_fastly_service_package.go
@@ -36,16 +36,16 @@ func (h *PackageServiceAttributeHandler) Register(s *schema.Resource) error {
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
 				"content": {
-					Type:          schema.TypeString,
-					Optional:      true,
-					Description:   "The contents of the Wasm deployment package as a base64 encoded string (e.g. could be provided using an input variable or via external data source output variable). Conflicts with `filename`. Exactly one of these two arguments must be specified",
-					ConflictsWith: []string{"package.0.filename"},
+					Type:         schema.TypeString,
+					Optional:     true,
+					Description:  "The contents of the Wasm deployment package as a base64 encoded string (e.g. could be provided using an input variable or via external data source output variable). Conflicts with `filename`. Exactly one of these two arguments must be specified",
+					ExactlyOneOf: []string{"package.0.content", "package.0.filename"},
 				},
 				"filename": {
-					Type:          schema.TypeString,
-					Optional:      true,
-					Description:   "The path to the Wasm deployment package within your local filesystem. Conflicts with `content`. Exactly one of these two arguments must be specified",
-					ConflictsWith: []string{"package.0.content"},
+					Type:         schema.TypeString,
+					Optional:     true,
+					Description:  "The path to the Wasm deployment package within your local filesystem. Conflicts with `content`. Exactly one of these two arguments must be specified",
+					ExactlyOneOf: []string{"package.0.content", "package.0.filename"},
 				},
 				"source_code_hash": {
 					Type:          schema.TypeString,

--- a/fastly/block_fastly_service_waf.go
+++ b/fastly/block_fastly_service_waf.go
@@ -190,7 +190,7 @@ func buildUpdateWAF(d *schema.ResourceData, wafMap any, serviceID string, servic
 	// This is because the schema defines the service as being of TypeList.
 	//
 	// Although there should only ever be one service (hence MaxItems: 1) we are
-	// unable to change the schema to a TypeMap as that would contrain the map's
+	// unable to change the schema to a TypeMap as that would constrain the map's
 	// value to a single type (e.g. TypeString, TypeBool, TypeInt, or TypeFloat).
 
 	if v, ok := d.GetOk("waf.0.prefetch_condition"); ok {


### PR DESCRIPTION
Fixes: https://github.com/fastly/terraform-provider-fastly/issues/583

Please refer to the linked issue above for more context.

**Summary**: Customers have been requesting more flexibility in how a compute package is provided via Terraform.

## Notes

The existing package integration test is still passing:

```
make testacc TESTARGS='-run=TestAccFastlyServiceVCL_package_basic'
```

I've written a test for the new `content` attribute/behaviour and validated it's passing. 

I've also compiled the provider locally and manually validated that the behaviour works as expected.

<img width="954" alt="Screenshot 2023-03-14 at 17 38 58" src="https://user-images.githubusercontent.com/180050/225091368-e0684ec9-554e-441d-9721-17f7d9db47bb.png">

For the sake of my local testing, I wrote a quick Go script to read the compute package tar.gz file and to return the base64 encoding of the contents (this was to mimic a common solution used by our customers, e.g. `google_storage_bucket_object_content`)...

```go
package main

import (
	"encoding/base64"
	"fmt"
	"os"
)

func main() {
	validPackageContent, _ := os.ReadFile("pkg/testing-compute-package.tar.gz")
	b64Content := base64.StdEncoding.EncodeToString(validPackageContent)
	fmt.Printf("%s", b64Content)
}
```

I then have the following Terraform configuration which I invoke via the Terraform CLI and pass in the `-var` flag so I can set the `package_content` input variable...

```tf
terraform {
  required_providers {
    fastly = {
      source = "fastly/fastly"
      version = "4.0.0"
    }
  }
}

variable "package_content" {
  type = string
}

resource "fastly_service_compute" "testing-compute-package" {
  name = "testing-compute-package"

  domain {
    name = "testing-compute-package.integralist.co.uk"
  }

  package {
    content = var.package_content
  }

  force_destroy = true
}
```

Running `terraform show` after `terraform apply` reveals the following state...

```
# fastly_service_compute.testing-compute-package:
resource "fastly_service_compute" "testing-compute-package" {
    activate       = true
    active_version = 1
    cloned_version = 1
    comment        = "Managed by Terraform"
    force_destroy  = true
    force_refresh  = false
    id             = "W8fGlE1Ww9wLRiCYkZeCT4"
    imported       = false
    name           = "testing-compute-package"

    domain {
        name = "testing-compute-package.integralist.co.uk"
    }

    package {
        content          = "H4sIAAAJbogA/+y9C5xdV3UfvJ/...LOTS_OF_TEXT.../BwAA//8DALk/RCkAjg0A"
        source_code_hash = "659521795434ed7f4476e16ef5a85b01465167179f5c0247827c758b174798e2dac3991278ec07f1b4e581ab1909cb1fe5056480ccc56e1410c84db4898c11f1"
    }
}
```

Running `terraform plan` again shows there are no changes necessary.

If I change my compute project's code and re-run `fastly compute build` this will produce a different package and so subsequently a different base64 encoding value will be part of the next `terraform plan` which should cause an update to be issued and a new `source_code_hash` attribute to be generated...

<img width="954" alt="Screenshot 2023-03-14 at 17 51 11" src="https://user-images.githubusercontent.com/180050/225094169-9cf44c85-4188-4c49-bb35-fe338af75e5f.png">
