### PR TITLE
fix(product_enablement/ngwaf): Allow traffic_ramp to be set to zero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - fix(snippets): delete dynamic snippet contents when the resource is deleted if `manage_snippets` is `true`. ([#1021](https://github.com/fastly/terraform-provider-fastly/pull/1021))
 - fix(examples): Replace http-me.glitch.me with http-me.fastly.dev ([#1026](https://github.com/fastly/terraform-provider-fastly/pull/1026))
+- fix(product_enablement/ngwaf): Allow traffic_ramp to be set to zero ([#10XX](https://github.com/fastly/terraform-provider-fastly/pull/10XX))
 
 ### DEPENDENCIES:
 - feat(deps): Upgrade to go-fastly version 11. ([#1028](https://github.com/fastly/terraform-provider-fastly/pull/1028))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 - fix(snippets): delete dynamic snippet contents when the resource is deleted if `manage_snippets` is `true`. ([#1021](https://github.com/fastly/terraform-provider-fastly/pull/1021))
 - fix(examples): Replace http-me.glitch.me with http-me.fastly.dev ([#1026](https://github.com/fastly/terraform-provider-fastly/pull/1026))
-- fix(product_enablement/ngwaf): Allow traffic_ramp to be set to zero ([#10XX](https://github.com/fastly/terraform-provider-fastly/pull/10XX))
+- fix(product_enablement/ngwaf): Allow traffic_ramp to be set to zero ([#1057](https://github.com/fastly/terraform-provider-fastly/pull/1057))
 
 ### DEPENDENCIES:
 - feat(deps): Upgrade to go-fastly version 11. ([#1028](https://github.com/fastly/terraform-provider-fastly/pull/1028))

--- a/fastly/block_fastly_service_product_enablement.go
+++ b/fastly/block_fastly_service_product_enablement.go
@@ -147,7 +147,7 @@ func (h *ProductEnablementServiceAttributeHandler) GetSchema() *schema.Schema {
 					Optional:     true,
 					Default:      100,
 					Description:  "The percentage of traffic to inspect",
-					ValidateFunc: validation.IntBetween(1, 100),
+					ValidateFunc: validation.IntBetween(0, 100),
 				},
 				"workspace_id": {
 					Type:        schema.TypeString,


### PR DESCRIPTION
Customers occasionally want to set traffic_ramp to zero but leave NGWAF enabled so that they can inspect the VCL snippets used for sending traffic to NGWAF.

 All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/go-fastly/pulls) for the same update/change?
