### PR TITLE
fix(tls/subscriptions): tls configuration id should always be passed

### DIFF
--- a/fastly/resource_fastly_tls_subscription.go
+++ b/fastly/resource_fastly_tls_subscription.go
@@ -336,7 +336,7 @@ func resourceFastlyTLSSubscriptionUpdate(ctx context.Context, d *schema.Resource
 	// This is why we wrap the API request in the following conditional check.
 	// We then send BOTH "domains" and "common_name" in the API request.
 	// This is because they both will have a pre-existing value.
-	if d.HasChange("domains") || d.HasChange("common_name") {
+	if d.HasChanges("domains", "common_name") {
 		// NOTE: The API doesn't care if the domains are in a different order.
 		// I mention this because if it did, then we'd only want to set the Domains
 		// field on the input struct if there was a change because we otherwise

--- a/fastly/resource_fastly_tls_subscription.go
+++ b/fastly/resource_fastly_tls_subscription.go
@@ -323,32 +323,47 @@ func resourceFastlyTLSSubscriptionRead(_ context.Context, d *schema.ResourceData
 }
 
 func resourceFastlyTLSSubscriptionUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*APIClient).conn
-
-	updates := &gofastly.UpdateTLSSubscriptionInput{
-		ID:    d.Id(),
-		Force: d.Get("force_update").(bool),
-	}
-
-	if d.HasChange("domains") {
+	// NOTE: Terraform might trigger an update even when it doesn't make sense.
+	//
+	// This is because along with the "domains" and "common_name" attributes,
+	// there are other attributes a customer might modify, such as
+	// "force_update" (which has no effect on the upstream data model).
+	//
+	// So we don't want to call the API if the customer neither passes a change to
+	// domains or to the common_name attributes as that would be a waste of
+	// network resources.
+	//
+	// This is why we wrap the API request in the following conditional check.
+	// We then send BOTH "domains" and "common_name" in the API request.
+	// This is because they both will have a pre-existing value.
+	if d.HasChange("domains") || d.HasChange("common_name") {
+		// NOTE: The API doesn't care if the domains are in a different order.
+		// I mention this because if it did, then we'd only want to set the Domains
+		// field on the input struct if there was a change because we otherwise
+		// can't guarantee the order.
 		var domains []*gofastly.TLSDomain
 		for _, domain := range d.Get("domains").(*schema.Set).List() {
 			domains = append(domains, &gofastly.TLSDomain{ID: domain.(string)})
 		}
-		updates.Domains = domains
-	}
-	if d.HasChange("common_name") {
-		updates.CommonName = &gofastly.TLSDomain{ID: d.Get("common_name").(string)}
-	}
-	if d.HasChange("configuration_id") {
-		updates.Configuration = &gofastly.TLSConfiguration{ID: d.Get("configuration_id").(string)}
+
+		updates := &gofastly.UpdateTLSSubscriptionInput{
+			ID:         d.Id(),
+			Force:      d.Get("force_update").(bool),
+			CommonName: &gofastly.TLSDomain{ID: d.Get("common_name").(string)},
+			Domains:    domains,
+
+			// IMPORTANT: We should always pass the configuration_id to the API.
+			Configuration: &gofastly.TLSConfiguration{ID: d.Get("configuration_id").(string)},
+		}
+
+		conn := meta.(*APIClient).conn
+		_, err := conn.UpdateTLSSubscription(updates)
+		if err != nil {
+			return diag.FromErr(err)
+		}
 	}
 
-	_, err := conn.UpdateTLSSubscription(updates)
-	if err != nil {
-		return diag.FromErr(err)
-	}
-
+	// If no meaningful attributes are passed, we just return the read data.
 	return resourceFastlyTLSSubscriptionRead(ctx, d, meta)
 }
 


### PR DESCRIPTION
Fixes: https://github.com/fastly/terraform-provider-fastly/issues/669

**Problem:** A customer noticed when modifying their TLS Subscription domains that an error was reported saying a TLS Configuration ID was missing. This was caused by the customer not having a default TLS Configuration set, only custom configuration objects (one of which they specify the ID for in their HCL config). But because that ID wasn't changing, the current TF implementation wouldn't send it in the API request, and so the API returned an error because it expected an ID.

**Solution**: We always provide the TLS Configuration object ID. Even if the customer has a default TLS Configuration object set on their account we'll still pass whatever the computed ID was to ensure the API doesn't error.

**NOTE:** I've run the complete end-to-end integration test suite and it's passing.