### PR TITLE
fix(product_enablement): skip disabling image_optimizer

### DIFF
--- a/fastly/block_fastly_service_product_enablement.go
+++ b/fastly/block_fastly_service_product_enablement.go
@@ -99,7 +99,7 @@ func (h *ProductEnablementServiceAttributeHandler) GetSchema() *schema.Schema {
 }
 
 // Create creates the resource.
-func (h *ProductEnablementServiceAttributeHandler) Create(_ context.Context, d *schema.ResourceData, resource map[string]any, serviceVersion int, conn *gofastly.Client) error {
+func (h *ProductEnablementServiceAttributeHandler) Create(_ context.Context, d *schema.ResourceData, resource map[string]any, _ int, conn *gofastly.Client) error {
 	serviceID := d.Id()
 
 	if h.GetServiceMetadata().serviceType == ServiceTypeCompute {
@@ -176,7 +176,7 @@ func (h *ProductEnablementServiceAttributeHandler) Create(_ context.Context, d *
 }
 
 // Read refreshes the resource.
-func (h *ProductEnablementServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, _ map[string]any, serviceVersion int, conn *gofastly.Client) error {
+func (h *ProductEnablementServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, _ map[string]any, _ int, conn *gofastly.Client) error {
 	localState := d.Get(h.Key()).(*schema.Set).List()
 
 	if len(localState) > 0 || d.Get("imported").(bool) || d.Get("force_refresh").(bool) {
@@ -279,7 +279,7 @@ func (h *ProductEnablementServiceAttributeHandler) Read(_ context.Context, d *sc
 }
 
 // Update updates the resource.
-func (h *ProductEnablementServiceAttributeHandler) Update(_ context.Context, d *schema.ResourceData, resource, modified map[string]any, serviceVersion int, conn *gofastly.Client) error {
+func (h *ProductEnablementServiceAttributeHandler) Update(_ context.Context, d *schema.ResourceData, _, modified map[string]any, _ int, conn *gofastly.Client) error {
 	serviceID := d.Id()
 
 	if h.GetServiceMetadata().serviceType == ServiceTypeCompute {
@@ -453,7 +453,7 @@ func (h *ProductEnablementServiceAttributeHandler) Update(_ context.Context, d *
 // `Process` method that handles both CREATE and UPDATE stages and doesn't get
 // passed a data structure that indicates what has changed like we do with the
 // TypeSet data type. So it'll be a trade-off.
-func (h *ProductEnablementServiceAttributeHandler) Delete(_ context.Context, d *schema.ResourceData, resource map[string]any, serviceVersion int, conn *gofastly.Client) error {
+func (h *ProductEnablementServiceAttributeHandler) Delete(_ context.Context, d *schema.ResourceData, _ map[string]any, _ int, conn *gofastly.Client) error {
 	if h.GetServiceMetadata().serviceType == ServiceTypeCompute {
 		log.Println("[DEBUG] disable fanout")
 		err := conn.DisableProduct(&gofastly.ProductEnablementInput{

--- a/fastly/block_fastly_service_product_enablement.go
+++ b/fastly/block_fastly_service_product_enablement.go
@@ -435,13 +435,13 @@ func (h *ProductEnablementServiceAttributeHandler) Update(_ context.Context, d *
 // then we'll skip the error as we want the `terraform apply` to be successful
 // and for the user to end up with a clean state.
 //
-// NOTE: We don't return the nil error, ensuring all products are processed.
-// We don't want to return the nil error (e.g. when a user is trying to clean-up
-// their state as they're not entitled to enable/disable the product) because
-// returning nil will short-circuit the `Delete` method and we'll not process
-// the disabling of other products they might be entitled to disable!
+// NOTE: We avoid returning early because there are multiple API calls.
+// For example, if the first API call to disable a product failed because the
+// user didn't have entitlement to disable, then returning either the error or
+// skipping it and returning nil would cause the Delete function to finish and
+// we wouldn't have a chance to disable the other products.
 //
-// FIXME: Looks like the use of a TypeSet means unnecessary API calls.
+// TODO: Consider switching from a TypeSet to avoid unnecessary API calls.
 // In a scenario where a new product is set to `true` (e.g. to be enabled) the
 // set hash changes and so the set 'as a whole' is deleted (causing all the
 // products to be disabled) and then all the APIs are called again to re-enable

--- a/fastly/block_fastly_service_product_enablement.go
+++ b/fastly/block_fastly_service_product_enablement.go
@@ -492,48 +492,40 @@ func (h *ProductEnablementServiceAttributeHandler) Delete(_ context.Context, d *
 
 		log.Println("[DEBUG] disable image_optimizer")
 
-		// IMPORTANT: There is no public API for checking user entitlement.
+		// IMPORTANT: Attempt to 'enable' the IO product to validate entitlement.
+		//
 		// This means if a user adds product_enablement and realises they can't
-		// enable products, then they'll need to delete the block from their config
-		// and that will cause this Delete function to be run. The problem now, is
-		// that the Product Enablement API allows you to disable the IO product even
-		// if you don't have entitlement to 'enable' it (this is because we need to
-		// allow a user to disable IO before their 'pro' free trial auto-renews).
+		// enable products, then they'll need to delete the block from their config.
+		// Doing that will cause the TF 'delete' flow to be run.
+		//
+		// The problem now, is that the Product Enablement API allows you to
+		// disable the IO product even if you don't have entitlement to 'enable' it.
+		// This is because an internal Fastly monitoring system needs to be able to
+		// disable access once a 'free trial' access has expired.
+		//
 		// The reason this is a problem is because a user might have requested
 		// Fastly Support add IO to their service and now Terraform will go ahead
-		// and disable it by accident. The only way to prevent that from happening
-		// is to make an additional API call (for IO only) to try and 'enable' IO
-		// and then if it fails with the error about missing entitlement we know we
-		// can skip trying to 'disable' it.
+		// and disable it by accident.
+		//
+		// The only way to prevent that from happening is to first call the 'enable'
+		// endpoint (for IO only) and then if it fails we know the user isn't
+		// entitled to disable it.
+		//
+		// This works because the Product Enablement API allows you to call the
+		// 'enable' endpoint multiple times and it will still 2xx if you've already
+		// enabled the product.
 		_, err = conn.EnableProduct(&gofastly.ProductEnablementInput{
 			ProductID: gofastly.ProductImageOptimizer,
 			ServiceID: d.Id(),
 		})
-		if err != nil {
-			if he, ok := err.(*gofastly.HTTPError); ok {
-				if he.StatusCode == http.StatusBadRequest {
-					for _, e := range he.Errors {
-						if !strings.Contains(e.Title, "not entitled to enable") && !strings.Contains(e.Title, "product cannot be self enabled") {
-							// NOTE: If this user is not entitled to disable IO it's still OK.
-							// For example, if the user has added product_enablement by
-							// accident (they don't have entitlement), then this call to
-							// disable the product will not get executed and the rest of the
-							// Delete method will run through until completion and because we
-							// ignore errors returned from the API when deleting it means the
-							// other calls to disable the other products won't cause the
-							// Delete method to fail and thus allows the user to clean-up
-							// their Terraform state.
-							err = conn.DisableProduct(&gofastly.ProductEnablementInput{
-								ProductID: gofastly.ProductImageOptimizer,
-								ServiceID: d.Id(),
-							})
-							if err != nil {
-								if e := h.checkAPIError(err); e != nil {
-									return e
-								}
-							}
-						}
-					}
+		if err == nil {
+			err = conn.DisableProduct(&gofastly.ProductEnablementInput{
+				ProductID: gofastly.ProductImageOptimizer,
+				ServiceID: d.Id(),
+			})
+			if err != nil {
+				if e := h.checkAPIError(err); e != nil {
+					return e
 				}
 			}
 		}

--- a/fastly/block_fastly_service_product_enablement.go
+++ b/fastly/block_fastly_service_product_enablement.go
@@ -453,6 +453,19 @@ func (h *ProductEnablementServiceAttributeHandler) Update(_ context.Context, d *
 // `Process` method that handles both CREATE and UPDATE stages and doesn't get
 // passed a data structure that indicates what has changed like we do with the
 // TypeSet data type. So it'll be a trade-off.
+//
+// IMPORTANT: There is no public API for checking user entitlement.
+// This means if a user adds product_enablement and realises they can't enable
+// products, then they'll need to delete the block from their config and that
+// will cause this Delete function to be run. The problem now, is that the
+// Product Enablement API allows you to disable the IO product even if you don't
+// have entitlement to 'enable' it (this is because we need to allow a user to
+// disable IO before their 'pro' free trial auto-renews). The reason this is a
+// problem is because a user might have requested Fastly Support add IO to their
+// service and now Terraform will go ahead and disable it by accident. The only
+// way to prevent that from happening is to make an additional API call (for IO
+// only) to try and 'enable' IO and then if it fails with the error about
+// missing entitlement we know we can skip trying to 'disable' it.
 func (h *ProductEnablementServiceAttributeHandler) Delete(_ context.Context, d *schema.ResourceData, _ map[string]any, _ int, conn *gofastly.Client) error {
 	if h.GetServiceMetadata().serviceType == ServiceTypeCompute {
 		log.Println("[DEBUG] disable fanout")


### PR DESCRIPTION
> **NOTE:** I've run the full test suite and it's passing ✅

## Problem

**Summary:** Users who accidentally end up with a `product_enablement` block in their Terraform config/state (even though they don't have entitlement to enable products) can end up disabling the ImageOptimizer product on their service if it was enabled separately by Fastly Support.

**Explanation:**
If I don't have the entitlement to enable products, then I need to go to Fastly Support to ask them to enable ImageOptimizer. 

If I later decide to add a `product_enablement` block to my Terraform (example below) because I think it's OK for me to add it and I'm not aware of any entitlement restrictions (e.g. I've added it by mistake), then Terraform will try to enable all the products (as I've configured it to):

```terraform
product_enablement {
    brotli_compression = true
    domain_inspector   = true
    image_optimizer    = true
    origin_inspector   = true
    websockets         = true
}
```

When I run `terraform apply` Terraform will return an API error that says "product cannot be self enabled".

But now, internally, Terraform's state will actually hold the following...

```terraform
product_enablement {
    brotli_compression = false
    domain_inspector   = false
    image_optimizer    = true
    origin_inspector   = false
    websockets         = false
}
```

It will have `image_optimizer = true` because when Terraform executes the `Read` method of the `product_enablement` 'block' it went to the Fastly API and discovered that IO was enabled (as per me asking Fastly Support previously to enable IO for me).

Now if I delete the `product_enablement` block from my config, Terraform will run its "Delete" method.

The delete flow will call https://developer.fastly.com/reference/api/products/enablement/#disable-product for each product, and consequently, Terraform will call the 'disable product' endpoint for the ImageOptimizer product and that would (unintuitively) successfully disable the IO product! When really you would expect the API call to fail (which currently Terraform silently ignores the API errors so that a user such as myself can allow the Delete method to complete and thus have Terraform clean-up my internal state to no longer contain a `product_enablement` block). 

> **NOTE:** The reason that particular API call doesn't error is because it's a special case. If a user is given a free trial to ImageOptimizer, when the free trial expires an internal Fastly monitoring tool will call the 'disable product' API endpoint for that user's service.

Now that's **_NOT_** what I want to have happen. I don't want to disable image_optimizer because I need it for my service, and I've now obviously discovered that I can't enable it again using Terraform, so this means I'd have to contact Fastly Support in a panic asking them to enable it again as my service is broken. The fact that Terraform disabled IO is a side-effect of me accidentally adding this `product_enablement` block in the first place and so Terraform's Delete method has to be called to clean things up.

> **NOTE:** Yes, it's possible to _manually_ strip out `product_enablement` from the Terraform state file but realistically that's a lot to ask of a customer to have to deal with.

## Solution

As far as I see it, if the Terraform "Delete" flow is actioned, then we can workaround image_optimzer being accidentally disabled by first making an API request to 'enable' IO and then if that call is successful we know that the user is entitled to 'disable' the same product.

This should mean all three known scenarios are catered for...

### 1. Entitled user

This means, for a user who has `product_enablement` in their config and who also has entitlement to self-enable/disable products, then deleting the `product_enablement` block from their Terraform config should be fine and the 'disable product' calls will all still be made.

### 2. Non-entitled user with IO enabled by Fastly Support

This means, for a user who accidentally adds the `product_enablement` block to their Terraform config but doesn't have entitlement to self-enable/disable products but they _do have_ IO enabled on their service, then they can delete `product_enablement` from their Terraform config, Terraform will run its Delete method and all the API calls to 'disable product' will be made _except for_ the call to disable IO (remember, the call to disable IO won't be called due to our check first to see if it can be enabled, and in this case the user is not entitled). Any API calls that are made to disable a product are going to fail silently anyway and is by design because we want the user to be able to successfully clean up their internal Terraform state. The intention is for this type of user to request IO be disabled via Fastly Support (as they would have done to get it enabled).

### 3. Non-entitled user with no products enabled

This means if a user accidentally adds `product_enablement` and doesn't have entitlement to self-enable/disable products and they _don't_ have IO enabled on their service either, then they can delete `product_enablement` from their Terraform config, Terraform will run its Delete method and all the API calls to 'disable product' that are made (remember, the call to disable IO won't be called due to our check first to see if it can be enabled), will fail silently and the user's internal state will be cleaned-up appropriately.