### PR TITLE
fix: update the default timeout value for healthcheck consistency with Fastly App (UI)

### DIFF
--- a/docs/resources/service_vcl.md
+++ b/docs/resources/service_vcl.md
@@ -506,7 +506,7 @@ Optional:
 - `initial` (Number) When loading a config, the initial number of probes to be seen as OK. Default `3`
 - `method` (String) Which HTTP method to use. Default `HEAD`
 - `threshold` (Number) How many Healthchecks must succeed to be considered healthy. Default `3`
-- `timeout` (Number) Timeout in milliseconds. Default `500`
+- `timeout` (Number) Timeout in milliseconds. Default `5000`
 - `window` (Number) The number of most recent Healthcheck queries to keep for this Healthcheck. Default `5`
 
 

--- a/fastly/block_fastly_service_healthcheck.go
+++ b/fastly/block_fastly_service_healthcheck.go
@@ -108,8 +108,8 @@ func (h *HealthCheckServiceAttributeHandler) GetSchema() *schema.Schema {
 				"timeout": {
 					Type:        schema.TypeInt,
 					Optional:    true,
-					Default:     500,
-					Description: "Timeout in milliseconds. Default `500`",
+					Default:     5000,
+					Description: "Timeout in milliseconds. Default `5000`",
 				},
 				"window": {
 					Type:        schema.TypeInt,


### PR DESCRIPTION
Currently timeout value for healthcheck is inconsistent with Fastly App (it's by default 5000ms in Fastly App [source](https://docs.fastly.com/img/guides/create-new-health-check.png), while with terraform it's set to 500). This PR addresses this issue. Although It's not a burning issue (ie there is a workaround for this - just by explicitly setting timeout value user can work around), given it's pretty much common to implicitly set value upon managing resources through Terraform, this could be easily a pitfall for developers who are familiar with Fastly/VCL. Also, with just a 500ms timeuout, it's possible that healthcheck request configured with this default timeout value will just fail depending on where and how this healthcheck will be done.

Fixes #825.