### PR TITLE
Fix YAML Frontmatter formatting in product_enablement.md

### DIFF
--- a/docs/guides/product_enablement.md
+++ b/docs/guides/product_enablement.md
@@ -1,6 +1,7 @@
-______________________________________________________________________
-
-## page_title: Product Enablement subcategory: Guides
+---
+page_title: product_enablement
+subcategory: "Guides"
+---
 
 ## Product Enablement
 

--- a/templates/guides/product_enablement.md
+++ b/templates/guides/product_enablement.md
@@ -1,6 +1,7 @@
-______________________________________________________________________
-
-## page_title: Product Enablement subcategory: Guides
+---
+page_title: product_enablement
+subcategory: "Guides"
+---
 
 ## Product Enablement
 


### PR DESCRIPTION
Updated documentation for Product Enablement to apply YAML Frontmatter.
Duplicate guides in the side menu at https://registry.terraform.io/providers/fastly/fastly/latest/docs and the header in https://registry.terraform.io/providers/fastly/fastly/latest/docs/guides/product_enablement will be fixed.