### PR TITLE
breaking(product_enablement): Remove support for NGWAF product.

### DIFF
--- a/docs/resources/service_vcl.md
+++ b/docs/resources/service_vcl.md
@@ -1139,7 +1139,6 @@ Optional:
 - `domain_inspector` (Boolean) Enable Domain Inspector support
 - `image_optimizer` (Boolean) Enable Image Optimizer support (all backends must have a `shield` attribute)
 - `name` (String) Used by the provider to identify modified settings (changing this value will force the entire block to be deleted, then recreated)
-- `ngwaf` (Boolean) Enable Next-Gen WAF support
 - `origin_inspector` (Boolean) Enable Origin Inspector support
 - `websockets` (Boolean) Enable WebSockets support
 

--- a/fastly/block_fastly_service_product_enablement.go
+++ b/fastly/block_fastly_service_product_enablement.go
@@ -71,11 +71,6 @@ func (h *ProductEnablementServiceAttributeHandler) GetSchema() *schema.Schema {
 			Optional:    true,
 			Description: "Enable Image Optimizer support (all backends must have a `shield` attribute)",
 		}
-		blockAttributes["ngwaf"] = &schema.Schema{
-			Type:        schema.TypeBool,
-			Optional:    true,
-			Description: "Enable Next-Gen WAF support",
-		}
 		blockAttributes["origin_inspector"] = &schema.Schema{
 			Type:        schema.TypeBool,
 			Optional:    true,
@@ -161,17 +156,6 @@ func (h *ProductEnablementServiceAttributeHandler) Create(_ context.Context, d *
 			})
 			if err != nil {
 				return fmt.Errorf("failed to enable image_optimizer: %w", err)
-			}
-		}
-
-		if resource["ngwaf"].(bool) {
-			log.Println("[DEBUG] ngwaf set")
-			_, err := conn.EnableProduct(&gofastly.ProductEnablementInput{
-				ProductID: gofastly.ProductNGWAF,
-				ServiceID: serviceID,
-			})
-			if err != nil {
-				return fmt.Errorf("failed to enable ngwaf: %w", err)
 			}
 		}
 
@@ -265,13 +249,6 @@ func (h *ProductEnablementServiceAttributeHandler) Read(_ context.Context, d *sc
 				ServiceID: d.Id(),
 			}); err == nil {
 				result["image_optimizer"] = true
-			}
-
-			if _, err := conn.GetProduct(&gofastly.ProductEnablementInput{
-				ProductID: gofastly.ProductNGWAF,
-				ServiceID: d.Id(),
-			}); err == nil {
-				result["ngwaf"] = true
 			}
 
 			if _, err := conn.GetProduct(&gofastly.ProductEnablementInput{
@@ -438,30 +415,6 @@ func (h *ProductEnablementServiceAttributeHandler) Update(_ context.Context, d *
 			}
 		}
 
-		if v, ok := modified["ngwaf"]; ok {
-			if v.(bool) {
-				log.Println("[DEBUG] ngwaf will be enabled")
-				_, err := conn.EnableProduct(&gofastly.ProductEnablementInput{
-					ProductID: gofastly.ProductNGWAF,
-					ServiceID: serviceID,
-				})
-				if err != nil {
-					return fmt.Errorf("failed to enable ngwaf: %w", err)
-				}
-			} else {
-				log.Println("[DEBUG] ngwaf will be disabled")
-				err := conn.DisableProduct(&gofastly.ProductEnablementInput{
-					ProductID: gofastly.ProductNGWAF,
-					ServiceID: serviceID,
-				})
-				if err != nil {
-					if e := h.checkAPIError(err); e != nil {
-						return e
-					}
-				}
-			}
-		}
-
 		if v, ok := modified["origin_inspector"]; ok {
 			if v.(bool) {
 				log.Println("[DEBUG] origin_inspector will be enabled")
@@ -596,17 +549,6 @@ func (h *ProductEnablementServiceAttributeHandler) Delete(_ context.Context, d *
 		log.Println("[DEBUG] disable image_optimizer")
 		err = conn.DisableProduct(&gofastly.ProductEnablementInput{
 			ProductID: gofastly.ProductImageOptimizer,
-			ServiceID: d.Id(),
-		})
-		if err != nil {
-			if e := h.checkAPIError(err); e != nil {
-				return e
-			}
-		}
-
-		log.Println("[DEBUG] disable ngwaf")
-		err = conn.DisableProduct(&gofastly.ProductEnablementInput{
-			ProductID: gofastly.ProductNGWAF,
 			ServiceID: d.Id(),
 		})
 		if err != nil {

--- a/fastly/block_fastly_service_product_enablement_test.go
+++ b/fastly/block_fastly_service_product_enablement_test.go
@@ -37,7 +37,6 @@ func TestAccFastlyServiceVCLProductEnablement_basic(t *testing.T) {
       brotli_compression = true
       domain_inspector   = false
       image_optimizer    = false
-      ngwaf              = false
       origin_inspector   = false
       websockets         = false
     }

--- a/tests/interface/main.tf
+++ b/tests/interface/main.tf
@@ -141,7 +141,6 @@ resource "fastly_service_vcl" "interface-test-project" {
     brotli_compression = true
     domain_inspector   = false
     image_optimizer    = false
-    ngwaf              = false
     origin_inspector   = false
     websockets         = false
   }


### PR DESCRIPTION
The support added for the NGWAF product in version 5.14.0 did not work, and is being removed so that it can be redesigned. Since the feature was non-operational, no users of the provider could have relied on it, so the major version number is not being incremented in spite of the breaking nature of the change.