### PR TITLE
fix(stores): remove store from state if not found remotely

### DIFF
--- a/fastly/resource_fastly_configstore.go
+++ b/fastly/resource_fastly_configstore.go
@@ -67,8 +67,11 @@ func resourceFastlyConfigStoreRead(_ context.Context, d *schema.ResourceData, me
 
 	store, err := conn.GetConfigStore(input)
 	if err != nil {
-		log.Printf("[WARN] No Config Store found '%s'", d.Id())
-		d.SetId("")
+		if e, ok := err.(*gofastly.HTTPError); ok && e.IsNotFound() {
+			log.Printf("[WARN] No Config Store found '%s'", d.Id())
+			d.SetId("")
+			return nil
+		}
 		return diag.FromErr(err)
 	}
 

--- a/fastly/resource_fastly_kvstore.go
+++ b/fastly/resource_fastly_kvstore.go
@@ -68,8 +68,11 @@ func resourceFastlyKVStoreRead(_ context.Context, d *schema.ResourceData, meta a
 
 	store, err := conn.GetKVStore(input)
 	if err != nil {
-		log.Printf("[WARN] No KV Store found '%s'", d.Id())
-		d.SetId("")
+		if e, ok := err.(*gofastly.HTTPError); ok && e.IsNotFound() {
+			log.Printf("[WARN] No KV Store found '%s'", d.Id())
+			d.SetId("")
+			return nil
+		}
 		return diag.FromErr(err)
 	}
 


### PR DESCRIPTION
The current implementation will return an error during the READ operation if the API endpoint returns an error.

This causes problems where a resource might be removed remotely and so will prevent a plan from continuing to be processed. 

If the API returns a 404, then we should return `nil`. 
If it's any other kind of error code, then we should return the error.

> ✅ The full end-to-end integration test suite is passing.