### PR TITLE
fix(fastly_vcl_service): ensure backend names are unique

### DIFF
--- a/fastly/base_fastly_service.go
+++ b/fastly/base_fastly_service.go
@@ -77,6 +77,7 @@ func resourceService(serviceDef ServiceDefinition) *schema.Resource {
 				// activate flag) then the active_version will be recomputed too.
 				return d.HasChange("cloned_version") && d.Get("activate").(bool)
 			}),
+			validateUniqueNames("backend"),
 			validateUniqueNames("rate_limiter"),
 			validateUniqueNames("snippet"),
 		),


### PR DESCRIPTION
This PR ensures the following config (which incorrectly sets the same value for the `name` attribute) will report an error...

```hcl
  backend {
    address = "httpbin.org"
    name    = "httpbin"
  }

  backend {
    address = "example.com"
    name    = "httpbin"
  }
```

![Screenshot 2024-04-18 at 12 43 21](https://github.com/fastly/terraform-provider-fastly/assets/180050/913210c2-0ee9-45cc-a66f-5bac8a155c10)
