### PR TITLE
fix(product_enablement): error message check was too specific

### DIFF
--- a/fastly/block_fastly_service_product_enablement.go
+++ b/fastly/block_fastly_service_product_enablement.go
@@ -535,7 +535,7 @@ func (h *ProductEnablementServiceAttributeHandler) checkAPIError(err error) erro
 	if he, ok := err.(*gofastly.HTTPError); ok {
 		if he.StatusCode == http.StatusBadRequest {
 			for _, e := range he.Errors {
-				if strings.Contains(e.Title, "is not entitled to disable product") {
+				if strings.Contains(e.Title, "not entitled to disable") || strings.Contains(e.Title, "product cannot be disabled") {
 					return nil
 				}
 			}


### PR DESCRIPTION
✅ Full end-to-end integration test suite is passing.

Some customers might be seeing a variation of the error "is not entitled to disable product"...

```
error: 400 - Bad Request:
    Title:  not entitled to disable
```

This means if the Terraform provider needed to call its DELETE flow for `product_enablement`, then it would end up _returning_ the error (which would then stop a user's `apply` from completing successfully) rather than failing silently (as it's supposed to do for users who aren't entitled to a product).