### PR TITLE
remove deprecated `geo_headers` field from fastly service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### BREAKING:
 
+- feat(fastly): remove deprecated `geo_headers` field from fastly service ([#992](https://github.com/fastly/terraform-provider-fastly/pull/992))
+
 ### ENHANCEMENTS:
 
 - feat(config): add an environment variable allowing users to override the sensitive attribute ([#985](https://github.com/fastly/terraform-provider-fastly/pull/985))

--- a/docs/resources/service_vcl.md
+++ b/docs/resources/service_vcl.md
@@ -1211,7 +1211,6 @@ Optional:
 - `default_host` (String) Sets the host header
 - `force_miss` (Boolean) Force a cache miss for the request. If specified, can be `true` or `false`
 - `force_ssl` (Boolean) Forces the request to use SSL (Redirects a non-SSL request to SSL)
-- `geo_headers` (Boolean, Deprecated) Injects Fastly-Geo-Country, Fastly-Geo-City, and Fastly-Geo-Region into the request headers
 - `hash_keys` (String) Comma separated list of varnish request object fields that should be in the hash key
 - `max_stale_age` (Number) How old an object is allowed to be to serve `stale-if-error` or `stale-while-revalidate`, in seconds
 - `request_condition` (String) Name of already defined `condition` to determine if this request setting should be applied (should be unique across multiple instances of `request_setting`)

--- a/fastly/block_fastly_service_requestsetting.go
+++ b/fastly/block_fastly_service_requestsetting.go
@@ -62,14 +62,6 @@ func (h *RequestSettingServiceAttributeHandler) GetSchema() *schema.Schema {
 					Optional:    true,
 					Description: "Forces the request to use SSL (Redirects a non-SSL request to SSL)",
 				},
-				// TODO: Although Fastly API has been exposing this parameter over years
-				// it turned out that setting this parameter does nothing. We should remove this attribute in v3.0.0
-				"geo_headers": {
-					Type:        schema.TypeBool,
-					Optional:    true,
-					Deprecated:  "'geo_headers' attribute has been deprecated and will be removed in the next major version release",
-					Description: "Injects Fastly-Geo-Country, Fastly-Geo-City, and Fastly-Geo-Region into the request headers",
-				},
 				"hash_keys": {
 					Type:        schema.TypeString,
 					Optional:    true,
@@ -199,9 +191,6 @@ func (h *RequestSettingServiceAttributeHandler) Update(_ context.Context, d *sch
 	if v, ok := modified["timer_support"]; ok {
 		opts.TimerSupport = gofastly.ToPointer(gofastly.Compatibool(v.(bool)))
 	}
-	if v, ok := modified["geo_headers"]; ok {
-		opts.GeoHeaders = gofastly.ToPointer(gofastly.Compatibool(v.(bool)))
-	}
 	if v, ok := modified["default_host"]; ok {
 		opts.DefaultHost = gofastly.ToPointer(v.(string))
 	}
@@ -270,9 +259,6 @@ func flattenRequestSettings(remoteState []*gofastly.RequestSetting) []map[string
 		if resource.TimerSupport != nil {
 			data["timer_support"] = *resource.TimerSupport
 		}
-		if resource.GeoHeaders != nil {
-			data["geo_headers"] = *resource.GeoHeaders
-		}
 		if resource.DefaultHost != nil {
 			data["default_host"] = *resource.DefaultHost
 		}
@@ -300,7 +286,6 @@ func buildRequestSetting(requestSettingMap any) (*gofastly.CreateRequestSettingI
 		DefaultHost:    gofastly.ToPointer(resource["default_host"].(string)),
 		ForceMiss:      gofastly.ToPointer(gofastly.Compatibool(resource["force_miss"].(bool))),
 		ForceSSL:       gofastly.ToPointer(gofastly.Compatibool(resource["force_ssl"].(bool))),
-		GeoHeaders:     gofastly.ToPointer(gofastly.Compatibool(resource["geo_headers"].(bool))),
 		HashKeys:       gofastly.ToPointer(resource["hash_keys"].(string)),
 		MaxStaleAge:    gofastly.ToPointer(resource["max_stale_age"].(int)),
 		Name:           gofastly.ToPointer(resource["name"].(string)),

--- a/fastly/block_fastly_service_requestsetting_test.go
+++ b/fastly/block_fastly_service_requestsetting_test.go
@@ -34,7 +34,6 @@ func TestResourceFastlyFlattenRequestSettings(t *testing.T) {
 					"default_host": "http-me.glitch.me",
 					// "force_miss":        false,
 					// "force_ssl":         false,
-					// "geo_headers":       false,
 					"max_stale_age":     90,
 					"name":              "alt_backend",
 					"request_condition": "serve_alt_backend",

--- a/tests/interface/main.tf
+++ b/tests/interface/main.tf
@@ -164,7 +164,6 @@ resource "fastly_service_vcl" "interface-test-project" {
     default_host      = "interface-test-project.fastly-terraform.com"
     force_miss        = true
     force_ssl         = false
-    geo_headers       = false                         # DEPRECATED
     hash_keys         = "req.url.path, req.http.host" # Omitted because of error... Syntax error: Expected string variable or constant
     max_stale_age     = "300"
     name              = "test_request_setting"


### PR DESCRIPTION
BREAKING CHANGE: remove deprecated `geo_headers` field from fastly service

 All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/go-fastly/pulls) for the same update/change?
