### PR TITLE
feat(product_enablement) - Add support for Fastly Bot Management.

### DIFF
--- a/docs/resources/service_vcl.md
+++ b/docs/resources/service_vcl.md
@@ -1134,6 +1134,7 @@ Optional:
 
 Optional:
 
+- `bot_management` (Boolean) Enable Bot Management support
 - `brotli_compression` (Boolean) Enable Brotli Compression support
 - `domain_inspector` (Boolean) Enable Domain Inspector support
 - `image_optimizer` (Boolean) Enable Image Optimizer support (all backends must have a `shield` attribute)

--- a/fastly/block_fastly_service_product_enablement.go
+++ b/fastly/block_fastly_service_product_enablement.go
@@ -51,11 +51,6 @@ func (h *ProductEnablementServiceAttributeHandler) GetSchema() *schema.Schema {
 	}
 
 	if h.GetServiceMetadata().serviceType == ServiceTypeVCL {
-		blockAttributes["bot_management"] = &schema.Schema{
-			Type:        schema.TypeBool,
-			Optional:    true,
-			Description: "Enable Bot Management support",
-		}
 		blockAttributes["brotli_compression"] = &schema.Schema{
 			Type:        schema.TypeBool,
 			Optional:    true,
@@ -116,16 +111,6 @@ func (h *ProductEnablementServiceAttributeHandler) Create(_ context.Context, d *
 	}
 
 	if h.GetServiceMetadata().serviceType == ServiceTypeVCL {
-		if resource["bot_management"].(bool) {
-			log.Println("[DEBUG] bot_management set")
-			_, err := conn.EnableProduct(&gofastly.ProductEnablementInput{
-				ProductID: gofastly.ProductBotManagement,
-				ServiceID: serviceID,
-			})
-			if err != nil {
-				return fmt.Errorf("failed to enable bot_management: %w", err)
-			}
-		}
 		if resource["brotli_compression"].(bool) {
 			log.Println("[DEBUG] brotli_compression set")
 			_, err := conn.EnableProduct(&gofastly.ProductEnablementInput{
@@ -225,12 +210,6 @@ func (h *ProductEnablementServiceAttributeHandler) Read(_ context.Context, d *sc
 
 		if h.GetServiceMetadata().serviceType == ServiceTypeVCL {
 			if _, err := conn.GetProduct(&gofastly.ProductEnablementInput{
-				ProductID: gofastly.ProductBotManagement,
-				ServiceID: d.Id(),
-			}); err == nil {
-				result["bot_management"] = true
-			}
-			if _, err := conn.GetProduct(&gofastly.ProductEnablementInput{
 				ProductID: gofastly.ProductBrotliCompression,
 				ServiceID: d.Id(),
 			}); err == nil {
@@ -320,29 +299,6 @@ func (h *ProductEnablementServiceAttributeHandler) Update(_ context.Context, d *
 	}
 
 	if h.GetServiceMetadata().serviceType == ServiceTypeVCL {
-		if v, ok := modified["bot_management"]; ok {
-			if v.(bool) {
-				log.Println("[DEBUG] bot_management will be enabled")
-				_, err := conn.EnableProduct(&gofastly.ProductEnablementInput{
-					ProductID: gofastly.ProductBotManagement,
-					ServiceID: serviceID,
-				})
-				if err != nil {
-					return fmt.Errorf("failed to enable bot_management: %w", err)
-				}
-			} else {
-				log.Println("[DEBUG] bot_management will be disabled")
-				err := conn.DisableProduct(&gofastly.ProductEnablementInput{
-					ProductID: gofastly.ProductBotManagement,
-					ServiceID: serviceID,
-				})
-				if err != nil {
-					if e := h.checkAPIError(err); e != nil {
-						return e
-					}
-				}
-			}
-		}
 		if v, ok := modified["brotli_compression"]; ok {
 			if v.(bool) {
 				log.Println("[DEBUG] brotli_compression will be enabled")
@@ -513,19 +469,8 @@ func (h *ProductEnablementServiceAttributeHandler) Delete(_ context.Context, d *
 	}
 
 	if h.GetServiceMetadata().serviceType == ServiceTypeVCL {
-		log.Println("[DEBUG] disable bot_management")
-		err := conn.DisableProduct(&gofastly.ProductEnablementInput{
-			ProductID: gofastly.ProductBotManagement,
-			ServiceID: d.Id(),
-		})
-		if err != nil {
-			if e := h.checkAPIError(err); e != nil {
-				return e
-			}
-		}
-
 		log.Println("[DEBUG] disable brotli_compression")
-		err = conn.DisableProduct(&gofastly.ProductEnablementInput{
+		err := conn.DisableProduct(&gofastly.ProductEnablementInput{
 			ProductID: gofastly.ProductBrotliCompression,
 			ServiceID: d.Id(),
 		})

--- a/fastly/block_fastly_service_product_enablement_test.go
+++ b/fastly/block_fastly_service_product_enablement_test.go
@@ -33,6 +33,7 @@ func TestAccFastlyServiceVCLProductEnablement_basic(t *testing.T) {
     }
 
     product_enablement {
+	  bot_management     = false
       brotli_compression = true
       domain_inspector   = false
       image_optimizer    = false

--- a/fastly/block_fastly_service_product_enablement_test.go
+++ b/fastly/block_fastly_service_product_enablement_test.go
@@ -33,7 +33,7 @@ func TestAccFastlyServiceVCLProductEnablement_basic(t *testing.T) {
     }
 
     product_enablement {
-	  bot_management     = false
+  bot_management     = false
       brotli_compression = true
       domain_inspector   = false
       image_optimizer    = false

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/bflad/tfproviderlint v0.30.0
-	github.com/fastly/go-fastly/v9 v9.8.0
+	github.com/fastly/go-fastly/v9 v9.9.0
 	github.com/google/go-cmp v0.6.0
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/terraform-plugin-docs v0.19.4

--- a/go.sum
+++ b/go.sum
@@ -36,8 +36,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dnaeon/go-vcr v1.2.0 h1:zHCHvJYTMh1N7xnV7zf1m1GPBF9Ad0Jk/whtQ1663qI=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
-github.com/fastly/go-fastly/v9 v9.8.0 h1:15dtV3fmLlS/8wbdU3tBsW3Tb0Tj/gQrdS4v5mhtDDE=
-github.com/fastly/go-fastly/v9 v9.8.0/go.mod h1:5w2jgJBZqQEebOwM/rRg7wutAcpDTziiMYWb/6qdM7U=
+github.com/fastly/go-fastly/v9 v9.9.0 h1:VDCyORoWi608l/LBp+tY+qic3M5/5ZFw+rtAfV6VR9E=
+github.com/fastly/go-fastly/v9 v9.9.0/go.mod h1:5w2jgJBZqQEebOwM/rRg7wutAcpDTziiMYWb/6qdM7U=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
 github.com/fatih/color v1.16.0 h1:zmkK9Ngbjj+K0yRhTVONQh1p/HknKYSlNT+vZCzyokM=
 github.com/fatih/color v1.16.0/go.mod h1:fL2Sau1YI5c0pdGEVCbKQbLXB6edEj1ZgiY4NijnWvE=

--- a/tests/interface/main.tf
+++ b/tests/interface/main.tf
@@ -137,6 +137,7 @@ resource "fastly_service_vcl" "interface-test-project" {
   }
 
   product_enablement {
+    bot_management     = false
     brotli_compression = true
     domain_inspector   = false
     image_optimizer    = false

--- a/vendor/github.com/fastly/go-fastly/v9/fastly/product_enablement.go
+++ b/vendor/github.com/fastly/go-fastly/v9/fastly/product_enablement.go
@@ -20,8 +20,6 @@ type Product int64
 
 func (p Product) String() string {
 	switch p {
-	case ProductBotManagement:
-		return "bot_management"
 	case ProductBrotliCompression:
 		return "brotli_compression"
 	case ProductDomainInspector:
@@ -42,7 +40,6 @@ func (p Product) String() string {
 
 const (
 	ProductUndefined Product = iota
-	ProductBotManagement
 	ProductBrotliCompression
 	ProductDomainInspector
 	ProductFanout

--- a/vendor/github.com/fastly/go-fastly/v9/fastly/product_enablement.go
+++ b/vendor/github.com/fastly/go-fastly/v9/fastly/product_enablement.go
@@ -20,6 +20,8 @@ type Product int64
 
 func (p Product) String() string {
 	switch p {
+	case ProductBotManagement:
+		return "bot_management"
 	case ProductBrotliCompression:
 		return "brotli_compression"
 	case ProductDomainInspector:
@@ -40,6 +42,7 @@ func (p Product) String() string {
 
 const (
 	ProductUndefined Product = iota
+	ProductBotManagement
 	ProductBrotliCompression
 	ProductDomainInspector
 	ProductFanout

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -214,7 +214,7 @@ github.com/cloudflare/circl/sign/ed448
 # github.com/davecgh/go-spew v1.1.1
 ## explicit
 github.com/davecgh/go-spew/spew
-# github.com/fastly/go-fastly/v9 v9.8.0
+# github.com/fastly/go-fastly/v9 v9.9.0
 ## explicit; go 1.20
 github.com/fastly/go-fastly/v9/fastly
 # github.com/fatih/color v1.16.0


### PR DESCRIPTION
This PR adds the ability to enable Fastly Bot Management via the product_enablement field in a fastly_service_vcl resource. Below is an example with `bot_management` enabled.

```  
product_enablement {
    bot_management = true
    origin_inspector = true
    domain_inspector = true
  }
```

I have successfully tested locally and updated the test file `fastly/block_fastly_service_product_enablement_test.go` to have the field `bot_management     = false`.

Please let me know if there are any other tests that I may run or updates that I may make to help get this PR merged. Thanks!