### PR TITLE
Clarify Image Optimizer shield requirements

### DIFF
--- a/docs/resources/service_vcl.md
+++ b/docs/resources/service_vcl.md
@@ -1136,7 +1136,7 @@ Optional:
 
 - `brotli_compression` (Boolean) Enable Brotli Compression support
 - `domain_inspector` (Boolean) Enable Domain Inspector support
-- `image_optimizer` (Boolean) Enable Image Optimizer support (requires at least one backend with a `shield` attribute)
+- `image_optimizer` (Boolean) Enable Image Optimizer support (all backends must have a `shield` attribute)
 - `name` (String) Used by the provider to identify modified settings (changing this value will force the entire block to be deleted, then recreated)
 - `origin_inspector` (Boolean) Enable Origin Inspector support
 - `websockets` (Boolean) Enable WebSockets support

--- a/fastly/block_fastly_service_product_enablement.go
+++ b/fastly/block_fastly_service_product_enablement.go
@@ -64,7 +64,7 @@ func (h *ProductEnablementServiceAttributeHandler) GetSchema() *schema.Schema {
 		blockAttributes["image_optimizer"] = &schema.Schema{
 			Type:        schema.TypeBool,
 			Optional:    true,
-			Description: "Enable Image Optimizer support (requires at least one backend with a `shield` attribute)",
+			Description: "Enable Image Optimizer support (all backends must have a `shield` attribute)",
 		}
 		blockAttributes["origin_inspector"] = &schema.Schema{
 			Type:        schema.TypeBool,


### PR DESCRIPTION
The documentation for the `image_optimizer` field is misleading. All backends must be shielded for Image Optimization to be enabled -- this updates the wording. 