### PR TITLE
fix(fastly/block_fastly_service_dictionary): adds error check preventing deletion of write only dictionaries without force destroy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### BUG FIXES:
 
+- fix(fastly/block_fastly_service_dictionary): adds error check preventing deletion of write only dictionaries without force destroy [#959](https://github.com/fastly/terraform-provider-fastly/pull/959)
+
 ### DEPENDENCIES:
 
 ## 6.0.0 (March 20, 2025)

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,7 +25,7 @@ terraform {
   required_providers {
     fastly = {
       source  = "fastly/fastly"
-      version = ">= 5.17.0"
+      version = ">= 6.0.0"
     }
   }
 }

--- a/fastly/block_fastly_service_dictionary.go
+++ b/fastly/block_fastly_service_dictionary.go
@@ -125,6 +125,10 @@ func (h *DictionaryServiceAttributeHandler) Update(_ context.Context, _ *schema.
 // Delete deletes the resource.
 func (h *DictionaryServiceAttributeHandler) Delete(_ context.Context, d *schema.ResourceData, resource map[string]any, serviceVersion int, conn *gofastly.Client) error {
 	if !resource["force_destroy"].(bool) {
+		if resource["write_only"].(bool) {
+			return fmt.Errorf("cannot delete dictionary (%s), it is write_only, so it may contain data. Set force_destroy to true and apply it before making this change", resource["dictionary_id"].(string))
+		}
+
 		mayDelete, err := isDictionaryEmpty(d.Id(), resource["dictionary_id"].(string), conn)
 		if err != nil {
 			return err

--- a/fastly/block_fastly_service_dictionary_test.go
+++ b/fastly/block_fastly_service_dictionary_test.go
@@ -122,7 +122,11 @@ func TestAccFastlyServiceVCL_dictionary_write_only(t *testing.T) {
 		CheckDestroy:      testAccCheckServiceVCLDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccServiceVCLConfigDictionaryWriteOnly(name, dictName, backendName, domainName),
+				Config:      testAccServiceVCLConfigDictionaryWriteOnly(name, dictName, backendName, domainName),
+				ExpectError: regexp.MustCompile("cannot delete.*write_only.*"),
+			},
+			{
+				Config: testAccServiceVCLConfigDictionaryWriteOnlyForceDestroy(name, dictName, backendName, domainName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceExists("fastly_service_vcl.foo", &service),
 					testAccCheckFastlyServiceVCLAttributesDictionary(&service, &dictionary, name, dictName, true),
@@ -247,6 +251,31 @@ resource "fastly_service_vcl" "foo" {
   dictionary {
     name       = "%s"
     write_only = true
+  }
+
+  force_destroy = true
+}`, name, domainName, backendName, dictName)
+}
+
+func testAccServiceVCLConfigDictionaryWriteOnlyForceDestroy(name, dictName, backendName, domainName string) string {
+	return fmt.Sprintf(`
+resource "fastly_service_vcl" "foo" {
+  name = "%s"
+
+  domain {
+    name    = "%s"
+    comment = "tf-testing-domain"
+  }
+
+  backend {
+    address = "%s"
+    name    = "tf -test backend"
+  }
+
+  dictionary {
+    name       		= "%s"
+    write_only 		= true
+	force_destroy 	= true
   }
 
   force_destroy = true


### PR DESCRIPTION
 All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/go-fastly/pulls) for the same update/change?

### New Feature Submissions:

* [x] Does your submission pass tests?

Originally pointed out [here](https://github.com/fastly/terraform-provider-fastly/pull/918)