### PR TITLE
fix: use paginator to fetch all ACL entries

### DIFF
--- a/fastly/resource_fastly_service_acl_entries.go
+++ b/fastly/resource_fastly_service_acl_entries.go
@@ -118,21 +118,15 @@ func resourceServiceACLEntriesRead(_ context.Context, d *schema.ResourceData, me
 	serviceID := d.Get("service_id").(string)
 	aclID := d.Get("acl_id").(string)
 
-	paginator := conn.NewListACLEntriesPaginator(&gofastly.ListACLEntriesInput{
+	remoteState, err := getAllAclEntriesViaPaginator(conn, &gofastly.ListACLEntriesInput{
 		ServiceID: serviceID,
 		ACLID:     aclID,
 	})
-
-	var remoteState []*gofastly.ACLEntry
-	for paginator.HasNext() {
-		results, err := paginator.GetNext()
-		if err != nil {
-			return diag.FromErr(err)
-		}
-		remoteState = append(remoteState, results...)
+	if err != nil {
+		return diag.FromErr(err)
 	}
 
-	err := d.Set("entry", flattenACLEntries(remoteState))
+	err = d.Set("entry", flattenACLEntries(remoteState))
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -334,4 +328,18 @@ func buildBatchACLEntry(v map[string]any, op gofastly.BatchOperation) *gofastly.
 func convertSubnetToInt(s string) int {
 	subnet, _ := strconv.Atoi(s)
 	return subnet
+}
+
+func getAllAclEntriesViaPaginator(conn *gofastly.Client, input *gofastly.ListACLEntriesInput) ([]*gofastly.ACLEntry, error) {
+	paginator := conn.NewListACLEntriesPaginator(input)
+
+	var entries []*gofastly.ACLEntry
+	for paginator.HasNext() {
+		results, err := paginator.GetNext()
+		if err != nil {
+			return nil, err
+		}
+		entries = append(entries, results...)
+	}
+	return entries, nil
 }

--- a/fastly/resource_fastly_service_acl_entries_test.go
+++ b/fastly/resource_fastly_service_acl_entries_test.go
@@ -132,7 +132,7 @@ func TestAccFastlyServiceAclEntries_create_more_than_one_page(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceExists("fastly_service_vcl.foo", &service),
 					testAccCheckFastlyServiceACLEntriesRemoteState(&service, serviceName, aclName, expectedRemoteEntries),
-					resource.TestCheckResourceAttr("fastly_service_acl_entries.entries", "entry.#", "1"),
+					resource.TestCheckResourceAttr("fastly_service_acl_entries.entries", "entry.#", "200"),
 				),
 			},
 			{

--- a/fastly/resource_fastly_service_acl_entries_test.go
+++ b/fastly/resource_fastly_service_acl_entries_test.go
@@ -431,17 +431,12 @@ func testAccCheckFastlyServiceACLEntriesRemoteState(service *gofastly.ServiceDet
 			return fmt.Errorf("error looking up ACL records for (%s), version (%v): %s", service.Name, service.ActiveVersion.Number, err)
 		}
 
-		paginator := conn.NewListACLEntriesPaginator(&gofastly.ListACLEntriesInput{
+		aclEntries, err := getAllAclEntriesViaPaginator(conn, &gofastly.ListACLEntriesInput{
 			ServiceID: service.ID,
 			ACLID:     acl.ID,
 		})
-		var aclEntries []*gofastly.ACLEntry
-		for paginator.HasNext() {
-			results, err := paginator.GetNext()
-			if err != nil {
-				return fmt.Errorf("error looking up ACL entry records for (%s), ACL (%s): %s", service.Name, acl.ID, err)
-			}
-			aclEntries = append(aclEntries, results...)
+		if err != nil {
+			return fmt.Errorf("error looking up ACL entry records for (%s), ACL (%s): %s", service.Name, acl.ID, err)
 		}
 
 		flatACLEntries := flattenACLEntries(aclEntries)


### PR DESCRIPTION
Fixes https://github.com/fastly/terraform-provider-fastly/issues/757

I think this should fix the issue above. I'm a Go newbie so happy to get any early feedback.

The acceptance tests still need to be run against this PR.