### PR TITLE
fix(tls_mutual_authentication): Ensure that 'enforced' property does not revert to default during changes.

### DIFF
--- a/fastly/resource_fastly_tls_mutual_authentication.go
+++ b/fastly/resource_fastly_tls_mutual_authentication.go
@@ -179,9 +179,11 @@ func resourceFastlyTLSMutualAuthenticationUpdate(_ context.Context, d *schema.Re
 		CertBundle: d.Get("cert_bundle").(string),
 	}
 
-	if d.HasChange("enforced") {
-		input.Enforced = d.Get("enforced").(bool)
-	}
+	// Since a boolean value is not 'optional', the input struct
+	// must always contain the expected value of the 'enforced'
+	// setting, whether it was changed or not
+	input.Enforced = d.Get("enforced").(bool)
+
 	if d.HasChange("name") {
 		input.Name = d.Get("name").(string)
 	}


### PR DESCRIPTION
Ensure that 'enforced' property does not revert to default during changes.

If the 'enforced' property was already set to true in the configuration, and the name (or certificate bundle) of an MTLS authentication resource was changed, the 'enforced' property would revert to 'false'.