### PR TITLE
fix(alerts): make `service_id` attribute optional

### DIFF
--- a/fastly/resource_fastly_alert.go
+++ b/fastly/resource_fastly_alert.go
@@ -102,7 +102,7 @@ func resourceFastlyAlert() *schema.Resource {
 
 			"service_id": {
 				Type:        schema.TypeString,
-				Required:    true,
+				Optional:    true,
 				ForceNew:    true,
 				Description: "The service which the alert monitors.",
 			},

--- a/fastly/resource_fastly_alert_test.go
+++ b/fastly/resource_fastly_alert_test.go
@@ -428,7 +428,6 @@ func testAccAlertPercentAggregateStatsConfig(alert gofastly.AlertDefinition) str
 resource "fastly_alert" "tf_percent" {
   name = "%s"
   description = "%s"
-  service_id = ""
   source = "%s"
   metric = "%s"
 


### PR DESCRIPTION
The PR aims to rectify the terraform definition of an alert when we configure an account aggregate alert.
The `service_id` on alerts is now optional when we configure an alerts on the `stats` source.
 