### PR TITLE
Replace http-me.glitch.me with http-me.fastly.dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 ### BUG FIXES:
 
 - fix(snippets): delete dynamic snippet contents when the resource is deleted if `manage_snippets` is `true`. ([#1021](https://github.com/fastly/terraform-provider-fastly/pull/1021))
-- fix(examples): Replace http-me.glitch.me with http-me.fastly.dev ([#10](https://github.com/fastly/terraform-provider-fastly/pull/10))
+- fix(examples): Replace http-me.glitch.me with http-me.fastly.dev ([#1026](https://github.com/fastly/terraform-provider-fastly/pull/1026))
 
 ### DEPENDENCIES:
 - build(deps): `github.com/fastly/go-fastly/v10` from 10.4.0 to 10.5.0 ([#1019](https://github.com/fastly/terraform-provider-fastly/pull/1019))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### BUG FIXES:
 
 - fix(snippets): delete dynamic snippet contents when the resource is deleted if `manage_snippets` is `true`. ([#1021](https://github.com/fastly/terraform-provider-fastly/pull/1021))
+- fix(examples): Replace http-me.glitch.me with http-me.fastly.dev ([#10](https://github.com/fastly/terraform-provider-fastly/pull/10))
 
 ### DEPENDENCIES:
 - build(deps): `github.com/fastly/go-fastly/v10` from 10.4.0 to 10.5.0 ([#1019](https://github.com/fastly/terraform-provider-fastly/pull/1019))

--- a/docs/resources/service_acl_entries.md
+++ b/docs/resources/service_acl_entries.md
@@ -32,7 +32,7 @@ resource "fastly_service_vcl" "myservice" {
   }
 
   backend {
-    address = "http-me.glitch.me"
+    address = "http-me.fastly.dev"
     name = "Glitch Test Site"
     port = 80
   }

--- a/docs/resources/service_dictionary_items.md
+++ b/docs/resources/service_dictionary_items.md
@@ -36,7 +36,7 @@ resource "fastly_service_vcl" "myservice" {
   }
 
   backend {
-    address = "http-me.glitch.me"
+    address = "http-me.fastly.dev"
     name    = "Glitch Test Site"
     port    = 80
   }
@@ -85,7 +85,7 @@ resource "fastly_service_vcl" "myservice" {
   }
 
   backend {
-    address = "http-me.glitch.me"
+    address = "http-me.fastly.dev"
     name    = "Glitch Test Site"
     port    = 80
   }
@@ -127,7 +127,7 @@ resource "fastly_service_vcl" "myservice" {
   }
 
   backend {
-    address = "http-me.glitch.me"
+    address = "http-me.fastly.dev"
     name    = "Glitch Test Site"
     port    = 80
   }

--- a/docs/resources/service_dynamic_snippet_content.md
+++ b/docs/resources/service_dynamic_snippet_content.md
@@ -28,7 +28,7 @@ resource "fastly_service_vcl" "myservice" {
   }
 
   backend {
-    address = "http-me.glitch.me"
+    address = "http-me.fastly.dev"
     name    = "Glitch Test Site"
     port    = 80
   }
@@ -39,7 +39,7 @@ resource "fastly_service_vcl" "myservice" {
     priority = 110
   }
 
-  default_host = "http-me.glitch.me"
+  default_host = "http-me.fastly.dev"
 
   force_destroy = true
 }
@@ -68,7 +68,7 @@ resource "fastly_service_vcl" "myservice" {
   }
 
   backend {
-    address = "http-me.glitch.me"
+    address = "http-me.fastly.dev"
     name    = "Glitch Test Site"
     port    = 80
   }
@@ -85,7 +85,7 @@ resource "fastly_service_vcl" "myservice" {
     priority = 110
   }
 
-  default_host = "http-me.glitch.me"
+  default_host = "http-me.fastly.dev"
 
   force_destroy = true
 }

--- a/docs/resources/service_vcl.md
+++ b/docs/resources/service_vcl.md
@@ -75,10 +75,10 @@ resource "fastly_service_vcl" "demo" {
   }
 
   backend {
-    address       = "http-me.glitch.me"
+    address       = "http-me.fastly.dev"
     name          = "Glitch Test Site"
     port          = 80
-    override_host = "http-me.glitch.me"
+    override_host = "http-me.fastly.dev"
   }
 
   header {

--- a/examples/resources/service_acl_entries_basic_usage.tf
+++ b/examples/resources/service_acl_entries_basic_usage.tf
@@ -12,7 +12,7 @@ resource "fastly_service_vcl" "myservice" {
   }
 
   backend {
-    address = "http-me.glitch.me"
+    address = "http-me.fastly.dev"
     name = "Glitch Test Site"
     port = 80
   }

--- a/examples/resources/service_dictionary_items_basic_usage.tf
+++ b/examples/resources/service_dictionary_items_basic_usage.tf
@@ -12,7 +12,7 @@ resource "fastly_service_vcl" "myservice" {
   }
 
   backend {
-    address = "http-me.glitch.me"
+    address = "http-me.fastly.dev"
     name    = "Glitch Test Site"
     port    = 80
   }

--- a/examples/resources/service_dictionary_items_complex_usage.tf
+++ b/examples/resources/service_dictionary_items_complex_usage.tf
@@ -18,7 +18,7 @@ resource "fastly_service_vcl" "myservice" {
   }
 
   backend {
-    address = "http-me.glitch.me"
+    address = "http-me.fastly.dev"
     name    = "Glitch Test Site"
     port    = 80
   }

--- a/examples/resources/service_dictionary_items_functions_usage.tf
+++ b/examples/resources/service_dictionary_items_functions_usage.tf
@@ -15,7 +15,7 @@ resource "fastly_service_vcl" "myservice" {
   }
 
   backend {
-    address = "http-me.glitch.me"
+    address = "http-me.fastly.dev"
     name    = "Glitch Test Site"
     port    = 80
   }

--- a/examples/resources/service_dynamic_snippet_content_basic_usage.tf
+++ b/examples/resources/service_dynamic_snippet_content_basic_usage.tf
@@ -7,7 +7,7 @@ resource "fastly_service_vcl" "myservice" {
   }
 
   backend {
-    address = "http-me.glitch.me"
+    address = "http-me.fastly.dev"
     name    = "Glitch Test Site"
     port    = 80
   }
@@ -18,7 +18,7 @@ resource "fastly_service_vcl" "myservice" {
     priority = 110
   }
 
-  default_host = "http-me.glitch.me"
+  default_host = "http-me.fastly.dev"
 
   force_destroy = true
 }

--- a/examples/resources/service_dynamic_snippet_content_multiple.tf
+++ b/examples/resources/service_dynamic_snippet_content_multiple.tf
@@ -7,7 +7,7 @@ resource "fastly_service_vcl" "myservice" {
   }
 
   backend {
-    address = "http-me.glitch.me"
+    address = "http-me.fastly.dev"
     name    = "Glitch Test Site"
     port    = 80
   }
@@ -24,7 +24,7 @@ resource "fastly_service_vcl" "myservice" {
     priority = 110
   }
 
-  default_host = "http-me.glitch.me"
+  default_host = "http-me.fastly.dev"
 
   force_destroy = true
 }

--- a/examples/resources/service_vcl_usage_with_s3.tf
+++ b/examples/resources/service_vcl_usage_with_s3.tf
@@ -7,10 +7,10 @@ resource "fastly_service_vcl" "demo" {
   }
 
   backend {
-    address       = "http-me.glitch.me"
+    address       = "http-me.fastly.dev"
     name          = "Glitch Test Site"
     port          = 80
-    override_host = "http-me.glitch.me"
+    override_host = "http-me.fastly.dev"
   }
 
   header {

--- a/fastly/block_fastly_service_cachesetting_test.go
+++ b/fastly/block_fastly_service_cachesetting_test.go
@@ -152,7 +152,7 @@ resource "fastly_service_vcl" "foo" {
   }
 
   backend {
-    address = "http-me.glitch.me"
+    address = "http-me.fastly.dev"
     name    = "Glitch Test Site"
     port    = 80
   }
@@ -177,7 +177,7 @@ resource "fastly_service_vcl" "foo" {
     action          = "pass"
   }
 
-  default_host = "http-me.glitch.me"
+  default_host = "http-me.fastly.dev"
 
   force_destroy = true
 }`, name, domain)
@@ -194,7 +194,7 @@ resource "fastly_service_vcl" "foo" {
   }
 
   backend {
-    address = "http-me.glitch.me"
+    address = "http-me.fastly.dev"
     name    = "Glitch Test Site"
     port    = 80
   }
@@ -234,7 +234,7 @@ resource "fastly_service_vcl" "foo" {
     ttl             = 300
   }
 
-  default_host = "http-me.glitch.me"
+  default_host = "http-me.fastly.dev"
 
   force_destroy = true
 }`, name, domain)

--- a/fastly/block_fastly_service_dynamicsnippet_test.go
+++ b/fastly/block_fastly_service_dynamicsnippet_test.go
@@ -185,7 +185,7 @@ resource "fastly_service_vcl" "foo" {
   }
 
   backend {
-    address = "http-me.glitch.me"
+    address = "http-me.fastly.dev"
     name    = "Glitch Test Site"
     port    = 80
   }
@@ -196,7 +196,7 @@ resource "fastly_service_vcl" "foo" {
     priority = "110"
   }
 
-  default_host = "http-me.glitch.me"
+  default_host = "http-me.fastly.dev"
 
   force_destroy = true
 }`, name, domain)
@@ -213,7 +213,7 @@ resource "fastly_service_vcl" "foo" {
   }
 
   backend {
-    address = "http-me.glitch.me"
+    address = "http-me.fastly.dev"
     name    = "Glitch Test Site"
     port    = 80
   }
@@ -230,7 +230,7 @@ resource "fastly_service_vcl" "foo" {
     priority = "50"
   }
 
-  default_host = "http-me.glitch.me"
+  default_host = "http-me.fastly.dev"
 
   force_destroy = true
 }`, name, domain)

--- a/fastly/block_fastly_service_requestsetting_test.go
+++ b/fastly/block_fastly_service_requestsetting_test.go
@@ -21,7 +21,7 @@ func TestResourceFastlyFlattenRequestSettings(t *testing.T) {
 			remote: []*gofastly.RequestSetting{
 				{
 					Action:           gofastly.ToPointer(gofastly.RequestSettingActionPass),
-					DefaultHost:      gofastly.ToPointer("http-me.glitch.me"),
+					DefaultHost:      gofastly.ToPointer("http-me.fastly.dev"),
 					MaxStaleAge:      gofastly.ToPointer(90),
 					Name:             gofastly.ToPointer("alt_backend"),
 					RequestCondition: gofastly.ToPointer("serve_alt_backend"),
@@ -32,7 +32,7 @@ func TestResourceFastlyFlattenRequestSettings(t *testing.T) {
 				{
 					"action": gofastly.RequestSettingActionPass,
 					// "bypass_busy_wait":  false,
-					"default_host": "http-me.glitch.me",
+					"default_host": "http-me.fastly.dev",
 					// "force_miss":        false,
 					// "force_ssl":         false,
 					"max_stale_age":     90,
@@ -59,7 +59,7 @@ func TestAccFastlyServiceVCLRequestSetting_basic(t *testing.T) {
 	domainName1 := fmt.Sprintf("fastly-test.tf-%s.com", acctest.RandString(10))
 
 	rq1 := gofastly.RequestSetting{
-		DefaultHost:      gofastly.ToPointer("http-me.glitch.me"),
+		DefaultHost:      gofastly.ToPointer("http-me.fastly.dev"),
 		MaxStaleAge:      gofastly.ToPointer(90),
 		Name:             gofastly.ToPointer("alt_backend"),
 		RequestCondition: gofastly.ToPointer("serve_alt_backend"),
@@ -80,7 +80,7 @@ func TestAccFastlyServiceVCLRequestSetting_basic(t *testing.T) {
 
 	rq2 := gofastly.RequestSetting{
 		Action:           gofastly.ToPointer(gofastly.RequestSettingActionLookup),
-		DefaultHost:      gofastly.ToPointer("http-me.glitch.me"),
+		DefaultHost:      gofastly.ToPointer("http-me.fastly.dev"),
 		MaxStaleAge:      gofastly.ToPointer(900),
 		Name:             gofastly.ToPointer("alt_backend"),
 		RequestCondition: gofastly.ToPointer("serve_alt_backend"),
@@ -100,7 +100,7 @@ func TestAccFastlyServiceVCLRequestSetting_basic(t *testing.T) {
 	}
 	rq3 := gofastly.RequestSetting{
 		Action:           gofastly.ToPointer(gofastly.RequestSettingActionUnset),
-		DefaultHost:      gofastly.ToPointer("http-me.glitch.me"),
+		DefaultHost:      gofastly.ToPointer("http-me.fastly.dev"),
 		MaxStaleAge:      gofastly.ToPointer(900),
 		Name:             gofastly.ToPointer("alt_backend"),
 		RequestCondition: gofastly.ToPointer("serve_alt_backend"),
@@ -228,7 +228,7 @@ resource "fastly_service_vcl" "foo" {
   }
 
   backend {
-    address = "http-me.glitch.me"
+    address = "http-me.fastly.dev"
     name    = "Glitch Test Site"
     port    = 80
   }
@@ -248,13 +248,13 @@ resource "fastly_service_vcl" "foo" {
 
   request_setting {
     action            = "%s"
-    default_host      = "http-me.glitch.me"
+    default_host      = "http-me.fastly.dev"
     name              = "alt_backend"
     request_condition = "serve_alt_backend"
     max_stale_age     = %s
   }
 
-  default_host = "http-me.glitch.me"
+  default_host = "http-me.fastly.dev"
 
   force_destroy = true
 }`, name, domain, action, maxStaleAge)

--- a/fastly/block_fastly_service_snippet_test.go
+++ b/fastly/block_fastly_service_snippet_test.go
@@ -208,7 +208,7 @@ resource "fastly_service_vcl" "foo" {
   }
 
   backend {
-    address = "http-me.glitch.me"
+    address = "http-me.fastly.dev"
     name    = "Glitch Test Site"
     port    = 80
   }
@@ -220,7 +220,7 @@ resource "fastly_service_vcl" "foo" {
     content  = "if ( req.url ) {\n set req.http.my-snippet-test-header = \"true\";\n}"
   }
 
-  default_host = "http-me.glitch.me"
+  default_host = "http-me.fastly.dev"
 
   force_destroy = true
 }`, name, domain)
@@ -237,7 +237,7 @@ resource "fastly_service_vcl" "foo" {
   }
 
   backend {
-    address = "http-me.glitch.me"
+    address = "http-me.fastly.dev"
     name    = "Glitch Test Site"
     port    = 80
   }
@@ -256,7 +256,7 @@ resource "fastly_service_vcl" "foo" {
     content  = "restart;\n"
   }
 
-  default_host = "http-me.glitch.me"
+  default_host = "http-me.fastly.dev"
 
   force_destroy = true
 }`, name, domain)
@@ -277,7 +277,7 @@ resource "fastly_service_vcl" "foo" {
   }
 
   backend {
-    address = "http-me.glitch.me"
+    address = "http-me.fastly.dev"
     name    = "Glitch Test Site"
     port    = 80
   }
@@ -303,7 +303,7 @@ resource "fastly_service_vcl" "foo" {
     content  = "restart;\n"
   }
 
-  default_host = "http-me.glitch.me"
+  default_host = "http-me.fastly.dev"
 
   force_destroy = true
 }`, name, domain)


### PR DESCRIPTION
While the old name will be available indefinitely, examples and documentation should use the new name.

 All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/go-fastly/pulls) for the same update/change?