### PR TITLE
feat(product_enablement): Add support for Log Explorer & Insights product.

### DIFF
--- a/docs/resources/service_compute.md
+++ b/docs/resources/service_compute.md
@@ -699,6 +699,7 @@ Optional:
 Optional:
 
 - `fanout` (Boolean) Enable Fanout support
+- `log_explorer_insights` (Boolean) Enable Log Explorer & Insights
 - `name` (String) Used by the provider to identify modified settings (changing this value will force the entire block to be deleted, then recreated)
 - `websockets` (Boolean) Enable WebSockets support
 

--- a/docs/resources/service_vcl.md
+++ b/docs/resources/service_vcl.md
@@ -1158,6 +1158,7 @@ Optional:
 - `brotli_compression` (Boolean) Enable Brotli Compression support
 - `domain_inspector` (Boolean) Enable Domain Inspector support
 - `image_optimizer` (Boolean) Enable Image Optimizer support (all backends must have a `shield` attribute)
+- `log_explorer_insights` (Boolean) Enable Log Explorer & Insights
 - `name` (String) Used by the provider to identify modified settings (changing this value will force the entire block to be deleted, then recreated)
 - `origin_inspector` (Boolean) Enable Origin Inspector support
 - `websockets` (Boolean) Enable WebSockets support

--- a/fastly/block_fastly_service_product_enablement_test.go
+++ b/fastly/block_fastly_service_product_enablement_test.go
@@ -33,12 +33,13 @@ func TestAccFastlyServiceVCLProductEnablement_basic(t *testing.T) {
     }
 
     product_enablement {
-      bot_management     = false
-      brotli_compression = true
-      domain_inspector   = false
-      image_optimizer    = false
-      origin_inspector   = false
-      websockets         = false
+      bot_management        = false
+      brotli_compression    = true
+      domain_inspector      = false
+      image_optimizer       = false
+      log_explorer_insights = false
+      origin_inspector      = false
+      websockets            = false
     }
 
     force_destroy = true


### PR DESCRIPTION
The 'product_enablement' block in both Delivery (VCL) and Compute (WASM) services can now be used to enable/disable the Log Explorer & Insights product.

`make testacc TESTARGS='-v -run=TestAccFastlyServiceVCLProductEnablement_basic'` passes as expected.