### PR TITLE
Add support for specifying location when creating KV stores

### DIFF
--- a/docs/resources/kvstore.md
+++ b/docs/resources/kvstore.md
@@ -67,6 +67,7 @@ $ terraform import fastly_kvstore.example xxxxxxxxxxxxxxxxxxxx
 ### Optional
 
 - `force_destroy` (Boolean) Allow the KV Store to be deleted, even if it contains entries. Defaults to false.
+- `location` (String) The regional location of the KV Store. Valid values are `US`, `EU`, `ASIA`, and `AUS`.
 
 ### Read-Only
 

--- a/fastly/resource_fastly_kvstore.go
+++ b/fastly/resource_fastly_kvstore.go
@@ -9,6 +9,7 @@ import (
 	gofastly "github.com/fastly/go-fastly/v9/fastly"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
 func resourceFastlyKVStore() *schema.Resource {
@@ -29,9 +30,12 @@ func resourceFastlyKVStore() *schema.Resource {
 			},
 			"location": {
 				Type:        schema.TypeString,
-				Default:     "",
 				Optional:    true,
 				Description: "The regional location of the KV Store. Valid values are `US`, `EU`, `ASIA`, and `AUS`.",
+				ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice(
+					[]string{"US", "EU", "ASIA", "AUS"},
+					false,
+				)),
 			},
 			"name": {
 				Type:        schema.TypeString,
@@ -47,8 +51,11 @@ func resourceFastlyKVStoreCreate(_ context.Context, d *schema.ResourceData, meta
 	conn := meta.(*APIClient).conn
 
 	input := &gofastly.CreateKVStoreInput{
-		Name:     d.Get("name").(string),
-		Location: d.Get("location").(string),
+		Name: d.Get("name").(string),
+	}
+
+	if v, ok := d.GetOk("location"); ok {
+		input.Location = v.(string)
 	}
 
 	log.Printf("[DEBUG] CREATE: KV Store input: %#v", input)

--- a/fastly/resource_fastly_kvstore.go
+++ b/fastly/resource_fastly_kvstore.go
@@ -31,7 +31,7 @@ func resourceFastlyKVStore() *schema.Resource {
 				Type:        schema.TypeString,
 				Default:     "",
 				Optional:    true,
-				Description: "The regional location of the KV Store. Valid values are US, EU, ASIA, and AUS.",
+				Description: "The regional location of the KV Store. Valid values are `US`, `EU`, `ASIA`, and `AUS`.",
 			},
 			"name": {
 				Type:        schema.TypeString,

--- a/fastly/resource_fastly_kvstore.go
+++ b/fastly/resource_fastly_kvstore.go
@@ -28,6 +28,7 @@ func resourceFastlyKVStore() *schema.Resource {
 				Optional:    true,
 				Description: "Allow the KV Store to be deleted, even if it contains entries. Defaults to false.",
 			},
+			// TODO: Move values to constants inside of go-fastly.
 			"location": {
 				Type:        schema.TypeString,
 				Optional:    true,

--- a/fastly/resource_fastly_kvstore.go
+++ b/fastly/resource_fastly_kvstore.go
@@ -27,6 +27,12 @@ func resourceFastlyKVStore() *schema.Resource {
 				Optional:    true,
 				Description: "Allow the KV Store to be deleted, even if it contains entries. Defaults to false.",
 			},
+			"location": {
+				Type:        schema.TypeString,
+				Default:     "",
+				Optional:    true,
+				Description: "The regional location of the KV Store. Valid values are US, EU, ASIA, and AUS.",
+			},
 			"name": {
 				Type:        schema.TypeString,
 				Required:    true,
@@ -41,7 +47,8 @@ func resourceFastlyKVStoreCreate(_ context.Context, d *schema.ResourceData, meta
 	conn := meta.(*APIClient).conn
 
 	input := &gofastly.CreateKVStoreInput{
-		Name: d.Get("name").(string),
+		Name:     d.Get("name").(string),
+		Location: d.Get("location").(string),
 	}
 
 	log.Printf("[DEBUG] CREATE: KV Store input: %#v", input)

--- a/fastly/resource_fastly_kvstore_test.go
+++ b/fastly/resource_fastly_kvstore_test.go
@@ -56,6 +56,53 @@ func TestAccFastlyKVStore_validate(t *testing.T) {
 	})
 }
 
+func TestAccFastlyKVStore_WithLocation_validate(t *testing.T) {
+	var (
+		kvStore gofastly.KVStore
+		service gofastly.ServiceDetail
+	)
+	kvStoreName := fmt.Sprintf("KV Store %s", acctest.RandString(10))
+	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	domainName := fmt.Sprintf("fastly-test.tf-%s.com", acctest.RandString(10))
+	linkName := fmt.Sprintf("resource_link_%s", acctest.RandString(10))
+	location := "EU"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckServiceVCLDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKVStoreConfigWithLocation(kvStoreName, serviceName, domainName, linkName, location),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceExists("fastly_service_compute.with_location", &service),
+					testAccCheckFastlyKVStoreRemoteState(&service, &kvStore, serviceName, kvStoreName, linkName),
+				),
+			},
+			{
+				ResourceName:      "fastly_kvstore.with_location",
+				ImportState:       true,
+				ImportStateVerify: true,
+				// These attributes are not stored on the Fastly API and must be ignored.
+				ImportStateVerifyIgnore: []string{"activate", "force_destroy", "package.0.filename", "imported", "location"},
+			},
+			// IMPORTANT: Add a key to the store so we can validate force delete.
+			{
+				Config: testAccKVStoreConfigWithLocation(kvStoreName, serviceName, domainName, linkName, location),
+				Check:  testAccAddKVStoreItems(&kvStore), // triggers side-effect of adding a KV Store key/value
+			},
+			{
+				Config: testAccKVStoreConfigWithLocationDeleteStep1(kvStoreName, serviceName, domainName, location),
+			},
+			{
+				Config: testAccKVStoreConfigWithLocationDeleteStep2(serviceName, domainName),
+			},
+		},
+	})
+}
+
 func testAccCheckFastlyKVStoreRemoteState(service *gofastly.ServiceDetail, kvStore *gofastly.KVStore, serviceName, kvStoreName, linkName string) resource.TestCheckFunc {
 	return func(_ *terraform.State) error {
 		if gofastly.ToValue(service.Name) != serviceName {
@@ -172,6 +219,97 @@ data "fastly_package_hash" "example" {
 func testAccKVStoreConfigDeleteStep2(serviceName, domainName string) string {
 	return fmt.Sprintf(`
 resource "fastly_service_compute" "example" {
+  name = "%s"
+
+  domain {
+    name = "%s"
+  }
+
+  package {
+    filename         = "test_fixtures/package/valid.tar.gz"
+    source_code_hash = data.fastly_package_hash.example.hash
+  }
+
+  force_destroy = true
+}
+
+data "fastly_package_hash" "example" {
+  filename = "./test_fixtures/package/valid.tar.gz"
+}
+    `, serviceName, domainName)
+}
+
+func testAccKVStoreConfigWithLocation(kvStoreName, serviceName, domainName, linkName, location string) string {
+	return fmt.Sprintf(`
+resource "fastly_kvstore" "with_location" {
+  name          = "%s"
+  location      = "%s"
+  force_destroy = true
+}
+
+resource "fastly_service_compute" "with_location" {
+  name = "%s"
+
+  domain {
+    name = "%s"
+  }
+
+  package {
+    filename         = "test_fixtures/package/valid.tar.gz"
+    source_code_hash = data.fastly_package_hash.example.hash
+  }
+
+  resource_link {
+    name        = "%s"
+    resource_id = fastly_kvstore.with_location.id
+  }
+
+  force_destroy = true
+}
+
+data "fastly_package_hash" "example" {
+  filename = "./test_fixtures/package/valid.tar.gz"
+}
+    `, kvStoreName, location, serviceName, domainName, linkName)
+}
+
+// IMPORTANT: Deleting a KV Store requires first deleting its resource_link.
+// This requires a two-step `terraform apply` as we can't guarantee deletion order.
+// e.g. resource_link deletion within fastly_service_compute might not finish first.
+func testAccKVStoreConfigWithLocationDeleteStep1(kvStoreName, serviceName, domainName, location string) string {
+	return fmt.Sprintf(`
+resource "fastly_kvstore" "with_location" {
+  name          = "%s"
+  location      = "%s"
+  force_destroy = true
+}
+
+resource "fastly_service_compute" "with_location" {
+  name = "%s"
+
+  domain {
+    name = "%s"
+  }
+
+  package {
+    filename         = "test_fixtures/package/valid.tar.gz"
+    source_code_hash = data.fastly_package_hash.example.hash
+  }
+
+  force_destroy = true
+}
+
+data "fastly_package_hash" "example" {
+  filename = "./test_fixtures/package/valid.tar.gz"
+}
+    `, kvStoreName, location, serviceName, domainName)
+}
+
+// Step 1 deleted the resource_link first.
+// Step 2 will now delete the fastly_kvstore.
+func testAccKVStoreConfigWithLocationDeleteStep2(serviceName, domainName string) string {
+	return fmt.Sprintf(`
+resource "fastly_service_compute" "with_location" {
   name = "%s"
 
   domain {

--- a/fastly/resource_fastly_kvstore_test.go
+++ b/fastly/resource_fastly_kvstore_test.go
@@ -86,6 +86,7 @@ func TestAccFastlyKVStore_WithLocation_validate(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				// These attributes are not stored on the Fastly API and must be ignored.
+				// Note: "location" should be validated if the API starts returning it in the response.
 				ImportStateVerifyIgnore: []string{"activate", "force_destroy", "package.0.filename", "imported", "location"},
 			},
 			// IMPORTANT: Add a key to the store so we can validate force delete.

--- a/fastly/resource_fastly_kvstore_test.go
+++ b/fastly/resource_fastly_kvstore_test.go
@@ -85,8 +85,8 @@ func TestAccFastlyKVStore_WithLocation_validate(t *testing.T) {
 				ResourceName:      "fastly_kvstore.with_location",
 				ImportState:       true,
 				ImportStateVerify: true,
-				// These attributes are not stored on the Fastly API and must be ignored.
-				// Note: "location" should be validated if the API starts returning it in the response.
+				// Attributes not stored on the Fastly API are ignored.
+				// "location" should be validated if the API starts returning it in the response.
 				ImportStateVerifyIgnore: []string{"activate", "force_destroy", "package.0.filename", "imported", "location"},
 			},
 			// IMPORTANT: Add a key to the store so we can validate force delete.

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/bflad/tfproviderlint v0.29.0
-	github.com/fastly/go-fastly/v9 v9.3.0
+	github.com/fastly/go-fastly/v9 v9.3.1
 	github.com/google/go-cmp v0.6.0
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/terraform-plugin-docs v0.16.0

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/bflad/tfproviderlint v0.29.0
-	github.com/fastly/go-fastly/v9 v9.2.2
+	github.com/fastly/go-fastly/v9 v9.3.0
 	github.com/google/go-cmp v0.6.0
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/terraform-plugin-docs v0.16.0

--- a/go.sum
+++ b/go.sum
@@ -33,8 +33,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dnaeon/go-vcr v1.2.0 h1:zHCHvJYTMh1N7xnV7zf1m1GPBF9Ad0Jk/whtQ1663qI=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
-github.com/fastly/go-fastly/v9 v9.2.2 h1:YNoinvf9vlPmsIbR6weT6XQ0l8nNPjS5DjC7ILwwaE8=
-github.com/fastly/go-fastly/v9 v9.2.2/go.mod h1:5w2jgJBZqQEebOwM/rRg7wutAcpDTziiMYWb/6qdM7U=
+github.com/fastly/go-fastly/v9 v9.3.0 h1:n5TYhp6GBkHebqL8A/BqoW+yxQfwOyzPvHPF1yEibbA=
+github.com/fastly/go-fastly/v9 v9.3.0/go.mod h1:5w2jgJBZqQEebOwM/rRg7wutAcpDTziiMYWb/6qdM7U=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
 github.com/fatih/color v1.15.0 h1:kOqh6YHBtK8aywxGerMG2Eq3H6Qgoqeo13Bk2Mv/nBs=

--- a/go.sum
+++ b/go.sum
@@ -33,8 +33,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dnaeon/go-vcr v1.2.0 h1:zHCHvJYTMh1N7xnV7zf1m1GPBF9Ad0Jk/whtQ1663qI=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
-github.com/fastly/go-fastly/v9 v9.3.0 h1:n5TYhp6GBkHebqL8A/BqoW+yxQfwOyzPvHPF1yEibbA=
-github.com/fastly/go-fastly/v9 v9.3.0/go.mod h1:5w2jgJBZqQEebOwM/rRg7wutAcpDTziiMYWb/6qdM7U=
+github.com/fastly/go-fastly/v9 v9.3.1 h1:2UZUe8Kkz60aPrkDV82dpHkEqsT/J2qxOZxFhWEJJ2k=
+github.com/fastly/go-fastly/v9 v9.3.1/go.mod h1:5w2jgJBZqQEebOwM/rRg7wutAcpDTziiMYWb/6qdM7U=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
 github.com/fatih/color v1.15.0 h1:kOqh6YHBtK8aywxGerMG2Eq3H6Qgoqeo13Bk2Mv/nBs=

--- a/vendor/github.com/fastly/go-fastly/v9/fastly/client.go
+++ b/vendor/github.com/fastly/go-fastly/v9/fastly/client.go
@@ -51,11 +51,14 @@ const RealtimeStatsEndpointEnvVar = "FASTLY_RTS_URL"
 // DefaultRealtimeStatsEndpoint is the realtime stats endpoint for Fastly.
 const DefaultRealtimeStatsEndpoint = "https://rt.fastly.com"
 
+// JSONMimeType is the MIME type for the JSON data format.
+const JSONMimeType = "application/json"
+
 // ProjectURL is the url for this library.
 var ProjectURL = "github.com/fastly/go-fastly"
 
 // ProjectVersion is the version of this library.
-var ProjectVersion = "9.3.0"
+var ProjectVersion = "9.3.1"
 
 // UserAgent is the user agent for this particular client.
 var UserAgent = fmt.Sprintf("FastlyGo/%s (+%s; %s)",
@@ -169,7 +172,10 @@ func (c *Client) init() (*Client, error) {
 	c.url = u
 
 	if c.HTTPClient == nil {
-		c.HTTPClient = cleanhttp.DefaultClient()
+		c.HTTPClient = &http.Client{
+			// IMPORTANT: Avoid cleanhttp.DefaultTransport() which disables keepalive.
+			Transport: cleanhttp.DefaultPooledTransport(),
+		}
 	}
 
 	return c, nil
@@ -423,7 +429,7 @@ func (c *Client) SimpleGet(target string) (*http.Response, error) {
 		return nil, err
 	}
 
-	request, err := http.NewRequest("GET", u.String(), nil)
+	request, err := http.NewRequest(http.MethodGet, u.String(), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -495,7 +501,7 @@ func (c *Client) RequestForm(verb, p string, i any, ro *RequestOptions) (*http.R
 func (c *Client) RequestFormFile(verb, urlPath, filePath, fieldName string, ro *RequestOptions) (*http.Response, error) {
 	file, err := os.Open(filepath.Clean(filePath))
 	if err != nil {
-		return nil, fmt.Errorf("error reading file: %v", err)
+		return nil, fmt.Errorf("error reading file: %w", err)
 	}
 	defer file.Close() // #nosec G307
 
@@ -508,17 +514,17 @@ func (c *Client) RequestFormFileFromReader(verb, urlPath, fileName string, fileB
 	writer := multipart.NewWriter(&body)
 	part, err := writer.CreateFormFile(fieldName, fileName)
 	if err != nil {
-		return nil, fmt.Errorf("error creating multipart form: %v", err)
+		return nil, fmt.Errorf("error creating multipart form: %w", err)
 	}
 
 	_, err = io.Copy(part, fileBytes)
 	if err != nil {
-		return nil, fmt.Errorf("error copying file to multipart form: %v", err)
+		return nil, fmt.Errorf("error copying file to multipart form: %w", err)
 	}
 
 	err = writer.Close()
 	if err != nil {
-		return nil, fmt.Errorf("error closing multipart form: %v", err)
+		return nil, fmt.Errorf("error closing multipart form: %w", err)
 	}
 
 	if ro == nil {
@@ -528,7 +534,7 @@ func (c *Client) RequestFormFileFromReader(verb, urlPath, fileName string, fileB
 		ro.Headers = make(map[string]string)
 	}
 	ro.Headers["Content-Type"] = writer.FormDataContentType()
-	ro.Headers["Accept"] = "application/json"
+	ro.Headers["Accept"] = JSONMimeType
 	ro.Body = &body
 	ro.BodyLength = int64(body.Len())
 
@@ -544,8 +550,8 @@ func (c *Client) RequestJSON(verb, p string, i any, ro *RequestOptions) (*http.R
 	if ro.Headers == nil {
 		ro.Headers = make(map[string]string)
 	}
-	ro.Headers["Content-Type"] = "application/json"
-	ro.Headers["Accept"] = "application/json"
+	ro.Headers["Content-Type"] = JSONMimeType
+	ro.Headers["Accept"] = JSONMimeType
 
 	body, err := json.Marshal(i)
 	if err != nil {
@@ -616,7 +622,7 @@ func checkResp(resp *http.Response, err error) (*http.Response, error) {
 	}
 
 	switch resp.StatusCode {
-	case 200, 201, 202, 204, 205, 206:
+	case http.StatusOK, http.StatusCreated, http.StatusAccepted, http.StatusNoContent, http.StatusResetContent, http.StatusPartialContent:
 		return resp, nil
 	default:
 		return resp, NewHTTPError(resp)

--- a/vendor/github.com/fastly/go-fastly/v9/fastly/client.go
+++ b/vendor/github.com/fastly/go-fastly/v9/fastly/client.go
@@ -55,7 +55,7 @@ const DefaultRealtimeStatsEndpoint = "https://rt.fastly.com"
 var ProjectURL = "github.com/fastly/go-fastly"
 
 // ProjectVersion is the version of this library.
-var ProjectVersion = "9.2.2"
+var ProjectVersion = "9.3.0"
 
 // UserAgent is the user agent for this particular client.
 var UserAgent = fmt.Sprintf("FastlyGo/%s (+%s; %s)",

--- a/vendor/github.com/fastly/go-fastly/v9/fastly/errors.go
+++ b/vendor/github.com/fastly/go-fastly/v9/fastly/errors.go
@@ -328,6 +328,10 @@ var ErrInvalidMethod = NewFieldError("Method").Message("invalid")
 // was set.
 var ErrMissingCertificateMTLS = NewFieldError("Certificate, MutualAuthentication").Message("at least one of the available optional fields is required")
 
+// ErrMissingIntegrationID is an error that is returned when an input struct
+// requires a "IntegrationID" key, but one was not set.
+var ErrMissingIntegrationID = NewFieldError("IntegrationID")
+
 // Ensure HTTPError is, in fact, an error.
 var _ error = (*HTTPError)(nil)
 

--- a/vendor/github.com/fastly/go-fastly/v9/fastly/kv_store.go
+++ b/vendor/github.com/fastly/go-fastly/v9/fastly/kv_store.go
@@ -24,6 +24,8 @@ type KVStore struct {
 type CreateKVStoreInput struct {
 	// Name is the name of the store to create (required).
 	Name string `json:"name"`
+	// Location is the regional location of the store (optional).
+	Location string `json:"-"`
 }
 
 // CreateKVStore creates a new resource.
@@ -32,8 +34,15 @@ func (c *Client) CreateKVStore(i *CreateKVStoreInput) (*KVStore, error) {
 		return nil, ErrMissingName
 	}
 
+	ro := &RequestOptions{
+		Params: map[string]string{},
+	}
+	if i.Location != "" {
+		ro.Params["location"] = i.Location
+	}
+
 	const path = "/resources/stores/kv"
-	resp, err := c.PostJSON(path, i, nil)
+	resp, err := c.PostJSON(path, i, ro)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/fastly/go-fastly/v9/fastly/notifications.go
+++ b/vendor/github.com/fastly/go-fastly/v9/fastly/notifications.go
@@ -1,0 +1,311 @@
+package fastly
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"time"
+)
+
+// Integration holds the configuration for one integration.
+type Integration struct {
+	CreatedAt   *time.Time        `json:"created_at"`
+	Description *string           `json:"description"`
+	Config      map[string]string `json:"config"`
+	ID          *string           `json:"id"`
+	Name        *string           `json:"name"`
+	Status      *string           `json:"status"`
+	Type        *string           `json:"type"`
+	UpdatedAt   *time.Time        `json:"updated_at"`
+}
+
+// SearchIntegrationsInput is used as input to the SearchIntegrations function.
+type SearchIntegrationsInput struct {
+	// Cursor is the pagination cursor from a previous request's meta.
+	Cursor *string
+	// Limit is the maximum number of items included in each response.
+	Limit *int
+	// Sort is the field on which to sort integrations.
+	Sort *string
+	// Type filters integrations by type.
+	Type *string
+}
+
+// SearchIntegrationsResponse is the response for an integrations query.
+type SearchIntegrationsResponse struct {
+	Data []Integration     `json:"data"`
+	Meta *IntegrationsMeta `json:"meta"`
+}
+
+// IntegrationsMeeta holds metadata about an integrations query.
+type IntegrationsMeta struct {
+	Limit      *int    `json:"limit"`
+	NextCursor *string `json:"next_cursor"`
+	Sort       *string `json:"sort"`
+	Total      *int    `json:"total"`
+	Type       *string `json:"type"`
+}
+
+// SearchIntegrations retrieves filtered, paginated integrations.
+func (c *Client) SearchIntegrations(i *SearchIntegrationsInput) (*SearchIntegrationsResponse, error) {
+	p := "/notifications/integrations"
+
+	ro := &RequestOptions{
+		Params: map[string]string{},
+	}
+	if i.Cursor != nil {
+		ro.Params["cursor"] = *i.Cursor
+	}
+	if i.Limit != nil {
+		ro.Params["limit"] = strconv.Itoa(*i.Limit)
+	}
+	if i.Sort != nil {
+		ro.Params["sort"] = *i.Sort
+	}
+	if i.Type != nil {
+		ro.Params["type"] = *i.Type
+	}
+
+	resp, err := c.Get(p, ro)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var sir *SearchIntegrationsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&sir); err != nil {
+		return nil, err
+	}
+
+	return sir, nil
+}
+
+// CreateIntegrationInput is used as input to the CreateIntegration function.
+type CreateIntegrationInput struct {
+	// Config is configuration specific to the integration type.
+	Config map[string]string
+	// Description is the user submitted description of the integration.
+	Description *string
+	// Name is the user submitted name of the integration.
+	Name *string
+	// Type is the type of integration.
+	Type *string
+}
+
+// CreateIntegrationResponse is the response for creating a new integration.
+type CreateIntegrationResponse struct {
+	// ID of created integration.
+	ID *string `json:"integration_id"`
+}
+
+// CreateIntegration creates a new integration.
+func (c *Client) CreateIntegration(i *CreateIntegrationInput) (*CreateIntegrationResponse, error) {
+	resp, err := c.PostJSON("/notifications/integrations", i, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var cir *CreateIntegrationResponse
+	if err := json.NewDecoder(resp.Body).Decode(&cir); err != nil {
+		return nil, err
+	}
+	return cir, nil
+}
+
+// GetIntegrationInput is used as input to the GetIntegration function.
+type GetIntegrationInput struct {
+	// ID of integration to fetch (required).
+	ID string
+}
+
+// GetIntegration retrieves a specified integration.
+func (c *Client) GetIntegration(i *GetIntegrationInput) (*Integration, error) {
+	if i.ID == "" {
+		return nil, ErrMissingID
+	}
+
+	path := fmt.Sprintf("/notifications/integrations/%s", i.ID)
+	resp, err := c.Get(path, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var integration *Integration
+	if err := json.NewDecoder(resp.Body).Decode(&integration); err != nil {
+		return nil, err
+	}
+
+	return integration, nil
+}
+
+// UpdateIntegrationInput is used as input to the UpdateIntegration function.
+type UpdateIntegrationInput struct {
+	// Config is configuration specific to the integration type.
+	Config map[string]string
+	// Description is the user submitted description of the integration.
+	Description *string
+	// ID of integration to update (required).
+	ID string
+	// Name is the user submitted name of the integration.
+	Name *string
+	// Type is the type of integration
+	Type *string
+}
+
+// UpdateIntegration updates the specified integration.
+func (c *Client) UpdateIntegration(i *UpdateIntegrationInput) error {
+	if i.ID == "" {
+		return ErrMissingID
+	}
+
+	path := fmt.Sprintf("/notifications/integrations/%s", i.ID)
+	resp, err := c.PatchJSON(path, i, nil)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNoContent {
+		return NewHTTPError(resp)
+	}
+
+	return nil
+}
+
+// DeleteIntegrationInput is used as input to the DeleteIntegration function.
+type DeleteIntegrationInput struct {
+	// ID of integration to delete (required).
+	ID string
+}
+
+// DeleteIntegration deletes the specified integration.
+func (c *Client) DeleteIntegration(i *DeleteIntegrationInput) error {
+	if i.ID == "" {
+		return ErrMissingID
+	}
+
+	path := fmt.Sprintf("/notifications/integrations/%s", i.ID)
+	resp, err := c.Delete(path, nil)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNoContent {
+		return NewHTTPError(resp)
+	}
+
+	return nil
+}
+
+// IntegrationType is an item in the response listing integration types.
+type IntegrationType struct {
+	Type         *string       `json:"type"`
+	DisplayName  *string       `json:"display_name"`
+	CustomFields []CustomField `json:"custom_fields"`
+}
+
+// CustomField describes a configuration required for a type of integration.
+type CustomField struct {
+	Name        *string `json:"name"`
+	DisplayName *string `json:"display_name"`
+	Format      *string `json:"format"`
+}
+
+// GetIntegrationTypes retrieves the supported integration types and what configuration they require.
+func (c *Client) GetIntegrationTypes() (*[]IntegrationType, error) {
+	path := "/notifications/integration-types"
+	resp, err := c.Get(path, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var its *[]IntegrationType
+	if err := json.NewDecoder(resp.Body).Decode(&its); err != nil {
+		return nil, err
+	}
+	return its, nil
+}
+
+// GetWebhookSigningKeyInput is used as input to the GetWebhookSigningKey function.
+type GetWebhookSigningKeyInput struct {
+	// IntegrationID is the ID of the webhook integration which signing key to get (required).
+	IntegrationID string
+}
+
+// WebhookSigningKeyResponse is the response for getting or rotating a webhook payload signing key.
+type WebhookSigningKeyResponse struct {
+	SigningKey *string `json:"signingKey"`
+}
+
+// GetWebhookSigningKey retrieves the signing key for a webhook integration.
+func (c *Client) GetWebhookSigningKey(i *GetWebhookSigningKeyInput) (*WebhookSigningKeyResponse, error) {
+	if i.IntegrationID == "" {
+		return nil, ErrMissingIntegrationID
+	}
+
+	path := fmt.Sprintf("/notifications/integrations/%s/signingKey", i.IntegrationID)
+	resp, err := c.Get(path, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var wskr *WebhookSigningKeyResponse
+	if err := json.NewDecoder(resp.Body).Decode(&wskr); err != nil {
+		return nil, err
+	}
+	return wskr, nil
+}
+
+// RotateWebhookSigningKeyInput is used as input to the RotateWebhookSigningKey function.
+type RotateWebhookSigningKeyInput struct {
+	// IntegrationID is the ID of the webhook integration which signing key to rotate (required).
+	IntegrationID string
+}
+
+// RotateWebhookSigningKey rotates the signing key for a webhook integration.
+func (c *Client) RotateWebhookSigningKey(i *RotateWebhookSigningKeyInput) (*WebhookSigningKeyResponse, error) {
+	if i.IntegrationID == "" {
+		return nil, ErrMissingIntegrationID
+	}
+
+	path := fmt.Sprintf("/notifications/integrations/%s/rotateSigningKey", i.IntegrationID)
+	resp, err := c.Post(path, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var wskr *WebhookSigningKeyResponse
+	if err := json.NewDecoder(resp.Body).Decode(&wskr); err != nil {
+		return nil, err
+	}
+	return wskr, nil
+}
+
+// CreateMailinglistConfirmationInput is used as input to the CreateMailinglistConfirmation function.
+type CreateMailinglistConfirmationInput struct {
+	// Email is the mailinglist address.
+	Email *string
+}
+
+// CreateMailinglistConfirmation sends a mailing list confirmation email.
+func (c *Client) CreateMailinglistConfirmation(i *CreateMailinglistConfirmationInput) error {
+	path := "/notifications/mailinglist-confirmations"
+	resp, err := c.PostJSON(path, i, nil)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNoContent {
+		return NewHTTPError(resp)
+	}
+
+	return nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -211,7 +211,7 @@ github.com/cloudflare/circl/sign/ed448
 # github.com/davecgh/go-spew v1.1.1
 ## explicit
 github.com/davecgh/go-spew/spew
-# github.com/fastly/go-fastly/v9 v9.3.0
+# github.com/fastly/go-fastly/v9 v9.3.1
 ## explicit; go 1.20
 github.com/fastly/go-fastly/v9/fastly
 # github.com/fatih/color v1.15.0

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -211,7 +211,7 @@ github.com/cloudflare/circl/sign/ed448
 # github.com/davecgh/go-spew v1.1.1
 ## explicit
 github.com/davecgh/go-spew/spew
-# github.com/fastly/go-fastly/v9 v9.2.2
+# github.com/fastly/go-fastly/v9 v9.3.0
 ## explicit; go 1.20
 github.com/fastly/go-fastly/v9/fastly
 # github.com/fatih/color v1.15.0


### PR DESCRIPTION
👋 This PR adds the ability to specify the location when creating a new KV store using Terraform.

Changes made:

- Update go-fastly to 9.3.0
- Add a new `location` field to the `fastly_kvstore` resource.
- Add a new acceptance test `TestAccFastlyKVStore_WithLocation_validate` and associated helper functions.
- Updated the document with the additional field.
