### PR TITLE
Pin goreleaser to v2.2.0, the last version compatible with Go 1.22.

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -162,7 +162,7 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v5
         with:
-          version: v2.6.1
+          version: v2.2.0
           install-only: true
       - name: Validate Goreleaser
         run: make goreleaser GORELEASER_ARGS="--skip=validate --clean --snapshot" # snapshot is needed as local git has no tags

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v5
         with:
-          version: v2.6.1
+          version: v2.2.0
           args: release --clean
         env:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 5.17.0 (Unreleased)
 
+DEPENDENCIES:
+
+- build(deps): Pin goreleaser to v2.2.0, the last version compatible with Go 1.22.
+
 ## 5.16.0 (January 31, 2025)
 
 ENHANCEMENTS:

--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ errcheck:
 	@sh -c "'$(CURDIR)/scripts/errcheck.sh'"
 
 goreleaser-bin:
-	$(GO_BIN) install github.com/goreleaser/goreleaser/v2@latest
+	$(GO_BIN) install github.com/goreleaser/goreleaser/v2@v2.2.0
 
 nilaway:
 	@nilaway ./...


### PR DESCRIPTION
 All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/go-fastly/pulls) for the same update/change?