### PR TITLE
fix(product_enablement): avoid unexpected diff

### DIFF
--- a/fastly/block_fastly_service_product_enablement.go
+++ b/fastly/block_fastly_service_product_enablement.go
@@ -464,13 +464,14 @@ func (h *ProductEnablementServiceAttributeHandler) Update(_ context.Context, d *
 // then we'll skip the error as we want the `terraform apply` to be successful
 // and for the user to end up with a clean state.
 //
-// NOTE: We don't return the nil error, ensuring all products are processed.
-// We don't want to return the nil error (e.g. when a user is trying to clean-up
-// their state as they're not entitled to enable/disable the product) because
-// returning nil will short-circuit the `Delete` method and we'll not process
-// the disabling of other products they might be entitled to disable!
+// NOTE: We avoid returning early because there are multiple API calls.
+// For example, if the first API call to disable a product failed because the
+// user didn't have entitlement to disable, then returning either the error or
+// skipping it and returning nil would cause the Delete function to finish and
+// we wouldn't have a chance to attempt disabling the other products which they
+// might be allowed to disable.
 //
-// FIXME: Looks like the use of a TypeSet means unnecessary API calls.
+// TODO: Consider switching from a TypeSet to avoid unnecessary API calls.
 // In a scenario where a new product is set to `true` (e.g. to be enabled) the
 // set hash changes and so the set 'as a whole' is deleted (causing all the
 // products to be disabled) and then all the APIs are called again to re-enable

--- a/fastly/block_fastly_service_product_enablement.go
+++ b/fastly/block_fastly_service_product_enablement.go
@@ -99,7 +99,7 @@ func (h *ProductEnablementServiceAttributeHandler) GetSchema() *schema.Schema {
 }
 
 // Create creates the resource.
-func (h *ProductEnablementServiceAttributeHandler) Create(_ context.Context, d *schema.ResourceData, resource map[string]any, serviceVersion int, conn *gofastly.Client) error {
+func (h *ProductEnablementServiceAttributeHandler) Create(_ context.Context, d *schema.ResourceData, resource map[string]any, _ int, conn *gofastly.Client) error {
 	serviceID := d.Id()
 
 	if h.GetServiceMetadata().serviceType == ServiceTypeCompute {
@@ -176,7 +176,7 @@ func (h *ProductEnablementServiceAttributeHandler) Create(_ context.Context, d *
 }
 
 // Read refreshes the resource.
-func (h *ProductEnablementServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, _ map[string]any, serviceVersion int, conn *gofastly.Client) error {
+func (h *ProductEnablementServiceAttributeHandler) Read(_ context.Context, d *schema.ResourceData, _ map[string]any, _ int, conn *gofastly.Client) error {
 	localState := d.Get(h.Key()).(*schema.Set).List()
 
 	// IMPORTANT: Avoid a diff unless state actually contains product_enablement.
@@ -308,7 +308,7 @@ func (h *ProductEnablementServiceAttributeHandler) Read(_ context.Context, d *sc
 }
 
 // Update updates the resource.
-func (h *ProductEnablementServiceAttributeHandler) Update(_ context.Context, d *schema.ResourceData, resource, modified map[string]any, serviceVersion int, conn *gofastly.Client) error {
+func (h *ProductEnablementServiceAttributeHandler) Update(_ context.Context, d *schema.ResourceData, _, modified map[string]any, serviceVersion int, conn *gofastly.Client) error {
 	serviceID := d.Id()
 
 	if h.GetServiceMetadata().serviceType == ServiceTypeCompute {
@@ -482,7 +482,7 @@ func (h *ProductEnablementServiceAttributeHandler) Update(_ context.Context, d *
 // `Process` method that handles both CREATE and UPDATE stages and doesn't get
 // passed a data structure that indicates what has changed like we do with the
 // TypeSet data type. So it'll be a trade-off.
-func (h *ProductEnablementServiceAttributeHandler) Delete(_ context.Context, d *schema.ResourceData, resource map[string]any, serviceVersion int, conn *gofastly.Client) error {
+func (h *ProductEnablementServiceAttributeHandler) Delete(_ context.Context, d *schema.ResourceData, _ map[string]any, _ int, conn *gofastly.Client) error {
 	if h.GetServiceMetadata().serviceType == ServiceTypeCompute {
 		log.Println("[DEBUG] disable fanout")
 		err := conn.DisableProduct(&gofastly.ProductEnablementInput{

--- a/fastly/resource_fastly_service_compute_test.go
+++ b/fastly/resource_fastly_service_compute_test.go
@@ -40,31 +40,7 @@ func TestAccFastlyServiceCompute_basic(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				// These attributes are not stored on the Fastly API and must be ignored.
-				ImportStateVerifyIgnore: []string{"activate", "force_destroy", "package.0.filename", "imported", "product_enablement"},
-				// Validate product_enablement state after import.
-				// If nothing has been configured, which is the default, we expect the
-				// following state to be the result.
-				ImportStateCheck: func(s []*terraform.InstanceState) error {
-					if len(s) != 1 {
-						return fmt.Errorf("expected 1 state: %+v", s)
-					}
-					if s[0].Attributes["product_enablement.#"] != "1" {
-						return fmt.Errorf("expected product_enablement to be imported into state")
-					}
-					if s[0].Attributes["product_enablement.0.%"] != "3" {
-						return fmt.Errorf("expected product_enablement to contain 3 keys")
-					}
-					if s[0].Attributes["product_enablement.0.fanout"] != "false" {
-						return fmt.Errorf("expected brotli_compression to be false")
-					}
-					if s[0].Attributes["product_enablement.0.websockets"] != "false" {
-						return fmt.Errorf("expected websockets to be false")
-					}
-					if s[0].Attributes["product_enablement.0.name"] != "products" {
-						return fmt.Errorf("expected the generated 'name' key to be 'products'")
-					}
-					return nil
-				},
+				ImportStateVerifyIgnore: []string{"activate", "force_destroy", "package.0.filename", "imported"},
 			},
 		},
 	})

--- a/fastly/resource_fastly_service_vcl_test.go
+++ b/fastly/resource_fastly_service_vcl_test.go
@@ -345,42 +345,9 @@ func TestAccFastlyServiceVCL_basic(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				// These attributes are not stored on the Fastly API and must be ignored.
-				ImportStateVerifyIgnore: []string{"activate", "force_destroy", "imported", "product_enablement"},
+				ImportStateVerifyIgnore: []string{"activate", "force_destroy", "imported"},
 				ImportStateIdFunc: func(_ *terraform.State) (string, error) {
 					return fmt.Sprintf("%s@2", service.ID), nil
-				},
-				// Validate product_enablement state after import.
-				// If nothing has been configured, which is the default, we expect the
-				// following state to be the result.
-				ImportStateCheck: func(s []*terraform.InstanceState) error {
-					if len(s) != 1 {
-						return fmt.Errorf("expected 1 state: %+v", s)
-					}
-					if s[0].Attributes["product_enablement.#"] != "1" {
-						return fmt.Errorf("expected product_enablement to be imported into state")
-					}
-					if s[0].Attributes["product_enablement.0.%"] != "6" {
-						return fmt.Errorf("expected product_enablement to contain 6 keys")
-					}
-					if s[0].Attributes["product_enablement.0.brotli_compression"] != "false" {
-						return fmt.Errorf("expected brotli_compression to be false")
-					}
-					if s[0].Attributes["product_enablement.0.domain_inspector"] != "false" {
-						return fmt.Errorf("expected domain_inspector to be false")
-					}
-					if s[0].Attributes["product_enablement.0.image_optimizer"] != "false" {
-						return fmt.Errorf("expected image_optimizer to be false")
-					}
-					if s[0].Attributes["product_enablement.0.origin_inspector"] != "false" {
-						return fmt.Errorf("expected origin_inspector to be false")
-					}
-					if s[0].Attributes["product_enablement.0.websockets"] != "false" {
-						return fmt.Errorf("expected websockets to be false")
-					}
-					if s[0].Attributes["product_enablement.0.name"] != "products" {
-						return fmt.Errorf("expected the generated 'name' key to be 'products'")
-					}
-					return nil
 				},
 			},
 		},


### PR DESCRIPTION
A specific logic flow scenario in the TF provider is causing the `product_enablement` block to be displayed to customers as a resource that is going to be deleted (as part of their plan’s diff output) which is confusing as most customers are not expecting to see it and have no idea what the `product_enablement` block is.

The reason this happens is because the TF provider has logic to handle fixing drift in service versions (e.g. a user makes changes outside of Terraform). If, for example, a customer clones their service version _outside_ of Terraform and activates a change separate from the TF provider, then this will cause the TF provider to call all Fastly APIs to see what has changed. 

This consequently means the Product Enablement API is called and the local TF state is updated to include a `product_block` and thus a diff that shows the same block being deleted (because the user doesn’t have that block defined in their TF config file) is displayed as part of the plan’s diff output.

To avoid this we only call the Fastly API for Product Enablement during the TF provider's READ operation _if_ this block already exists within the user's local state (i.e. they've successfully applied a plan with `product_enablement` explicitly defined in their Terraform configuration file) OR if it exists in their state PLUS an import or resync of data is required.