### PR TITLE
feat(alert): append 'Managed by Terraform' to descriptions

### DIFF
--- a/fastly/resource_fastly_alert.go
+++ b/fastly/resource_fastly_alert.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"log"
+	"strings"
 
 	gofastly "github.com/fastly/go-fastly/v9/fastly"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -11,6 +12,7 @@ import (
 )
 
 const badAlertSourceServiceIdConfig = "empty `service_id` is only supported for `stats` as a source"
+const managedByTerraform = "Managed by Terraform"
 
 func resourceFastlyAlert() *schema.Resource {
 	return &schema.Resource{
@@ -135,9 +137,11 @@ func resourceFastlyAlertCreate(_ context.Context, d *schema.ResourceData, meta a
 		Source:    gofastly.ToPointer(d.Get("source").(string)),
 	}
 
+	description := managedByTerraform
 	if v, ok := d.GetOk("description"); ok {
-		input.Description = gofastly.ToPointer(v.(string))
+		description = v.(string) + " " + managedByTerraform
 	}
+	input.Description = gofastly.ToPointer(description)
 
 	input.Dimensions = map[string][]string{}
 	if v, ok := d.GetOk("dimensions"); ok {
@@ -183,8 +187,9 @@ func resourceFastlyAlertRead(_ context.Context, d *schema.ResourceData, meta any
 		return diag.FromErr(err)
 	}
 
-	if len(ad.Description) > 0 {
-		err = d.Set("description", ad.Description)
+	description := strings.TrimSpace(strings.TrimSuffix(ad.Description, managedByTerraform))
+	if len(description) > 0 {
+		err = d.Set("description", description)
 		if err != nil {
 			return diag.FromErr(err)
 		}
@@ -241,9 +246,11 @@ func resourceFastlyAlertUpdate(ctx context.Context, d *schema.ResourceData, meta
 		Name:   gofastly.ToPointer(d.Get("name").(string)),
 	}
 
+	description := managedByTerraform
 	if v, ok := d.GetOk("description"); ok {
-		input.Description = gofastly.ToPointer(v.(string))
+		description = v.(string) + " " + managedByTerraform
 	}
+	input.Description = gofastly.ToPointer(description)
 
 	input.Dimensions = map[string][]string{}
 	if v, ok := d.GetOk("dimensions"); ok {

--- a/fastly/resource_fastly_alert.go
+++ b/fastly/resource_fastly_alert.go
@@ -12,7 +12,7 @@ import (
 )
 
 const badAlertSourceServiceIdConfig = "empty `service_id` is only supported for `stats` as a source"
-const managedByTerraform = "Managed by Terraform"
+const ManagedByTerraform = "Managed by Terraform"
 
 func resourceFastlyAlert() *schema.Resource {
 	return &schema.Resource{
@@ -137,9 +137,9 @@ func resourceFastlyAlertCreate(_ context.Context, d *schema.ResourceData, meta a
 		Source:    gofastly.ToPointer(d.Get("source").(string)),
 	}
 
-	description := managedByTerraform
+	description := ManagedByTerraform
 	if v, ok := d.GetOk("description"); ok {
-		description = v.(string) + " " + managedByTerraform
+		description = v.(string) + " " + ManagedByTerraform
 	}
 	input.Description = gofastly.ToPointer(description)
 
@@ -187,7 +187,7 @@ func resourceFastlyAlertRead(_ context.Context, d *schema.ResourceData, meta any
 		return diag.FromErr(err)
 	}
 
-	description := strings.TrimSpace(strings.TrimSuffix(ad.Description, managedByTerraform))
+	description := strings.TrimSpace(strings.TrimSuffix(ad.Description, ManagedByTerraform))
 	if len(description) > 0 {
 		err = d.Set("description", description)
 		if err != nil {
@@ -246,9 +246,9 @@ func resourceFastlyAlertUpdate(ctx context.Context, d *schema.ResourceData, meta
 		Name:   gofastly.ToPointer(d.Get("name").(string)),
 	}
 
-	description := managedByTerraform
+	description := ManagedByTerraform
 	if v, ok := d.GetOk("description"); ok {
-		description = v.(string) + " " + managedByTerraform
+		description = v.(string) + " " + ManagedByTerraform
 	}
 	input.Description = gofastly.ToPointer(description)
 

--- a/fastly/resource_fastly_alert_test.go
+++ b/fastly/resource_fastly_alert_test.go
@@ -344,7 +344,7 @@ func testAccCheckFastlyAlertsRemoteState(service *gofastly.ServiceDetail, servic
 		if got == nil {
 			return fmt.Errorf("error looking up the alert")
 		}
-		expectedDescription := strings.TrimSpace(expected.Description + " Managed by Terraform")
+		expectedDescription := strings.TrimSpace(expected.Description + " " + ManagedByTerraform)
 		if expectedDescription != got.Description {
 			return fmt.Errorf("bad description, expected (%s), got (%s)", expectedDescription, got.Description)
 		}

--- a/fastly/resource_fastly_alert_test.go
+++ b/fastly/resource_fastly_alert_test.go
@@ -18,7 +18,6 @@ func TestAccFastlyAlert_Basic(t *testing.T) {
 	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	domainName := fmt.Sprintf("fastly-test.tf-%s.com", acctest.RandString(10))
 	createAlert := gofastly.AlertDefinition{
-		Description: "my description",
 		Dimensions: map[string][]string{
 			"domains": {"example.com", "fastly.com"},
 		},
@@ -345,8 +344,9 @@ func testAccCheckFastlyAlertsRemoteState(service *gofastly.ServiceDetail, servic
 		if got == nil {
 			return fmt.Errorf("error looking up the alert")
 		}
-		if expected.Description != got.Description {
-			return fmt.Errorf("bad description, expected (%s), got (%s)", expected.Description, got.Description)
+		expectedDescription := strings.TrimSpace(expected.Description + " Managed by Terraform")
+		if expectedDescription != got.Description {
+			return fmt.Errorf("bad description, expected (%s), got (%s)", expectedDescription, got.Description)
 		}
 		if diff := cmp.Diff(expected.Dimensions, got.Dimensions); diff != "" {
 			return fmt.Errorf("bad dimensions -expected +got\n%v", diff)


### PR DESCRIPTION
This change will inform users of the Fastly app of alerts that are being managed in Terraform.

The managed by string is appended to the description field because it commonly also holds information such as runbook links and instructions provided in the alert notifications, so applying the defaulting behavior that is used for the `comment` field on a Fastly service isn't adequate in this case.