### PR TITLE
fix: delete content from dynamic snippet if manage_contents is true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [UNRELEASED]
 
+- fix(snippets): delete dynamic snippets contents when the resource is deleted if `manage_snippets` is `true`. ([#1021](https://github.com/fastly/terraform-provider-fastly/pull/ 1021))
+
 ### BREAKING:
 
 ### ENHANCEMENTS:


### PR DESCRIPTION
Closes #968

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/go-fastly/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

* [x] Does your submission pass tests? 
* [x] Post the output of your test runs



### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?: This is covered in the issue
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally? New tests run with

```
$ make testacc TESTARGS='-run=TestAccFastlyServiceDynamicSnippetContent_*'
golangci-lint run --verbose
INFO golangci-lint has version 2.1.6 built with go1.24.2 from eabc2638 on 2025-05-04T15:41:19Z 
INFO [config_reader] Used config file .golangci.yml 
INFO [config_reader] Module name "github.com/fastly/terraform-provider-fastly" 
INFO maxprocs: Leaving GOMAXPROCS=10: CPU quota undefined 
INFO [lintersdb] Active 19 linters: [durationcheck errcheck exhaustive gocritic godot gofumpt goimports gosec govet ineffassign makezero misspell nilerr predeclared revive staticcheck unconvert unparam unused] 
INFO [loader] Go packages loading at mode 8767 (deps|exports_file|name|compiled_files|files|imports|types_sizes) took 587.609208ms 
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 39.42225ms 
INFO [linters_context/goanalysis] analyzers took 0s with no stages 
INFO [runner/exclusion_paths] Skipped 0 issues by pattern "builtin$" 
INFO [runner/exclusion_paths] Skipped 0 issues by pattern "examples$" 
INFO [runner/exclusion_paths] Skipped 0 issues by pattern "third_party$" 
INFO [runner/exclusion_rules] Skipped 0 issues by rules: [Path: "third_party$", Linters: "gofumpt, goimports"] 
INFO [runner/exclusion_rules] Skipped 0 issues by rules: [Path: "builtin$", Linters: "gofumpt, goimports"] 
INFO [runner/exclusion_rules] Skipped 0 issues by rules: [Path: "examples$", Linters: "gofumpt, goimports"] 
INFO [runner] Issues before processing: 13, after processing: 0 
INFO [runner] Processors filtering stat (in/out): path_absoluter: 13/13, cgo: 13/13, filename_unadjuster: 13/13, invalid_issue: 13/13, nolint_filter: 2/0, path_relativity: 13/13, exclusion_paths: 13/13, generated_file_filter: 13/13, exclusion_rules: 13/2 
INFO [runner] processing took 951.46µs with stages: nolint_filter: 437.084µs, generated_file_filter: 388.75µs, exclusion_rules: 56.75µs, exclusion_paths: 26.334µs, cgo: 17.667µs, path_relativity: 12.167µs, sort_results: 8.459µs, max_same_issues: 1.124µs, invalid_issue: 876ns, filename_unadjuster: 500ns, path_absoluter: 376ns, fixer: 333ns, diff: 291ns, source_code: 208ns, path_prettifier: 207ns, uniq_by_line: 84ns, max_from_linter: 84ns, severity-rules: 83ns, path_shortener: 42ns, max_per_file_from_linter: 41ns 
INFO [runner] linters took 579.099208ms with stages: goanalysis_metalinter: 578.06575ms 
0 issues.
INFO File cache stats: 0 entries of total size 0B 
INFO Memory: 14 samples, avg is 57.9MB, max is 88.8MB 
INFO Execution took 1.232827167s                  
go  tool -modfile=tools.mod tfproviderlintx -R001=false -R018=false -R019=false -XR001=false -XAT001=false  ./...
golangci-lint fmt
TF_ACC=1 go  test $(go  list ./...) -v -run=TestAccFastlyServiceDynamicSnippetContent_* -parallel=4 -timeout 360m -ldflags="-X=github.com/fastly/terraform-provider-fastly/version.ProviderVersion=acc"
?       github.com/fastly/terraform-provider-fastly     [no test files]
=== RUN   TestAccFastlyServiceDynamicSnippetContent_create
=== PAUSE TestAccFastlyServiceDynamicSnippetContent_create
=== RUN   TestAccFastlyServiceDynamicSnippetContent_update
=== PAUSE TestAccFastlyServiceDynamicSnippetContent_update
=== RUN   TestAccFastlyServiceDynamicSnippetContent_delete_manage_snippets_true
=== PAUSE TestAccFastlyServiceDynamicSnippetContent_delete_manage_snippets_true
=== RUN   TestAccFastlyServiceDynamicSnippetContent_delete_manage_snippets_false
=== PAUSE TestAccFastlyServiceDynamicSnippetContent_delete_manage_snippets_false
=== RUN   TestAccFastlyServiceDynamicSnippetContent_external_snippet_is_removed
=== PAUSE TestAccFastlyServiceDynamicSnippetContent_external_snippet_is_removed
=== RUN   TestAccFastlyServiceDynamicSnippetContent_normal_snippet_is_not_removed
=== PAUSE TestAccFastlyServiceDynamicSnippetContent_normal_snippet_is_not_removed
=== CONT  TestAccFastlyServiceDynamicSnippetContent_create
=== CONT  TestAccFastlyServiceDynamicSnippetContent_delete_manage_snippets_false
=== CONT  TestAccFastlyServiceDynamicSnippetContent_normal_snippet_is_not_removed
=== CONT  TestAccFastlyServiceDynamicSnippetContent_external_snippet_is_removed
--- PASS: TestAccFastlyServiceDynamicSnippetContent_create (22.62s)
=== CONT  TestAccFastlyServiceDynamicSnippetContent_delete_manage_snippets_true
--- PASS: TestAccFastlyServiceDynamicSnippetContent_normal_snippet_is_not_removed (35.61s)
=== CONT  TestAccFastlyServiceDynamicSnippetContent_update
--- PASS: TestAccFastlyServiceDynamicSnippetContent_delete_manage_snippets_false (36.28s)
--- PASS: TestAccFastlyServiceDynamicSnippetContent_delete_manage_snippets_true (28.17s)
--- PASS: TestAccFastlyServiceDynamicSnippetContent_external_snippet_is_removed (51.51s)
--- PASS: TestAccFastlyServiceDynamicSnippetContent_update (30.43s)
PASS
ok      github.com/fastly/terraform-provider-fastly/fastly      66.465s
?       github.com/fastly/terraform-provider-fastly/fastly/hashcode     [no test files]
?       github.com/fastly/terraform-provider-fastly/version     [no test files]
```

### User Impact

* [x] What is the user impact of this change?

If users are relying on the existing functionality to remove dynamic snippets from terraform state without removing the contents even when `manage_snippets` is true they will be impacted. It is not expected that this is being widely used. `manage_snippets` should be false in those cases.

### Are there any considerations that need to be addressed for release?

Explain that the existing functionality will change in case it is being relied upon.

<!-- Any breaking changes, etc -->
