### PR TITLE
lint fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ test:
 # reference:
 # https://www.terraform.io/docs/extend/testing/acceptance-tests/index.html#running-acceptance-tests
 #
-testacc: fmtcheck
+testacc: staticcheck tfproviderlintx fmtcheck
 	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -parallel=$(TEST_PARALLELISM) -timeout 360m -ldflags="-X=$(FULL_PKG_NAME)/$(VERSION_PLACEHOLDER)=acc"
 
 # WARNING: This target will delete infrastructure.

--- a/fastly/block_fastly_service_logging_gcs_test.go
+++ b/fastly/block_fastly_service_logging_gcs_test.go
@@ -254,35 +254,6 @@ resource "fastly_service_compute" "foo" {
 }`, name, domainName, backendName, gcsName, secretKey)
 }
 
-func testAccServiceVCLConfigGCSEnv(name, gcsName string) string {
-	backendName := fmt.Sprintf("%s.aws.amazon.com", acctest.RandString(3))
-	domainName := fmt.Sprintf("fastly-test.tf-%s.com", acctest.RandString(10))
-
-	return fmt.Sprintf(`
-resource "fastly_service_vcl" "foo" {
-  name = "%s"
-
-  domain {
-    name = "%s"
-    comment = "tf-testing-domain"
-  }
-
-  backend {
-    address = "%s"
-    name = "tf -test backend"
-  }
-
-  logging_gcs {
-    name = "%s"
-    bucket_name = "bucketname"
-    format = "log format"
-    response_condition = ""
-  }
-
-  force_destroy = true
-}`, name, domainName, backendName, gcsName)
-}
-
 func setGcsEnv(email, secretKey string, t *testing.T) func() {
 	e := getGcsEnv()
 	// Set all the envs to a dummy value

--- a/fastly/block_fastly_service_logging_splunk_test.go
+++ b/fastly/block_fastly_service_logging_splunk_test.go
@@ -673,32 +673,6 @@ resource "fastly_service_vcl" "foo" {
 }`, serviceName, domainName)
 }
 
-func testAccServiceVCLSplunkConfigEnv(serviceName string) string {
-	domainName := fmt.Sprintf("fastly-test.tf-%s.com", acctest.RandString(10))
-
-	return fmt.Sprintf(`
-resource "fastly_service_vcl" "foo" {
-  name = %q
-
-  domain {
-    name    = %q
-    comment = "tf-testing-domain"
-  }
-
-  backend {
-    address = "aws.amazon.com"
-    name    = "tf-test-backend"
-  }
-
-  logging_splunk {
-    name = "test-splunk"
-    url  = "https://mysplunkendpoint.example.com/services/collector/event"
-  }
-
-  force_destroy = true
-}`, serviceName, domainName)
-}
-
 // setSplunkEnv sets the specified values as environment variables and returns a
 // function that can be used to reset the environment variables in case the
 // same variables happen to be in the user's environment when running the tests.

--- a/fastly/config.go
+++ b/fastly/config.go
@@ -74,9 +74,9 @@ func (c *Config) Client() (*APIClient, diag.Diagnostics) {
 	http2DefaultTransport := &http2.Transport{}
 
 	if c.ForceHTTP2 {
-		fastlyClient.HTTPClient.Transport = logging.NewTransport("Fastly", http2DefaultTransport)
+		fastlyClient.HTTPClient.Transport = logging.NewSubsystemLoggingHTTPTransport("Fastly", http2DefaultTransport)
 	} else {
-		fastlyClient.HTTPClient.Transport = logging.NewTransport("Fastly", httpDefaultTransport)
+		fastlyClient.HTTPClient.Transport = logging.NewSubsystemLoggingHTTPTransport("Fastly", httpDefaultTransport)
 	}
 
 	client.conn = fastlyClient

--- a/fastly/resource_fastly_tls_platform_certificate_test.go
+++ b/fastly/resource_fastly_tls_platform_certificate_test.go
@@ -138,6 +138,7 @@ func testSweepTLSPlatformCertificates(region string) error {
 
 	for _, certificate := range certificates {
 		for _, domain := range certificate.Domains {
+			//lint:ignore SA4017 ignoring because HasPrefix returned value IS being used.
 			if !strings.HasPrefix(domain.ID, testResourcePrefix) || !strings.HasPrefix(domain.ID, ".test") {
 				continue
 			}

--- a/main.go
+++ b/main.go
@@ -2,7 +2,6 @@
 package main
 
 import (
-	"context"
 	"flag"
 	"log"
 
@@ -25,11 +24,7 @@ func main() {
 	log.SetFlags(noLogPrefix)
 
 	if debugMode {
-		err := plugin.Debug(context.Background(), "fastly/fastly", opts)
-		if err != nil {
-			log.Fatal(err.Error())
-		}
-		return
+		opts.Debug = true
 	}
 
 	plugin.Serve(opts)


### PR DESCRIPTION
**NOTE:** I've run the full integration tests and they're passing.

**CHANGES**:

- Remove unused functions (`testAccServiceVCLConfigGCSEnv`, `testAccServiceVCLSplunkConfigEnv `).
- Replace deprecated `logging.NewTransport` with `logging.NewSubsystemLoggingHTTPTransport`.
- Ignore `strings.HasPrefix` linter issue ([SA4017](https://staticcheck.io/docs/checks#SA4017)) as we ARE using the return value, not discarding it.
- Replace `plugin.Debug` with `Debug` field set on `plugin.ServeOpts`.