### PR TITLE
fix(request_settings): don't send empty string for request_condition

### DIFF
--- a/docs/resources/service_vcl.md
+++ b/docs/resources/service_vcl.md
@@ -1148,7 +1148,7 @@ Optional:
 - `geo_headers` (Boolean, Deprecated) Injects Fastly-Geo-Country, Fastly-Geo-City, and Fastly-Geo-Region into the request headers
 - `hash_keys` (String) Comma separated list of varnish request object fields that should be in the hash key
 - `max_stale_age` (Number) How old an object is allowed to be to serve `stale-if-error` or `stale-while-revalidate`, in seconds
-- `request_condition` (String) Name of already defined `condition` to determine if this request setting should be applied
+- `request_condition` (String) Name of already defined `condition` to determine if this request setting should be applied (should be unique across multiple instances of `request_setting`)
 - `timer_support` (Boolean) Injects the X-Timer info into the request for viewing origin fetch durations
 - `xff` (String) X-Forwarded-For, should be `clear`, `leave`, `append`, `append_all`, or `overwrite`. Default `append`
 

--- a/fastly/block_fastly_service_requestsetting.go
+++ b/fastly/block_fastly_service_requestsetting.go
@@ -89,7 +89,7 @@ func (h *RequestSettingServiceAttributeHandler) GetSchema() *schema.Schema {
 					Type:        schema.TypeString,
 					Optional:    true,
 					Default:     "",
-					Description: "Name of already defined `condition` to determine if this request setting should be applied",
+					Description: "Name of already defined `condition` to determine if this request setting should be applied (should be unique across multiple instances of `request_setting`)",
 				},
 				"timer_support": {
 					Type:        schema.TypeBool,
@@ -270,16 +270,19 @@ func flattenRequestSettings(remoteState []*gofastly.RequestSetting) []map[string
 func buildRequestSetting(requestSettingMap any) (*gofastly.CreateRequestSettingInput, error) {
 	resource := requestSettingMap.(map[string]any)
 	opts := gofastly.CreateRequestSettingInput{
-		Name:             gofastly.String(resource["name"].(string)),
-		MaxStaleAge:      gofastly.Int(resource["max_stale_age"].(int)),
-		ForceMiss:        gofastly.CBool(resource["force_miss"].(bool)),
-		ForceSSL:         gofastly.CBool(resource["force_ssl"].(bool)),
-		BypassBusyWait:   gofastly.CBool(resource["bypass_busy_wait"].(bool)),
-		HashKeys:         gofastly.String(resource["hash_keys"].(string)),
-		TimerSupport:     gofastly.CBool(resource["timer_support"].(bool)),
-		GeoHeaders:       gofastly.CBool(resource["geo_headers"].(bool)),
-		DefaultHost:      gofastly.String(resource["default_host"].(string)),
-		RequestCondition: gofastly.String(resource["request_condition"].(string)),
+		Name:           gofastly.String(resource["name"].(string)),
+		MaxStaleAge:    gofastly.Int(resource["max_stale_age"].(int)),
+		ForceMiss:      gofastly.CBool(resource["force_miss"].(bool)),
+		ForceSSL:       gofastly.CBool(resource["force_ssl"].(bool)),
+		BypassBusyWait: gofastly.CBool(resource["bypass_busy_wait"].(bool)),
+		HashKeys:       gofastly.String(resource["hash_keys"].(string)),
+		TimerSupport:   gofastly.CBool(resource["timer_support"].(bool)),
+		GeoHeaders:     gofastly.CBool(resource["geo_headers"].(bool)),
+		DefaultHost:    gofastly.String(resource["default_host"].(string)),
+	}
+
+	if v := resource["request_condition"].(string); v != "" {
+		opts.RequestCondition = gofastly.String(v)
 	}
 
 	act := strings.ToLower(resource["action"].(string))


### PR DESCRIPTION
The API will consider the service invalid if it has multiple instances of `request_setting` with the same `request_condition` attribute value.

This PR doesn't fix that issue. This PR change is here because it's the correct thing to do. 

It doesn't help though (even though we're not sending `request_condition` to the API if it's an empty string) because the API itself still assigns an empty string as a default for each `request_setting` object, and so later on in the Terraform flow when the service is 'validated' (i.e. `GET /service/<SERVICE_ID>/version/<VERSION>/validate`) it will return an error because it sees there are multiple `request_setting` objects each with an empty string for the `request_condition` attribute.