### PR TITLE
fix(fastly_package_hash): unnecessary source_code_hash conflict

### DIFF
--- a/fastly/block_fastly_service_package.go
+++ b/fastly/block_fastly_service_package.go
@@ -51,7 +51,6 @@ func (h *PackageServiceAttributeHandler) Register(s *schema.Resource) error {
 					Optional:      true,
 					Computed:      true,
 					Description:   "Used to trigger updates. Must be set to a SHA512 hash of all files (in sorted order) within the package. The usual way to set this is using the fastly_package_hash data source.",
-					ConflictsWith: []string{"package.0.content"},
 				},
 			},
 		},


### PR DESCRIPTION
This removes the configuration that `source_code_hash` conflicts with
`content`. Regardless of how bytes are provided for the package, it
stands to reason it should be possible to also provide the files hash (as
computed by `fastly compute hash-files`) so the provider can correctly
detect drift.

Fixes https://github.com/fastly/terraform-provider-fastly/issues/908
