### PR TITLE
Set Actions token permissions to minimum required.

### DIFF
--- a/.github/workflows/dependabot_changelog_update.yml
+++ b/.github/workflows/dependabot_changelog_update.yml
@@ -1,4 +1,6 @@
 name: Generate changelog entry for Dependabot
+permissions:
+  contents: read
 
 on:
   pull_request:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -9,6 +9,8 @@ on:
   repository_dispatch:
     types: [ok-to-test-command] # corresponds to ./ok-to-test.yml `commands:` field
 name: Pull request
+permissions:
+  contents: read
 jobs:
   changelog:
     if: github.actor != 'dependabot[bot]'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,8 @@
 # private key in the `GPG_PRIVATE_KEY` secret and passphrase in the `PASSPHRASE`
 # secret. We use the fastly fork to ensure safety GPG handling.
 name: release
+permissions:
+  contents: write
 on:
   push:
     tags:


### PR DESCRIPTION
Each of the three Actions workflows requires fewer permissions than GITHUB_TOKEN has by default, so each of them are now configured with the minimum permissions required.

Resolves https://github.com/fastly/terraform-provider-fastly/security/code-scanning/20, https://github.com/fastly/terraform-provider-fastly/security/code-scanning/21, and https://github.com/fastly/terraform-provider-fastly/security/code-scanning/22.

 All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/go-fastly/pulls) for the same update/change?