### PR TITLE
Fix breaking changes snippet data resource introduced by go-fastly v10.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,9 @@
 
 ### BUG FIXES:
 
-- fix(snippet): breaking changes introduced by `go-fastly` v10.0.1 ([#981](https://github.com/fastly/terraform-provider-fastly/pull/981))
-- fix(dynamicsnippet): breaking changes introduced by `go-fastly` v10.0.1 ([#981](https://github.com/fastly/terraform-provider-fastly/pull/981))
+- fix(block_fastly_service_snippet_test.go): breaking changes introduced by `go-fastly` v10.0.1 ([#981](https://github.com/fastly/terraform-provider-fastly/pull/981))
+- fix(block_fastly_service_dynamicsnippet.go): breaking changes introduced by `go-fastly` v10.0.1 ([#981](https://github.com/fastly/terraform-provider-fastly/pull/981))
+- fix(data_source_vcl_snippets.go): breaking changes introduced by `go-fastly` v10.0.1 ([#982](https://github.com/fastly/terraform-provider-fastly/pull/982))
 
 ### DEPENDENCIES:
 

--- a/fastly/data_source_vcl_snippets.go
+++ b/fastly/data_source_vcl_snippets.go
@@ -110,7 +110,8 @@ func flattenDataSourceVCLSnippets(remoteState []*gofastly.Snippet) []map[string]
 			result[i]["name"] = *resource.Name
 		}
 		if resource.Priority != nil {
-			result[i]["priority"] = *resource.Priority
+			p, _ := strconv.Atoi(*resource.Priority)
+			result[i]["priority"] = p
 		}
 		if resource.Type != nil {
 			result[i]["type"] = *resource.Type


### PR DESCRIPTION
 All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/go-fastly/pulls) for the same update/change?

Test result of modified resource:

```
philipp@philipp-XPS-15-9500:~/src/fastly/terraform-provider-fastly$ make testacc TESTARGS='-v -run=TestAccFastlyDataSourceVCLSnippets_Config'
staticcheck -f json ./... | jq
/home/philipp/src/fastly/terraform-provider-fastly/bin/tfproviderlintx -R001=false -R018=false -R019=false -XAT001=false  ./...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go  test $(go  list ./...) -v -v -run=TestAccFastlyDataSourceVCLSnippets_Config -parallel=4 -timeout 360m -ldflags="-X=github.com/fastly/terraform-provider-fastly/version.ProviderVersion=acc"
?   	github.com/fastly/terraform-provider-fastly	[no test files]
?   	github.com/fastly/terraform-provider-fastly/fastly/hashcode	[no test files]
?   	github.com/fastly/terraform-provider-fastly/version	[no test files]
=== RUN   TestAccFastlyDataSourceVCLSnippets_Config
=== PAUSE TestAccFastlyDataSourceVCLSnippets_Config
=== CONT  TestAccFastlyDataSourceVCLSnippets_Config
--- PASS: TestAccFastlyDataSourceVCLSnippets_Config (10.95s)
PASS
ok  	github.com/fastly/terraform-provider-fastly/fastly	10.954s
```