### PR TITLE
Remove mTLS from state that returns 404

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,4 +1,7 @@
-on: pull_request
+on:
+  pull_request:
+  repository_dispatch:
+    types: [ok-to-test-command] # corresponds to ./ok-to-test.yml `commands:` field
 name: Pull request
 jobs:
   lint:
@@ -62,8 +65,12 @@ jobs:
     - name: Check diff
       run: |
         git diff --exit-code --ignore-all-space ./docs/
-  validate-interface:
-    if: "!contains(github.event.pull_request.labels.*.name, 'breaking-change')"
+
+  # NOTE: The following two `validate-` jobs (and the top-of-file config) are inspired by: https://github.com/imjohnbo/ok-to-test
+
+  # Branch-based pull request from owner or trusted developer who has WRITE access.
+  validate-interface-trusted:
+    if: "!contains(github.event.pull_request.labels.*.name, 'breaking-change') && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository"
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
@@ -87,6 +94,85 @@ jobs:
         FASTLY_API_KEY: ${{ secrets.FASTLY_API_TOKEN }}
         # IMPORTANT: Workflows from forks do not have access to sensitive data such as secrets
         # https://bit.ly/gh-actions-fork-secret-access
+        # We work around this using ./ok-to-test.yml
+
+  # Repo owner has commented /ok-to-test on a (fork-based) pull request
+  # This will run the build not as the forked owner but as your own token user.
+  validate-interface-fork:
+    permissions:
+      pull-requests: write
+      checks: write
+    if: |
+      !contains(github.event.pull_request.labels.*.name, 'breaking-change') &&
+      github.event_name == 'repository_dispatch' &&
+      github.event.client_payload.slash_command.args.named.sha != '' &&
+      contains(
+        github.event.client_payload.pull_request.head.sha,
+        github.event.client_payload.slash_command.args.named.sha
+      )
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fork based /ok-to-test checkout
+        uses: actions/checkout@v4
+        with:
+          ref: 'refs/pull/${{ github.event.client_payload.pull_request.number }}/merge'
+
+      # START `validate-interface-trusted`
+      - name: Install Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: 1.19.x
+      - name: Restore cache
+        uses: actions/cache@v3
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-mod-
+      - name: Install Terraform CLI
+        uses: hashicorp/setup-terraform@v3
+      - name: Validate Interface
+        run: make validate-interface
+        env:
+          FASTLY_API_KEY: ${{ secrets.FASTLY_API_TOKEN }}
+      # END `validate-interface-trusted`
+
+      - run: |
+          echo "Integration tests... success! ;-)"
+
+      # Update check run called "integration-fork"
+      - uses: actions/github-script@v6
+        id: update-check-run
+        if: ${{ always() }}
+        env:
+          number: ${{ github.event.client_payload.pull_request.number }}
+          job: ${{ github.job }}
+          # Conveniently, job.status maps to https://developer.github.com/v3/checks/runs/#update-a-check-run
+          conclusion: ${{ job.status }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { data: pull } = await github.rest.pulls.get({
+              ...context.repo,
+              pull_number: process.env.number
+            });
+            const ref = pull.head.sha;
+
+            const { data: checks } = await github.rest.checks.listForRef({
+              ...context.repo,
+              ref
+            });
+
+            const check = checks.check_runs.filter(c => c.name === process.env.job);
+
+            const { data: result } = await github.rest.checks.update({
+              ...context.repo,
+              check_run_id: check[0].id,
+              status: 'completed',
+              conclusion: process.env.conclusion
+            });
+
+            return result;
   validate-goreleaser:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,4 +1,7 @@
-on: pull_request
+on:
+  pull_request:
+  repository_dispatch:
+    types: [ok-to-test-command] # corresponds to ./ok-to-test.yml `commands:` field
 name: Pull request
 jobs:
   lint:
@@ -62,8 +65,12 @@ jobs:
     - name: Check diff
       run: |
         git diff --exit-code --ignore-all-space ./docs/
-  validate-interface:
-    if: "!contains(github.event.pull_request.labels.*.name, 'breaking-change')"
+
+  # NOTE: The following two `validate-` jobs (and the top-of-file config) are inspired by: https://github.com/imjohnbo/ok-to-test
+
+  # Branch-based pull request from owner or trusted developer who has WRITE access.
+  validate-interface-trusted:
+    if: "!contains(github.event.pull_request.labels.*.name, 'breaking-change') && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository"
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
@@ -87,6 +94,82 @@ jobs:
         FASTLY_API_KEY: ${{ secrets.FASTLY_API_TOKEN }}
         # IMPORTANT: Workflows from forks do not have access to sensitive data such as secrets
         # https://bit.ly/gh-actions-fork-secret-access
+        # We work around this using ./ok-to-test.yml
+
+  # Repo owner has commented /ok-to-test on a (fork-based) pull request
+  # This will run the build not as the forked owner but as your own token user.
+  validate-interface-fork:
+    if: |
+      !contains(github.event.pull_request.labels.*.name, 'breaking-change') &&
+      github.event_name == 'repository_dispatch' &&
+      github.event.client_payload.slash_command.args.named.sha != '' &&
+      contains(
+        github.event.client_payload.pull_request.head.sha,
+        github.event.client_payload.slash_command.args.named.sha
+      )
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fork based /ok-to-test checkout
+        uses: actions/checkout@v4
+        with:
+          ref: 'refs/pull/${{ github.event.client_payload.pull_request.number }}/merge'
+
+      # START `validate-interface-trusted`
+      - name: Install Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: 1.19.x
+      - name: Restore cache
+        uses: actions/cache@v3
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-mod-
+      - name: Install Terraform CLI
+        uses: hashicorp/setup-terraform@v3
+      - name: Validate Interface
+        run: make validate-interface
+        env:
+          FASTLY_API_KEY: ${{ secrets.FASTLY_API_TOKEN }}
+      # END `validate-interface-trusted`
+
+      - run: |
+          echo "Integration tests... success! ;-)"
+
+      # Update check run called "integration-fork"
+      - uses: actions/github-script@v6
+        id: update-check-run
+        if: ${{ always() }}
+        env:
+          number: ${{ github.event.client_payload.pull_request.number }}
+          job: ${{ github.job }}
+          # Conveniently, job.status maps to https://developer.github.com/v3/checks/runs/#update-a-check-run
+          conclusion: ${{ job.status }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { data: pull } = await github.rest.pulls.get({
+              ...context.repo,
+              pull_number: process.env.number
+            });
+            const ref = pull.head.sha;
+
+            const { data: checks } = await github.rest.checks.listForRef({
+              ...context.repo,
+              ref
+            });
+
+            const check = checks.check_runs.filter(c => c.name === process.env.job);
+
+            const { data: result } = await github.rest.checks.update({
+              ...context.repo,
+              check_run_id: check[0].id,
+              status: 'completed',
+              conclusion: process.env.conclusion
+            });
+
+            return result;
   validate-goreleaser:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -62,8 +62,9 @@ jobs:
     - name: Check diff
       run: |
         git diff --exit-code --ignore-all-space ./docs/
-  validate-interface:
-    if: "!contains(github.event.pull_request.labels.*.name, 'breaking-change')"
+  # Branch-based pull request from owner or trusted developer who has WRITE access.
+  validate-interface-trusted:
+    if: "!contains(github.event.pull_request.labels.*.name, 'breaking-change') && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository"
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
@@ -87,6 +88,85 @@ jobs:
         FASTLY_API_KEY: ${{ secrets.FASTLY_API_TOKEN }}
         # IMPORTANT: Workflows from forks do not have access to sensitive data such as secrets
         # https://bit.ly/gh-actions-fork-secret-access
+        # We work around this using ./ok-to-test.yml
+
+  # Repo owner has commented /ok-to-test on a (fork-based) pull request
+  # This will run the build not as the forked owner but as your own token user.
+  validate-interface-fork:
+    permissions:
+      pull-requests: write
+      checks: write
+    if: |
+      !contains(github.event.pull_request.labels.*.name, 'breaking-change') &&
+      github.event_name == 'repository_dispatch' &&
+      github.event.client_payload.slash_command.args.named.sha != '' &&
+      contains(
+        github.event.client_payload.pull_request.head.sha,
+        github.event.client_payload.slash_command.args.named.sha
+      )
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fork based /ok-to-test checkout
+        uses: actions/checkout@v4
+        with:
+          ref: 'refs/pull/${{ github.event.client_payload.pull_request.number }}/merge'
+
+      # START `validate-interface-trusted`
+      - name: Install Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: 1.19.x
+      - name: Restore cache
+        uses: actions/cache@v3
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-mod-
+      - name: Install Terraform CLI
+        uses: hashicorp/setup-terraform@v3
+      - name: Validate Interface
+        run: make validate-interface
+        env:
+          FASTLY_API_KEY: ${{ secrets.FASTLY_API_TOKEN }}
+      # END `validate-interface-trusted`
+
+      - run: |
+          echo "Integration tests... success! ;-)"
+
+      # Update check run called "integration-fork"
+      - uses: actions/github-script@v6
+        id: update-check-run
+        if: ${{ always() }}
+        env:
+          number: ${{ github.event.client_payload.pull_request.number }}
+          job: ${{ github.job }}
+          # Conveniently, job.status maps to https://developer.github.com/v3/checks/runs/#update-a-check-run
+          conclusion: ${{ job.status }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { data: pull } = await github.rest.pulls.get({
+              ...context.repo,
+              pull_number: process.env.number
+            });
+            const ref = pull.head.sha;
+
+            const { data: checks } = await github.rest.checks.listForRef({
+              ...context.repo,
+              ref
+            });
+
+            const check = checks.check_runs.filter(c => c.name === process.env.job);
+
+            const { data: result } = await github.rest.checks.update({
+              ...context.repo,
+              check_run_id: check[0].id,
+              status: 'completed',
+              conclusion: process.env.conclusion
+            });
+
+            return result;
   validate-goreleaser:
     runs-on: ubuntu-latest
     steps:

--- a/fastly/resource_fastly_tls_mutual_authentication.go
+++ b/fastly/resource_fastly_tls_mutual_authentication.go
@@ -107,17 +107,19 @@ func resourceFastlyTLSMutualAuthenticationRead(_ context.Context, d *schema.Reso
 	log.Printf("[DEBUG] REFRESH: TLS Mutual Authentication input: %#v", input)
 
 	tma, err := conn.GetTLSMutualAuthentication(input)
-        if err, ok := err.(*gofastly.HTTPError); ok && err.IsNotFound() {
-                id := d.Id()
-                d.SetId("")
-                return diag.Diagnostics{
-                        diag.Diagnostic{
-                                Severity:      diag.Warning,
-                                Summary:       fmt.Sprintf("TLS Mutual Authentication (%s) not found - removing from state", id),
-                                AttributePath: cty.Path{cty.GetAttrStep{Name: id}},
-                        },
-                }
-        } else if err != nil {
+
+	if err != nil {
+        	if err, ok := err.(*gofastly.HTTPError); ok && err.IsNotFound() {
+        	        id := d.Id()
+        	        d.SetId("")
+        	        return diag.Diagnostics{
+        	                diag.Diagnostic{
+        	                        Severity:      diag.Warning,
+        	                        Summary:       fmt.Sprintf("TLS Mutual Authentication (%s) not found - removing from state", id),
+        	                        AttributePath: cty.Path{cty.GetAttrStep{Name: id}},
+        	                },
+        	        }
+        	}
 		return diag.FromErr(err)
 	}
 


### PR DESCRIPTION
When TLS Mutual Authentication is removed outside of terraform the following error occurs.

```terraform
╷
│ Error: 404 - Not Found:
│ 
│     Title:  Not found
│     Detail: The mutual_authentication you requested was not found
│ 
│ 
╵
```

Expected is to be removed from the state instead, similar to TLS Subscription
