### PR TITLE
Update Certainly Documentation to Remove Beta Label

### DIFF
--- a/docs/resources/tls_subscription.md
+++ b/docs/resources/tls_subscription.md
@@ -337,7 +337,7 @@ $ terraform import fastly_tls_subscription.demo xxxxxxxxxxx
 
 ### Required
 
-- `certificate_authority` (String) The entity that issues and certifies the TLS certificates for your subscription. Valid values are `lets-encrypt`, `globalsign` or `certainly` (beta).
+- `certificate_authority` (String) The entity that issues and certifies the TLS certificates for your subscription. Valid values are `lets-encrypt`, `globalsign` or `certainly`.
 - `domains` (Set of String) List of domains on which to enable TLS.
 
 ### Optional

--- a/fastly/resource_fastly_tls_subscription.go
+++ b/fastly/resource_fastly_tls_subscription.go
@@ -36,7 +36,7 @@ func resourceFastlyTLSSubscription() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"certificate_authority": {
 				Type:         schema.TypeString,
-				Description:  "The entity that issues and certifies the TLS certificates for your subscription. Valid values are `lets-encrypt`, `globalsign` or `certainly` (beta).",
+				Description:  "The entity that issues and certifies the TLS certificates for your subscription. Valid values are `lets-encrypt`, `globalsign` or `certainly`.",
 				Required:     true,
 				ForceNew:     true,
 				ValidateFunc: validation.StringInSlice([]string{"lets-encrypt", "globalsign", "certainly"}, false),


### PR DESCRIPTION
# What and Why

- Removes `beta` label from Certainly CA and updates documentation
- This feature has been GA since last August