### PR TITLE
fix(alerts): make service_id attribute optional

### DIFF
--- a/docs/resources/alert.md
+++ b/docs/resources/alert.md
@@ -55,7 +55,6 @@ $ terraform import fastly_alert.example xxxxxxxxxxxxxxxxxxxx
 - `evaluation_strategy` (Block List, Min: 1, Max: 1) Criteria on how to alert. (see [below for nested schema](#nestedblock--evaluation_strategy))
 - `metric` (String) The metric name to alert on for a specific source: [domains](https://developer.fastly.com/reference/api/metrics-stats/domain-inspector/historical), [origins](https://developer.fastly.com/reference/api/metrics-stats/origin-inspector/historical), or [stats](https://developer.fastly.com/reference/api/metrics-stats/historical-stats).
 - `name` (String) The name of the alert.
-- `service_id` (String) The service which the alert monitors.
 - `source` (String) The source where the metric comes from. One of: `domains`, `origins`, `stats`.
 
 ### Optional
@@ -63,6 +62,7 @@ $ terraform import fastly_alert.example xxxxxxxxxxxxxxxxxxxx
 - `description` (String) Additional text that is included in the alert notification.
 - `dimensions` (Block List, Max: 1) More filters depending on the source type. (see [below for nested schema](#nestedblock--dimensions))
 - `integration_ids` (Set of String) List of integrations used to notify when alert fires.
+- `service_id` (String) The service which the alert monitors. Optional when using `stats` as the `source`.
 
 ### Read-Only
 

--- a/fastly/resource_fastly_alert.go
+++ b/fastly/resource_fastly_alert.go
@@ -102,9 +102,9 @@ func resourceFastlyAlert() *schema.Resource {
 
 			"service_id": {
 				Type:        schema.TypeString,
-				Required:    true,
+				Optional:    true,
 				ForceNew:    true,
-				Description: "The service which the alert monitors.",
+				Description: "The service which the alert monitors. Optional when using `stats` as the `source`.",
 			},
 
 			"source": {

--- a/fastly/resource_fastly_alert_test.go
+++ b/fastly/resource_fastly_alert_test.go
@@ -2,6 +2,7 @@ package fastly
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -251,6 +252,55 @@ func TestAccFastlyAlert_BasicStatsAggregatePercent(t *testing.T) {
 				ResourceName:      "fastly_alert.tf_percent",
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccFastlyAlert_BasicStatsBadConfig(t *testing.T) {
+	createAlert := gofastly.AlertDefinition{
+		Description: "Terraform percent test",
+		Dimensions:  map[string][]string{},
+		// 25 percent increase
+		EvaluationStrategy: map[string]any{
+			"type":         "percent_increase",
+			"period":       "2m",
+			"threshold":    0.25,
+			"ignore_below": float64(10),
+		},
+		Metric: "status_4xx",
+		Name:   fmt.Sprintf("Terraform test percent alert %s", acctest.RandString(10)),
+		Source: "origins",
+	}
+	updateAlert := gofastly.AlertDefinition{
+		Description: "Terraform test with new description",
+		Dimensions:  map[string][]string{},
+		// 10 percent increase
+		EvaluationStrategy: map[string]any{
+			"type":         "percent_increase",
+			"period":       "2m",
+			"threshold":    0.1,
+			"ignore_below": float64(10),
+		},
+		Metric: "status_4xx",
+		Name:   fmt.Sprintf("Terraform test update percent alert %s", acctest.RandString(10)),
+		Source: "domains",
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAlertDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccAlertPercentAggregateStatsConfig(createAlert),
+				ExpectError: regexp.MustCompile(badAlertSourceServiceIdConfig),
+			},
+			{
+				Config:      testAccAlertPercentAggregateStatsConfig(updateAlert),
+				ExpectError: regexp.MustCompile(badAlertSourceServiceIdConfig),
 			},
 		},
 	})

--- a/fastly/resource_fastly_alert_test.go
+++ b/fastly/resource_fastly_alert_test.go
@@ -428,7 +428,6 @@ func testAccAlertPercentAggregateStatsConfig(alert gofastly.AlertDefinition) str
 resource "fastly_alert" "tf_percent" {
   name = "%s"
   description = "%s"
-  service_id = ""
   source = "%s"
   metric = "%s"
 


### PR DESCRIPTION
The PR aims to rectify the terraform definition of an alert when we configure an account aggregate alert.
The `service_id` on alerts is now optional when we configure an alerts on the `stats` source.