### PR TITLE
[CDTOOL-1071] feat(logging): Add support for 'processing region' attribute.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - feat(domains/v1): add `description` field ([#1002](https://github.com/fastly/terraform-provider-fastly/pull/1002))
 - feat(backend): Add support for 'prefer IPv6' attribute. ([#1003](https://github.com/fastly/terraform-provider-fastly/pull/1003))
+- feat(logging): Add support for 'processing region' attribute. ([#10](https://github.com/fastly/terraform-provider-fastly/pull/10))
 
 ### BUG FIXES:
 - fix(block_fastly_service_settings): fix detection of falsey value for stale_if_error field ([#1003](https://github.com/fastly/terraform-provider-fastly/pull/1009))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - feat(domains/v1): add `description` field ([#1002](https://github.com/fastly/terraform-provider-fastly/pull/1002))
 - feat(backend): Add support for 'prefer IPv6' attribute. ([#1003](https://github.com/fastly/terraform-provider-fastly/pull/1003))
-- feat(logging): Add support for 'processing region' attribute. ([#10](https://github.com/fastly/terraform-provider-fastly/pull/10))
+- feat(logging): Add support for 'processing region' attribute. ([#1011](https://github.com/fastly/terraform-provider-fastly/pull/1011))
 
 ### BUG FIXES:
 - fix(block_fastly_service_settings): fix detection of falsey value for stale_if_error field ([#1003](https://github.com/fastly/terraform-provider-fastly/pull/1009))

--- a/docs/resources/service_compute.md
+++ b/docs/resources/service_compute.md
@@ -253,6 +253,7 @@ Optional:
 
 - `account_name` (String) The google account name used to obtain temporary credentials (default none). You may optionally provide this via an environment variable, `FASTLY_GCS_ACCOUNT_NAME`.
 - `email` (String, Sensitive) The email for the service account with write access to your BigQuery dataset. If not provided, this will be pulled from a `FASTLY_BQ_EMAIL` environment variable
+- `processing_region` (String) Region where logs will be processed before streaming to BigQuery. Valid values are 'none', 'us' and 'eu'.
 - `secret_key` (String, Sensitive) The secret key associated with the service account that has write access to your BigQuery table. If not provided, this will be pulled from the `FASTLY_BQ_SECRET_KEY` environment variable. Typical format for this is a private key in a string with newlines
 - `template` (String) BigQuery table name suffix template
 
@@ -274,6 +275,7 @@ Optional:
 - `message_type` (String) How the message should be formatted. Can be either `classic`, `loggly`, `logplex` or `blank`. Default is `classic`
 - `path` (String) The path to upload logs to. Must end with a trailing slash. If this field is left empty, the files will be saved in the container's root path
 - `period` (Number) How frequently the logs should be transferred in seconds. Default `3600`
+- `processing_region` (String) Region where logs will be processed before streaming to BigQuery. Valid values are 'none', 'us' and 'eu'.
 - `public_key` (String) A PGP public key that Fastly will use to encrypt your log files before writing them to disk
 - `sas_token` (String, Sensitive) The Azure shared access signature providing write access to the blob service objects. Be sure to update your token before it expires or the logging functionality will not work
 - `timestamp_format` (String) The `strftime` specified timestamp formatting (default `%Y-%m-%dT%H:%M:%S.000`)
@@ -296,6 +298,7 @@ Optional:
 - `message_type` (String) How the message should be formatted. Can be either `classic`, `loggly`, `logplex` or `blank`. Default is `classic`
 - `path` (String) The path to upload logs to
 - `period` (Number) How frequently log files are finalized so they can be available for reading (in seconds, default `3600`)
+- `processing_region` (String) Region where logs will be processed before streaming to BigQuery. Valid values are 'none', 'us' and 'eu'.
 - `public_key` (String) The PGP public key that Fastly will use to encrypt your log files before writing them to disk
 - `region` (String) The region to stream logs to. One of: DFW (Dallas), ORD (Chicago), IAD (Northern Virginia), LON (London), SYD (Sydney), HKG (Hong Kong)
 - `timestamp_format` (String) The `strftime` specified timestamp formatting (default `%Y-%m-%dT%H:%M:%S.000`)
@@ -311,6 +314,7 @@ Required:
 
 Optional:
 
+- `processing_region` (String) Region where logs will be processed before streaming to BigQuery. Valid values are 'none', 'us' and 'eu'.
 - `region` (String) The region that log data will be sent to. One of `US` or `EU`. Defaults to `US` if undefined
 
 
@@ -332,6 +336,7 @@ Optional:
 - `message_type` (String) How the message should be formatted. Can be either `classic`, `loggly`, `logplex` or `blank`. Default is `classic`
 - `path` (String) The path to upload logs to
 - `period` (Number) How frequently log files are finalized so they can be available for reading (in seconds, default `3600`)
+- `processing_region` (String) Region where logs will be processed before streaming to BigQuery. Valid values are 'none', 'us' and 'eu'.
 - `public_key` (String) A PGP public key that Fastly will use to encrypt your log files before writing them to disk
 - `timestamp_format` (String) The `strftime` specified timestamp formatting (default `%Y-%m-%dT%H:%M:%S.000`)
 
@@ -349,6 +354,7 @@ Optional:
 
 - `password` (String, Sensitive) BasicAuth password for Elasticsearch
 - `pipeline` (String) The ID of the Elasticsearch ingest pipeline to apply pre-process transformations to before indexing
+- `processing_region` (String) Region where logs will be processed before streaming to BigQuery. Valid values are 'none', 'us' and 'eu'.
 - `request_max_bytes` (Number) The maximum number of logs sent in one request. Defaults to `0` for unbounded
 - `request_max_entries` (Number) The maximum number of bytes sent in one request. Defaults to `0` for unbounded
 - `tls_ca_cert` (String) A secure certificate to authenticate the server with. Must be in PEM format
@@ -376,6 +382,7 @@ Optional:
 - `message_type` (String) How the message should be formatted. Can be either `classic`, `loggly`, `logplex` or `blank`. Default is `classic`
 - `period` (Number) How frequently the logs should be transferred, in seconds (Default `3600`)
 - `port` (Number) The port number. Default: `21`
+- `processing_region` (String) Region where logs will be processed before streaming to BigQuery. Valid values are 'none', 'us' and 'eu'.
 - `public_key` (String) The PGP public key that Fastly will use to encrypt your log files before writing them to disk
 - `timestamp_format` (String) The `strftime` specified timestamp formatting (default `%Y-%m-%dT%H:%M:%S.000`)
 
@@ -396,6 +403,7 @@ Optional:
 - `message_type` (String) How the message should be formatted. Can be either `classic`, `loggly`, `logplex` or `blank`. Default is `classic`
 - `path` (String) Path to store the files. Must end with a trailing slash. If this field is left empty, the files will be saved in the bucket's root path
 - `period` (Number) How frequently the logs should be transferred, in seconds (Default 3600)
+- `processing_region` (String) Region where logs will be processed before streaming to BigQuery. Valid values are 'none', 'us' and 'eu'.
 - `project_id` (String) The ID of your Google Cloud Platform project
 - `secret_key` (String, Sensitive) The secret key associated with the target gcs bucket on your account. You may optionally provide this secret via an environment variable, `FASTLY_GCS_SECRET_KEY`. A typical format for the key is PEM format, containing actual newline characters where required
 - `timestamp_format` (String) The `strftime` specified timestamp formatting (default `%Y-%m-%dT%H:%M:%S.000`)
@@ -414,6 +422,7 @@ Required:
 Optional:
 
 - `account_name` (String) The google account name used to obtain temporary credentials (default none). You may optionally provide this via an environment variable, `FASTLY_GCS_ACCOUNT_NAME`.
+- `processing_region` (String) Region where logs will be processed before streaming to BigQuery. Valid values are 'none', 'us' and 'eu'.
 - `secret_key` (String, Sensitive) Your Google Cloud Platform account secret key. The `private_key` field in your service account authentication JSON. You may optionally provide this secret via an environment variable, `FASTLY_GOOGLE_PUBSUB_SECRET_KEY`.
 - `user` (String) Your Google Cloud Platform service account email address. The `client_email` field in your service account authentication JSON. You may optionally provide this via an environment variable, `FASTLY_GOOGLE_PUBSUB_EMAIL`.
 
@@ -429,6 +438,10 @@ Required:
 - `url` (String) The URL to stream logs to
 - `user` (String) The Grafana User ID
 
+Optional:
+
+- `processing_region` (String) Region where logs will be processed before streaming to BigQuery. Valid values are 'none', 'us' and 'eu'.
+
 
 <a id="nestedblock--logging_heroku"></a>
 ### Nested Schema for `logging_heroku`
@@ -439,6 +452,10 @@ Required:
 - `token` (String, Sensitive) The token to use for authentication (https://www.heroku.com/docs/customer-token-authentication-token/)
 - `url` (String) The URL to stream logs to
 
+Optional:
+
+- `processing_region` (String) Region where logs will be processed before streaming to BigQuery. Valid values are 'none', 'us' and 'eu'.
+
 
 <a id="nestedblock--logging_honeycomb"></a>
 ### Nested Schema for `logging_honeycomb`
@@ -448,6 +465,10 @@ Required:
 - `dataset` (String) The Honeycomb Dataset you want to log to
 - `name` (String) The unique name of the Honeycomb logging endpoint. It is important to note that changing this attribute will delete and recreate the resource
 - `token` (String, Sensitive) The Write Key from the Account page of your Honeycomb account
+
+Optional:
+
+- `processing_region` (String) Region where logs will be processed before streaming to BigQuery. Valid values are 'none', 'us' and 'eu'.
 
 
 <a id="nestedblock--logging_https"></a>
@@ -466,6 +487,7 @@ Optional:
 - `json_format` (String) Formats log entries as JSON. Can be either disabled (`0`), array of json (`1`), or newline delimited json (`2`)
 - `message_type` (String) How the message should be formatted. Can be either `classic`, `loggly`, `logplex` or `blank`. Default is `classic`
 - `method` (String) HTTP method used for request. Can be either `POST` or `PUT`. Default `POST`
+- `processing_region` (String) Region where logs will be processed before streaming to BigQuery. Valid values are 'none', 'us' and 'eu'.
 - `request_max_bytes` (Number) The maximum number of bytes sent in one request
 - `request_max_entries` (Number) The maximum number of logs sent in one request
 - `tls_ca_cert` (String) A secure certificate to authenticate the server with. Must be in PEM format
@@ -489,6 +511,7 @@ Optional:
 - `compression_codec` (String) The codec used for compression of your logs. One of: `gzip`, `snappy`, `lz4`
 - `parse_log_keyvals` (Boolean) Enables parsing of key=value tuples from the beginning of a logline, turning them into record headers
 - `password` (String, Sensitive) SASL Pass
+- `processing_region` (String) Region where logs will be processed before streaming to BigQuery. Valid values are 'none', 'us' and 'eu'.
 - `request_max_bytes` (Number) Maximum size of log batch, if non-zero. Defaults to 0 for unbounded
 - `required_acks` (String) The Number of acknowledgements a leader must receive before a write is considered successful. One of: `1` (default) One server needs to respond. `0` No servers need to respond. `-1` Wait for all in-sync replicas to respond
 - `tls_ca_cert` (String) A secure certificate to authenticate the server with. Must be in PEM format
@@ -511,6 +534,7 @@ Optional:
 
 - `access_key` (String, Sensitive) The AWS access key to be used to write to the stream
 - `iam_role` (String) The Amazon Resource Name (ARN) for the IAM role granting Fastly access to Kinesis. Not required if `access_key` and `secret_key` are provided.
+- `processing_region` (String) Region where logs will be processed before streaming to BigQuery. Valid values are 'none', 'us' and 'eu'.
 - `region` (String) The AWS region the stream resides in. (Default: `us-east-1`)
 - `secret_key` (String, Sensitive) The AWS secret access key to authenticate with
 
@@ -526,6 +550,7 @@ Required:
 Optional:
 
 - `port` (Number) The port number configured in Logentries
+- `processing_region` (String) Region where logs will be processed before streaming to BigQuery. Valid values are 'none', 'us' and 'eu'.
 - `use_tls` (Boolean) Whether to use TLS for secure logging
 
 
@@ -537,6 +562,10 @@ Required:
 - `name` (String) The unique name of the Loggly logging endpoint. It is important to note that changing this attribute will delete and recreate the resource
 - `token` (String, Sensitive) The token to use for authentication (https://www.loggly.com/docs/customer-token-authentication-token/).
 
+Optional:
+
+- `processing_region` (String) Region where logs will be processed before streaming to BigQuery. Valid values are 'none', 'us' and 'eu'.
+
 
 <a id="nestedblock--logging_logshuttle"></a>
 ### Nested Schema for `logging_logshuttle`
@@ -546,6 +575,10 @@ Required:
 - `name` (String) The unique name of the Log Shuttle logging endpoint. It is important to note that changing this attribute will delete and recreate the resource
 - `token` (String, Sensitive) The data authentication token associated with this endpoint
 - `url` (String) Your Log Shuttle endpoint URL
+
+Optional:
+
+- `processing_region` (String) Region where logs will be processed before streaming to BigQuery. Valid values are 'none', 'us' and 'eu'.
 
 
 <a id="nestedblock--logging_newrelic"></a>
@@ -558,6 +591,7 @@ Required:
 
 Optional:
 
+- `processing_region` (String) Region where logs will be processed before streaming to BigQuery. Valid values are 'none', 'us' and 'eu'.
 - `region` (String) The region that log data will be sent to. Default: `US`
 
 
@@ -579,6 +613,7 @@ Optional:
 - `message_type` (String) How the message should be formatted. Can be either `classic`, `loggly`, `logplex` or `blank`. Default is `classic`
 - `path` (String) Path to store the files. Must end with a trailing slash. If this field is left empty, the files will be saved in the bucket's root path
 - `period` (Number) How frequently the logs should be transferred, in seconds. Default `3600`
+- `processing_region` (String) Region where logs will be processed before streaming to BigQuery. Valid values are 'none', 'us' and 'eu'.
 - `public_key` (String) A PGP public key that Fastly will use to encrypt your log files before writing them to disk
 - `timestamp_format` (String) The `strftime` specified timestamp formatting (default `%Y-%m-%dT%H:%M:%S.000`)
 
@@ -591,6 +626,10 @@ Required:
 - `address` (String) The address of the Papertrail endpoint
 - `name` (String) A unique name to identify this Papertrail endpoint. It is important to note that changing this attribute will delete and recreate the resource
 - `port` (Number) The port associated with the address where the Papertrail endpoint can be accessed
+
+Optional:
+
+- `processing_region` (String) Region where logs will be processed before streaming to BigQuery. Valid values are 'none', 'us' and 'eu'.
 
 
 <a id="nestedblock--logging_s3"></a>
@@ -611,6 +650,7 @@ Optional:
 - `message_type` (String) How the message should be formatted. Can be either `classic`, `loggly`, `logplex` or `blank`. Default is `classic`
 - `path` (String) Path to store the files. Must end with a trailing slash. If this field is left empty, the files will be saved in the bucket's root path
 - `period` (Number) How frequently the logs should be transferred, in seconds. Default `3600`
+- `processing_region` (String) Region where logs will be processed before streaming to BigQuery. Valid values are 'none', 'us' and 'eu'.
 - `public_key` (String) A PGP public key that Fastly will use to encrypt your log files before writing them to disk
 - `redundancy` (String) The S3 storage class (redundancy level). Should be one of: `standard`, `intelligent_tiering`, `standard_ia`, `onezone_ia`, `glacier`, `glacier_ir`, `deep_archive`, or `reduced_redundancy`
 - `s3_access_key` (String, Sensitive) AWS Access Key of an account with the required permissions to post logs. It is **strongly** recommended you create a separate IAM user with permissions to only operate on this Bucket. This key will be not be encrypted. Not required if `iam_role` is provided. You can provide this key via an environment variable, `FASTLY_S3_ACCESS_KEY`
@@ -631,6 +671,7 @@ Required:
 
 Optional:
 
+- `processing_region` (String) Region where logs will be processed before streaming to BigQuery. Valid values are 'none', 'us' and 'eu'.
 - `project_id` (String) The name of the logfile field sent to Scalyr
 - `region` (String) The region that log data will be sent to. One of `US` or `EU`. Defaults to `US` if undefined
 
@@ -654,6 +695,7 @@ Optional:
 - `password` (String, Sensitive) The password for the server. If both `password` and `secret_key` are passed, `secret_key` will be preferred
 - `period` (Number) How frequently log files are finalized so they can be available for reading (in seconds, default `3600`)
 - `port` (Number) The port the SFTP service listens on. (Default: `22`)
+- `processing_region` (String) Region where logs will be processed before streaming to BigQuery. Valid values are 'none', 'us' and 'eu'.
 - `public_key` (String) A PGP public key that Fastly will use to encrypt your log files before writing them to disk
 - `secret_key` (String, Sensitive) The SSH private key for the server. If both `password` and `secret_key` are passed, `secret_key` will be preferred
 - `timestamp_format` (String) The `strftime` specified timestamp formatting (default `%Y-%m-%dT%H:%M:%S.000`)
@@ -670,6 +712,7 @@ Required:
 
 Optional:
 
+- `processing_region` (String) Region where logs will be processed before streaming to BigQuery. Valid values are 'none', 'us' and 'eu'.
 - `tls_ca_cert` (String) A secure certificate to authenticate the server with. Must be in PEM format. You can provide this certificate via an environment variable, `FASTLY_SPLUNK_CA_CERT`
 - `tls_client_cert` (String) The client certificate used to make authenticated requests. Must be in PEM format.
 - `tls_client_key` (String, Sensitive) The client private key used to make authenticated requests. Must be in PEM format.
@@ -688,6 +731,7 @@ Required:
 Optional:
 
 - `message_type` (String) How the message should be formatted. Can be either `classic`, `loggly`, `logplex` or `blank`. Default is `classic`
+- `processing_region` (String) Region where logs will be processed before streaming to BigQuery. Valid values are 'none', 'us' and 'eu'.
 
 
 <a id="nestedblock--logging_syslog"></a>
@@ -702,6 +746,7 @@ Optional:
 
 - `message_type` (String) How the message should be formatted. Can be either `classic`, `loggly`, `logplex` or `blank`. Default is `classic`
 - `port` (Number) The port associated with the address where the Syslog endpoint can be accessed. Default `514`
+- `processing_region` (String) Region where logs will be processed before streaming to BigQuery. Valid values are 'none', 'us' and 'eu'.
 - `tls_ca_cert` (String) A secure certificate to authenticate the server with. Must be in PEM format. You can provide this certificate via an environment variable, `FASTLY_SYSLOG_CA_CERT`
 - `tls_client_cert` (String) The client certificate used to make authenticated requests. Must be in PEM format. You can provide this certificate via an environment variable, `FASTLY_SYSLOG_CLIENT_CERT`
 - `tls_client_key` (String, Sensitive) The client private key used to make authenticated requests. Must be in PEM format. You can provide this key via an environment variable, `FASTLY_SYSLOG_CLIENT_KEY`

--- a/docs/resources/service_vcl.md
+++ b/docs/resources/service_vcl.md
@@ -525,6 +525,7 @@ Optional:
 - `email` (String, Sensitive) The email for the service account with write access to your BigQuery dataset. If not provided, this will be pulled from a `FASTLY_BQ_EMAIL` environment variable
 - `format` (String) The logging format desired.
 - `placement` (String) Where in the generated VCL the logging call should be placed.
+- `processing_region` (String) Region where logs will be processed before streaming to BigQuery. Valid values are 'none', 'us' and 'eu'.
 - `response_condition` (String) Name of a condition to apply this logging.
 - `secret_key` (String, Sensitive) The secret key associated with the service account that has write access to your BigQuery table. If not provided, this will be pulled from the `FASTLY_BQ_SECRET_KEY` environment variable. Typical format for this is a private key in a string with newlines
 - `template` (String) BigQuery table name suffix template
@@ -550,6 +551,7 @@ Optional:
 - `path` (String) The path to upload logs to. Must end with a trailing slash. If this field is left empty, the files will be saved in the container's root path
 - `period` (Number) How frequently the logs should be transferred in seconds. Default `3600`
 - `placement` (String) Where in the generated VCL the logging call should be placed
+- `processing_region` (String) Region where logs will be processed before streaming to BigQuery. Valid values are 'none', 'us' and 'eu'.
 - `public_key` (String) A PGP public key that Fastly will use to encrypt your log files before writing them to disk
 - `response_condition` (String) The name of the condition to apply
 - `sas_token` (String, Sensitive) The Azure shared access signature providing write access to the blob service objects. Be sure to update your token before it expires or the logging functionality will not work
@@ -576,6 +578,7 @@ Optional:
 - `path` (String) The path to upload logs to
 - `period` (Number) How frequently log files are finalized so they can be available for reading (in seconds, default `3600`)
 - `placement` (String) Where in the generated VCL the logging call should be placed. Can be `none` or `none`.
+- `processing_region` (String) Region where logs will be processed before streaming to BigQuery. Valid values are 'none', 'us' and 'eu'.
 - `public_key` (String) The PGP public key that Fastly will use to encrypt your log files before writing them to disk
 - `region` (String) The region to stream logs to. One of: DFW (Dallas), ORD (Chicago), IAD (Northern Virginia), LON (London), SYD (Sydney), HKG (Hong Kong)
 - `response_condition` (String) The name of an existing condition in the configured endpoint, or leave blank to always execute.
@@ -595,6 +598,7 @@ Optional:
 - `format` (String) Apache-style string or VCL variables to use for log formatting.
 - `format_version` (Number) The version of the custom logging format used for the configured endpoint. Can be either `1` or `2`. (default: `2`).
 - `placement` (String) Where in the generated VCL the logging call should be placed.
+- `processing_region` (String) Region where logs will be processed before streaming to BigQuery. Valid values are 'none', 'us' and 'eu'.
 - `region` (String) The region that log data will be sent to. One of `US` or `EU`. Defaults to `US` if undefined
 - `response_condition` (String) The name of the condition to apply.
 
@@ -620,6 +624,7 @@ Optional:
 - `path` (String) The path to upload logs to
 - `period` (Number) How frequently log files are finalized so they can be available for reading (in seconds, default `3600`)
 - `placement` (String) Where in the generated VCL the logging call should be placed. Can be `none` or `none`.
+- `processing_region` (String) Region where logs will be processed before streaming to BigQuery. Valid values are 'none', 'us' and 'eu'.
 - `public_key` (String) A PGP public key that Fastly will use to encrypt your log files before writing them to disk
 - `response_condition` (String) The name of an existing condition in the configured endpoint, or leave blank to always execute.
 - `timestamp_format` (String) The `strftime` specified timestamp formatting (default `%Y-%m-%dT%H:%M:%S.000`)
@@ -641,6 +646,7 @@ Optional:
 - `password` (String, Sensitive) BasicAuth password for Elasticsearch
 - `pipeline` (String) The ID of the Elasticsearch ingest pipeline to apply pre-process transformations to before indexing
 - `placement` (String) Where in the generated VCL the logging call should be placed.
+- `processing_region` (String) Region where logs will be processed before streaming to BigQuery. Valid values are 'none', 'us' and 'eu'.
 - `request_max_bytes` (Number) The maximum number of logs sent in one request. Defaults to `0` for unbounded
 - `request_max_entries` (Number) The maximum number of bytes sent in one request. Defaults to `0` for unbounded
 - `response_condition` (String) The name of the condition to apply
@@ -672,6 +678,7 @@ Optional:
 - `period` (Number) How frequently the logs should be transferred, in seconds (Default `3600`)
 - `placement` (String) Where in the generated VCL the logging call should be placed.
 - `port` (Number) The port number. Default: `21`
+- `processing_region` (String) Region where logs will be processed before streaming to BigQuery. Valid values are 'none', 'us' and 'eu'.
 - `public_key` (String) The PGP public key that Fastly will use to encrypt your log files before writing them to disk
 - `response_condition` (String) The name of the condition to apply.
 - `timestamp_format` (String) The `strftime` specified timestamp formatting (default `%Y-%m-%dT%H:%M:%S.000`)
@@ -696,6 +703,7 @@ Optional:
 - `path` (String) Path to store the files. Must end with a trailing slash. If this field is left empty, the files will be saved in the bucket's root path
 - `period` (Number) How frequently the logs should be transferred, in seconds (Default 3600)
 - `placement` (String) Where in the generated VCL the logging call should be placed.
+- `processing_region` (String) Region where logs will be processed before streaming to BigQuery. Valid values are 'none', 'us' and 'eu'.
 - `project_id` (String) The ID of your Google Cloud Platform project
 - `response_condition` (String) Name of a condition to apply this logging.
 - `secret_key` (String, Sensitive) The secret key associated with the target gcs bucket on your account. You may optionally provide this secret via an environment variable, `FASTLY_GCS_SECRET_KEY`. A typical format for the key is PEM format, containing actual newline characters where required
@@ -718,6 +726,7 @@ Optional:
 - `format` (String) Apache style log formatting.
 - `format_version` (Number) The version of the custom logging format used for the configured endpoint. Can be either 1 or 2. (default: 2).
 - `placement` (String) Where in the generated VCL the logging call should be placed.
+- `processing_region` (String) Region where logs will be processed before streaming to BigQuery. Valid values are 'none', 'us' and 'eu'.
 - `response_condition` (String) The name of an existing condition in the configured endpoint, or leave blank to always execute.
 - `secret_key` (String, Sensitive) Your Google Cloud Platform account secret key. The `private_key` field in your service account authentication JSON. You may optionally provide this secret via an environment variable, `FASTLY_GOOGLE_PUBSUB_SECRET_KEY`.
 - `user` (String) Your Google Cloud Platform service account email address. The `client_email` field in your service account authentication JSON. You may optionally provide this via an environment variable, `FASTLY_GOOGLE_PUBSUB_EMAIL`.
@@ -739,6 +748,7 @@ Optional:
 - `format` (String) Apache-style string or VCL variables to use for log formatting.
 - `format_version` (Number) The version of the custom logging format used for the configured endpoint. Can be either `1` or `2`. (default: `2`).
 - `placement` (String) Where in the generated VCL the logging call should be placed.
+- `processing_region` (String) Region where logs will be processed before streaming to BigQuery. Valid values are 'none', 'us' and 'eu'.
 - `response_condition` (String) The name of the condition to apply.
 
 
@@ -756,6 +766,7 @@ Optional:
 - `format` (String) Apache-style string or VCL variables to use for log formatting.
 - `format_version` (Number) The version of the custom logging format used for the configured endpoint. Can be either `1` or `2`. (default: `2`).
 - `placement` (String) Where in the generated VCL the logging call should be placed. Can be `none` or `none`.
+- `processing_region` (String) Region where logs will be processed before streaming to BigQuery. Valid values are 'none', 'us' and 'eu'.
 - `response_condition` (String) The name of an existing condition in the configured endpoint, or leave blank to always execute.
 
 
@@ -773,6 +784,7 @@ Optional:
 - `format` (String) Apache style log formatting. Your log must produce valid JSON that Honeycomb can ingest.
 - `format_version` (Number) The version of the custom logging format used for the configured endpoint. Can be either `1` or `2`. (default: `2`).
 - `placement` (String) Where in the generated VCL the logging call should be placed. Can be `none` or `none`.
+- `processing_region` (String) Region where logs will be processed before streaming to BigQuery. Valid values are 'none', 'us' and 'eu'.
 - `response_condition` (String) The name of an existing condition in the configured endpoint, or leave blank to always execute.
 
 
@@ -795,6 +807,7 @@ Optional:
 - `message_type` (String) How the message should be formatted. Can be either `classic`, `loggly`, `logplex` or `blank`. Default is `classic`
 - `method` (String) HTTP method used for request. Can be either `POST` or `PUT`. Default `POST`
 - `placement` (String) Where in the generated VCL the logging call should be placed
+- `processing_region` (String) Region where logs will be processed before streaming to BigQuery. Valid values are 'none', 'us' and 'eu'.
 - `request_max_bytes` (Number) The maximum number of bytes sent in one request
 - `request_max_entries` (Number) The maximum number of logs sent in one request
 - `response_condition` (String) The name of the condition to apply
@@ -822,6 +835,7 @@ Optional:
 - `parse_log_keyvals` (Boolean) Enables parsing of key=value tuples from the beginning of a logline, turning them into record headers
 - `password` (String, Sensitive) SASL Pass
 - `placement` (String) Where in the generated VCL the logging call should be placed.
+- `processing_region` (String) Region where logs will be processed before streaming to BigQuery. Valid values are 'none', 'us' and 'eu'.
 - `request_max_bytes` (Number) Maximum size of log batch, if non-zero. Defaults to 0 for unbounded
 - `required_acks` (String) The Number of acknowledgements a leader must receive before a write is considered successful. One of: `1` (default) One server needs to respond. `0` No servers need to respond. `-1` Wait for all in-sync replicas to respond
 - `response_condition` (String) The name of an existing condition in the configured endpoint, or leave blank to always execute.
@@ -848,6 +862,7 @@ Optional:
 - `format_version` (Number) The version of the custom logging format used for the configured endpoint. Can be either `1` or `2`. (default: `2`).
 - `iam_role` (String) The Amazon Resource Name (ARN) for the IAM role granting Fastly access to Kinesis. Not required if `access_key` and `secret_key` are provided.
 - `placement` (String) Where in the generated VCL the logging call should be placed. Can be `none` or `none`.
+- `processing_region` (String) Region where logs will be processed before streaming to BigQuery. Valid values are 'none', 'us' and 'eu'.
 - `region` (String) The AWS region the stream resides in. (Default: `us-east-1`)
 - `response_condition` (String) The name of an existing condition in the configured endpoint, or leave blank to always execute.
 - `secret_key` (String, Sensitive) The AWS secret access key to authenticate with
@@ -867,6 +882,7 @@ Optional:
 - `format_version` (Number) The version of the custom logging format used for the configured endpoint. Can be either 1 or 2. (Default: 2)
 - `placement` (String) Where in the generated VCL the logging call should be placed.
 - `port` (Number) The port number configured in Logentries
+- `processing_region` (String) Region where logs will be processed before streaming to BigQuery. Valid values are 'none', 'us' and 'eu'.
 - `response_condition` (String) Name of blockAttributes condition to apply this logging.
 - `use_tls` (Boolean) Whether to use TLS for secure logging
 
@@ -884,6 +900,7 @@ Optional:
 - `format` (String) Apache-style string or VCL variables to use for log formatting.
 - `format_version` (Number) The version of the custom logging format used for the configured endpoint. Can be either `1` or `2`. (default: `2`).
 - `placement` (String) Where in the generated VCL the logging call should be placed. Can be `none` or `none`.
+- `processing_region` (String) Region where logs will be processed before streaming to BigQuery. Valid values are 'none', 'us' and 'eu'.
 - `response_condition` (String) The name of an existing condition in the configured endpoint, or leave blank to always execute.
 
 
@@ -901,6 +918,7 @@ Optional:
 - `format` (String) Apache style log formatting.
 - `format_version` (Number) The version of the custom logging format used for the configured endpoint. Can be either `1` or `2`. (default: `2`).
 - `placement` (String) Where in the generated VCL the logging call should be placed. Can be `none` or `none`.
+- `processing_region` (String) Region where logs will be processed before streaming to BigQuery. Valid values are 'none', 'us' and 'eu'.
 - `response_condition` (String) The name of an existing condition in the configured endpoint, or leave blank to always execute.
 
 
@@ -917,6 +935,7 @@ Optional:
 - `format` (String) Apache style log formatting. Your log must produce valid JSON that New Relic Logs can ingest.
 - `format_version` (Number) The version of the custom logging format used for the configured endpoint. Can be either `1` or `2`. (default: `2`).
 - `placement` (String) Where in the generated VCL the logging call should be placed.
+- `processing_region` (String) Region where logs will be processed before streaming to BigQuery. Valid values are 'none', 'us' and 'eu'.
 - `region` (String) The region that log data will be sent to. Default: `US`
 - `response_condition` (String) The name of the condition to apply.
 
@@ -934,6 +953,7 @@ Optional:
 - `format` (String) Apache style log formatting. Your log must produce valid JSON that New Relic OTLP can ingest.
 - `format_version` (Number) The version of the custom logging format used for the configured endpoint. Can be either `1` or `2`. (default: `2`).
 - `placement` (String) Where in the generated VCL the logging call should be placed.
+- `processing_region` (String) Region where logs will be processed before streaming to BigQuery. Valid values are 'none', 'us' and 'eu'.
 - `region` (String) The region that log data will be sent to. Default: `US`
 - `response_condition` (String) The name of the condition to apply.
 - `url` (String) The optional New Relic Trace Observer URL to stream logs to for Infinite Tracing.
@@ -960,6 +980,7 @@ Optional:
 - `path` (String) Path to store the files. Must end with a trailing slash. If this field is left empty, the files will be saved in the bucket's root path
 - `period` (Number) How frequently the logs should be transferred, in seconds. Default `3600`
 - `placement` (String) Where in the generated VCL the logging call should be placed. Can be `none` or `none`.
+- `processing_region` (String) Region where logs will be processed before streaming to BigQuery. Valid values are 'none', 'us' and 'eu'.
 - `public_key` (String) A PGP public key that Fastly will use to encrypt your log files before writing them to disk
 - `response_condition` (String) The name of an existing condition in the configured endpoint, or leave blank to always execute.
 - `timestamp_format` (String) The `strftime` specified timestamp formatting (default `%Y-%m-%dT%H:%M:%S.000`)
@@ -979,6 +1000,7 @@ Optional:
 - `format` (String) A Fastly [log format string](https://docs.fastly.com/en/guides/custom-log-formats)
 - `format_version` (Number) The version of the custom logging format used for the configured endpoint. The logging call gets placed by default in `vcl_log` if `format_version` is set to `2` and in `vcl_deliver` if `format_version` is set to `1`
 - `placement` (String) Where in the generated VCL the logging call should be placed. If not set, endpoints with `format_version` of 2 are placed in `vcl_log` and those with `format_version` of 1 are placed in `vcl_deliver`
+- `processing_region` (String) Region where logs will be processed before streaming to BigQuery. Valid values are 'none', 'us' and 'eu'.
 - `response_condition` (String) The name of an existing condition in the configured endpoint, or leave blank to always execute
 
 
@@ -1003,6 +1025,7 @@ Optional:
 - `path` (String) Path to store the files. Must end with a trailing slash. If this field is left empty, the files will be saved in the bucket's root path
 - `period` (Number) How frequently the logs should be transferred, in seconds. Default `3600`
 - `placement` (String) Where in the generated VCL the logging call should be placed.
+- `processing_region` (String) Region where logs will be processed before streaming to BigQuery. Valid values are 'none', 'us' and 'eu'.
 - `public_key` (String) A PGP public key that Fastly will use to encrypt your log files before writing them to disk
 - `redundancy` (String) The S3 storage class (redundancy level). Should be one of: `standard`, `intelligent_tiering`, `standard_ia`, `onezone_ia`, `glacier`, `glacier_ir`, `deep_archive`, or `reduced_redundancy`
 - `response_condition` (String) Name of blockAttributes condition to apply this logging.
@@ -1027,6 +1050,7 @@ Optional:
 - `format` (String) Apache style log formatting.
 - `format_version` (Number) The version of the custom logging format used for the configured endpoint. Can be either 1 or 2. (default: 2).
 - `placement` (String) Where in the generated VCL the logging call should be placed.
+- `processing_region` (String) Region where logs will be processed before streaming to BigQuery. Valid values are 'none', 'us' and 'eu'.
 - `project_id` (String) The name of the logfile field sent to Scalyr
 - `region` (String) The region that log data will be sent to. One of `US` or `EU`. Defaults to `US` if undefined
 - `response_condition` (String) The name of an existing condition in the configured endpoint, or leave blank to always execute.
@@ -1054,6 +1078,7 @@ Optional:
 - `period` (Number) How frequently log files are finalized so they can be available for reading (in seconds, default `3600`)
 - `placement` (String) Where in the generated VCL the logging call should be placed.
 - `port` (Number) The port the SFTP service listens on. (Default: `22`)
+- `processing_region` (String) Region where logs will be processed before streaming to BigQuery. Valid values are 'none', 'us' and 'eu'.
 - `public_key` (String) A PGP public key that Fastly will use to encrypt your log files before writing them to disk
 - `response_condition` (String) The name of the condition to apply.
 - `secret_key` (String, Sensitive) The SSH private key for the server. If both `password` and `secret_key` are passed, `secret_key` will be preferred
@@ -1074,6 +1099,7 @@ Optional:
 - `format` (String) Apache-style string or VCL variables to use for log formatting (default: `%h %l %u %t "%r" %>s %b`)
 - `format_version` (Number) The version of the custom logging format used for the configured endpoint. Can be either 1 or 2. (default: 2)
 - `placement` (String) Where in the generated VCL the logging call should be placed
+- `processing_region` (String) Region where logs will be processed before streaming to BigQuery. Valid values are 'none', 'us' and 'eu'.
 - `response_condition` (String) The name of the condition to apply
 - `tls_ca_cert` (String) A secure certificate to authenticate the server with. Must be in PEM format. You can provide this certificate via an environment variable, `FASTLY_SPLUNK_CA_CERT`
 - `tls_client_cert` (String) The client certificate used to make authenticated requests. Must be in PEM format.
@@ -1096,6 +1122,7 @@ Optional:
 - `format_version` (Number) The version of the custom logging format used for the configured endpoint. Can be either 1 or 2. (Default: 2)
 - `message_type` (String) How the message should be formatted. Can be either `classic`, `loggly`, `logplex` or `blank`. Default is `classic`
 - `placement` (String) Where in the generated VCL the logging call should be placed.
+- `processing_region` (String) Region where logs will be processed before streaming to BigQuery. Valid values are 'none', 'us' and 'eu'.
 - `response_condition` (String) Name of blockAttributes condition to apply this logging.
 
 
@@ -1114,6 +1141,7 @@ Optional:
 - `message_type` (String) How the message should be formatted. Can be either `classic`, `loggly`, `logplex` or `blank`. Default is `classic`
 - `placement` (String) Where in the generated VCL the logging call should be placed.
 - `port` (Number) The port associated with the address where the Syslog endpoint can be accessed. Default `514`
+- `processing_region` (String) Region where logs will be processed before streaming to BigQuery. Valid values are 'none', 'us' and 'eu'.
 - `response_condition` (String) Name of blockAttributes condition to apply this logging.
 - `tls_ca_cert` (String) A secure certificate to authenticate the server with. Must be in PEM format. You can provide this certificate via an environment variable, `FASTLY_SYSLOG_CA_CERT`
 - `tls_client_cert` (String) The client certificate used to make authenticated requests. Must be in PEM format. You can provide this certificate via an environment variable, `FASTLY_SYSLOG_CLIENT_CERT`

--- a/fastly/block_fastly_service_logging_bigquery.go
+++ b/fastly/block_fastly_service_logging_bigquery.go
@@ -6,6 +6,7 @@ import (
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	gofastly "github.com/fastly/go-fastly/v10/fastly"
 )
@@ -55,6 +56,13 @@ func (h *BigQueryLoggingServiceAttributeHandler) GetSchema() *schema.Schema {
 			Type:        schema.TypeString,
 			Required:    true,
 			Description: "A unique name to identify this BigQuery logging endpoint. It is important to note that changing this attribute will delete and recreate the resource",
+		},
+		"processing_region": {
+			Type:         schema.TypeString,
+			Optional:     true,
+			Default:      "none",
+			Description:  "Region where logs will be processed before streaming to BigQuery. Valid values are 'none', 'us' and 'eu'.",
+			ValidateFunc: validation.StringInSlice([]string{"none", "us", "eu"}, false),
 		},
 		"project_id": {
 			Type:        schema.TypeString,
@@ -116,15 +124,16 @@ func (h *BigQueryLoggingServiceAttributeHandler) GetSchema() *schema.Schema {
 func (h *BigQueryLoggingServiceAttributeHandler) Create(_ context.Context, d *schema.ResourceData, resource map[string]any, serviceVersion int, conn *gofastly.Client) error {
 	vla := h.getVCLLoggingAttributes(resource)
 	opts := gofastly.CreateBigQueryInput{
-		ServiceID:      d.Id(),
-		ServiceVersion: serviceVersion,
-		Name:           gofastly.ToPointer(resource["name"].(string)),
-		ProjectID:      gofastly.ToPointer(resource["project_id"].(string)),
-		Dataset:        gofastly.ToPointer(resource["dataset"].(string)),
-		Table:          gofastly.ToPointer(resource["table"].(string)),
-		User:           gofastly.ToPointer(resource["email"].(string)),
-		SecretKey:      gofastly.ToPointer(resource["secret_key"].(string)),
-		Template:       gofastly.ToPointer(resource["template"].(string)),
+		ServiceID:        d.Id(),
+		ServiceVersion:   serviceVersion,
+		Name:             gofastly.ToPointer(resource["name"].(string)),
+		ProjectID:        gofastly.ToPointer(resource["project_id"].(string)),
+		Dataset:          gofastly.ToPointer(resource["dataset"].(string)),
+		Table:            gofastly.ToPointer(resource["table"].(string)),
+		User:             gofastly.ToPointer(resource["email"].(string)),
+		SecretKey:        gofastly.ToPointer(resource["secret_key"].(string)),
+		Template:         gofastly.ToPointer(resource["template"].(string)),
+		ProcessingRegion: gofastly.ToPointer(resource["processing_region"].(string)),
 	}
 
 	// WARNING: The following fields shouldn't have an empty string passed.
@@ -223,6 +232,9 @@ func (h *BigQueryLoggingServiceAttributeHandler) Update(_ context.Context, d *sc
 	if v, ok := modified["format_version"]; ok {
 		opts.FormatVersion = gofastly.ToPointer(v.(int))
 	}
+	if v, ok := modified["processing_region"]; ok {
+		opts.ProcessingRegion = gofastly.ToPointer(v.(string))
+	}
 
 	log.Printf("[DEBUG] Update BigQuery Opts: %#v", opts)
 	_, err := conn.UpdateBigQuery(&opts)
@@ -292,6 +304,9 @@ func flattenBigQuery(remoteState []*gofastly.BigQuery) []map[string]any {
 		}
 		if resource.Placement != nil {
 			data["placement"] = *resource.Placement
+		}
+		if resource.ProcessingRegion != nil {
+			data["processing_region"] = *resource.ProcessingRegion
 		}
 
 		// prune any empty values that come from the default string value in structs

--- a/fastly/block_fastly_service_logging_bigquery_test.go
+++ b/fastly/block_fastly_service_logging_bigquery_test.go
@@ -191,6 +191,7 @@ resource "fastly_service_vcl" "foo" {
     dataset    = "example_bq_dataset"
     table      = "example_bq_table"
     format     = "%%h %%l %%u %%t %%r %%>s"
+    processing_region = "us"
   }
 
   force_destroy = true
@@ -225,6 +226,7 @@ resource "fastly_service_compute" "foo" {
     project_id = "example-gcp-project"
     dataset    = "example_bq_dataset"
     table      = "example_bq_table"
+    processing_region = "us"
   }
 
   package {
@@ -316,6 +318,7 @@ func TestResourceFastlyFlattenBigQuery(t *testing.T) {
 					Placement:         gofastly.ToPointer("none"),
 					ResponseCondition: gofastly.ToPointer("error_response"),
 					SecretKey:         gofastly.ToPointer(secretKey),
+					ProcessingRegion:  gofastly.ToPointer("eu"),
 				},
 			},
 			local: []map[string]any{
@@ -329,6 +332,7 @@ func TestResourceFastlyFlattenBigQuery(t *testing.T) {
 					"format":             "%h %l %u %t \"%r\" %>s %b",
 					"placement":          "none",
 					"response_condition": "error_response",
+					"processing_region":  "eu",
 				},
 			},
 		},

--- a/fastly/block_fastly_service_logging_cloudfiles_test.go
+++ b/fastly/block_fastly_service_logging_cloudfiles_test.go
@@ -38,6 +38,7 @@ func TestResourceFastlyFlattenCloudfiles(t *testing.T) {
 					ResponseCondition: gofastly.ToPointer("response_condition"),
 					TimestampFormat:   gofastly.ToPointer("%Y-%m-%dT%H:%M:%S.000"),
 					CompressionCodec:  gofastly.ToPointer("zstd"),
+					ProcessingRegion:  gofastly.ToPointer("eu"),
 				},
 			},
 			local: []map[string]any{
@@ -58,6 +59,7 @@ func TestResourceFastlyFlattenCloudfiles(t *testing.T) {
 					"response_condition": "response_condition",
 					"timestamp_format":   "%Y-%m-%dT%H:%M:%S.000",
 					"compression_codec":  "zstd",
+					"processing_region":  "eu",
 				},
 			},
 		},
@@ -94,6 +96,7 @@ func TestAccFastlyServiceVCL_logging_cloudfiles_basic(t *testing.T) {
 		ServiceVersion:    gofastly.ToPointer(1),
 		TimestampFormat:   gofastly.ToPointer("%Y-%m-%dT%H:%M:%S.000"),
 		User:              gofastly.ToPointer("user"),
+		ProcessingRegion:  gofastly.ToPointer("us"),
 	}
 
 	log1AfterUpdate := gofastly.Cloudfiles{
@@ -113,6 +116,7 @@ func TestAccFastlyServiceVCL_logging_cloudfiles_basic(t *testing.T) {
 		ServiceVersion:    gofastly.ToPointer(1),
 		TimestampFormat:   gofastly.ToPointer("%Y-%m-%dT%H:%M:%S.000"),
 		User:              gofastly.ToPointer("userupdate"),
+		ProcessingRegion:  gofastly.ToPointer("none"),
 	}
 
 	log2 := gofastly.Cloudfiles{
@@ -133,6 +137,7 @@ func TestAccFastlyServiceVCL_logging_cloudfiles_basic(t *testing.T) {
 		ServiceVersion:    gofastly.ToPointer(1),
 		TimestampFormat:   gofastly.ToPointer("%Y-%m-%dT%H:%M:%S.000"),
 		User:              gofastly.ToPointer("user2"),
+		ProcessingRegion:  gofastly.ToPointer("none"),
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -184,6 +189,7 @@ func TestAccFastlyServiceVCL_logging_cloudfiles_basic_compute(t *testing.T) {
 		Period:           gofastly.ToPointer(3600),
 		TimestampFormat:  gofastly.ToPointer("%Y-%m-%dT%H:%M:%S.000"),
 		CompressionCodec: gofastly.ToPointer("zstd"),
+		ProcessingRegion: gofastly.ToPointer("us"),
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -286,6 +292,7 @@ resource "fastly_service_compute" "none" {
     period = 3600
     timestamp_format = "%%Y-%%m-%%dT%%H:%%M:%%S.000"
     compression_codec = "zstd"
+    processing_region = "us"
   }
 
   package {
@@ -336,6 +343,7 @@ resource "fastly_service_vcl" "none" {
     response_condition = "response_condition_test"
     timestamp_format = "%%Y-%%m-%%dT%%H:%%M:%%S.000"
     user = "user"
+    processing_region = "us"
   }
 
   force_destroy = true

--- a/fastly/block_fastly_service_logging_datadog.go
+++ b/fastly/block_fastly_service_logging_datadog.go
@@ -6,6 +6,7 @@ import (
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	gofastly "github.com/fastly/go-fastly/v10/fastly"
 )
@@ -37,6 +38,13 @@ func (h *DatadogServiceAttributeHandler) GetSchema() *schema.Schema {
 			Type:        schema.TypeString,
 			Required:    true,
 			Description: "The unique name of the Datadog logging endpoint. It is important to note that changing this attribute will delete and recreate the resource",
+		},
+		"processing_region": {
+			Type:         schema.TypeString,
+			Optional:     true,
+			Default:      "none",
+			Description:  "Region where logs will be processed before streaming to BigQuery. Valid values are 'none', 'us' and 'eu'.",
+			ValidateFunc: validation.StringInSlice([]string{"none", "us", "eu"}, false),
 		},
 		"region": {
 			Type:        schema.TypeString,
@@ -150,6 +158,9 @@ func (h *DatadogServiceAttributeHandler) Update(_ context.Context, d *schema.Res
 	if v, ok := modified["placement"]; ok {
 		opts.Placement = gofastly.ToPointer(v.(string))
 	}
+	if v, ok := modified["processing_region"]; ok {
+		opts.ProcessingRegion = gofastly.ToPointer(v.(string))
+	}
 
 	log.Printf("[DEBUG] Update Datadog Opts: %#v", opts)
 	_, err := conn.UpdateDatadog(&opts)
@@ -217,6 +228,9 @@ func flattenDatadog(remoteState []*gofastly.Datadog) []map[string]any {
 		if resource.ResponseCondition != nil {
 			data["response_condition"] = *resource.ResponseCondition
 		}
+		if resource.ProcessingRegion != nil {
+			data["processing_region"] = *resource.ProcessingRegion
+		}
 
 		// Prune any empty values that come from the default string value in structs.
 		for k, v := range data {
@@ -236,13 +250,14 @@ func (h *DatadogServiceAttributeHandler) buildCreate(datadogMap any, serviceID s
 
 	vla := h.getVCLLoggingAttributes(resource)
 	opts := &gofastly.CreateDatadogInput{
-		Format:         gofastly.ToPointer(vla.format),
-		FormatVersion:  vla.formatVersion,
-		Name:           gofastly.ToPointer(resource["name"].(string)),
-		Region:         gofastly.ToPointer(resource["region"].(string)),
-		ServiceID:      serviceID,
-		ServiceVersion: serviceVersion,
-		Token:          gofastly.ToPointer(resource["token"].(string)),
+		Format:           gofastly.ToPointer(vla.format),
+		FormatVersion:    vla.formatVersion,
+		Name:             gofastly.ToPointer(resource["name"].(string)),
+		Region:           gofastly.ToPointer(resource["region"].(string)),
+		ServiceID:        serviceID,
+		ServiceVersion:   serviceVersion,
+		Token:            gofastly.ToPointer(resource["token"].(string)),
+		ProcessingRegion: gofastly.ToPointer(resource["processing_region"].(string)),
 	}
 
 	// WARNING: The following fields shouldn't have an empty string passed.

--- a/fastly/block_fastly_service_logging_datadog_test.go
+++ b/fastly/block_fastly_service_logging_datadog_test.go
@@ -21,19 +21,21 @@ func TestResourceFastlyFlattenDatadog(t *testing.T) {
 		{
 			remote: []*gofastly.Datadog{
 				{
-					ServiceVersion: gofastly.ToPointer(1),
-					Name:           gofastly.ToPointer("datadog-endpoint"),
-					Token:          gofastly.ToPointer("token"),
-					Region:         gofastly.ToPointer("US"),
-					FormatVersion:  gofastly.ToPointer(2),
+					ServiceVersion:   gofastly.ToPointer(1),
+					Name:             gofastly.ToPointer("datadog-endpoint"),
+					Token:            gofastly.ToPointer("token"),
+					Region:           gofastly.ToPointer("US"),
+					FormatVersion:    gofastly.ToPointer(2),
+					ProcessingRegion: gofastly.ToPointer("eu"),
 				},
 			},
 			local: []map[string]any{
 				{
-					"name":           "datadog-endpoint",
-					"token":          "token",
-					"region":         "US",
-					"format_version": 2,
+					"name":              "datadog-endpoint",
+					"token":             "token",
+					"region":            "US",
+					"format_version":    2,
+					"processing_region": "eu",
 				},
 			},
 		},
@@ -142,6 +144,7 @@ func TestAccFastlyServiceVCL_logging_datadog_basic(t *testing.T) {
 		ResponseCondition: gofastly.ToPointer(""),
 		ServiceVersion:    gofastly.ToPointer(1),
 		Token:             gofastly.ToPointer("token"),
+		ProcessingRegion:  gofastly.ToPointer("us"),
 	}
 
 	log1AfterUpdate := gofastly.Datadog{
@@ -152,6 +155,7 @@ func TestAccFastlyServiceVCL_logging_datadog_basic(t *testing.T) {
 		ResponseCondition: gofastly.ToPointer(""),
 		ServiceVersion:    gofastly.ToPointer(1),
 		Token:             gofastly.ToPointer("t0k3n"),
+		ProcessingRegion:  gofastly.ToPointer("none"),
 	}
 
 	log2 := gofastly.Datadog{
@@ -162,6 +166,7 @@ func TestAccFastlyServiceVCL_logging_datadog_basic(t *testing.T) {
 		ResponseCondition: gofastly.ToPointer(""),
 		ServiceVersion:    gofastly.ToPointer(1),
 		Token:             gofastly.ToPointer("another-token"),
+		ProcessingRegion:  gofastly.ToPointer("none"),
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -200,10 +205,11 @@ func TestAccFastlyServiceVCL_logging_datadog_basic_compute(t *testing.T) {
 	domain := fmt.Sprintf("fastly-test.%s.com", name)
 
 	log1 := gofastly.Datadog{
-		ServiceVersion: gofastly.ToPointer(1),
-		Name:           gofastly.ToPointer("datadog-endpoint"),
-		Token:          gofastly.ToPointer("token"),
-		Region:         gofastly.ToPointer("US"),
+		ServiceVersion:   gofastly.ToPointer(1),
+		Name:             gofastly.ToPointer("datadog-endpoint"),
+		Token:            gofastly.ToPointer("token"),
+		Region:           gofastly.ToPointer("US"),
+		ProcessingRegion: gofastly.ToPointer("us"),
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -301,6 +307,7 @@ resource "fastly_service_vcl" "foo" {
     token  = "token"
     region = "US"
     format = "%%h %%l %%u %%t \"%%r\" %%>s %%b"
+    processing_region = "us"
   }
 
   force_destroy = true
@@ -366,6 +373,7 @@ resource "fastly_service_compute" "foo" {
     name   = "datadog-endpoint"
     token  = "token"
     region = "US"
+    processing_region = "us"
   }
 
   package {

--- a/fastly/block_fastly_service_logging_digitalocean_test.go
+++ b/fastly/block_fastly_service_logging_digitalocean_test.go
@@ -38,6 +38,7 @@ func TestResourceFastlyFlattenDigitalOcean(t *testing.T) {
 					Placement:         gofastly.ToPointer("none"),
 					ResponseCondition: gofastly.ToPointer("always"),
 					CompressionCodec:  gofastly.ToPointer("zstd"),
+					ProcessingRegion:  gofastly.ToPointer("eu"),
 				},
 			},
 			local: []map[string]any{
@@ -58,6 +59,7 @@ func TestResourceFastlyFlattenDigitalOcean(t *testing.T) {
 					"placement":          "none",
 					"response_condition": "always",
 					"compression_codec":  "zstd",
+					"processing_region":  "eu",
 				},
 			},
 		},
@@ -94,6 +96,7 @@ func TestAccFastlyServiceVCL_logging_digitalocean_basic(t *testing.T) {
 		SecretKey:         gofastly.ToPointer("secret"),
 		ServiceVersion:    gofastly.ToPointer(1),
 		TimestampFormat:   gofastly.ToPointer("%Y-%m-%dT%H:%M:%S.000"),
+		ProcessingRegion:  gofastly.ToPointer("us"),
 	}
 
 	log1AfterUpdate := gofastly.DigitalOcean{
@@ -113,6 +116,7 @@ func TestAccFastlyServiceVCL_logging_digitalocean_basic(t *testing.T) {
 		SecretKey:         gofastly.ToPointer("secretupdate"),
 		ServiceVersion:    gofastly.ToPointer(1),
 		TimestampFormat:   gofastly.ToPointer("%Y-%m-%dT%H:%M:%S.000"),
+		ProcessingRegion:  gofastly.ToPointer("none"),
 	}
 
 	log2 := gofastly.DigitalOcean{
@@ -133,6 +137,7 @@ func TestAccFastlyServiceVCL_logging_digitalocean_basic(t *testing.T) {
 		SecretKey:         gofastly.ToPointer("secret2"),
 		ServiceVersion:    gofastly.ToPointer(1),
 		TimestampFormat:   gofastly.ToPointer("%Y-%m-%dT%H:%M:%S.000"),
+		ProcessingRegion:  gofastly.ToPointer("none"),
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -184,6 +189,7 @@ func TestAccFastlyServiceVCL_logging_digitalocean_basic_compute(t *testing.T) {
 		SecretKey:        gofastly.ToPointer("secret"),
 		ServiceVersion:   gofastly.ToPointer(1),
 		TimestampFormat:  gofastly.ToPointer("%Y-%m-%dT%H:%M:%S.000"),
+		ProcessingRegion: gofastly.ToPointer("us"),
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -290,6 +296,7 @@ resource "fastly_service_vcl" "foo" {
     placement = "none"
     response_condition = "response_condition_test"
     compression_codec = "zstd"
+    processing_region = "us"
   }
 
   force_destroy = true
@@ -389,6 +396,7 @@ resource "fastly_service_compute" "foo" {
     timestamp_format = "%%Y-%%m-%%dT%%H:%%M:%%S.000"
     message_type = "classic"
     compression_codec = "zstd"
+    processing_region = "us"
   }
 
   package {

--- a/fastly/block_fastly_service_logging_elasticsearch_test.go
+++ b/fastly/block_fastly_service_logging_elasticsearch_test.go
@@ -38,6 +38,7 @@ func TestResourceFastlyFlattenElasticsearch(t *testing.T) {
 					Format:            gofastly.ToPointer(`%a %l %u %t %m %U%q %H %>s %b %T`),
 					FormatVersion:     gofastly.ToPointer(2),
 					Placement:         gofastly.ToPointer("none"),
+					ProcessingRegion:  gofastly.ToPointer("eu"),
 				},
 			},
 			local: []map[string]any{
@@ -58,6 +59,7 @@ func TestResourceFastlyFlattenElasticsearch(t *testing.T) {
 					"request_max_entries": 10,
 					"request_max_bytes":   10,
 					"format_version":      2,
+					"processing_region":   "eu",
 				},
 			},
 		},
@@ -94,6 +96,7 @@ func TestAccFastlyServiceVCL_logging_elasticsearch_basic(t *testing.T) {
 		TLSHostname:       gofastly.ToPointer("example.com"),
 		ResponseCondition: gofastly.ToPointer("response_condition_test"),
 		Placement:         gofastly.ToPointer("none"),
+		ProcessingRegion:  gofastly.ToPointer("us"),
 	}
 
 	log1AfterUpdate := gofastly.Elasticsearch{
@@ -114,6 +117,7 @@ func TestAccFastlyServiceVCL_logging_elasticsearch_basic(t *testing.T) {
 		TLSHostname:       gofastly.ToPointer("example.com"),
 		ResponseCondition: gofastly.ToPointer("response_condition_test"),
 		Placement:         gofastly.ToPointer("none"),
+		ProcessingRegion:  gofastly.ToPointer("none"),
 	}
 
 	log2 := gofastly.Elasticsearch{
@@ -134,6 +138,7 @@ func TestAccFastlyServiceVCL_logging_elasticsearch_basic(t *testing.T) {
 		TLSHostname:       gofastly.ToPointer("example.com"),
 		ResponseCondition: gofastly.ToPointer("response_condition_test"),
 		Placement:         gofastly.ToPointer("none"),
+		ProcessingRegion:  gofastly.ToPointer("none"),
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -189,6 +194,7 @@ func TestAccFastlyServiceVCL_logging_elasticsearch_basic_compute(t *testing.T) {
 		TLSClientCert:     gofastly.ToPointer(certificate(t)),
 		TLSClientKey:      gofastly.ToPointer(privateKey(t)),
 		TLSHostname:       gofastly.ToPointer("example.com"),
+		ProcessingRegion:  gofastly.ToPointer("us"),
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -296,6 +302,7 @@ resource "fastly_service_compute" "foo" {
     tls_client_cert   = file("test_fixtures/fastly_test_certificate")
     tls_client_key    = file("test_fixtures/fastly_test_privatekey")
     tls_hostname       = "example.com"
+    processing_region = "us"
   }
 
   package {
@@ -344,6 +351,7 @@ resource "fastly_service_vcl" "foo" {
 		tls_hostname       = "example.com"
 		response_condition = "response_condition_test"
 		placement          = "none"
+    processing_region = "us"
   }
 
   force_destroy = true

--- a/fastly/block_fastly_service_logging_ftp_test.go
+++ b/fastly/block_fastly_service_logging_ftp_test.go
@@ -37,6 +37,7 @@ func TestResourceFastlyFlattenFTP(t *testing.T) {
 					Placement:        gofastly.ToPointer("none"),
 					MessageType:      gofastly.ToPointer("classic"),
 					CompressionCodec: gofastly.ToPointer("zstd"),
+					ProcessingRegion: gofastly.ToPointer("eu"),
 				},
 			},
 			local: []map[string]any{
@@ -56,6 +57,7 @@ func TestResourceFastlyFlattenFTP(t *testing.T) {
 					"placement":         "none",
 					"message_type":      "classic",
 					"compression_codec": "zstd",
+					"processing_region": "eu",
 				},
 			},
 		},
@@ -92,6 +94,7 @@ func TestAccFastlyServiceVCL_logging_ftp_basic(t *testing.T) {
 		ServiceVersion:    gofastly.ToPointer(1),
 		TimestampFormat:   gofastly.ToPointer("%Y-%m-%dT%H:%M:%S.000"),
 		Username:          gofastly.ToPointer("user"),
+		ProcessingRegion:  gofastly.ToPointer("us"),
 	}
 
 	log1AfterUpdate := gofastly.FTP{
@@ -111,6 +114,7 @@ func TestAccFastlyServiceVCL_logging_ftp_basic(t *testing.T) {
 		ServiceVersion:    gofastly.ToPointer(1),
 		TimestampFormat:   gofastly.ToPointer("%Y-%m-%dT%H:%M:%S.000"),
 		Username:          gofastly.ToPointer("user"),
+		ProcessingRegion:  gofastly.ToPointer("none"),
 	}
 
 	log2 := gofastly.FTP{
@@ -131,6 +135,7 @@ func TestAccFastlyServiceVCL_logging_ftp_basic(t *testing.T) {
 		ServiceVersion:    gofastly.ToPointer(1),
 		TimestampFormat:   gofastly.ToPointer("%Y-%m-%dT%H:%M:%S.000"),
 		Username:          gofastly.ToPointer("user"),
+		ProcessingRegion:  gofastly.ToPointer("none"),
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -181,6 +186,7 @@ func TestAccFastlyServiceVCL_logging_ftp_basic_compute(t *testing.T) {
 		ServiceVersion:   gofastly.ToPointer(1),
 		TimestampFormat:  gofastly.ToPointer("%Y-%m-%dT%H:%M:%S.000"),
 		Username:         gofastly.ToPointer("user"),
+		ProcessingRegion: gofastly.ToPointer("us"),
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -287,6 +293,7 @@ resource "fastly_service_compute" "foo" {
     timestamp_format = "%%Y-%%m-%%dT%%H:%%M:%%S.000"
     message_type = "classic"
     compression_codec = "zstd"
+    processing_region = "us"
   }
 
   package {
@@ -325,6 +332,7 @@ resource "fastly_service_vcl" "foo" {
     timestamp_format = "%%Y-%%m-%%dT%%H:%%M:%%S.000"
     placement = "none"
     compression_codec = "zstd"
+    processing_region = "us"
   }
 
   force_destroy = true

--- a/fastly/block_fastly_service_logging_gcs.go
+++ b/fastly/block_fastly_service_logging_gcs.go
@@ -6,6 +6,7 @@ import (
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	gofastly "github.com/fastly/go-fastly/v10/fastly"
 )
@@ -82,6 +83,13 @@ func (h *GCSLoggingServiceAttributeHandler) GetSchema() *schema.Schema {
 			Optional:    true,
 			Default:     3600,
 			Description: "How frequently the logs should be transferred, in seconds (Default 3600)",
+		},
+		"processing_region": {
+			Type:         schema.TypeString,
+			Optional:     true,
+			Default:      "none",
+			Description:  "Region where logs will be processed before streaming to BigQuery. Valid values are 'none', 'us' and 'eu'.",
+			ValidateFunc: validation.StringInSlice([]string{"none", "us", "eu"}, false),
 		},
 		"project_id": {
 			Type:        schema.TypeString,
@@ -163,6 +171,7 @@ func (h *GCSLoggingServiceAttributeHandler) Create(_ context.Context, d *schema.
 		ServiceVersion:   serviceVersion,
 		TimestampFormat:  gofastly.ToPointer(resource["timestamp_format"].(string)),
 		User:             gofastly.ToPointer(resource["user"].(string)),
+		ProcessingRegion: gofastly.ToPointer(resource["processing_region"].(string)),
 	}
 
 	// NOTE: go-fastly v7+ expects a pointer, so TF can't set the zero type value.
@@ -274,6 +283,9 @@ func (h *GCSLoggingServiceAttributeHandler) Update(_ context.Context, d *schema.
 	if v, ok := modified["placement"]; ok {
 		opts.Placement = gofastly.ToPointer(v.(string))
 	}
+	if v, ok := modified["processing_region"]; ok {
+		opts.ProcessingRegion = gofastly.ToPointer(v.(string))
+	}
 
 	log.Printf("[DEBUG] Update GCS Opts: %#v", opts)
 	_, err := conn.UpdateGCS(&opts)
@@ -379,6 +391,9 @@ func flattenGCS(remoteState []*gofastly.GCS, state []any) []map[string]any {
 		}
 		if resources.CompressionCodec != nil {
 			data["compression_codec"] = *resources.CompressionCodec
+		}
+		if resources.ProcessingRegion != nil {
+			data["processing_region"] = *resources.ProcessingRegion
 		}
 
 		// prune any empty values that come from the default string value in structs

--- a/fastly/block_fastly_service_logging_gcs_test.go
+++ b/fastly/block_fastly_service_logging_gcs_test.go
@@ -38,6 +38,7 @@ func TestResourceFastlyFlattenGCS(t *testing.T) {
 					CompressionCodec: gofastly.ToPointer("zstd"),
 					AccountName:      gofastly.ToPointer("service-account"),
 					ProjectID:        gofastly.ToPointer("project-id"),
+					ProcessingRegion: gofastly.ToPointer("eu"),
 				},
 			},
 			local: []map[string]any{
@@ -53,6 +54,7 @@ func TestResourceFastlyFlattenGCS(t *testing.T) {
 					"compression_codec": "zstd",
 					"account_name":      "service-account",
 					"project_id":        "project-id",
+					"processing_region": "eu",
 				},
 			},
 		},
@@ -216,6 +218,7 @@ resource "fastly_service_vcl" "foo" {
     format = "log format"
     response_condition = ""
     compression_codec = "zstd"
+    processing_region = "us"
   }
 
   force_destroy = true
@@ -252,6 +255,7 @@ resource "fastly_service_compute" "foo" {
     bucket_name = "bucketname"
     secret_key = %q
     compression_codec = "zstd"
+    processing_region = "us"
   }
 
  package {

--- a/fastly/block_fastly_service_logging_googlepubsub_test.go
+++ b/fastly/block_fastly_service_logging_googlepubsub_test.go
@@ -34,6 +34,7 @@ func TestResourceFastlyFlattenGooglePubSub(t *testing.T) {
 					Format:            gofastly.ToPointer(`%a %l %u %t %m %U%q %H %>s %b %T`),
 					FormatVersion:     gofastly.ToPointer(2),
 					Placement:         gofastly.ToPointer("none"),
+					ProcessingRegion:  gofastly.ToPointer("eu"),
 				},
 			},
 			local: []map[string]any{
@@ -47,6 +48,7 @@ func TestResourceFastlyFlattenGooglePubSub(t *testing.T) {
 					"format":             `%a %l %u %t %m %U%q %H %>s %b %T`,
 					"placement":          "none",
 					"format_version":     2,
+					"processing_region":  "eu",
 				},
 			},
 		},
@@ -173,6 +175,7 @@ func TestAccFastlyServiceVCL_googlepubsublogging_basic(t *testing.T) {
 		Format:            gofastly.ToPointer(`%a %l %u %t %m %U%q %H %>s %b %T`),
 		FormatVersion:     gofastly.ToPointer(2),
 		Placement:         gofastly.ToPointer("none"),
+		ProcessingRegion:  gofastly.ToPointer("us"),
 	}
 
 	log1AfterUpdate := gofastly.Pubsub{
@@ -186,6 +189,7 @@ func TestAccFastlyServiceVCL_googlepubsublogging_basic(t *testing.T) {
 		Format:            gofastly.ToPointer(`%a %l %u %t %m %U%q %H %>s %b %T`),
 		FormatVersion:     gofastly.ToPointer(2),
 		Placement:         gofastly.ToPointer("none"),
+		ProcessingRegion:  gofastly.ToPointer("none"),
 	}
 
 	log2 := gofastly.Pubsub{
@@ -199,6 +203,7 @@ func TestAccFastlyServiceVCL_googlepubsublogging_basic(t *testing.T) {
 		Format:            gofastly.ToPointer(`%a %l %u %t %m %U%q %H %>s %b %T`),
 		FormatVersion:     gofastly.ToPointer(2),
 		Placement:         gofastly.ToPointer("none"),
+		ProcessingRegion:  gofastly.ToPointer("none"),
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -241,12 +246,13 @@ func TestAccFastlyServiceVCL_googlepubsublogging_basic_compute(t *testing.T) {
 	domain := fmt.Sprintf("fastly-test.%s.com", name)
 
 	log1 := gofastly.Pubsub{
-		ServiceVersion: gofastly.ToPointer(1),
-		Name:           gofastly.ToPointer("googlepubsublogger"),
-		User:           gofastly.ToPointer("user"),
-		SecretKey:      gofastly.ToPointer(privateKey(t)),
-		ProjectID:      gofastly.ToPointer("project-id"),
-		Topic:          gofastly.ToPointer("topic"),
+		ServiceVersion:   gofastly.ToPointer(1),
+		Name:             gofastly.ToPointer("googlepubsublogger"),
+		User:             gofastly.ToPointer("user"),
+		SecretKey:        gofastly.ToPointer(privateKey(t)),
+		ProjectID:        gofastly.ToPointer("project-id"),
+		Topic:            gofastly.ToPointer("topic"),
+		ProcessingRegion: gofastly.ToPointer("us"),
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -349,6 +355,7 @@ resource "fastly_service_compute" "foo" {
 		secret_key         = file("test_fixtures/fastly_test_privatekey")
 		project_id         = "project-id"
 	  topic  						 = "topic"
+    processing_region = "us"
 	}
 
 	package {
@@ -393,6 +400,7 @@ resource "fastly_service_vcl" "foo" {
 		format             = "%%a %%l %%u %%t %%m %%U%%q %%H %%>s %%b %%T"
 		format_version     = 2
 		placement          = "none"
+    processing_region = "us"
 	}
 
 	force_destroy = true

--- a/fastly/block_fastly_service_logging_grafanacloudlogs.go
+++ b/fastly/block_fastly_service_logging_grafanacloudlogs.go
@@ -6,6 +6,7 @@ import (
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	gofastly "github.com/fastly/go-fastly/v10/fastly"
 )
@@ -42,6 +43,13 @@ func (h *GrafanaCloudLogsServiceAttributeHandler) GetSchema() *schema.Schema {
 			Type:        schema.TypeString,
 			Required:    true,
 			Description: "The unique name of the GrafanaCloudLogs logging endpoint. It is important to note that changing this attribute will delete and recreate the resource",
+		},
+		"processing_region": {
+			Type:         schema.TypeString,
+			Optional:     true,
+			Default:      "none",
+			Description:  "Region where logs will be processed before streaming to BigQuery. Valid values are 'none', 'us' and 'eu'.",
+			ValidateFunc: validation.StringInSlice([]string{"none", "us", "eu"}, false),
 		},
 		"token": {
 			Type:        schema.TypeString,
@@ -167,6 +175,9 @@ func (h *GrafanaCloudLogsServiceAttributeHandler) Update(_ context.Context, d *s
 	if v, ok := modified["placement"]; ok {
 		opts.Placement = gofastly.ToPointer(v.(string))
 	}
+	if v, ok := modified["processing_region"]; ok {
+		opts.ProcessingRegion = gofastly.ToPointer(v.(string))
+	}
 
 	log.Printf("[DEBUG] Update GrafanaCloudLogs Opts: %#v", opts)
 	_, err := conn.UpdateGrafanaCloudLogs(&opts)
@@ -240,6 +251,9 @@ func flattenGrafanaCloudLogs(remoteState []*gofastly.GrafanaCloudLogs) []map[str
 		if resource.ResponseCondition != nil {
 			data["response_condition"] = *resource.ResponseCondition
 		}
+		if resource.ProcessingRegion != nil {
+			data["processing_region"] = *resource.ProcessingRegion
+		}
 
 		// Prune any empty values that come from the default string value in structs.
 		for k, v := range data {
@@ -259,15 +273,16 @@ func (h *GrafanaCloudLogsServiceAttributeHandler) buildCreate(grafanacloudlogsMa
 
 	vla := h.getVCLLoggingAttributes(resource)
 	opts := &gofastly.CreateGrafanaCloudLogsInput{
-		Format:         gofastly.ToPointer(vla.format),
-		FormatVersion:  vla.formatVersion,
-		Name:           gofastly.ToPointer(resource["name"].(string)),
-		ServiceID:      serviceID,
-		ServiceVersion: serviceVersion,
-		User:           gofastly.ToPointer(resource["user"].(string)),
-		Token:          gofastly.ToPointer(resource["token"].(string)),
-		URL:            gofastly.ToPointer(resource["url"].(string)),
-		Index:          gofastly.ToPointer(resource["index"].(string)),
+		Format:           gofastly.ToPointer(vla.format),
+		FormatVersion:    vla.formatVersion,
+		Name:             gofastly.ToPointer(resource["name"].(string)),
+		ServiceID:        serviceID,
+		ServiceVersion:   serviceVersion,
+		User:             gofastly.ToPointer(resource["user"].(string)),
+		Token:            gofastly.ToPointer(resource["token"].(string)),
+		URL:              gofastly.ToPointer(resource["url"].(string)),
+		Index:            gofastly.ToPointer(resource["index"].(string)),
+		ProcessingRegion: gofastly.ToPointer(resource["processing_region"].(string)),
 	}
 
 	// WARNING: The following fields shouldn't have an empty string passed.

--- a/fastly/block_fastly_service_logging_grafanacloudlogs_test.go
+++ b/fastly/block_fastly_service_logging_grafanacloudlogs_test.go
@@ -28,17 +28,19 @@ func TestResourceFastlyFlattenGrafanaCloudLogs(t *testing.T) {
 					URL:            gofastly.ToPointer("https://test123.grafana.net"),
 					Index:          gofastly.ToPointer("{\"label\": \"value\"}"),
 
-					FormatVersion: gofastly.ToPointer(2),
+					FormatVersion:    gofastly.ToPointer(2),
+					ProcessingRegion: gofastly.ToPointer("eu"),
 				},
 			},
 			local: []map[string]any{
 				{
-					"name":           "grafanacloudlogs-endpoint",
-					"user":           "123456",
-					"token":          "token",
-					"url":            "https://test123.grafana.net",
-					"index":          "{\"label\": \"value\"}",
-					"format_version": 2,
+					"name":              "grafanacloudlogs-endpoint",
+					"user":              "123456",
+					"token":             "token",
+					"url":               "https://test123.grafana.net",
+					"index":             "{\"label\": \"value\"}",
+					"format_version":    2,
+					"processing_region": "eu",
 				},
 			},
 		},
@@ -86,6 +88,7 @@ func TestAccFastlyServiceVCL_logging_grafanacloudlogs_basic(t *testing.T) {
 		Token:             gofastly.ToPointer("token"),
 		URL:               gofastly.ToPointer("https://test123.grafana.net"),
 		Index:             gofastly.ToPointer("{\"label\": \"value\"}"),
+		ProcessingRegion:  gofastly.ToPointer("us"),
 	}
 
 	log1AfterUpdate := gofastly.GrafanaCloudLogs{
@@ -98,6 +101,7 @@ func TestAccFastlyServiceVCL_logging_grafanacloudlogs_basic(t *testing.T) {
 		Token:             gofastly.ToPointer("t0k3n"),
 		URL:               gofastly.ToPointer("https://test456.grafana.net"),
 		Index:             gofastly.ToPointer("{\"label2\": \"value2\"}"),
+		ProcessingRegion:  gofastly.ToPointer("none"),
 	}
 
 	log2 := gofastly.GrafanaCloudLogs{
@@ -110,6 +114,7 @@ func TestAccFastlyServiceVCL_logging_grafanacloudlogs_basic(t *testing.T) {
 		URL:               gofastly.ToPointer("https://test789.grafana.net"),
 		Index:             gofastly.ToPointer("{\"label3\": \"value3\"}"),
 		Token:             gofastly.ToPointer("another-token"),
+		ProcessingRegion:  gofastly.ToPointer("none"),
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -148,12 +153,13 @@ func TestAccFastlyServiceVCL_logging_grafanacloudlogs_basic_compute(t *testing.T
 	domain := fmt.Sprintf("fastly-test.%s.com", name)
 
 	log1 := gofastly.GrafanaCloudLogs{
-		ServiceVersion: gofastly.ToPointer(1),
-		Name:           gofastly.ToPointer("grafanacloudlogs-endpoint"),
-		User:           gofastly.ToPointer("123456"),
-		Token:          gofastly.ToPointer("token"),
-		URL:            gofastly.ToPointer("https://test123.grafana.net"),
-		Index:          gofastly.ToPointer("{\"label\": \"value\"}"),
+		ServiceVersion:   gofastly.ToPointer(1),
+		Name:             gofastly.ToPointer("grafanacloudlogs-endpoint"),
+		User:             gofastly.ToPointer("123456"),
+		Token:            gofastly.ToPointer("token"),
+		URL:              gofastly.ToPointer("https://test123.grafana.net"),
+		Index:            gofastly.ToPointer("{\"label\": \"value\"}"),
+		ProcessingRegion: gofastly.ToPointer("us"),
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -253,6 +259,7 @@ resource "fastly_service_vcl" "foo" {
 	url    = "https://test123.grafana.net"
 	index  = "{\"label\": \"value\"}"
     format = "%%h %%l %%u %%t \"%%r\" %%>s %%b"
+    processing_region = "us"
   }
 
   force_destroy = true
@@ -325,6 +332,7 @@ resource "fastly_service_compute" "foo" {
     token  = "token"
 	url    = "https://test123.grafana.net"
 	index  = "{\"label\": \"value\"}"
+    processing_region = "us"
   }
 
   package {

--- a/fastly/block_fastly_service_logging_heroku_test.go
+++ b/fastly/block_fastly_service_logging_heroku_test.go
@@ -29,6 +29,7 @@ func TestResourceFastlyFlattenHeroku(t *testing.T) {
 					ResponseCondition: gofastly.ToPointer("always"),
 					Format:            gofastly.ToPointer("%h %l %u %t \"%r\" %>s %b"),
 					FormatVersion:     gofastly.ToPointer(2),
+					ProcessingRegion:  gofastly.ToPointer("eu"),
 				},
 			},
 			local: []map[string]any{
@@ -40,6 +41,7 @@ func TestResourceFastlyFlattenHeroku(t *testing.T) {
 					"format":             "%h %l %u %t \"%r\" %>s %b",
 					"response_condition": "always",
 					"format_version":     2,
+					"processing_region":  "eu",
 				},
 			},
 		},
@@ -66,6 +68,7 @@ func TestAccFastlyServiceVCL_logging_heroku_basic(t *testing.T) {
 		ServiceVersion:    gofastly.ToPointer(1),
 		Token:             gofastly.ToPointer("s3cr3t"),
 		URL:               gofastly.ToPointer("https://example.com"),
+		ProcessingRegion:  gofastly.ToPointer("us"),
 	}
 
 	log1AfterUpdate := gofastly.Heroku{
@@ -77,6 +80,7 @@ func TestAccFastlyServiceVCL_logging_heroku_basic(t *testing.T) {
 		ServiceVersion:    gofastly.ToPointer(1),
 		Token:             gofastly.ToPointer("secret"),
 		URL:               gofastly.ToPointer("https://example.com"),
+		ProcessingRegion:  gofastly.ToPointer("none"),
 	}
 
 	log2 := gofastly.Heroku{
@@ -87,6 +91,7 @@ func TestAccFastlyServiceVCL_logging_heroku_basic(t *testing.T) {
 		ServiceVersion:    gofastly.ToPointer(1),
 		Token:             gofastly.ToPointer("another-token"),
 		URL:               gofastly.ToPointer("https://new.example.com"),
+		ProcessingRegion:  gofastly.ToPointer("none"),
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -125,10 +130,11 @@ func TestAccFastlyServiceVCL_logging_heroku_basic_compute(t *testing.T) {
 	domain := fmt.Sprintf("fastly-test.%s.com", name)
 
 	log1 := gofastly.Heroku{
-		Name:           gofastly.ToPointer("heroku-endpoint"),
-		ServiceVersion: gofastly.ToPointer(1),
-		Token:          gofastly.ToPointer("s3cr3t"),
-		URL:            gofastly.ToPointer("https://example.com"),
+		Name:             gofastly.ToPointer("heroku-endpoint"),
+		ServiceVersion:   gofastly.ToPointer(1),
+		Token:            gofastly.ToPointer("s3cr3t"),
+		URL:              gofastly.ToPointer("https://example.com"),
+		ProcessingRegion: gofastly.ToPointer("us"),
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -218,6 +224,7 @@ resource "fastly_service_vcl" "foo" {
     token  = "s3cr3t"
 		url    = "https://example.com"
     format = "%%h %%l %%u %%t \"%%r\" %%>s %%b"
+    processing_region = "us"
   }
 
   force_destroy = true
@@ -291,6 +298,7 @@ resource "fastly_service_compute" "foo" {
     name   = "heroku-endpoint"
     token  = "s3cr3t"
     url    = "https://example.com"
+    processing_region = "us"
   }
 
   package {

--- a/fastly/block_fastly_service_logging_honeycomb_test.go
+++ b/fastly/block_fastly_service_logging_honeycomb_test.go
@@ -60,6 +60,7 @@ func TestResourceFastlyFlattenHoneycomb(t *testing.T) {
 					ResponseCondition: gofastly.ToPointer("always"),
 					Format:            gofastly.ToPointer(honeycombDefaultFormat),
 					FormatVersion:     gofastly.ToPointer(2),
+					ProcessingRegion:  gofastly.ToPointer("eu"),
 				},
 			},
 			local: []map[string]any{
@@ -71,6 +72,7 @@ func TestResourceFastlyFlattenHoneycomb(t *testing.T) {
 					"response_condition": "always",
 					"format":             honeycombDefaultFormat,
 					"format_version":     2,
+					"processing_region":  "eu",
 				},
 			},
 		},
@@ -97,6 +99,7 @@ func TestAccFastlyServiceVCL_logging_honeycomb_basic(t *testing.T) {
 		ResponseCondition: gofastly.ToPointer(""),
 		ServiceVersion:    gofastly.ToPointer(1),
 		Token:             gofastly.ToPointer("s3cr3t"),
+		ProcessingRegion:  gofastly.ToPointer("us"),
 	}
 
 	log1AfterUpdate := gofastly.Honeycomb{
@@ -108,6 +111,7 @@ func TestAccFastlyServiceVCL_logging_honeycomb_basic(t *testing.T) {
 		ResponseCondition: gofastly.ToPointer("response_condition_test"),
 		ServiceVersion:    gofastly.ToPointer(1),
 		Token:             gofastly.ToPointer("secret"),
+		ProcessingRegion:  gofastly.ToPointer("none"),
 	}
 
 	log2 := gofastly.Honeycomb{
@@ -119,6 +123,7 @@ func TestAccFastlyServiceVCL_logging_honeycomb_basic(t *testing.T) {
 		ResponseCondition: gofastly.ToPointer("response_condition_test"),
 		ServiceVersion:    gofastly.ToPointer(1),
 		Token:             gofastly.ToPointer("another-token"),
+		ProcessingRegion:  gofastly.ToPointer("none"),
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -157,10 +162,11 @@ func TestAccFastlyServiceVCL_logging_honeycomb_basic_compute(t *testing.T) {
 	domain := fmt.Sprintf("fastly-test.%s.com", name)
 
 	log1 := gofastly.Honeycomb{
-		Dataset:        gofastly.ToPointer("dataset"),
-		Name:           gofastly.ToPointer("honeycomb-endpoint"),
-		ServiceVersion: gofastly.ToPointer(1),
-		Token:          gofastly.ToPointer("s3cr3t"),
+		Dataset:          gofastly.ToPointer("dataset"),
+		Name:             gofastly.ToPointer("honeycomb-endpoint"),
+		ServiceVersion:   gofastly.ToPointer(1),
+		Token:            gofastly.ToPointer("s3cr3t"),
+		ProcessingRegion: gofastly.ToPointer("us"),
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -252,6 +258,7 @@ resource "fastly_service_vcl" "foo" {
     format = <<EOF
 `+escapePercentSign(honeycombDefaultFormat)+`
 EOF
+    processing_region = "us"
   }
 
   force_destroy = true
@@ -331,6 +338,7 @@ resource "fastly_service_compute" "foo" {
     name   = "honeycomb-endpoint"
     token  = "s3cr3t"
     dataset = "dataset"
+    processing_region = "us"
   }
 
   package {

--- a/fastly/block_fastly_service_logging_https_test.go
+++ b/fastly/block_fastly_service_logging_https_test.go
@@ -29,6 +29,7 @@ func TestResourceFastlyFlattenHTTPS(t *testing.T) {
 					ContentType:       gofastly.ToPointer("application/json"),
 					MessageType:       gofastly.ToPointer("blank"),
 					FormatVersion:     gofastly.ToPointer(2),
+					ProcessingRegion:  gofastly.ToPointer("eu"),
 				},
 			},
 			local: []map[string]any{
@@ -40,6 +41,7 @@ func TestResourceFastlyFlattenHTTPS(t *testing.T) {
 					"content_type":        "application/json",
 					"message_type":        "blank",
 					"format_version":      2,
+					"processing_region":   "eu",
 				},
 			},
 		},
@@ -74,6 +76,7 @@ func TestAccFastlyServiceVCL_httpslogging_basic(t *testing.T) {
 		ServiceVersion:    gofastly.ToPointer(1),
 		TLSHostname:       gofastly.ToPointer(""),
 		URL:               gofastly.ToPointer("https://example.com/logs/1"),
+		ProcessingRegion:  gofastly.ToPointer("us"),
 	}
 
 	log1AfterUpdate := gofastly.HTTPS{
@@ -92,6 +95,7 @@ func TestAccFastlyServiceVCL_httpslogging_basic(t *testing.T) {
 		ServiceVersion:    gofastly.ToPointer(1),
 		TLSHostname:       gofastly.ToPointer(""),
 		URL:               gofastly.ToPointer("https://example.com/logs/1"),
+		ProcessingRegion:  gofastly.ToPointer("none"),
 	}
 
 	log2 := gofastly.HTTPS{
@@ -110,6 +114,7 @@ func TestAccFastlyServiceVCL_httpslogging_basic(t *testing.T) {
 		ServiceVersion:    gofastly.ToPointer(1),
 		TLSHostname:       gofastly.ToPointer(""),
 		URL:               gofastly.ToPointer("https://example.com/logs/2"),
+		ProcessingRegion:  gofastly.ToPointer("none"),
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -160,6 +165,7 @@ func TestAccFastlyServiceVCL_httpslogging_basic_compute(t *testing.T) {
 		ServiceVersion:    gofastly.ToPointer(1),
 		TLSHostname:       gofastly.ToPointer(""),
 		URL:               gofastly.ToPointer("https://example.com/logs/1"),
+		ProcessingRegion:  gofastly.ToPointer("us"),
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -254,6 +260,7 @@ resource "fastly_service_vcl" "foo" {
 		format             = "%%a %%l %%u %%t %%m %%U%%q %%H %%>s %%b %%T"
 		method             = "PUT"
 		url                = "https://example.com/logs/1"
+    processing_region = "us"
 	}
 
 	force_destroy = true
@@ -283,6 +290,7 @@ resource "fastly_service_compute" "foo" {
 		name               = "httpslogger"
 		method             = "PUT"
 		url                = "https://example.com/logs/1"
+    processing_region = "us"
 	}
 
   package {

--- a/fastly/block_fastly_service_logging_kafka_test.go
+++ b/fastly/block_fastly_service_logging_kafka_test.go
@@ -41,6 +41,7 @@ func TestResourceFastlyFlattenKafka(t *testing.T) {
 					AuthMethod:        gofastly.ToPointer("scram-sha-512"),
 					User:              gofastly.ToPointer("user"),
 					Password:          gofastly.ToPointer("password"),
+					ProcessingRegion:  gofastly.ToPointer("eu"),
 				},
 			},
 			local: []map[string]any{
@@ -64,6 +65,7 @@ func TestResourceFastlyFlattenKafka(t *testing.T) {
 					"auth_method":        "scram-sha-512",
 					"user":               "user",
 					"password":           "password",
+					"processing_region":  "eu",
 				},
 			},
 		},
@@ -103,6 +105,7 @@ func TestAccFastlyServiceVCL_kafkalogging_basic(t *testing.T) {
 		AuthMethod:        gofastly.ToPointer("plain"),
 		User:              gofastly.ToPointer("user"),
 		Password:          gofastly.ToPointer("password"),
+		ProcessingRegion:  gofastly.ToPointer("us"),
 	}
 
 	log1AfterUpdate := gofastly.Kafka{
@@ -126,6 +129,7 @@ func TestAccFastlyServiceVCL_kafkalogging_basic(t *testing.T) {
 		AuthMethod:        gofastly.ToPointer("scram-sha-256"),
 		User:              gofastly.ToPointer("user"),
 		Password:          gofastly.ToPointer("password"),
+		ProcessingRegion:  gofastly.ToPointer("none"),
 	}
 
 	log2 := gofastly.Kafka{
@@ -149,6 +153,7 @@ func TestAccFastlyServiceVCL_kafkalogging_basic(t *testing.T) {
 		AuthMethod:        gofastly.ToPointer("scram-sha-256"),
 		User:              gofastly.ToPointer("user"),
 		Password:          gofastly.ToPointer("password"),
+		ProcessingRegion:  gofastly.ToPointer("none"),
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -207,6 +212,7 @@ func TestAccFastlyServiceVCL_kafkalogging_basic_compute(t *testing.T) {
 		Topic:            gofastly.ToPointer("topic"),
 		UseTLS:           gofastly.ToPointer(true),
 		User:             gofastly.ToPointer(""),
+		ProcessingRegion: gofastly.ToPointer("us"),
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -312,6 +318,7 @@ resource "fastly_service_compute" "foo" {
 		tls_client_cert    = file("test_fixtures/fastly_test_certificate")
 		tls_client_key     = file("test_fixtures/fastly_test_privatekey")
 		tls_hostname       = "example.com"
+    processing_region = "us"
 	}
 
 	package {
@@ -366,6 +373,7 @@ resource "fastly_service_vcl" "foo" {
 		auth_method        = "plain"
 		user               = "user"
 		password           = "password"
+    processing_region = "us"
 	}
 
 	force_destroy = true

--- a/fastly/block_fastly_service_logging_kinesis.go
+++ b/fastly/block_fastly_service_logging_kinesis.go
@@ -6,6 +6,7 @@ import (
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	gofastly "github.com/fastly/go-fastly/v10/fastly"
 )
@@ -49,6 +50,13 @@ func (h *KinesisServiceAttributeHandler) GetSchema() *schema.Schema {
 			Type:        schema.TypeString,
 			Required:    true,
 			Description: "The unique name of the Kinesis logging endpoint. It is important to note that changing this attribute will delete and recreate the resource",
+		},
+		"processing_region": {
+			Type:         schema.TypeString,
+			Optional:     true,
+			Default:      "none",
+			Description:  "Region where logs will be processed before streaming to BigQuery. Valid values are 'none', 'us' and 'eu'.",
+			ValidateFunc: validation.StringInSlice([]string{"none", "us", "eu"}, false),
 		},
 		"region": {
 			Type:        schema.TypeString,
@@ -178,6 +186,9 @@ func (h *KinesisServiceAttributeHandler) Update(_ context.Context, d *schema.Res
 	if v, ok := modified["placement"]; ok {
 		opts.Placement = gofastly.ToPointer(v.(string))
 	}
+	if v, ok := modified["processing_region"]; ok {
+		opts.ProcessingRegion = gofastly.ToPointer(v.(string))
+	}
 
 	log.Printf("[DEBUG] Update Kinesis Opts: %#v", opts)
 	_, err := conn.UpdateKinesis(&opts)
@@ -254,6 +265,9 @@ func flattenKinesis(remoteState []*gofastly.Kinesis) []map[string]any {
 		if resource.ResponseCondition != nil {
 			data["response_condition"] = *resource.ResponseCondition
 		}
+		if resource.ProcessingRegion != nil {
+			data["processing_region"] = *resource.ProcessingRegion
+		}
 
 		// Prune any empty values that come from the default string value in structs.
 		for k, v := range data {
@@ -273,16 +287,17 @@ func (h *KinesisServiceAttributeHandler) buildCreate(kinesisMap any, serviceID s
 
 	vla := h.getVCLLoggingAttributes(resource)
 	opts := &gofastly.CreateKinesisInput{
-		AccessKey:      gofastly.ToPointer(resource["access_key"].(string)),
-		Format:         gofastly.ToPointer(vla.format),
-		FormatVersion:  vla.formatVersion,
-		IAMRole:        gofastly.ToPointer(resource["iam_role"].(string)),
-		Name:           gofastly.ToPointer(resource["name"].(string)),
-		Region:         gofastly.ToPointer(resource["region"].(string)),
-		SecretKey:      gofastly.ToPointer(resource["secret_key"].(string)),
-		ServiceID:      serviceID,
-		ServiceVersion: serviceVersion,
-		StreamName:     gofastly.ToPointer(resource["topic"].(string)),
+		AccessKey:        gofastly.ToPointer(resource["access_key"].(string)),
+		Format:           gofastly.ToPointer(vla.format),
+		FormatVersion:    vla.formatVersion,
+		IAMRole:          gofastly.ToPointer(resource["iam_role"].(string)),
+		Name:             gofastly.ToPointer(resource["name"].(string)),
+		Region:           gofastly.ToPointer(resource["region"].(string)),
+		SecretKey:        gofastly.ToPointer(resource["secret_key"].(string)),
+		ServiceID:        serviceID,
+		ServiceVersion:   serviceVersion,
+		StreamName:       gofastly.ToPointer(resource["topic"].(string)),
+		ProcessingRegion: gofastly.ToPointer(resource["processing_region"].(string)),
 	}
 
 	// WARNING: The following fields shouldn't have an empty string passed.

--- a/fastly/block_fastly_service_logging_kinesis_test.go
+++ b/fastly/block_fastly_service_logging_kinesis_test.go
@@ -33,6 +33,7 @@ func TestResourceFastlyFlattenKinesis(t *testing.T) {
 					Placement:         gofastly.ToPointer("none"),
 					ResponseCondition: gofastly.ToPointer("always"),
 					FormatVersion:     gofastly.ToPointer(2),
+					ProcessingRegion:  gofastly.ToPointer("eu"),
 				},
 			},
 			local: []map[string]any{
@@ -46,6 +47,7 @@ func TestResourceFastlyFlattenKinesis(t *testing.T) {
 					"placement":          "none",
 					"response_condition": "always",
 					"format_version":     2,
+					"processing_region":  "eu",
 				},
 			},
 		},
@@ -102,6 +104,7 @@ func TestAccFastlyServiceVCL_logging_kinesis_basic(t *testing.T) {
 		SecretKey:         gofastly.ToPointer("thisisthesecretthatneedstobe40characters"),
 		ServiceVersion:    gofastly.ToPointer(1),
 		StreamName:        gofastly.ToPointer("stream-name"),
+		ProcessingRegion:  gofastly.ToPointer("us"),
 	}
 
 	log1AfterUpdate := gofastly.Kinesis{
@@ -115,6 +118,7 @@ func TestAccFastlyServiceVCL_logging_kinesis_basic(t *testing.T) {
 		SecretKey:         gofastly.ToPointer(""),
 		ServiceVersion:    gofastly.ToPointer(1),
 		StreamName:        gofastly.ToPointer("new-stream-name"),
+		ProcessingRegion:  gofastly.ToPointer("none"),
 	}
 
 	log2 := gofastly.Kinesis{
@@ -128,6 +132,7 @@ func TestAccFastlyServiceVCL_logging_kinesis_basic(t *testing.T) {
 		SecretKey:         gofastly.ToPointer(""),
 		ServiceVersion:    gofastly.ToPointer(1),
 		StreamName:        gofastly.ToPointer("another-stream-name"),
+		ProcessingRegion:  gofastly.ToPointer("none"),
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -166,13 +171,14 @@ func TestAccFastlyServiceVCL_logging_kinesis_basic_compute(t *testing.T) {
 	domain := fmt.Sprintf("fastly-test.%s.com", name)
 
 	log1 := gofastly.Kinesis{
-		AccessKey:      gofastly.ToPointer("whywouldyoucheckthis"),
-		IAMRole:        gofastly.ToPointer(""),
-		Name:           gofastly.ToPointer("kinesis-endpoint"),
-		Region:         gofastly.ToPointer("us-east-1"),
-		SecretKey:      gofastly.ToPointer("thisisthesecretthatneedstobe40characters"),
-		ServiceVersion: gofastly.ToPointer(1),
-		StreamName:     gofastly.ToPointer("stream-name"),
+		AccessKey:        gofastly.ToPointer("whywouldyoucheckthis"),
+		IAMRole:          gofastly.ToPointer(""),
+		Name:             gofastly.ToPointer("kinesis-endpoint"),
+		Region:           gofastly.ToPointer("us-east-1"),
+		SecretKey:        gofastly.ToPointer("thisisthesecretthatneedstobe40characters"),
+		ServiceVersion:   gofastly.ToPointer(1),
+		StreamName:       gofastly.ToPointer("stream-name"),
+		ProcessingRegion: gofastly.ToPointer("us"),
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -264,6 +270,7 @@ resource "fastly_service_vcl" "foo" {
     access_key  = "whywouldyoucheckthis"
     secret_key  = "thisisthesecretthatneedstobe40characters"
     format      = "%%h %%l %%u %%t \"%%r\" %%>s %%b"
+    processing_region = "us"
   }
 
   force_destroy = true
@@ -339,6 +346,7 @@ resource "fastly_service_compute" "foo" {
     region      = "us-east-1"
     access_key  = "whywouldyoucheckthis"
     secret_key  = "thisisthesecretthatneedstobe40characters"
+    processing_region = "us"
   }
 
   package {

--- a/fastly/block_fastly_service_logging_logentries_test.go
+++ b/fastly/block_fastly_service_logging_logentries_test.go
@@ -29,6 +29,7 @@ func TestResourceFastlyFlattenLogentries(t *testing.T) {
 					ResponseCondition: gofastly.ToPointer("response_condition_test"),
 					ServiceVersion:    gofastly.ToPointer(1), // expect this not to be persisted to tf state as it's tracked by the parent 'service' resource
 					Token:             gofastly.ToPointer("mytoken"),
+					ProcessingRegion:  gofastly.ToPointer("eu"),
 				},
 			},
 			local: []map[string]any{
@@ -40,6 +41,7 @@ func TestResourceFastlyFlattenLogentries(t *testing.T) {
 					"port":               8080,
 					"response_condition": "response_condition_test",
 					"token":              "mytoken",
+					"processing_region":  "eu",
 				},
 			},
 		},
@@ -67,6 +69,7 @@ func TestAccFastlyServiceVCL_logentries_basic(t *testing.T) {
 		Format:            gofastly.ToPointer(`%h %l %u %t "%r" %>s %b`),
 		FormatVersion:     gofastly.ToPointer(2),
 		ResponseCondition: gofastly.ToPointer("response_condition_test"),
+		ProcessingRegion:  gofastly.ToPointer("us"),
 	}
 
 	log2 := gofastly.Logentries{
@@ -78,6 +81,7 @@ func TestAccFastlyServiceVCL_logentries_basic(t *testing.T) {
 		Format:            gofastly.ToPointer("%h %u %t %r %>s"),
 		FormatVersion:     gofastly.ToPointer(2),
 		ResponseCondition: gofastly.ToPointer("response_condition_test"),
+		ProcessingRegion:  gofastly.ToPointer("none"),
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -127,6 +131,7 @@ func TestAccFastlyServiceVCL_logentries_basic_compute(t *testing.T) {
 		Format:            gofastly.ToPointer(`%h %l %u %t "%r" %>s %b`),
 		FormatVersion:     gofastly.ToPointer(2),
 		ResponseCondition: gofastly.ToPointer("response_condition_test"),
+		ProcessingRegion:  gofastly.ToPointer("us"),
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -262,6 +267,7 @@ resource "fastly_service_compute" "foo" {
   logging_logentries {
     name               = "somelogentriesname"
     token              = "token"
+    processing_region = "us"
   }
 
   package {
@@ -295,6 +301,7 @@ resource "fastly_service_vcl" "foo" {
     name               = "somelogentriesname"
     token              = "token"
     response_condition = "response_condition_test"
+    processing_region = "us"
   }
   force_destroy = true
 }`, name, domain)

--- a/fastly/block_fastly_service_logging_loggly.go
+++ b/fastly/block_fastly_service_logging_loggly.go
@@ -6,6 +6,7 @@ import (
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	gofastly "github.com/fastly/go-fastly/v10/fastly"
 )
@@ -39,7 +40,13 @@ func (h *LogglyServiceAttributeHandler) GetSchema() *schema.Schema {
 			Required:    true,
 			Description: "The unique name of the Loggly logging endpoint. It is important to note that changing this attribute will delete and recreate the resource",
 		},
-
+		"processing_region": {
+			Type:         schema.TypeString,
+			Optional:     true,
+			Default:      "none",
+			Description:  "Region where logs will be processed before streaming to BigQuery. Valid values are 'none', 'us' and 'eu'.",
+			ValidateFunc: validation.StringInSlice([]string{"none", "us", "eu"}, false),
+		},
 		"token": {
 			Type:        schema.TypeString,
 			Required:    true,
@@ -145,6 +152,9 @@ func (h *LogglyServiceAttributeHandler) Update(_ context.Context, d *schema.Reso
 	if v, ok := modified["placement"]; ok {
 		opts.Placement = gofastly.ToPointer(v.(string))
 	}
+	if v, ok := modified["processing_region"]; ok {
+		opts.ProcessingRegion = gofastly.ToPointer(v.(string))
+	}
 
 	log.Printf("[DEBUG] Update Loggly Opts: %#v", opts)
 	_, err := conn.UpdateLoggly(&opts)
@@ -209,6 +219,9 @@ func flattenLoggly(remoteState []*gofastly.Loggly) []map[string]any {
 		if resource.ResponseCondition != nil {
 			data["response_condition"] = *resource.ResponseCondition
 		}
+		if resource.ProcessingRegion != nil {
+			data["processing_region"] = *resource.ProcessingRegion
+		}
 
 		// Prune any empty values that come from the default string value in structs.
 		for k, v := range data {
@@ -228,12 +241,13 @@ func (h *LogglyServiceAttributeHandler) buildCreate(logglyMap any, serviceID str
 
 	vla := h.getVCLLoggingAttributes(resource)
 	opts := &gofastly.CreateLogglyInput{
-		Format:         gofastly.ToPointer(vla.format),
-		FormatVersion:  vla.formatVersion,
-		Name:           gofastly.ToPointer(resource["name"].(string)),
-		ServiceID:      serviceID,
-		ServiceVersion: serviceVersion,
-		Token:          gofastly.ToPointer(resource["token"].(string)),
+		Format:           gofastly.ToPointer(vla.format),
+		FormatVersion:    vla.formatVersion,
+		Name:             gofastly.ToPointer(resource["name"].(string)),
+		ServiceID:        serviceID,
+		ServiceVersion:   serviceVersion,
+		Token:            gofastly.ToPointer(resource["token"].(string)),
+		ProcessingRegion: gofastly.ToPointer(resource["processing_region"].(string)),
 	}
 
 	// WARNING: The following fields shouldn't have an empty string passed.

--- a/fastly/block_fastly_service_logging_loggly_test.go
+++ b/fastly/block_fastly_service_logging_loggly_test.go
@@ -21,17 +21,19 @@ func TestResourceFastlyFlattenLoggly(t *testing.T) {
 		{
 			remote: []*gofastly.Loggly{
 				{
-					ServiceVersion: gofastly.ToPointer(1),
-					Name:           gofastly.ToPointer("loggly-endpoint"),
-					Token:          gofastly.ToPointer("token"),
-					FormatVersion:  gofastly.ToPointer(2),
+					ServiceVersion:   gofastly.ToPointer(1),
+					Name:             gofastly.ToPointer("loggly-endpoint"),
+					Token:            gofastly.ToPointer("token"),
+					FormatVersion:    gofastly.ToPointer(2),
+					ProcessingRegion: gofastly.ToPointer("eu"),
 				},
 			},
 			local: []map[string]any{
 				{
-					"name":           "loggly-endpoint",
-					"token":          "token",
-					"format_version": 2,
+					"name":              "loggly-endpoint",
+					"token":             "token",
+					"format_version":    2,
+					"processing_region": "eu",
 				},
 			},
 		},
@@ -57,6 +59,7 @@ func TestAccFastlyServiceVCL_logging_loggly_basic(t *testing.T) {
 		ResponseCondition: gofastly.ToPointer(""),
 		ServiceVersion:    gofastly.ToPointer(1),
 		Token:             gofastly.ToPointer("s3cr3t"),
+		ProcessingRegion:  gofastly.ToPointer("us"),
 	}
 
 	log1AfterUpdate := gofastly.Loggly{
@@ -66,6 +69,7 @@ func TestAccFastlyServiceVCL_logging_loggly_basic(t *testing.T) {
 		ResponseCondition: gofastly.ToPointer(""),
 		ServiceVersion:    gofastly.ToPointer(1),
 		Token:             gofastly.ToPointer("secret"),
+		ProcessingRegion:  gofastly.ToPointer("none"),
 	}
 
 	log2 := gofastly.Loggly{
@@ -75,6 +79,7 @@ func TestAccFastlyServiceVCL_logging_loggly_basic(t *testing.T) {
 		ResponseCondition: gofastly.ToPointer(""),
 		ServiceVersion:    gofastly.ToPointer(1),
 		Token:             gofastly.ToPointer("another-token"),
+		ProcessingRegion:  gofastly.ToPointer("none"),
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -113,9 +118,10 @@ func TestAccFastlyServiceVCL_logging_loggly_basic_compute(t *testing.T) {
 	domain := fmt.Sprintf("fastly-test.%s.com", name)
 
 	log1 := gofastly.Loggly{
-		Name:           gofastly.ToPointer("loggly-endpoint"),
-		ServiceVersion: gofastly.ToPointer(1),
-		Token:          gofastly.ToPointer("s3cr3t"),
+		Name:             gofastly.ToPointer("loggly-endpoint"),
+		ServiceVersion:   gofastly.ToPointer(1),
+		Token:            gofastly.ToPointer("s3cr3t"),
+		ProcessingRegion: gofastly.ToPointer("us"),
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -213,6 +219,7 @@ resource "fastly_service_compute" "foo" {
   logging_loggly {
     name   = "loggly-endpoint"
     token  = "s3cr3t"
+    processing_region = "us"
   }
 
   package {
@@ -244,6 +251,7 @@ resource "fastly_service_vcl" "foo" {
     name   = "loggly-endpoint"
     token  = "s3cr3t"
     format = "%%h %%l %%u %%t \"%%r\" %%>s %%b"
+    processing_region = "us"
   }
 
   force_destroy = true

--- a/fastly/block_fastly_service_logging_logshuttle.go
+++ b/fastly/block_fastly_service_logging_logshuttle.go
@@ -6,6 +6,7 @@ import (
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	gofastly "github.com/fastly/go-fastly/v10/fastly"
 )
@@ -38,6 +39,13 @@ func (h *LogshuttleServiceAttributeHandler) GetSchema() *schema.Schema {
 			Type:        schema.TypeString,
 			Required:    true,
 			Description: "The unique name of the Log Shuttle logging endpoint. It is important to note that changing this attribute will delete and recreate the resource",
+		},
+		"processing_region": {
+			Type:         schema.TypeString,
+			Optional:     true,
+			Default:      "none",
+			Description:  "Region where logs will be processed before streaming to BigQuery. Valid values are 'none', 'us' and 'eu'.",
+			ValidateFunc: validation.StringInSlice([]string{"none", "us", "eu"}, false),
 		},
 		"token": {
 			Type:        schema.TypeString,
@@ -152,6 +160,9 @@ func (h *LogshuttleServiceAttributeHandler) Update(_ context.Context, d *schema.
 	if v, ok := modified["url"]; ok {
 		opts.URL = gofastly.ToPointer(v.(string))
 	}
+	if v, ok := modified["processing_region"]; ok {
+		opts.ProcessingRegion = gofastly.ToPointer(v.(string))
+	}
 
 	log.Printf("[DEBUG] Update Log Shuttle Opts: %#v", opts)
 	_, err := conn.UpdateLogshuttle(&opts)
@@ -219,6 +230,9 @@ func flattenLogshuttle(remoteState []*gofastly.Logshuttle) []map[string]any {
 		if resource.ResponseCondition != nil {
 			data["response_condition"] = *resource.ResponseCondition
 		}
+		if resource.ProcessingRegion != nil {
+			data["processing_region"] = *resource.ProcessingRegion
+		}
 
 		// Prune any empty values that come from the default string value in structs.
 		for k, v := range data {
@@ -238,13 +252,14 @@ func (h *LogshuttleServiceAttributeHandler) buildCreate(logshuttleMap any, servi
 
 	vla := h.getVCLLoggingAttributes(resource)
 	opts := &gofastly.CreateLogshuttleInput{
-		Format:         gofastly.ToPointer(vla.format),
-		FormatVersion:  vla.formatVersion,
-		Name:           gofastly.ToPointer(resource["name"].(string)),
-		ServiceID:      serviceID,
-		ServiceVersion: serviceVersion,
-		Token:          gofastly.ToPointer(resource["token"].(string)),
-		URL:            gofastly.ToPointer(resource["url"].(string)),
+		Format:           gofastly.ToPointer(vla.format),
+		FormatVersion:    vla.formatVersion,
+		Name:             gofastly.ToPointer(resource["name"].(string)),
+		ServiceID:        serviceID,
+		ServiceVersion:   serviceVersion,
+		Token:            gofastly.ToPointer(resource["token"].(string)),
+		URL:              gofastly.ToPointer(resource["url"].(string)),
+		ProcessingRegion: gofastly.ToPointer(resource["processing_region"].(string)),
 	}
 
 	// WARNING: The following fields shouldn't have an empty string passed.

--- a/fastly/block_fastly_service_logging_logshuttle_test.go
+++ b/fastly/block_fastly_service_logging_logshuttle_test.go
@@ -29,6 +29,7 @@ func TestResourceFastlyFlattenLogshuttle(t *testing.T) {
 					Placement:         gofastly.ToPointer("none"),
 					ResponseCondition: gofastly.ToPointer("always"),
 					FormatVersion:     gofastly.ToPointer(2),
+					ProcessingRegion:  gofastly.ToPointer("eu"),
 				},
 			},
 			local: []map[string]any{
@@ -40,6 +41,7 @@ func TestResourceFastlyFlattenLogshuttle(t *testing.T) {
 					"placement":          "none",
 					"response_condition": "always",
 					"format_version":     2,
+					"processing_region":  "eu",
 				},
 			},
 		},
@@ -66,6 +68,7 @@ func TestAccFastlyServiceVCL_logging_logshuttle_basic(t *testing.T) {
 		ServiceVersion:    gofastly.ToPointer(1),
 		Token:             gofastly.ToPointer("s3cr3t"),
 		URL:               gofastly.ToPointer("https://example.com"),
+		ProcessingRegion:  gofastly.ToPointer("us"),
 	}
 
 	log1AfterUpdate := gofastly.Logshuttle{
@@ -76,6 +79,7 @@ func TestAccFastlyServiceVCL_logging_logshuttle_basic(t *testing.T) {
 		ServiceVersion:    gofastly.ToPointer(1),
 		Token:             gofastly.ToPointer("secret"),
 		URL:               gofastly.ToPointer("https://new.example.com"),
+		ProcessingRegion:  gofastly.ToPointer("none"),
 	}
 
 	log2 := gofastly.Logshuttle{
@@ -87,6 +91,7 @@ func TestAccFastlyServiceVCL_logging_logshuttle_basic(t *testing.T) {
 		ServiceVersion:    gofastly.ToPointer(1),
 		Token:             gofastly.ToPointer("another-token"),
 		URL:               gofastly.ToPointer("https://another.example.com"),
+		ProcessingRegion:  gofastly.ToPointer("none"),
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -125,10 +130,11 @@ func TestAccFastlyServiceVCL_logging_logshuttle_basic_compute(t *testing.T) {
 	domain := fmt.Sprintf("fastly-test.%s.com", name)
 
 	log1 := gofastly.Logshuttle{
-		Name:           gofastly.ToPointer("logshuttle-endpoint"),
-		ServiceVersion: gofastly.ToPointer(1),
-		Token:          gofastly.ToPointer("s3cr3t"),
-		URL:            gofastly.ToPointer("https://example.com"),
+		Name:             gofastly.ToPointer("logshuttle-endpoint"),
+		ServiceVersion:   gofastly.ToPointer(1),
+		Token:            gofastly.ToPointer("s3cr3t"),
+		URL:              gofastly.ToPointer("https://example.com"),
+		ProcessingRegion: gofastly.ToPointer("us"),
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -218,6 +224,7 @@ resource "fastly_service_vcl" "foo" {
     token  = "s3cr3t"
 		url    = "https://example.com"
     format = "%%h %%l %%u %%t \"%%r\" %%>s %%b"
+    processing_region = "us"
   }
 
   force_destroy = true
@@ -291,6 +298,7 @@ resource "fastly_service_compute" "foo" {
     name   = "logshuttle-endpoint"
     token  = "s3cr3t"
     url    = "https://example.com"
+    processing_region = "us"
   }
 
   package {

--- a/fastly/block_fastly_service_logging_newrelic_test.go
+++ b/fastly/block_fastly_service_logging_newrelic_test.go
@@ -21,19 +21,21 @@ func TestResourceFastlyFlattenNewRelic(t *testing.T) {
 		{
 			remote: []*gofastly.NewRelic{
 				{
-					ServiceVersion: gofastly.ToPointer(1),
-					Name:           gofastly.ToPointer("newrelic-endpoint"),
-					Token:          gofastly.ToPointer("token"),
-					Region:         gofastly.ToPointer("US"),
-					FormatVersion:  gofastly.ToPointer(2),
+					ServiceVersion:   gofastly.ToPointer(1),
+					Name:             gofastly.ToPointer("newrelic-endpoint"),
+					Token:            gofastly.ToPointer("token"),
+					Region:           gofastly.ToPointer("US"),
+					FormatVersion:    gofastly.ToPointer(2),
+					ProcessingRegion: gofastly.ToPointer("eu"),
 				},
 			},
 			local: []map[string]any{
 				{
-					"name":           "newrelic-endpoint",
-					"token":          "token",
-					"region":         "US",
-					"format_version": 2,
+					"name":              "newrelic-endpoint",
+					"token":             "token",
+					"region":            "US",
+					"format_version":    2,
+					"processing_region": "eu",
 				},
 			},
 		},
@@ -76,6 +78,7 @@ func TestAccFastlyServiceVCL_logging_newrelic_basic(t *testing.T) {
 		ResponseCondition: gofastly.ToPointer(""),
 		ServiceVersion:    gofastly.ToPointer(1),
 		Token:             gofastly.ToPointer("token"),
+		ProcessingRegion:  gofastly.ToPointer("us"),
 	}
 
 	log1AfterUpdate := gofastly.NewRelic{
@@ -86,6 +89,7 @@ func TestAccFastlyServiceVCL_logging_newrelic_basic(t *testing.T) {
 		ResponseCondition: gofastly.ToPointer(""),
 		ServiceVersion:    gofastly.ToPointer(1),
 		Token:             gofastly.ToPointer("t0k3n"),
+		ProcessingRegion:  gofastly.ToPointer("none"),
 	}
 
 	log2 := gofastly.NewRelic{
@@ -96,6 +100,7 @@ func TestAccFastlyServiceVCL_logging_newrelic_basic(t *testing.T) {
 		ResponseCondition: gofastly.ToPointer(""),
 		ServiceVersion:    gofastly.ToPointer(1),
 		Token:             gofastly.ToPointer("another-token"),
+		ProcessingRegion:  gofastly.ToPointer("none"),
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -135,12 +140,13 @@ func TestAccFastlyServiceVCL_logging_newrelic_basic_compute(t *testing.T) {
 	domain := fmt.Sprintf("fastly-test.%s.com", name)
 
 	log1 := gofastly.NewRelic{
-		Format:         gofastly.ToPointer("%h %l %u %t \"%r\" %>s %b"),
-		FormatVersion:  gofastly.ToPointer(2),
-		Name:           gofastly.ToPointer("newrelic-endpoint"),
-		Region:         gofastly.ToPointer("US"),
-		ServiceVersion: gofastly.ToPointer(1),
-		Token:          gofastly.ToPointer("token"),
+		Format:           gofastly.ToPointer("%h %l %u %t \"%r\" %>s %b"),
+		FormatVersion:    gofastly.ToPointer(2),
+		Name:             gofastly.ToPointer("newrelic-endpoint"),
+		Region:           gofastly.ToPointer("US"),
+		ServiceVersion:   gofastly.ToPointer(1),
+		Token:            gofastly.ToPointer("token"),
+		ProcessingRegion: gofastly.ToPointer("us"),
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -238,6 +244,7 @@ resource "fastly_service_compute" "foo" {
   logging_newrelic {
     name   = "newrelic-endpoint"
     token  = "token"
+    processing_region = "us"
   }
 
   package {
@@ -269,6 +276,7 @@ resource "fastly_service_vcl" "foo" {
     name   = "newrelic-endpoint"
     token  = "token"
     format = "%%h %%l %%u %%t \"%%r\" %%>s %%b"
+    processing_region = "us"
   }
 
   force_destroy = true

--- a/fastly/block_fastly_service_logging_newrelicotlp_test.go
+++ b/fastly/block_fastly_service_logging_newrelicotlp_test.go
@@ -22,11 +22,12 @@ func TestResourceFastlyFlattenNewRelicOTLP(t *testing.T) {
 		{
 			remote: []*gofastly.NewRelicOTLP{
 				{
-					ServiceVersion: gofastly.ToPointer(1),
-					Name:           gofastly.ToPointer("newrelicotlp-endpoint"),
-					Token:          gofastly.ToPointer("token"),
-					Region:         gofastly.ToPointer("US"),
-					FormatVersion:  gofastly.ToPointer(2),
+					ServiceVersion:   gofastly.ToPointer(1),
+					Name:             gofastly.ToPointer("newrelicotlp-endpoint"),
+					Token:            gofastly.ToPointer("token"),
+					Region:           gofastly.ToPointer("US"),
+					FormatVersion:    gofastly.ToPointer(2),
+					ProcessingRegion: gofastly.ToPointer("eu"),
 				},
 			},
 			local: []map[string]any{
@@ -39,6 +40,7 @@ func TestResourceFastlyFlattenNewRelicOTLP(t *testing.T) {
 					"response_condition": responseCondition, // implies nil
 					"token":              gofastly.ToPointer("token"),
 					"url":                loggingURL, // implies nil
+					"processing_region":  gofastly.ToPointer("eu"),
 				},
 			},
 		},
@@ -83,6 +85,7 @@ func TestAccFastlyServiceVCL_logging_newrelicotlp_basic(t *testing.T) {
 		// The Fastly API returns an empty string if nothing set by the user (it should probably set null)
 		ResponseCondition: gofastly.ToPointer(""),
 		URL:               gofastly.ToPointer(""),
+		ProcessingRegion:  gofastly.ToPointer("us"),
 	}
 
 	log1AfterUpdate := gofastly.NewRelicOTLP{
@@ -95,6 +98,7 @@ func TestAccFastlyServiceVCL_logging_newrelicotlp_basic(t *testing.T) {
 		// The Fastly API returns an empty string if nothing set by the user (it should probably set null)
 		ResponseCondition: gofastly.ToPointer(""),
 		URL:               gofastly.ToPointer(""),
+		ProcessingRegion:  gofastly.ToPointer("none"),
 	}
 
 	log2 := gofastly.NewRelicOTLP{
@@ -107,6 +111,7 @@ func TestAccFastlyServiceVCL_logging_newrelicotlp_basic(t *testing.T) {
 		Format:         gofastly.ToPointer(appendNewLine(newrelicotlpDefaultFormat)),
 		// The Fastly API returns an empty string if nothing set by the user (it should probably set null)
 		ResponseCondition: gofastly.ToPointer(""),
+		ProcessingRegion:  gofastly.ToPointer("none"),
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -204,6 +209,7 @@ resource "fastly_service_vcl" "foo" {
     name   = "newrelicotlp-endpoint"
     token  = "token"
     format = "%%h %%l %%u %%t \"%%r\" %%>s %%b"
+    processing_region = "us"
   }
 
   force_destroy = true

--- a/fastly/block_fastly_service_logging_openstack.go
+++ b/fastly/block_fastly_service_logging_openstack.go
@@ -6,6 +6,7 @@ import (
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	gofastly "github.com/fastly/go-fastly/v10/fastly"
 )
@@ -82,6 +83,13 @@ func (h *OpenstackServiceAttributeHandler) GetSchema() *schema.Schema {
 			Optional:    true,
 			Default:     3600,
 			Description: "How frequently the logs should be transferred, in seconds. Default `3600`",
+		},
+		"processing_region": {
+			Type:         schema.TypeString,
+			Optional:     true,
+			Default:      "none",
+			Description:  "Region where logs will be processed before streaming to BigQuery. Valid values are 'none', 'us' and 'eu'.",
+			ValidateFunc: validation.StringInSlice([]string{"none", "us", "eu"}, false),
 		},
 		"public_key": {
 			Type:             schema.TypeString,
@@ -234,6 +242,9 @@ func (h *OpenstackServiceAttributeHandler) Update(_ context.Context, d *schema.R
 	if v, ok := modified["public_key"]; ok {
 		opts.PublicKey = gofastly.ToPointer(v.(string))
 	}
+	if v, ok := modified["processing_region"]; ok {
+		opts.ProcessingRegion = gofastly.ToPointer(v.(string))
+	}
 
 	log.Printf("[DEBUG] Update OpenStack Opts: %#v", opts)
 	_, err := conn.UpdateOpenstack(&opts)
@@ -351,6 +362,9 @@ func flattenOpenstack(remoteState []*gofastly.Openstack, localState []any) []map
 		if resource.CompressionCodec != nil {
 			data["compression_codec"] = *resource.CompressionCodec
 		}
+		if resource.ProcessingRegion != nil {
+			data["processing_region"] = *resource.ProcessingRegion
+		}
 
 		// Prune any empty values that come from the default string value in structs.
 		for k, v := range data {
@@ -385,6 +399,7 @@ func (h *OpenstackServiceAttributeHandler) buildCreate(openstackMap any, service
 		TimestampFormat:  gofastly.ToPointer(resource["timestamp_format"].(string)),
 		URL:              gofastly.ToPointer(resource["url"].(string)),
 		User:             gofastly.ToPointer(resource["user"].(string)),
+		ProcessingRegion: gofastly.ToPointer(resource["processing_region"].(string)),
 	}
 
 	// NOTE: go-fastly v7+ expects a pointer, so TF can't set the zero type value.

--- a/fastly/block_fastly_service_logging_openstack_test.go
+++ b/fastly/block_fastly_service_logging_openstack_test.go
@@ -37,6 +37,7 @@ func TestResourceFastlyFlattenOpenstack(t *testing.T) {
 					Period:            gofastly.ToPointer(3600),
 					GzipLevel:         gofastly.ToPointer(0),
 					CompressionCodec:  gofastly.ToPointer("zstd"),
+					ProcessingRegion:  gofastly.ToPointer("eu"),
 				},
 			},
 			local: []map[string]any{
@@ -57,6 +58,7 @@ func TestResourceFastlyFlattenOpenstack(t *testing.T) {
 					"period":             3600,
 					"gzip_level":         0,
 					"compression_codec":  "zstd",
+					"processing_region":  "eu",
 				},
 			},
 		},
@@ -93,6 +95,7 @@ func TestAccFastlyServiceVCL_logging_openstack_basic(t *testing.T) {
 		TimestampFormat:   gofastly.ToPointer(`%Y-%m-%dT%H:%M:%S.000`),
 		URL:               gofastly.ToPointer("https://auth.example.com/v1"), // /v1, /v2 or /v3 are required to be in the path.
 		User:              gofastly.ToPointer("user"),
+		ProcessingRegion:  gofastly.ToPointer("us"),
 	}
 
 	log1AfterUpdate := gofastly.Openstack{
@@ -112,6 +115,7 @@ func TestAccFastlyServiceVCL_logging_openstack_basic(t *testing.T) {
 		TimestampFormat:   gofastly.ToPointer(`%Y-%m-%dT%H:%M:%S.000`),
 		URL:               gofastly.ToPointer("https://auth.example.com/v2"), // /v1, /v2 or /v3 are required to be in the path.
 		User:              gofastly.ToPointer("userupdate"),
+		ProcessingRegion:  gofastly.ToPointer("none"),
 	}
 
 	log2 := gofastly.Openstack{
@@ -132,6 +136,7 @@ func TestAccFastlyServiceVCL_logging_openstack_basic(t *testing.T) {
 		TimestampFormat:   gofastly.ToPointer(`%Y-%m-%dT%H:%M:%S.000`),
 		URL:               gofastly.ToPointer("https://auth.example.com/v3"), // /v1, /v2 or /v3 are required to be in the path.
 		User:              gofastly.ToPointer("user2"),
+		ProcessingRegion:  gofastly.ToPointer("none"),
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -183,6 +188,7 @@ func TestAccFastlyServiceVCL_logging_openstack_basic_compute(t *testing.T) {
 		TimestampFormat:  gofastly.ToPointer(`%Y-%m-%dT%H:%M:%S.000`),
 		URL:              gofastly.ToPointer("https://auth.example.com/v1"), // /v1, /v2 or /v3 are required to be in the path.
 		User:             gofastly.ToPointer("user"),
+		ProcessingRegion: gofastly.ToPointer("us"),
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -287,6 +293,7 @@ resource "fastly_service_vcl" "foo" {
 		timestamp_format = "%%Y-%%m-%%dT%%H:%%M:%%S.000"
     response_condition = "response_condition_test"
     compression_codec = "zstd"
+    processing_region = "us"
   }
 
   force_destroy = true
@@ -380,6 +387,7 @@ resource "fastly_service_compute" "foo" {
     path = "/"
     timestamp_format = "%%Y-%%m-%%dT%%H:%%M:%%S.000"
     compression_codec = "zstd"
+    processing_region = "us"
   }
 
   package {

--- a/fastly/block_fastly_service_logging_papertrail_test.go
+++ b/fastly/block_fastly_service_logging_papertrail_test.go
@@ -27,6 +27,7 @@ func TestResourceFastlyFlattenPapertrail(t *testing.T) {
 					Format:            gofastly.ToPointer("%h %l %u %t %r %>s"),
 					FormatVersion:     gofastly.ToPointer(2),
 					ResponseCondition: gofastly.ToPointer("test_response_condition"),
+					ProcessingRegion:  gofastly.ToPointer("eu"),
 				},
 			},
 			local: []map[string]any{
@@ -37,6 +38,7 @@ func TestResourceFastlyFlattenPapertrail(t *testing.T) {
 					"format":             "%h %l %u %t %r %>s",
 					"format_version":     2,
 					"response_condition": "test_response_condition",
+					"processing_region":  "eu",
 				},
 			},
 		},
@@ -63,6 +65,7 @@ func TestAccFastlyServiceVCL_papertrail_basic(t *testing.T) {
 		Port:              gofastly.ToPointer(3600),
 		ResponseCondition: gofastly.ToPointer("test_response_condition"),
 		ServiceVersion:    gofastly.ToPointer(1),
+		ProcessingRegion:  gofastly.ToPointer("us"),
 	}
 
 	log2 := gofastly.Papertrail{
@@ -73,6 +76,7 @@ func TestAccFastlyServiceVCL_papertrail_basic(t *testing.T) {
 		Port:              gofastly.ToPointer(8080),
 		ResponseCondition: gofastly.ToPointer(""),
 		ServiceVersion:    gofastly.ToPointer(1),
+		ProcessingRegion:  gofastly.ToPointer("none"),
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -111,10 +115,11 @@ func TestAccFastlyServiceVCL_papertrail_basic_compute(t *testing.T) {
 	domainName1 := fmt.Sprintf("fastly-test.tf-%s.com", acctest.RandString(10))
 
 	log1 := gofastly.Papertrail{
-		Address:        gofastly.ToPointer("test1.papertrailapp.com"),
-		Name:           gofastly.ToPointer("papertrailtesting"),
-		Port:           gofastly.ToPointer(3600),
-		ServiceVersion: gofastly.ToPointer(1),
+		Address:          gofastly.ToPointer("test1.papertrailapp.com"),
+		Name:             gofastly.ToPointer("papertrailtesting"),
+		Port:             gofastly.ToPointer(3600),
+		ServiceVersion:   gofastly.ToPointer(1),
+		ProcessingRegion: gofastly.ToPointer("us"),
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -211,6 +216,7 @@ resource "fastly_service_compute" "foo" {
     name               = "papertrailtesting"
     address            = "test1.papertrailapp.com"
     port               = 3600
+    processing_region = "us"
   }
 
   package {
@@ -249,6 +255,7 @@ resource "fastly_service_vcl" "foo" {
     address            = "test1.papertrailapp.com"
     port               = 3600
 		response_condition = "test_response_condition"
+    processing_region = "us"
   }
 
   force_destroy = true

--- a/fastly/block_fastly_service_logging_s3_test.go
+++ b/fastly/block_fastly_service_logging_s3_test.go
@@ -50,6 +50,7 @@ func TestResourceFastlyFlattenS3(t *testing.T) {
 					ServerSideEncryption:         gofastly.ToPointer(gofastly.S3ServerSideEncryptionAES),
 					ServerSideEncryptionKMSKeyID: gofastly.ToPointer("kmskey"),
 					TimestampFormat:              gofastly.ToPointer("%Y-%m-%dT%H:%M:%S.000"),
+					ProcessingRegion:             gofastly.ToPointer("eu"),
 				},
 			},
 			local: []map[string]any{
@@ -73,6 +74,7 @@ func TestResourceFastlyFlattenS3(t *testing.T) {
 					"server_side_encryption":            gofastly.S3ServerSideEncryptionAES,
 					"server_side_encryption_kms_key_id": "kmskey",
 					"timestamp_format":                  "%Y-%m-%dT%H:%M:%S.000",
+					"processing_region":                 "eu",
 				},
 			},
 			unset: true, // validating the user didn't set gzip_level
@@ -182,6 +184,7 @@ func TestAccFastlyServiceVCL_s3logging_basic(t *testing.T) {
 		ServerSideEncryptionKMSKeyID: gofastly.ToPointer(""),
 		ServiceVersion:               gofastly.ToPointer(1),
 		TimestampFormat:              gofastly.ToPointer("%Y-%m-%dT%H:%M:%S.000"),
+		ProcessingRegion:             gofastly.ToPointer("us"),
 	}
 
 	log1AfterUpdate := gofastly.S3{
@@ -205,6 +208,7 @@ func TestAccFastlyServiceVCL_s3logging_basic(t *testing.T) {
 		ServerSideEncryptionKMSKeyID: gofastly.ToPointer(""),
 		ServiceVersion:               gofastly.ToPointer(1),
 		TimestampFormat:              gofastly.ToPointer("%Y-%m-%dT%H:%M:%S.000"),
+		ProcessingRegion:             gofastly.ToPointer("none"),
 	}
 
 	log2 := gofastly.S3{
@@ -229,6 +233,7 @@ func TestAccFastlyServiceVCL_s3logging_basic(t *testing.T) {
 		ServerSideEncryptionKMSKeyID: gofastly.ToPointer(""),
 		ServiceVersion:               gofastly.ToPointer(1),
 		TimestampFormat:              gofastly.ToPointer("%Y-%m-%dT%H:%M:%S.000"),
+		ProcessingRegion:             gofastly.ToPointer("none"),
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -285,6 +290,7 @@ func TestAccFastlyServiceVCL_s3logging_basic_compute(t *testing.T) {
 		ServerSideEncryptionKMSKeyID: gofastly.ToPointer(""),
 		ServiceVersion:               gofastly.ToPointer(1),
 		TimestampFormat:              gofastly.ToPointer("%Y-%m-%dT%H:%M:%S.000"),
+		ProcessingRegion:             gofastly.ToPointer("us"),
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -333,6 +339,7 @@ func TestAccFastlyServiceVCL_s3logging_domain_default(t *testing.T) {
 		ServerSideEncryptionKMSKeyID: gofastly.ToPointer(""),
 		ServiceVersion:               gofastly.ToPointer(1),
 		TimestampFormat:              gofastly.ToPointer("%Y-%m-%dT%H:%M:%S.000"),
+		ProcessingRegion:             gofastly.ToPointer("none"),
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -381,6 +388,7 @@ func TestAccFastlyServiceVCL_s3logging_formatVersion(t *testing.T) {
 		ServerSideEncryptionKMSKeyID: gofastly.ToPointer(""),
 		ServiceVersion:               gofastly.ToPointer(1),
 		TimestampFormat:              gofastly.ToPointer("%Y-%m-%dT%H:%M:%S.000"),
+		ProcessingRegion:             gofastly.ToPointer("none"),
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -560,6 +568,7 @@ resource "fastly_service_compute" "foo" {
     s3_secret_key = "%s"
     public_key = file("test_fixtures/fastly_test_publickey")
     compression_codec = "zstd"
+    processing_region = "us"
   }
 
   package {
@@ -602,6 +611,7 @@ resource "fastly_service_vcl" "foo" {
     response_condition = "response_condition_test"
     public_key = file("test_fixtures/fastly_test_publickey")
     compression_codec = "zstd"
+    processing_region = "us"
   }
 
   force_destroy = true

--- a/fastly/block_fastly_service_logging_scalyr_test.go
+++ b/fastly/block_fastly_service_logging_scalyr_test.go
@@ -30,6 +30,7 @@ func TestResourceFastlyFlattenScalyr(t *testing.T) {
 					FormatVersion:     gofastly.ToPointer(2),
 					Placement:         gofastly.ToPointer("none"),
 					ProjectID:         gofastly.ToPointer("example-project"),
+					ProcessingRegion:  gofastly.ToPointer("eu"),
 				},
 			},
 			local: []map[string]any{
@@ -42,6 +43,7 @@ func TestResourceFastlyFlattenScalyr(t *testing.T) {
 					"placement":          "none",
 					"format_version":     2,
 					"project_id":         "example-project",
+					"processing_region":  "eu",
 				},
 			},
 		},
@@ -69,6 +71,7 @@ func TestAccFastlyServiceVCL_scalyrlogging_basic(t *testing.T) {
 		ResponseCondition: gofastly.ToPointer("response_condition_test"),
 		ServiceVersion:    gofastly.ToPointer(1),
 		Token:             gofastly.ToPointer("tkn"),
+		ProcessingRegion:  gofastly.ToPointer("us"),
 	}
 
 	log1AfterUpdate := gofastly.Scalyr{
@@ -81,6 +84,7 @@ func TestAccFastlyServiceVCL_scalyrlogging_basic(t *testing.T) {
 		ServiceVersion:    gofastly.ToPointer(1),
 		Token:             gofastly.ToPointer("newtkn"),
 		ProjectID:         gofastly.ToPointer("example-project"),
+		ProcessingRegion:  gofastly.ToPointer("none"),
 	}
 
 	log2 := gofastly.Scalyr{
@@ -92,6 +96,7 @@ func TestAccFastlyServiceVCL_scalyrlogging_basic(t *testing.T) {
 		ResponseCondition: gofastly.ToPointer(""),
 		ServiceVersion:    gofastly.ToPointer(1),
 		Token:             gofastly.ToPointer("tknb"),
+		ProcessingRegion:  gofastly.ToPointer("none"),
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -130,10 +135,11 @@ func TestAccFastlyServiceVCL_scalyrlogging_basic_compute(t *testing.T) {
 	domain := fmt.Sprintf("fastly-test.%s.com", name)
 
 	log1 := gofastly.Scalyr{
-		Name:           gofastly.ToPointer("scalyrlogger"),
-		Region:         gofastly.ToPointer("US"),
-		ServiceVersion: gofastly.ToPointer(1),
-		Token:          gofastly.ToPointer("tkn"),
+		Name:             gofastly.ToPointer("scalyrlogger"),
+		Region:           gofastly.ToPointer("US"),
+		ServiceVersion:   gofastly.ToPointer(1),
+		Token:            gofastly.ToPointer("tkn"),
+		ProcessingRegion: gofastly.ToPointer("us"),
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -232,6 +238,7 @@ resource "fastly_service_compute" "foo" {
 		name               = "scalyrlogger"
 		region             = "US"
 		token              = "tkn"
+    processing_region = "us"
 	}
 
   package {
@@ -274,6 +281,7 @@ resource "fastly_service_vcl" "foo" {
 		format             = "%%a %%l %%u %%t %%m %%U%%q %%H %%>s %%b %%T"
 		format_version 		 = 2
 		placement 				 = "none"
+    processing_region = "us"
 	}
 
 	force_destroy = true

--- a/fastly/block_fastly_service_logging_sftp_test.go
+++ b/fastly/block_fastly_service_logging_sftp_test.go
@@ -41,6 +41,7 @@ func TestResourceFastlyFlattenSFTP(t *testing.T) {
 					Placement:         gofastly.ToPointer("none"),
 					GzipLevel:         gofastly.ToPointer(0),
 					CompressionCodec:  gofastly.ToPointer("zstd"),
+					ProcessingRegion:  gofastly.ToPointer("eu"),
 				},
 			},
 			local: []map[string]any{
@@ -63,6 +64,7 @@ func TestResourceFastlyFlattenSFTP(t *testing.T) {
 					"timestamp_format":   "%Y-%m-%dT%H:%M:%S.000",
 					"placement":          "none",
 					"compression_codec":  "zstd",
+					"processing_region":  "eu",
 				},
 			},
 		},
@@ -101,6 +103,7 @@ func TestAccFastlyServiceVCL_logging_sftp_basic(t *testing.T) {
 		ServiceVersion:    gofastly.ToPointer(1),
 		TimestampFormat:   gofastly.ToPointer("%Y-%m-%dT%H:%M:%S.000"),
 		User:              gofastly.ToPointer("username"),
+		ProcessingRegion:  gofastly.ToPointer("us"),
 	}
 
 	log1AfterUpdate := gofastly.SFTP{
@@ -122,6 +125,7 @@ func TestAccFastlyServiceVCL_logging_sftp_basic(t *testing.T) {
 		ServiceVersion:    gofastly.ToPointer(1),
 		TimestampFormat:   gofastly.ToPointer("%Y-%m-%dT%H:%M:%S.000"),
 		User:              gofastly.ToPointer("user"),
+		ProcessingRegion:  gofastly.ToPointer("none"),
 	}
 
 	log2 := gofastly.SFTP{
@@ -144,6 +148,7 @@ func TestAccFastlyServiceVCL_logging_sftp_basic(t *testing.T) {
 		ServiceVersion:    gofastly.ToPointer(1),
 		TimestampFormat:   gofastly.ToPointer("%Y-%m-%dT%H:%M:%S.000"),
 		User:              gofastly.ToPointer("user"),
+		ProcessingRegion:  gofastly.ToPointer("none"),
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -197,6 +202,7 @@ func TestAccFastlyServiceVCL_logging_sftp_basic_compute(t *testing.T) {
 		ServiceVersion:   gofastly.ToPointer(1),
 		TimestampFormat:  gofastly.ToPointer("%Y-%m-%dT%H:%M:%S.000"),
 		User:             gofastly.ToPointer("username"),
+		ProcessingRegion: gofastly.ToPointer("us"),
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -320,6 +326,7 @@ resource "fastly_service_compute" "foo" {
     ssh_known_hosts = "sftp.example.com"
     message_type = "classic"
     compression_codec = "zstd"
+    processing_region = "us"
   }
 
   package {
@@ -366,6 +373,7 @@ resource "fastly_service_vcl" "foo" {
     placement = "none"
     response_condition = "response_condition_test"
     compression_codec = "zstd"
+    processing_region = "us"
   }
   force_destroy = true
 }`, name, domain)

--- a/fastly/block_fastly_service_logging_splunk_test.go
+++ b/fastly/block_fastly_service_logging_splunk_test.go
@@ -41,6 +41,7 @@ func TestResourceFastlyFlattenSplunk(t *testing.T) {
 					TLSHostname:       gofastly.ToPointer("example.com"),
 					Token:             gofastly.ToPointer("test-token"),
 					URL:               gofastly.ToPointer("https://mysplunkendpoint.example.com/services/collector/event"),
+					ProcessingRegion:  gofastly.ToPointer("eu"),
 				},
 			},
 			local: []map[string]any{
@@ -56,6 +57,7 @@ func TestResourceFastlyFlattenSplunk(t *testing.T) {
 					"tls_hostname":       "example.com",
 					"token":              "test-token",
 					"url":                "https://mysplunkendpoint.example.com/services/collector/event",
+					"processing_region":  "eu",
 				},
 			},
 		},
@@ -85,6 +87,7 @@ func TestAccFastlyServiceVCL_splunk_basic(t *testing.T) {
 		Token:             gofastly.ToPointer("test-token"),
 		URL:               gofastly.ToPointer("https://mysplunkendpoint.example.com/services/collector/event"),
 		UseTLS:            gofastly.ToPointer(true),
+		ProcessingRegion:  gofastly.ToPointer("us"),
 	}
 
 	splunkLogOneUpdated := gofastly.Splunk{
@@ -99,6 +102,7 @@ func TestAccFastlyServiceVCL_splunk_basic(t *testing.T) {
 		Token:             gofastly.ToPointer("test-token"),
 		URL:               gofastly.ToPointer("https://mysplunkendpoint.example.com/services/collector/event"),
 		UseTLS:            gofastly.ToPointer(false),
+		ProcessingRegion:  gofastly.ToPointer("none"),
 	}
 
 	splunkLogTwo := gofastly.Splunk{
@@ -113,6 +117,7 @@ func TestAccFastlyServiceVCL_splunk_basic(t *testing.T) {
 		Token:             gofastly.ToPointer("test-token"),
 		URL:               gofastly.ToPointer("https://mysplunkendpoint.example.com/services/collector/event"),
 		UseTLS:            gofastly.ToPointer(false),
+		ProcessingRegion:  gofastly.ToPointer("none"),
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -157,6 +162,7 @@ func TestAccFastlyServiceVCL_splunk_basic_compute(t *testing.T) {
 		Token:             gofastly.ToPointer("test-token"),
 		URL:               gofastly.ToPointer("https://mysplunkendpoint.example.com/services/collector/event"),
 		UseTLS:            gofastly.ToPointer(false),
+		ProcessingRegion:  gofastly.ToPointer("us"),
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -430,6 +436,7 @@ resource "fastly_service_compute" "foo" {
     name               = "test-splunk-1"
     url                = "https://mysplunkendpoint.example.com/services/collector/event"
     token              = "test-token"
+    processing_region = "us"
   }
 
   package {
@@ -476,6 +483,7 @@ resource "fastly_service_vcl" "foo" {
     placement          = "none"
     response_condition = "error_response_5XX"
 	use_tls            = true
+    processing_region = "us"
   }
 
   force_destroy = true

--- a/fastly/block_fastly_service_logging_sumologic_test.go
+++ b/fastly/block_fastly_service_logging_sumologic_test.go
@@ -26,6 +26,7 @@ func TestResourceFastlyFlattenSumologic(t *testing.T) {
 					FormatVersion:     gofastly.ToPointer(2),
 					MessageType:       gofastly.ToPointer("classic"),
 					ResponseCondition: gofastly.ToPointer("condition 1"),
+					ProcessingRegion:  gofastly.ToPointer("eu"),
 				},
 			},
 			local: []map[string]any{
@@ -36,6 +37,7 @@ func TestResourceFastlyFlattenSumologic(t *testing.T) {
 					"format_version":     2,
 					"message_type":       "classic",
 					"response_condition": "condition 1",
+					"processing_region":  "eu",
 				},
 			},
 		},
@@ -56,17 +58,19 @@ func TestAccFastlyServiceVCL_sumologic(t *testing.T) {
 	domainName := fmt.Sprintf("fastly-test.tf-%s.com", acctest.RandString(10))
 
 	s := gofastly.Sumologic{
-		Name:          gofastly.ToPointer("sumologger"),
-		URL:           gofastly.ToPointer("https://collectors.sumologic.com/receiver/1"),
-		FormatVersion: gofastly.ToPointer(2),
-		Format:        gofastly.ToPointer("my format"),
+		Name:             gofastly.ToPointer("sumologger"),
+		URL:              gofastly.ToPointer("https://collectors.sumologic.com/receiver/1"),
+		FormatVersion:    gofastly.ToPointer(2),
+		Format:           gofastly.ToPointer("my format"),
+		ProcessingRegion: gofastly.ToPointer("us"),
 	}
 
 	sn := gofastly.Sumologic{
-		Name:          gofastly.ToPointer("sumologger"),
-		URL:           gofastly.ToPointer("https://collectors.sumologic.com/receiver/1"),
-		FormatVersion: gofastly.ToPointer(2),
-		Format:        gofastly.ToPointer("my format new"),
+		Name:             gofastly.ToPointer("sumologger"),
+		URL:              gofastly.ToPointer("https://collectors.sumologic.com/receiver/1"),
+		FormatVersion:    gofastly.ToPointer(2),
+		Format:           gofastly.ToPointer("my format new"),
+		ProcessingRegion: gofastly.ToPointer("none"),
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -109,8 +113,9 @@ func TestAccFastlyServiceVCL_sumologic_compute(t *testing.T) {
 	domainName := fmt.Sprintf("fastly-test.tf-%s.com", acctest.RandString(10))
 
 	s := gofastly.Sumologic{
-		Name: gofastly.ToPointer("sumologger"),
-		URL:  gofastly.ToPointer("https://collectors.sumologic.com/receiver/1"),
+		Name:             gofastly.ToPointer("sumologger"),
+		URL:              gofastly.ToPointer("https://collectors.sumologic.com/receiver/1"),
+		ProcessingRegion: gofastly.ToPointer("us"),
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -188,6 +193,7 @@ resource "fastly_service_compute" "foo" {
   logging_sumologic {
     name = "%s"
     url = "%s"
+    processing_region = "us"
   }
 
   package {
@@ -219,6 +225,7 @@ resource "fastly_service_vcl" "foo" {
     url = "%s"
     format_version = %d
     format = "%s"
+    processing_region = "us"
   }
 
   force_destroy = true

--- a/fastly/block_fastly_service_logging_syslog_test.go
+++ b/fastly/block_fastly_service_logging_syslog_test.go
@@ -42,6 +42,7 @@ func TestResourceFastlyFlattenSyslog(t *testing.T) {
 					TLSHostname:       gofastly.ToPointer("example.com"),
 					TLSClientCert:     gofastly.ToPointer(cert),
 					TLSClientKey:      gofastly.ToPointer(key),
+					ProcessingRegion:  gofastly.ToPointer("eu"),
 				},
 			},
 			local: []map[string]any{
@@ -59,6 +60,7 @@ func TestResourceFastlyFlattenSyslog(t *testing.T) {
 					"tls_ca_cert":        cert,
 					"tls_client_cert":    cert,
 					"tls_client_key":     key,
+					"processing_region":  "eu",
 				},
 			},
 		},
@@ -96,6 +98,7 @@ func TestAccFastlyServiceVCL_syslog_basic(t *testing.T) {
 		TLSHostname:       gofastly.ToPointer(""),
 		Token:             gofastly.ToPointer(""),
 		UseTLS:            gofastly.ToPointer(false),
+		ProcessingRegion:  gofastly.ToPointer("us"),
 	}
 	log1AfterUpdate := gofastly.Syslog{
 		Address:           gofastly.ToPointer("127.0.0.1"),
@@ -110,6 +113,7 @@ func TestAccFastlyServiceVCL_syslog_basic(t *testing.T) {
 		TLSHostname:       gofastly.ToPointer(""),
 		Token:             gofastly.ToPointer(""),
 		UseTLS:            gofastly.ToPointer(false),
+		ProcessingRegion:  gofastly.ToPointer("none"),
 	}
 	log2 := gofastly.Syslog{
 		Address:           gofastly.ToPointer("127.0.0.2"),
@@ -124,6 +128,7 @@ func TestAccFastlyServiceVCL_syslog_basic(t *testing.T) {
 		TLSHostname:       gofastly.ToPointer(""),
 		Token:             gofastly.ToPointer(""),
 		UseTLS:            gofastly.ToPointer(false),
+		ProcessingRegion:  gofastly.ToPointer("none"),
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -166,15 +171,16 @@ func TestAccFastlyServiceVCL_syslog_basic_compute(t *testing.T) {
 	domainName1 := fmt.Sprintf("fastly-test.tf-%s.com", acctest.RandString(10))
 
 	log1 := gofastly.Syslog{
-		ServiceVersion: gofastly.ToPointer(1),
-		Name:           gofastly.ToPointer("somesyslogname"),
-		Address:        gofastly.ToPointer("127.0.0.1"),
-		IPV4:           gofastly.ToPointer("127.0.0.1"),
-		Port:           gofastly.ToPointer(514),
-		MessageType:    gofastly.ToPointer("classic"),
-		TLSHostname:    gofastly.ToPointer(""),
-		Token:          gofastly.ToPointer(""),
-		UseTLS:         gofastly.ToPointer(false),
+		ServiceVersion:   gofastly.ToPointer(1),
+		Name:             gofastly.ToPointer("somesyslogname"),
+		Address:          gofastly.ToPointer("127.0.0.1"),
+		IPV4:             gofastly.ToPointer("127.0.0.1"),
+		Port:             gofastly.ToPointer(514),
+		MessageType:      gofastly.ToPointer("classic"),
+		TLSHostname:      gofastly.ToPointer(""),
+		Token:            gofastly.ToPointer(""),
+		UseTLS:           gofastly.ToPointer(false),
+		ProcessingRegion: gofastly.ToPointer("us"),
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -378,6 +384,7 @@ resource "fastly_service_compute" "foo" {
   logging_syslog {
     name               = "somesyslogname"
     address            = "127.0.0.1"
+    processing_region = "us"
   }
   package {
     filename = "test_fixtures/package/valid.tar.gz"
@@ -409,6 +416,7 @@ resource "fastly_service_vcl" "foo" {
     name               = "somesyslogname"
     address            = "127.0.0.1"
     response_condition = "response_condition_test"
+    processing_region = "us"
   }
   force_destroy = true
 }`, name, domain)


### PR DESCRIPTION
Adds the 'processing_region' attribute to all logging endpoint blocks.

 All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/go-fastly/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

* [X] Does your submission pass tests? 
* [X] Post the output of your test runs

```
kpfleming@kpfleming:~/src/fastly/terraform-provider-fastly$ make testacc TESTARGS="-run=logging"
golangci-lint run --verbose
INFO golangci-lint has version 2.1.6 built with go1.24.2 from eabc2638 on 2025-05-04T15:41:19Z 
INFO [config_reader] Config search paths: [./ /home/kpfleming/src/fastly/terraform-provider-fastly /home/kpfleming/src/fastly /home/kpfleming/src /home/kpfleming /home /] 
INFO [config_reader] Used config file .golangci.yml 
INFO [config_reader] Module name "github.com/fastly/terraform-provider-fastly" 
INFO maxprocs: Leaving GOMAXPROCS=8: CPU quota undefined 
INFO [goenv] Read go env for 1.964168ms: map[string]string{"GOCACHE":"/home/kpfleming/.cache/go-build", "GOROOT":"/home/kpfleming/golang"} 
INFO [lintersdb] Active 19 linters: [durationcheck errcheck exhaustive gocritic godot gofumpt goimports gosec govet ineffassign makezero misspell nilerr predeclared revive staticcheck unconvert unparam unused] 
INFO [loader] Go packages loading at mode 8767 (compiled_files|exports_file|name|types_sizes|deps|files|imports) took 179.789958ms 
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 38.688241ms 
INFO [linters_context/goanalysis] analyzers took 0s with no stages 
INFO [runner/exclusion_paths] Skipped 0 issues by pattern "third_party$" 
INFO [runner/exclusion_paths] Skipped 0 issues by pattern "builtin$" 
INFO [runner/exclusion_paths] Skipped 0 issues by pattern "examples$" 
INFO [runner/exclusion_rules] Skipped 0 issues by rules: [Path: "third_party$", Linters: "gofumpt, goimports"] 
INFO [runner/exclusion_rules] Skipped 0 issues by rules: [Path: "builtin$", Linters: "gofumpt, goimports"] 
INFO [runner/exclusion_rules] Skipped 0 issues by rules: [Path: "examples$", Linters: "gofumpt, goimports"] 
INFO [runner] Issues before processing: 12, after processing: 0 
INFO [runner] Processors filtering stat (in/out): filename_unadjuster: 12/12, generated_file_filter: 12/12, exclusion_rules: 12/1, invalid_issue: 12/12, nolint_filter: 1/0, path_relativity: 12/12, exclusion_paths: 12/12, path_absoluter: 12/12, cgo: 12/12 
INFO [runner] processing took 504.703µs with stages: nolint_filter: 284.781µs, generated_file_filter: 90.943µs, exclusion_rules: 64.17µs, exclusion_paths: 28.124µs, path_relativity: 13.96µs, diff: 11.932µs, filename_unadjuster: 1.977µs, sort_results: 1.713µs, cgo: 1.443µs, invalid_issue: 1.382µs, path_absoluter: 1.367µs, max_per_file_from_linter: 768ns, max_same_issues: 736ns, fixer: 421ns, path_shortener: 204ns, path_prettifier: 199ns, source_code: 195ns, uniq_by_line: 193ns, max_from_linter: 116ns, severity-rules: 79ns 
INFO [runner] linters took 263.214474ms with stages: goanalysis_metalinter: 262.670688ms 
0 issues.
INFO File cache stats: 0 entries of total size 0B 
INFO Memory: 6 samples, avg is 61.2MB, max is 88.9MB 
INFO Execution took 484.219915ms                  
go  tool -modfile=tools.mod tfproviderlintx -R001=false -R018=false -R019=false -XAT001=false  ./...
golangci-lint fmt
TF_ACC=1 go  test $(go  list ./...) -v -run=logging -parallel=4 -timeout 360m -ldflags="-X=github.com/fastly/terraform-provider-fastly/version.ProviderVersion=acc"
?   	github.com/fastly/terraform-provider-fastly	[no test files]
=== RUN   TestAccFastlyServiceVCL_bigquerylogging
=== PAUSE TestAccFastlyServiceVCL_bigquerylogging
=== RUN   TestAccFastlyServiceVCL_bigquerylogging_compute
=== PAUSE TestAccFastlyServiceVCL_bigquerylogging_compute
=== RUN   TestBigqueryloggingEnvDefaultFuncAttributes
--- PASS: TestBigqueryloggingEnvDefaultFuncAttributes (0.21s)
=== RUN   TestAccFastlyServiceVCL_blobstoragelogging_basic
=== PAUSE TestAccFastlyServiceVCL_blobstoragelogging_basic
=== RUN   TestAccFastlyServiceVCL_blobstoragelogging_basic_compute
=== PAUSE TestAccFastlyServiceVCL_blobstoragelogging_basic_compute
=== RUN   TestAccFastlyServiceVCL_blobstoragelogging_default
=== PAUSE TestAccFastlyServiceVCL_blobstoragelogging_default
=== RUN   TestBlobstorageloggingEnvDefaultFuncAttributes
--- PASS: TestBlobstorageloggingEnvDefaultFuncAttributes (0.00s)
=== RUN   TestAccFastlyServiceVCL_logging_cloudfiles_basic
=== PAUSE TestAccFastlyServiceVCL_logging_cloudfiles_basic
=== RUN   TestAccFastlyServiceVCL_logging_cloudfiles_basic_compute
=== PAUSE TestAccFastlyServiceVCL_logging_cloudfiles_basic_compute
=== RUN   TestAccFastlyServiceVCL_logging_datadog_basic
=== PAUSE TestAccFastlyServiceVCL_logging_datadog_basic
=== RUN   TestAccFastlyServiceVCL_logging_datadog_basic_compute
=== PAUSE TestAccFastlyServiceVCL_logging_datadog_basic_compute
=== RUN   TestAccFastlyServiceVCL_logging_digitalocean_basic
=== PAUSE TestAccFastlyServiceVCL_logging_digitalocean_basic
=== RUN   TestAccFastlyServiceVCL_logging_digitalocean_basic_compute
=== PAUSE TestAccFastlyServiceVCL_logging_digitalocean_basic_compute
=== RUN   TestAccFastlyServiceVCL_logging_elasticsearch_basic
=== PAUSE TestAccFastlyServiceVCL_logging_elasticsearch_basic
=== RUN   TestAccFastlyServiceVCL_logging_elasticsearch_basic_compute
=== PAUSE TestAccFastlyServiceVCL_logging_elasticsearch_basic_compute
=== RUN   TestAccFastlyServiceVCL_logging_ftp_basic
=== PAUSE TestAccFastlyServiceVCL_logging_ftp_basic
=== RUN   TestAccFastlyServiceVCL_logging_ftp_basic_compute
=== PAUSE TestAccFastlyServiceVCL_logging_ftp_basic_compute
=== RUN   TestAccFastlyServiceVCL_gcslogging
=== PAUSE TestAccFastlyServiceVCL_gcslogging
=== RUN   TestAccFastlyServiceVCL_gcslogging_compute
=== PAUSE TestAccFastlyServiceVCL_gcslogging_compute
=== RUN   TestGcsloggingEnvDefaultFuncAttributes
--- PASS: TestGcsloggingEnvDefaultFuncAttributes (0.04s)
=== RUN   TestAccFastlyServiceVCL_googlepubsublogging_basic
=== PAUSE TestAccFastlyServiceVCL_googlepubsublogging_basic
=== RUN   TestAccFastlyServiceVCL_googlepubsublogging_basic_compute
=== PAUSE TestAccFastlyServiceVCL_googlepubsublogging_basic_compute
=== RUN   TestAccFastlyServiceVCL_logging_grafanacloudlogs_basic
=== PAUSE TestAccFastlyServiceVCL_logging_grafanacloudlogs_basic
=== RUN   TestAccFastlyServiceVCL_logging_grafanacloudlogs_basic_compute
=== PAUSE TestAccFastlyServiceVCL_logging_grafanacloudlogs_basic_compute
=== RUN   TestAccFastlyServiceVCL_logging_heroku_basic
=== PAUSE TestAccFastlyServiceVCL_logging_heroku_basic
=== RUN   TestAccFastlyServiceVCL_logging_heroku_basic_compute
=== PAUSE TestAccFastlyServiceVCL_logging_heroku_basic_compute
=== RUN   TestAccFastlyServiceVCL_logging_honeycomb_basic
=== PAUSE TestAccFastlyServiceVCL_logging_honeycomb_basic
=== RUN   TestAccFastlyServiceVCL_logging_honeycomb_basic_compute
=== PAUSE TestAccFastlyServiceVCL_logging_honeycomb_basic_compute
=== RUN   TestAccFastlyServiceVCL_httpslogging_basic
=== PAUSE TestAccFastlyServiceVCL_httpslogging_basic
=== RUN   TestAccFastlyServiceVCL_httpslogging_basic_compute
=== PAUSE TestAccFastlyServiceVCL_httpslogging_basic_compute
=== RUN   TestAccFastlyServiceVCL_kafkalogging_basic
=== PAUSE TestAccFastlyServiceVCL_kafkalogging_basic
=== RUN   TestAccFastlyServiceVCL_kafkalogging_basic_compute
=== PAUSE TestAccFastlyServiceVCL_kafkalogging_basic_compute
=== RUN   TestAccFastlyServiceVCL_logging_kinesis_basic
=== PAUSE TestAccFastlyServiceVCL_logging_kinesis_basic
=== RUN   TestAccFastlyServiceVCL_logging_kinesis_basic_compute
=== PAUSE TestAccFastlyServiceVCL_logging_kinesis_basic_compute
=== RUN   TestAccFastlyServiceVCL_logging_loggly_basic
=== PAUSE TestAccFastlyServiceVCL_logging_loggly_basic
=== RUN   TestAccFastlyServiceVCL_logging_loggly_basic_compute
=== PAUSE TestAccFastlyServiceVCL_logging_loggly_basic_compute
=== RUN   TestAccFastlyServiceVCL_logging_logshuttle_basic
=== PAUSE TestAccFastlyServiceVCL_logging_logshuttle_basic
=== RUN   TestAccFastlyServiceVCL_logging_logshuttle_basic_compute
=== PAUSE TestAccFastlyServiceVCL_logging_logshuttle_basic_compute
=== RUN   TestAccFastlyServiceVCL_logging_newrelic_basic
=== PAUSE TestAccFastlyServiceVCL_logging_newrelic_basic
=== RUN   TestAccFastlyServiceVCL_logging_newrelic_basic_compute
=== PAUSE TestAccFastlyServiceVCL_logging_newrelic_basic_compute
=== RUN   TestAccFastlyServiceVCL_logging_newrelicotlp_basic
=== PAUSE TestAccFastlyServiceVCL_logging_newrelicotlp_basic
=== RUN   TestAccFastlyServiceVCL_logging_openstack_basic
=== PAUSE TestAccFastlyServiceVCL_logging_openstack_basic
=== RUN   TestAccFastlyServiceVCL_logging_openstack_basic_compute
=== PAUSE TestAccFastlyServiceVCL_logging_openstack_basic_compute
=== RUN   TestAccFastlyServiceVCL_s3logging_basic
=== PAUSE TestAccFastlyServiceVCL_s3logging_basic
=== RUN   TestAccFastlyServiceVCL_s3logging_basic_compute
=== PAUSE TestAccFastlyServiceVCL_s3logging_basic_compute
=== RUN   TestAccFastlyServiceVCL_s3logging_domain_default
=== PAUSE TestAccFastlyServiceVCL_s3logging_domain_default
=== RUN   TestAccFastlyServiceVCL_s3logging_formatVersion
=== PAUSE TestAccFastlyServiceVCL_s3logging_formatVersion
=== RUN   TestS3loggingEnvDefaultFuncAttributes
--- PASS: TestS3loggingEnvDefaultFuncAttributes (0.00s)
=== RUN   TestAccFastlyServiceVCL_scalyrlogging_basic
=== PAUSE TestAccFastlyServiceVCL_scalyrlogging_basic
=== RUN   TestAccFastlyServiceVCL_scalyrlogging_basic_compute
=== PAUSE TestAccFastlyServiceVCL_scalyrlogging_basic_compute
=== RUN   TestAccFastlyServiceVCL_logging_sftp_basic
=== PAUSE TestAccFastlyServiceVCL_logging_sftp_basic
=== RUN   TestAccFastlyServiceVCL_logging_sftp_basic_compute
=== PAUSE TestAccFastlyServiceVCL_logging_sftp_basic_compute
=== RUN   TestAccFastlyServiceVCL_logging_sftp_password_secret_key
=== PAUSE TestAccFastlyServiceVCL_logging_sftp_password_secret_key
=== CONT  TestAccFastlyServiceVCL_bigquerylogging
=== CONT  TestAccFastlyServiceVCL_httpslogging_basic
=== CONT  TestAccFastlyServiceVCL_logging_datadog_basic
=== CONT  TestAccFastlyServiceVCL_logging_ftp_basic
--- PASS: TestAccFastlyServiceVCL_httpslogging_basic (27.81s)
=== CONT  TestAccFastlyServiceVCL_logging_digitalocean_basic_compute
--- PASS: TestAccFastlyServiceVCL_logging_ftp_basic (28.46s)
=== CONT  TestAccFastlyServiceVCL_logging_cloudfiles_basic
--- PASS: TestAccFastlyServiceVCL_bigquerylogging (30.51s)
=== CONT  TestAccFastlyServiceVCL_blobstoragelogging_default
--- PASS: TestAccFastlyServiceVCL_logging_datadog_basic (30.72s)
=== CONT  TestAccFastlyServiceVCL_blobstoragelogging_basic_compute
--- PASS: TestAccFastlyServiceVCL_blobstoragelogging_default (7.61s)
=== CONT  TestAccFastlyServiceVCL_blobstoragelogging_basic
--- PASS: TestAccFastlyServiceVCL_logging_digitalocean_basic_compute (10.46s)
=== CONT  TestAccFastlyServiceVCL_bigquerylogging_compute
--- PASS: TestAccFastlyServiceVCL_blobstoragelogging_basic_compute (10.87s)
=== CONT  TestAccFastlyServiceVCL_logging_cloudfiles_basic_compute
--- PASS: TestAccFastlyServiceVCL_logging_cloudfiles_basic_compute (10.30s)
=== CONT  TestAccFastlyServiceVCL_logging_digitalocean_basic
--- PASS: TestAccFastlyServiceVCL_logging_cloudfiles_basic (23.73s)
=== CONT  TestAccFastlyServiceVCL_logging_elasticsearch_basic_compute
--- PASS: TestAccFastlyServiceVCL_blobstoragelogging_basic (23.81s)
=== CONT  TestAccFastlyServiceVCL_logging_elasticsearch_basic
--- PASS: TestAccFastlyServiceVCL_logging_elasticsearch_basic_compute (10.94s)
=== CONT  TestAccFastlyServiceVCL_logging_datadog_basic_compute
--- PASS: TestAccFastlyServiceVCL_bigquerylogging_compute (25.79s)
=== CONT  TestAccFastlyServiceVCL_gcslogging_compute
--- PASS: TestAccFastlyServiceVCL_gcslogging_compute (9.75s)
=== CONT  TestAccFastlyServiceVCL_googlepubsublogging_basic_compute
--- PASS: TestAccFastlyServiceVCL_logging_datadog_basic_compute (10.76s)
=== CONT  TestAccFastlyServiceVCL_googlepubsublogging_basic
--- PASS: TestAccFastlyServiceVCL_logging_digitalocean_basic (22.43s)
=== CONT  TestAccFastlyServiceVCL_logging_newrelicotlp_basic
--- PASS: TestAccFastlyServiceVCL_googlepubsublogging_basic_compute (10.03s)
=== CONT  TestAccFastlyServiceVCL_logging_grafanacloudlogs_basic
--- PASS: TestAccFastlyServiceVCL_logging_elasticsearch_basic (23.99s)
=== CONT  TestAccFastlyServiceVCL_logging_honeycomb_basic_compute
--- PASS: TestAccFastlyServiceVCL_logging_honeycomb_basic_compute (10.09s)
=== CONT  TestAccFastlyServiceVCL_logging_honeycomb_basic
--- PASS: TestAccFastlyServiceVCL_logging_newrelicotlp_basic (21.70s)
=== CONT  TestAccFastlyServiceVCL_logging_sftp_password_secret_key
--- PASS: TestAccFastlyServiceVCL_googlepubsublogging_basic (24.00s)
=== CONT  TestAccFastlyServiceVCL_logging_heroku_basic_compute
--- PASS: TestAccFastlyServiceVCL_logging_sftp_password_secret_key (3.35s)
=== CONT  TestAccFastlyServiceVCL_logging_heroku_basic
--- PASS: TestAccFastlyServiceVCL_logging_grafanacloudlogs_basic (22.72s)
=== CONT  TestAccFastlyServiceVCL_logging_grafanacloudlogs_basic_compute
--- PASS: TestAccFastlyServiceVCL_logging_heroku_basic_compute (10.43s)
=== CONT  TestAccFastlyServiceVCL_logging_sftp_basic_compute
--- PASS: TestAccFastlyServiceVCL_logging_grafanacloudlogs_basic_compute (10.14s)
=== CONT  TestAccFastlyServiceVCL_gcslogging
--- PASS: TestAccFastlyServiceVCL_logging_sftp_basic_compute (9.33s)
=== CONT  TestAccFastlyServiceVCL_logging_sftp_basic
--- PASS: TestAccFastlyServiceVCL_logging_honeycomb_basic (23.37s)
=== CONT  TestAccFastlyServiceVCL_logging_ftp_basic_compute
--- PASS: TestAccFastlyServiceVCL_logging_heroku_basic (22.35s)
=== CONT  TestAccFastlyServiceVCL_scalyrlogging_basic_compute
--- PASS: TestAccFastlyServiceVCL_gcslogging (7.60s)
=== CONT  TestAccFastlyServiceVCL_scalyrlogging_basic
--- PASS: TestAccFastlyServiceVCL_logging_ftp_basic_compute (9.73s)
=== CONT  TestAccFastlyServiceVCL_s3logging_formatVersion
--- PASS: TestAccFastlyServiceVCL_scalyrlogging_basic_compute (10.02s)
=== CONT  TestAccFastlyServiceVCL_s3logging_domain_default
--- PASS: TestAccFastlyServiceVCL_s3logging_formatVersion (7.82s)
=== CONT  TestAccFastlyServiceVCL_logging_loggly_basic
--- PASS: TestAccFastlyServiceVCL_s3logging_domain_default (8.35s)
=== CONT  TestAccFastlyServiceVCL_kafkalogging_basic_compute
--- PASS: TestAccFastlyServiceVCL_logging_sftp_basic (22.70s)
=== CONT  TestAccFastlyServiceVCL_s3logging_basic_compute
--- PASS: TestAccFastlyServiceVCL_scalyrlogging_basic (23.18s)
=== CONT  TestAccFastlyServiceVCL_logging_kinesis_basic_compute
--- PASS: TestAccFastlyServiceVCL_kafkalogging_basic_compute (10.25s)
=== CONT  TestAccFastlyServiceVCL_logging_newrelic_basic_compute
--- PASS: TestAccFastlyServiceVCL_s3logging_basic_compute (10.02s)
=== CONT  TestAccFastlyServiceVCL_s3logging_basic
--- PASS: TestAccFastlyServiceVCL_logging_kinesis_basic_compute (10.15s)
=== CONT  TestAccFastlyServiceVCL_logging_openstack_basic_compute
--- PASS: TestAccFastlyServiceVCL_logging_loggly_basic (22.72s)
=== CONT  TestAccFastlyServiceVCL_logging_newrelic_basic
--- PASS: TestAccFastlyServiceVCL_logging_newrelic_basic_compute (9.98s)
=== CONT  TestAccFastlyServiceVCL_logging_logshuttle_basic_compute
--- PASS: TestAccFastlyServiceVCL_logging_openstack_basic_compute (10.02s)
=== CONT  TestAccFastlyServiceVCL_logging_logshuttle_basic
--- PASS: TestAccFastlyServiceVCL_logging_logshuttle_basic_compute (10.13s)
=== CONT  TestAccFastlyServiceVCL_logging_loggly_basic_compute
--- PASS: TestAccFastlyServiceVCL_s3logging_basic (22.43s)
=== CONT  TestAccFastlyServiceVCL_logging_openstack_basic
--- PASS: TestAccFastlyServiceVCL_logging_loggly_basic_compute (10.34s)
=== CONT  TestAccFastlyServiceVCL_kafkalogging_basic
--- PASS: TestAccFastlyServiceVCL_logging_newrelic_basic (22.14s)
=== CONT  TestAccFastlyServiceVCL_httpslogging_basic_compute
--- PASS: TestAccFastlyServiceVCL_logging_logshuttle_basic (22.18s)
=== CONT  TestAccFastlyServiceVCL_logging_kinesis_basic
--- PASS: TestAccFastlyServiceVCL_httpslogging_basic_compute (9.69s)
--- PASS: TestAccFastlyServiceVCL_logging_openstack_basic (23.04s)
--- PASS: TestAccFastlyServiceVCL_kafkalogging_basic (23.12s)
--- PASS: TestAccFastlyServiceVCL_logging_kinesis_basic (21.81s)
PASS
ok  	github.com/fastly/terraform-provider-fastly/fastly	212.027s
?   	github.com/fastly/terraform-provider-fastly/fastly/hashcode	[no test files]
?   	github.com/fastly/terraform-provider-fastly/version	[no test files]
```

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

### User Impact

* [ ] What is the user impact of this change?

### Are there any considerations that need to be addressed for release?

<!-- Any breaking changes, etc -->
