### PR TITLE
docs(CHANGELOG.md): add missing entry to v5.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ENHANCEMENTS:
 
+- Upgrade to Go 1.22 for building the provider [#917](https://github.com/fastly/terraform-provider-fastly/pull/917)
 - feat(domains): add support for v1 functionality [#917](https://github.com/fastly/terraform-provider-fastly/pull/917)
 - feat(dashboard): add support for Observability custom dashboards [#905](https://github.com/fastly/terraform-provider-fastly/pull/905)
 - feat(alerts): append 'Managed by Terraform' to descriptions [#914](https://github.com/fastly/terraform-provider-fastly/pull/914)


### PR DESCRIPTION
I forgot to list this change in #919. The change should have been in its own PR but it has been made in #917.