### PR TITLE
ci: validate interface not broken

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -84,3 +84,25 @@ jobs:
       run: make validate-interface
       env:
         FASTLY_API_KEY: ${{ secrets.FASTLY_API_TOKEN }}
+  validate-goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Install Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: 1.19.x
+      - name: Restore cache
+        uses: actions/cache@v3
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-mod-
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v4
+        with:
+          install-only: true
+      - name: Validate Goreleaser
+        run: make goreleaser GORELEASER_ARGS="--skip-validate --clean --snapshot" # snapshot is needed as local git has no tags

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -63,6 +63,7 @@ jobs:
       run: |
         git diff --exit-code --ignore-all-space ./docs/
   validate-interface:
+    if: "!contains(github.event.pull_request.labels.*.name, 'breaking-change')"
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -9,7 +9,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v4
       with:
-        go-version: 1.18.x
+        go-version: 1.19.x
     - name: Restore cache
       uses: actions/cache@v3
       with:
@@ -26,7 +26,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.18.x]
+        go-version: [1.19.x]
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:
@@ -55,7 +55,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v4
       with:
-        go-version: 1.18.x
+        go-version: 1.19.x
     - name: Generate Docs
       run: |
         make generate-docs

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -62,3 +62,25 @@ jobs:
     - name: Check diff
       run: |
         git diff --exit-code --ignore-all-space ./docs/
+  validate-interface:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+    - name: Install Go
+      uses: actions/setup-go@v4
+      with:
+        go-version: 1.19.x
+    - name: Restore cache
+      uses: actions/cache@v3
+      with:
+        path: ~/go/pkg/mod
+        key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-mod-
+    - name: Install Terraform CLI
+      uses: hashicorp/setup-terraform@v2
+    - name: Validate Interface
+      run: make validate-interface
+      env:
+        FASTLY_API_KEY: ${{ secrets.FASTLY_API_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.18.x
+          go-version: 1.19.x
       - name: Import GPG key
         id: import_gpg
         uses: fastly/ghaction-import-gpg@v2.1.0
@@ -33,7 +33,7 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v4
         with:
-          version: v1.18.2 # TODO: change to 'latest' once Go 1.21 is released (August 2023). This is so we can bump min Go version to 1.19.x which will fix a goreleaser dependency requirement.
+          version: latest
           args: release --clean
         env:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 example.tf
 terraform.tfplan
 terraform.tfstate
+terraform.tfstate*
 bin/
 dist/
 modules-dev/
@@ -16,6 +17,7 @@ website/node_modules
 *.backup
 ./*.tfstate
 .terraform/
+.terraform*
 *.log
 *.bak
 *~

--- a/Makefile
+++ b/Makefile
@@ -134,4 +134,7 @@ sweep:
 clean:
 	rm -rf ./bin
 
-.PHONY: all build clean clean_test default errcheck fmt fmtcheck generate-docs goreleaser goreleaser-bin sweep test test-compile testacc validate-docs vet
+validate-interface:
+	@./tests/interface/script.sh
+
+.PHONY: all build clean clean_test default errcheck fmt fmtcheck generate-docs goreleaser goreleaser-bin sweep test test-compile testacc validate-docs validate-interface vet

--- a/tests/interface/README.md
+++ b/tests/interface/README.md
@@ -1,0 +1,3 @@
+# Validate Interface
+
+To ensure the Fastly Terraform Provider doesn't break the interface for users of the current release, we setup a real project using the current release and then compile the version of the provider from the `main` branch and run it against the project.

--- a/tests/interface/main.tf
+++ b/tests/interface/main.tf
@@ -1,0 +1,25 @@
+terraform {
+  required_providers {
+    fastly = {
+      source  = "fastly/fastly"
+      version = ">1.0.0"
+    }
+  }
+}
+
+resource "fastly_service_vcl" "interface-test-project" {
+  name = "interface-test-project"
+
+  domain {
+    name    = "interface-test-project.fastly-terraform.com"
+    comment = "demo"
+  }
+
+  backend {
+    address = "127.0.0.1"
+    name    = "localhost"
+    port    = 80
+  }
+
+  force_destroy = true
+}

--- a/tests/interface/script.sh
+++ b/tests/interface/script.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+cd ./tests/interface/ || exit
+
+terraform init -upgrade
+terraform apply -auto-approve
+
+cleanup() {
+  # reset back to the installed provider so we can destroy the service
+  unset TF_CLI_CONFIG_FILE
+  terraform init
+  echo ""
+  echo "Running terraform destroy..."
+  terraform destroy -auto-approve
+}
+trap cleanup EXIT
+
+cd - || exit
+make build
+BIN_DIR=$PWD/bin
+OVERRIDES_FILENAME=developer_overrides.tfrc
+export TF_CLI_CONFIG_FILE="$BIN_DIR/$OVERRIDES_FILENAME"
+cd - || exit
+
+plan_output=$(terraform plan -no-color 2>&1)
+
+if [[ "$plan_output" == *"No changes. Your infrastructure matches the configuration."* ]]; then
+  echo ""
+  echo "Terraform plan succeeded: No changes detected."
+  exit 0
+else
+  echo ""
+  echo "Terraform plan failed: Changes detected or unexpected output."
+  echo "$plan_output"
+  exit 1
+fi


### PR DESCRIPTION
**Problem:** Breaking interface changes have still managed to be released.
**Solution:** Setup a CI validation step that compares plan output between latest release and proposed changes.
**Notes:** `breaking-change` label will skip `validate-interface` job (as we _expect_ it to fail).

I confirmed the new validation job was working as intended by committing a breaking interface change to both the `backend` and `domain` implementations, and then checking that the CI job failed (I've, of course, since reverted those breaking interface changes as they were only made to validate the new CI job).