### PR TITLE
chore: as file() already returns string, there is no need to do another string interpolation

### DIFF
--- a/docs/resources/service_vcl.md
+++ b/docs/resources/service_vcl.md
@@ -106,13 +106,13 @@ resource "fastly_service_vcl" "demo" {
 
   vcl {
     name    = "my_custom_main_vcl"
-    content = "${file("${path.module}/my_custom_main.vcl")}"
+    content = file("${path.module}/my_custom_main.vcl")
     main    = true
   }
 
   vcl {
     name    = "my_custom_library_vcl"
-    content = "${file("${path.module}/my_custom_library.vcl")}"
+    content = file("${path.module}/my_custom_library.vcl")
   }
 }
 ```

--- a/examples/resources/service_vcl_usage_with_custom_vcl.tf
+++ b/examples/resources/service_vcl_usage_with_custom_vcl.tf
@@ -16,12 +16,12 @@ resource "fastly_service_vcl" "demo" {
 
   vcl {
     name    = "my_custom_main_vcl"
-    content = "${file("${path.module}/my_custom_main.vcl")}"
+    content = file("${path.module}/my_custom_main.vcl")
     main    = true
   }
 
   vcl {
     name    = "my_custom_library_vcl"
-    content = "${file("${path.module}/my_custom_library.vcl")}"
+    content = file("${path.module}/my_custom_library.vcl")
   }
 }


### PR DESCRIPTION
I think my engineer use some example code in here, which has some copy paste issue did not get caught with CI, I dont think there is need to do string interpolation with `file()` call as it would already return string, thus updating the code accordingly. Let me know if that makes sense. 


----

Actually this is also consistent with the rest of the codebase. 