### PR TITLE
Virtual Patch Hotfix

### DIFF
--- a/fastly/resource_fastly_ngwaf_virtualpatches.go
+++ b/fastly/resource_fastly_ngwaf_virtualpatches.go
@@ -54,10 +54,32 @@ func resourceFastlyNGWAFVirtualPatches() *schema.Resource {
 	}
 }
 
-func resourceFastlyNGWAFVirtualPatchCreate(_ context.Context, d *schema.ResourceData, _ any) diag.Diagnostics {
-	return diag.Errorf("Virtual Patches cannot be created. Use this resource to configure existing Virtual Patches. Ensure the virtual_patch_id '%s' exists in workspace '%s' before applying.",
-		d.Get("virtual_patch_id").(string),
-		d.Get("workspace_id").(string))
+func resourceFastlyNGWAFVirtualPatchCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+	conn := meta.(*APIClient).conn
+
+	i := ws.GetInput{
+		WorkspaceID:    gofastly.ToPointer(d.Get("workspace_id").(string)),
+		VirtualPatchID: gofastly.ToPointer(d.Get("virtual_patch_id").(string)),
+	}
+
+	log.Printf("[DEBUG] CREATE: NGWAF virtual patch input: %#v", i)
+
+	// Check if the virtual patch exists
+	_, err := ws.Get(gofastly.NewContextForResourceID(ctx, d.Get("workspace_id").(string)), conn, &i)
+	if err != nil {
+		if e, ok := err.(*gofastly.HTTPError); ok && e.IsNotFound() {
+			return diag.Errorf("Virtual Patches cannot be created. Use this resource to configure existing Virtual Patches. Virtual patch ID '%s' does not exist in workspace '%s'.",
+				d.Get("virtual_patch_id").(string),
+				d.Get("workspace_id").(string))
+		}
+		return diag.FromErr(err)
+	}
+
+	// Virtual patch exists, set the ID and update it with the desired configuration
+	d.SetId(d.Get("virtual_patch_id").(string))
+
+	// Apply the desired configuration by calling update
+	return resourceFastlyNGWAFVirtualPatchUpdate(ctx, d, meta)
 }
 
 func resourceFastlyNGWAFVirtualPatchRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {

--- a/fastly/resource_fastly_ngwaf_virtualpatches.go
+++ b/fastly/resource_fastly_ngwaf_virtualpatches.go
@@ -64,7 +64,7 @@ func resourceFastlyNGWAFVirtualPatchCreate(ctx context.Context, d *schema.Resour
 
 	log.Printf("[DEBUG] CREATE: NGWAF virtual patch input: %#v", i)
 
-	// Check if the virtual patch exists
+	// Check if the virtual patch exists prior to throwing an error for any resource statement
 	_, err := ws.Get(gofastly.NewContextForResourceID(ctx, d.Get("workspace_id").(string)), conn, &i)
 	if err != nil {
 		if e, ok := err.(*gofastly.HTTPError); ok && e.IsNotFound() {


### PR DESCRIPTION
 All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/go-fastly/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

* [x] Does your submission pass tests? 
* [x] Post the output of your test runs

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### User Impact

* [x] What is the user impact of this change?

### Are there any considerations that need to be addressed for release?

This update corrects the behavior or stating a Virtual Patch resource in a HCL file immediately throwing an error. We now validate the Virtual Patch ID before throwing any type of Create error. 

Test Output:
<img width="1420" height="1045" alt="image" src="https://github.com/user-attachments/assets/05274d7d-75df-4672-963b-9e135d6741d7" />

Make Output: 
<img width="1400" height="202" alt="image" src="https://github.com/user-attachments/assets/ca20900c-4326-454b-b2b6-f12d0f79907a" />

