### PR TITLE
Always validate VCL services after applying changes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ ENHANCEMENTS:
 
 BUG FIXES:
 
+- fix(fastly_vcl_service): Always 'validate' services after applying changes.
+
 DEPENDENCIES:
 
 - build(deps): `github.com/hashicorp/terraform-plugin-docs` from 0.19.4 to 0.21.0 ([#937](https://github.com/fastly/terraform-provider-fastly/pull/937))


### PR DESCRIPTION
In PR #733 the validation logic was changed to only attempt validation of services if they would also be activated, in order to avoid failing validation of Compute services which do not have WASM packages attached to them. Unfortunately this breaks customer workflows for VCL services, as they no longer get feedback about validation failures until they attempt to activate the service outside of Terraform.

This patch changes the logic so that VCL services are always validated, even if they will not be activated or staged.

 All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/go-fastly/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

* [ ] Does your submission pass tests?

### Changes to Core Features:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [X] Have you successfully run tests with your changes locally?

### User Impact

* [ ] What is the user impact of this change?

### Are there any considerations that need to be addressed for release?

<!-- Any breaking changes, etc -->
