### PR TITLE
Make Compute Package content sensitve

### DIFF
--- a/docs/resources/service_compute.md
+++ b/docs/resources/service_compute.md
@@ -650,7 +650,7 @@ Optional:
 
 Optional:
 
-- `content` (String) The contents of the Wasm deployment package as a base64 encoded string (e.g. could be provided using an input variable or via external data source output variable). Conflicts with `filename`. Exactly one of these two arguments must be specified
+- `content` (String, Sensitive) The contents of the Wasm deployment package as a base64 encoded string (e.g. could be provided using an input variable or via external data source output variable). Conflicts with `filename`. Exactly one of these two arguments must be specified
 - `filename` (String) The path to the Wasm deployment package within your local filesystem. Conflicts with `content`. Exactly one of these two arguments must be specified
 - `source_code_hash` (String) Used to trigger updates. Must be set to a SHA512 hash of all files (in sorted order) within the package. The usual way to set this is using the fastly_package_hash data source.
 

--- a/fastly/block_fastly_service_package.go
+++ b/fastly/block_fastly_service_package.go
@@ -37,6 +37,7 @@ func (h *PackageServiceAttributeHandler) Register(s *schema.Resource) error {
 				"content": {
 					Type:         schema.TypeString,
 					Optional:     true,
+					Sensitive:    true,
 					Description:  "The contents of the Wasm deployment package as a base64 encoded string (e.g. could be provided using an input variable or via external data source output variable). Conflicts with `filename`. Exactly one of these two arguments must be specified",
 					ExactlyOneOf: []string{"package.0.content", "package.0.filename"},
 				},


### PR DESCRIPTION
When providing the content directly to a fastly compute service

```
resource "fastly_service_compute" "my_service" {
  // ...
  package {
    content = data.some_content_provider.content
  }
}
```

It will output the full base64 content in the terminal and other interfaces for terraform (e.g. atlantis) when planning the change.

Because packages typically range in megabytes, that's a lot of (useless) information to have displayed.

While "sensitive" might not be exactly true (it's not a password), the [documentation][schema-doc] for sensitive in the Schema states

> It should be used for password or other values which should be hidden.

This would fall in the category "other values which should be hidden".

It can be worked around locally by passing the contents to the [sensitive][sensitive] function

```
package {
  content = sensitive(data.some_content_provider.content)
}
```

[schema-doc]: https://pkg.go.dev/github.com/hashicorp/terraform-plugin-sdk/v2@v2.31.0/helper/schema#Schema.Sensitive
[sensitive]: https://developer.hashicorp.com/terraform/language/functions/sensitive