### PR TITLE
fix(alerts): ensure that alert creation works properly when 'ignore_below' is not specified

### DIFF
--- a/fastly/resource_fastly_alert.go
+++ b/fastly/resource_fastly_alert.go
@@ -318,7 +318,9 @@ func buildEvaluationStrategy(v map[string]any) map[string]any {
 
 	// Optional attributes
 	if value, ok := v["ignore_below"]; ok {
-		m["ignore_below"] = value.(float64)
+		if value.(float64) > 0 {
+			m["ignore_below"] = value.(float64)
+		}
 	}
 
 	return m

--- a/fastly/resource_fastly_alert.go
+++ b/fastly/resource_fastly_alert.go
@@ -318,8 +318,8 @@ func buildEvaluationStrategy(v map[string]any) map[string]any {
 
 	// Optional attributes
 	if value, ok := v["ignore_below"]; ok {
-		if value.(float64) > 0 {
-			m["ignore_below"] = value.(float64)
+		if v := value.(float64); v > 0 {
+			m["ignore_below"] = v
 		}
 	}
 


### PR DESCRIPTION
If 'ignore_below' is not specified in the 'evaluation_strategy' for an alert, Terraform gives it a value of zero, which the API will not accept. Since zero is not a valid value in the configuration, this change causes it to be ignored when the API operations are invoked.

Closes #868.