### PR TITLE
fix(backend): Set default 'prefer IPv6' attribute differently for Delivery and Compute services.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### BUG FIXES:
 - fix(block_fastly_service_settings): fix detection of falsey value for stale_if_error field ([#1003](https://github.com/fastly/terraform-provider-fastly/pull/1009))
+- fix(backend): Set default 'prefer IPv6' attribute differently for Delivery and Compute services. ([#10](https://github.com/fastly/terraform-provider-fastly/pull/10))
 
 ### DEPENDENCIES:
 - build(deps): `github.com/fastly/go-fastly/v10` from 10.2.0 to 10.3.0 ([#1004](https://github.com/fastly/terraform-provider-fastly/pull/1004))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ### BUG FIXES:
 - fix(block_fastly_service_settings): fix detection of falsey value for stale_if_error field ([#1003](https://github.com/fastly/terraform-provider-fastly/pull/1009))
-- fix(backend): Set default 'prefer IPv6' attribute differently for Delivery and Compute services. ([#10](https://github.com/fastly/terraform-provider-fastly/pull/10))
+- fix(backend): Set default 'prefer IPv6' attribute differently for Delivery and Compute services. ([#1010](https://github.com/fastly/terraform-provider-fastly/pull/1010))
 
 ### DEPENDENCIES:
 - build(deps): `github.com/fastly/go-fastly/v10` from 10.2.0 to 10.3.0 ([#1004](https://github.com/fastly/terraform-provider-fastly/pull/1004))

--- a/docs/resources/service_compute.md
+++ b/docs/resources/service_compute.md
@@ -185,7 +185,7 @@ Optional:
 - `min_tls_version` (String) Minimum allowed TLS version on SSL connections to this backend.
 - `override_host` (String) The hostname to override the Host header
 - `port` (Number) The port number on which the Backend responds. Default `80`
-- `prefer_ipv6` (Boolean) Prefer IPv6 connections to origins for hostname backends. Default `false`
+- `prefer_ipv6` (Boolean) Prefer IPv6 connections to origins for hostname backends. Default `true`
 - `share_key` (String) Value that when shared across backends will enable those backends to share the same health check.
 - `shield` (String) The POP of the shield designated to reduce inbound load. Valid values for `shield` are included in the `GET /datacenters` API response
 - `ssl_ca_cert` (String) CA certificate attached to origin.

--- a/fastly/block_fastly_service_backend.go
+++ b/fastly/block_fastly_service_backend.go
@@ -194,14 +194,14 @@ func (h *BackendServiceAttributeHandler) GetSchema() *schema.Schema {
 			Default:     "",
 			Description: "Name of a condition, which if met, will select this backend during a request.",
 		}
-		blockAttributes["prefer_ipv6"]  = &schema.Schema {
+		blockAttributes["prefer_ipv6"] = &schema.Schema{
 			Type:        schema.TypeBool,
 			Optional:    true,
 			Default:     false,
 			Description: "Prefer IPv6 connections to origins for hostname backends. Default `false`",
 		}
 	} else {
-		blockAttributes["prefer_ipv6"]  = &schema.Schema {
+		blockAttributes["prefer_ipv6"] = &schema.Schema{
 			Type:        schema.TypeBool,
 			Optional:    true,
 			Default:     true,

--- a/fastly/block_fastly_service_backend.go
+++ b/fastly/block_fastly_service_backend.go
@@ -108,12 +108,6 @@ func (h *BackendServiceAttributeHandler) GetSchema() *schema.Schema {
 			Default:     80,
 			Description: "The port number on which the Backend responds. Default `80`",
 		},
-		"prefer_ipv6": {
-			Type:        schema.TypeBool,
-			Optional:    true,
-			Default:     false,
-			Description: "Prefer IPv6 connections to origins for hostname backends. Default `false`",
-		},
 		"share_key": {
 			Type:        schema.TypeString,
 			Optional:    true,
@@ -199,6 +193,19 @@ func (h *BackendServiceAttributeHandler) GetSchema() *schema.Schema {
 			Optional:    true,
 			Default:     "",
 			Description: "Name of a condition, which if met, will select this backend during a request.",
+		}
+		blockAttributes["prefer_ipv6"]  = &schema.Schema {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Default:     false,
+			Description: "Prefer IPv6 connections to origins for hostname backends. Default `false`",
+		}
+	} else {
+		blockAttributes["prefer_ipv6"]  = &schema.Schema {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Default:     true,
+			Description: "Prefer IPv6 connections to origins for hostname backends. Default `true`",
 		}
 	}
 


### PR DESCRIPTION
The default for this attribute is 'false' for Delivery and 'true' for Compute.

 All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/go-fastly/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

* [ ] Does your submission pass tests? 
* [ ] Post the output of your test runs

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

### User Impact

* [ ] What is the user impact of this change?

### Are there any considerations that need to be addressed for release?

<!-- Any breaking changes, etc -->
