### PR TITLE
fix(fastly_service_vcl): validate snippet names

### DIFF
--- a/fastly/base_fastly_service.go
+++ b/fastly/base_fastly_service.go
@@ -77,6 +77,7 @@ func resourceService(serviceDef ServiceDefinition) *schema.Resource {
 				// activate flag) then the active_version will be recomputed too.
 				return d.HasChange("cloned_version") && d.Get("activate").(bool)
 			}),
+			validateSnippetNames,
 		),
 		Schema: map[string]*schema.Schema{
 			"activate": {
@@ -153,6 +154,36 @@ func resourceService(serviceDef ServiceDefinition) *schema.Resource {
 	}
 
 	return s
+}
+
+func validateSnippetNames(_ context.Context, rd *schema.ResourceDiff, _ any) error {
+	names := make(map[string]int)
+
+	c := rd.GetRawConfig()
+	m := c.AsValueMap()
+	s, ok := m["snippet"]
+	if ok {
+		set := s.AsValueSet()
+		vs := set.Values()
+		for _, v := range vs {
+			m := v.AsValueMap()
+			if val, ok := m["name"]; ok {
+				name := val.AsString()
+				if n, ok := names[name]; ok {
+					names[name] = n + 1
+				} else {
+					names[name] = 1
+				}
+			}
+		}
+	}
+
+	for k, v := range names {
+		if v > 1 {
+			return fmt.Errorf("multiple snippets with the same name '%s' (each snippet name should be unique)", k)
+		}
+	}
+	return nil
 }
 
 // resourceCreate satisfies the Terraform resource schema Create "interface"


### PR DESCRIPTION
## Problem

A user can define multiple `snippets` with the same `name` attribute. 
This causes the Fastly API to treat the data using 'last entry wins' behaviour.
Resulting in invalid plan diffs and state changes.

## Solution

The Fastly Terraform provider should validate that snippet names are unique.

<img width="918" alt="Screenshot 2023-03-29 at 12 56 24" src="https://user-images.githubusercontent.com/180050/228556196-007bc388-c1ef-498a-97cf-aa5684f6683b.png">

## Notes

I checked the `schema.Schema` type to see if there were any useful validation fields, and although there is `ValidateFunc` it only validates that specific instance of a block type and so it isn't useful for comparing across _separate_ blocks within a resource.

Because of this I had to resort to adding extra validation via the existing `fastly_service_vcl` resource's `CustomizeDiff`.

Fixes https://github.com/fastly/terraform-provider-fastly/issues/672