### PR TITLE
Fix breaking changes introduced by go-fastly v10.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,15 @@
 
 ### ENHANCEMENTS:
 
-- feat(logging): Restore support for 'placement' attribute
+- feat(logging): restore support for `placement` attribute ([#965](https://github.com/fastly/terraform-provider-fastly/pull/965))
 
 ### BUG FIXES:
 
+- fix(snippet): breaking changes introduced by `go-fastly` v10.0.1 ([#981](https://github.com/fastly/terraform-provider-fastly/pull/981))
+- fix(dynamicsnippet): breaking changes introduced by `go-fastly` v10.0.1 ([#981](https://github.com/fastly/terraform-provider-fastly/pull/981))
+
 ### DEPENDENCIES:
+
 - build(deps): `golang.org/x/net` from 0.37.0 to 0.38.0 ([#966](https://github.com/fastly/terraform-provider-fastly/pull/966))
 - build(deps): `go-fastly` from 9.14.0 to 10.0.0 ([#970](https://github.com/fastly/terraform-provider-fastly/pull/970))
 - build(deps): `golang.org/x/net` from 0.38.0 to 0.39.0 ([#974](https://github.com/fastly/terraform-provider-fastly/pull/974))

--- a/fastly/block_fastly_service_dynamicsnippet.go
+++ b/fastly/block_fastly_service_dynamicsnippet.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"strconv"
 	"strings"
 
 	gofastly "github.com/fastly/go-fastly/v10/fastly"
@@ -122,7 +123,7 @@ func (h *DynamicSnippetServiceAttributeHandler) Update(_ context.Context, d *sch
 	// NOTE: When converting from an interface{} we lose the underlying type.
 	// Converting to the wrong type will result in a runtime panic.
 	if v, ok := modified["priority"]; ok {
-		opts.Priority = gofastly.ToPointer(v.(string))
+		opts.Priority = gofastly.ToPointer(strconv.Itoa(v.(int)))
 	}
 	if v, ok := modified["content"]; ok {
 		opts.Content = gofastly.ToPointer(v.(string))
@@ -165,7 +166,7 @@ func buildDynamicSnippet(dynamicSnippetMap any) (*gofastly.CreateSnippetInput, e
 		Content:  gofastly.ToPointer(resource["content"].(string)),
 		Dynamic:  gofastly.ToPointer(1),
 		Name:     gofastly.ToPointer(resource["name"].(string)),
-		Priority: gofastly.ToPointer(resource["priority"].(string)),
+		Priority: gofastly.ToPointer(strconv.Itoa(resource["priority"].(int))),
 	}
 
 	snippetType := strings.ToLower(resource["type"].(string))
@@ -195,7 +196,8 @@ func flattenDynamicSnippets(remoteState []*gofastly.Snippet) []map[string]any {
 			data["type"] = *resource.Type
 		}
 		if resource.Priority != nil {
-			data["priority"] = *resource.Priority
+			p, _ := strconv.Atoi(*resource.Priority)
+			data["priority"] = p
 		}
 
 		// prune any empty values that come from the default string value in structs

--- a/fastly/block_fastly_service_dynamicsnippet_test.go
+++ b/fastly/block_fastly_service_dynamicsnippet_test.go
@@ -30,7 +30,7 @@ func TestResourceFastlyFlattenDynamicSnippets(t *testing.T) {
 				{
 					"name":     "recv_test_01",
 					"type":     gofastly.SnippetTypeRecv,
-					"priority": "110",
+					"priority": 110,
 				},
 			},
 		},

--- a/fastly/block_fastly_service_snippet.go
+++ b/fastly/block_fastly_service_snippet.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"strconv"
 	"strings"
 
 	gofastly "github.com/fastly/go-fastly/v10/fastly"
@@ -110,7 +111,7 @@ func (h *SnippetServiceAttributeHandler) Read(_ context.Context, d *schema.Resou
 func (h *SnippetServiceAttributeHandler) Update(_ context.Context, d *schema.ResourceData, resource, modified map[string]any, serviceVersion int, conn *gofastly.Client) error {
 	// Safety check in case keys aren't actually set in the HCL.
 	name, _ := resource["name"].(string)
-	priority, _ := resource["priority"].(string)
+	priority := strconv.Itoa(resource["priority"].(int))
 	content, _ := resource["content"].(string)
 	stype, _ := resource["type"].(string)
 
@@ -127,7 +128,7 @@ func (h *SnippetServiceAttributeHandler) Update(_ context.Context, d *schema.Res
 	// NOTE: When converting from an interface{} we lose the underlying type.
 	// Converting to the wrong type will result in a runtime panic.
 	if v, ok := modified["priority"]; ok {
-		opts.Priority = gofastly.ToPointer(v.(string))
+		opts.Priority = gofastly.ToPointer(strconv.Itoa(v.(int)))
 	}
 	if v, ok := modified["content"]; ok {
 		opts.Content = gofastly.ToPointer(v.(string))
@@ -170,7 +171,7 @@ func buildSnippet(snippetMap any) (*gofastly.CreateSnippetInput, error) {
 	opts := gofastly.CreateSnippetInput{
 		Name:     gofastly.ToPointer(resource["name"].(string)),
 		Content:  gofastly.ToPointer(resource["content"].(string)),
-		Priority: gofastly.ToPointer(resource["priority"].(string)),
+		Priority: gofastly.ToPointer(strconv.Itoa(resource["priority"].(int))),
 		Dynamic:  gofastly.ToPointer(0),
 	}
 
@@ -198,7 +199,8 @@ func flattenSnippets(remoteState []*gofastly.Snippet) []map[string]any {
 			data["type"] = *resource.Type
 		}
 		if resource.Priority != nil {
-			data["priority"] = *resource.Priority
+			p, _ := strconv.Atoi(*resource.Priority)
+			data["priority"] = p
 		}
 		if resource.Content != nil {
 			data["content"] = *resource.Content

--- a/fastly/block_fastly_service_snippet_test.go
+++ b/fastly/block_fastly_service_snippet_test.go
@@ -30,7 +30,7 @@ func TestResourceFastlyFlattenSnippets(t *testing.T) {
 				{
 					"name":     "recv_test",
 					"type":     gofastly.SnippetTypeRecv,
-					"priority": "110",
+					"priority": 110,
 					"content":  "if ( req.url ) {\n set req.http.my-snippet-test-header = \"true\";\n}",
 				},
 			},


### PR DESCRIPTION
 All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/go-fastly/pulls) for the same update/change?

Test results for modified resources:

```
philipp@philipp-XPS-15-9500:~/src/fastly/terraform-provider-fastly$ make testacc TESTARGS='-v -run=TestResourceFastlyFlattenSnippets'
staticcheck -f json ./... | jq
/home/philipp/src/fastly/terraform-provider-fastly/bin/tfproviderlintx -R001=false -R018=false -R019=false -XAT001=false  ./...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go  test $(go  list ./...) -v -v -run=TestResourceFastlyFlattenSnippets -parallel=4 -timeout 360m -ldflags="-X=github.com/fastly/terraform-provider-fastly/version.ProviderVersion=acc"
?   	github.com/fastly/terraform-provider-fastly	[no test files]
?   	github.com/fastly/terraform-provider-fastly/fastly/hashcode	[no test files]
?   	github.com/fastly/terraform-provider-fastly/version	[no test files]
=== RUN   TestResourceFastlyFlattenSnippets
--- PASS: TestResourceFastlyFlattenSnippets (0.00s)
PASS
ok  	github.com/fastly/terraform-provider-fastly/fastly	0.007s
```

```
/home/philipp/src/fastly/terraform-provider-fastly/bin/tfproviderlintx -R001=false -R018=false -R019=false -XAT001=false  ./...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go  test $(go  list ./...) -v -v -run=TestAccFastlyServiceVCLSnippet_basic -parallel=4 -timeout 360m -ldflags="-X=github.com/fastly/terraform-provider-fastly/version.ProviderVersion=acc"
?   	github.com/fastly/terraform-provider-fastly	[no test files]
?   	github.com/fastly/terraform-provider-fastly/fastly/hashcode	[no test files]
?   	github.com/fastly/terraform-provider-fastly/version	[no test files]
=== RUN   TestAccFastlyServiceVCLSnippet_basic
=== PAUSE TestAccFastlyServiceVCLSnippet_basic
=== CONT  TestAccFastlyServiceVCLSnippet_basic
    testing_new.go:85: Error running post-test destroy, there may be dangling resources: tried deleting Service (sWa5rTEiYWOnnLXLJ1IU20), but was still found
--- FAIL: TestAccFastlyServiceVCLSnippet_basic (24.84s)
FAIL
FAIL	github.com/fastly/terraform-provider-fastly/fastly	24.849s
FAIL
```
 
 The above test fail is known and only releated to cleanup! I already pointed this issue with the test suite out and will fix this shortly.
 
 ```
 philipp@philipp-XPS-15-9500:~/src/fastly/terraform-provider-fastly$ make testacc TESTARGS='-v -run=TestResourceFastlyFlattenDynamicSnippets'
staticcheck -f json ./... | jq
/home/philipp/src/fastly/terraform-provider-fastly/bin/tfproviderlintx -R001=false -R018=false -R019=false -XAT001=false  ./...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go  test $(go  list ./...) -v -v -run=TestResourceFastlyFlattenDynamicSnippets -parallel=4 -timeout 360m -ldflags="-X=github.com/fastly/terraform-provider-fastly/version.ProviderVersion=acc"
?   	github.com/fastly/terraform-provider-fastly	[no test files]
?   	github.com/fastly/terraform-provider-fastly/fastly/hashcode	[no test files]
?   	github.com/fastly/terraform-provider-fastly/version	[no test files]
=== RUN   TestResourceFastlyFlattenDynamicSnippets
--- PASS: TestResourceFastlyFlattenDynamicSnippets (0.00s)
PASS
ok  	github.com/fastly/terraform-provider-fastly/fastly	0.006s
```

```
philipp@philipp-XPS-15-9500:~/src/fastly/terraform-provider-fastly$ make testacc TESTARGS='-v -run=TestAccFastlyServiceVCLDynamicSnippet_basic'
staticcheck -f json ./... | jq
/home/philipp/src/fastly/terraform-provider-fastly/bin/tfproviderlintx -R001=false -R018=false -R019=false -XAT001=false  ./...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go  test $(go  list ./...) -v -v -run=TestAccFastlyServiceVCLDynamicSnippet_basic -parallel=4 -timeout 360m -ldflags="-X=github.com/fastly/terraform-provider-fastly/version.ProviderVersion=acc"
?   	github.com/fastly/terraform-provider-fastly	[no test files]
?   	github.com/fastly/terraform-provider-fastly/fastly/hashcode	[no test files]
?   	github.com/fastly/terraform-provider-fastly/version	[no test files]
=== RUN   TestAccFastlyServiceVCLDynamicSnippet_basic
=== PAUSE TestAccFastlyServiceVCLDynamicSnippet_basic
=== CONT  TestAccFastlyServiceVCLDynamicSnippet_basic
--- PASS: TestAccFastlyServiceVCLDynamicSnippet_basic (22.95s)
PASS
ok  	github.com/fastly/terraform-provider-fastly/fastly	22.956s
```