### PR TITLE
Add support for workspace level rate limit rules

### DIFF
--- a/docs/resources/ngwaf_account_rule.md
+++ b/docs/resources/ngwaf_account_rule.md
@@ -124,9 +124,6 @@ Required:
 Required:
 
 - `client_identifiers` (Block Set, Min: 1) List of client identifiers used for rate limiting. Can only be length 1 or 2. (see [below for nested schema](#nestedblock--rate_limit--client_identifiers))
-
-Optional:
-
 - `duration` (Number) Duration in seconds for the rate limit.
 - `interval` (Number) Time interval for the rate limit in seconds (60, 600, or 3600 minutes).
 - `signal` (String) Reference ID of the custom singal this rule uses.
@@ -135,8 +132,11 @@ Optional:
 <a id="nestedblock--rate_limit--client_identifiers"></a>
 ### Nested Schema for `rate_limit.client_identifiers`
 
+Required:
+
+- `type` (String) typ for the Client Identifier
+
 Optional:
 
 - `key` (String) Key for the Client Identifier
 - `name` (String) Name for the Client Identifier
-- `type` (String) typ for the Client Identifier

--- a/docs/resources/ngwaf_account_rule.md
+++ b/docs/resources/ngwaf_account_rule.md
@@ -134,7 +134,7 @@ Required:
 
 Required:
 
-- `type` (String) typ for the Client Identifier
+- `type` (String) Type for the Client Identifier
 
 Optional:
 

--- a/docs/resources/ngwaf_account_rule.md
+++ b/docs/resources/ngwaf_account_rule.md
@@ -70,6 +70,7 @@ $ terraform import fastly_ngwaf_account_rule.demo <ruleID>
 - `condition` (Block List) Flat list of individual conditions. Each must include `field`, `operator`, and `value`. (see [below for nested schema](#nestedblock--condition))
 - `group_condition` (Block List) List of grouped conditions with nested logic. Each group must define a `group_operator` and at least one condition. (see [below for nested schema](#nestedblock--group_condition))
 - `group_operator` (String) Logical operator to apply to group conditions (`any` or `all`).
+- `rate_limit` (Block List, Max: 1) Block specifically for rate_limit rules. (see [below for nested schema](#nestedblock--rate_limit))
 - `request_logging` (String) Logging behavior for matching requests (`sampled` or `none`).
 
 ### Read-Only
@@ -114,3 +115,28 @@ Required:
 - `field` (String) Field to inspect (e.g., `ip`, `path`).
 - `operator` (String) Operator to apply (e.g., `equals`, `contains`).
 - `value` (String) The value to test the field against.
+
+
+
+<a id="nestedblock--rate_limit"></a>
+### Nested Schema for `rate_limit`
+
+Required:
+
+- `client_identifiers` (Block Set, Min: 1) List of client identifiers used for rate limiting. Can only be length 1 or 2. (see [below for nested schema](#nestedblock--rate_limit--client_identifiers))
+
+Optional:
+
+- `duration` (Number) Duration in seconds for the rate limit.
+- `interval` (Number) Time interval for the rate limit in seconds (60, 600, or 3600 minutes).
+- `signal` (String) Reference ID of the custom singal this rule uses.
+- `threshold` (Number) Rate limit threshold (between 1 and 10000).
+
+<a id="nestedblock--rate_limit--client_identifiers"></a>
+### Nested Schema for `rate_limit.client_identifiers`
+
+Optional:
+
+- `key` (String) Key for the Client Identifier
+- `name` (String) Name for the Client Identifier
+- `type` (String) typ for the Client Identifier

--- a/docs/resources/ngwaf_workspace_rule.md
+++ b/docs/resources/ngwaf_workspace_rule.md
@@ -177,9 +177,6 @@ Required:
 Required:
 
 - `client_identifiers` (Block Set, Min: 1) List of client identifiers used for rate limiting. Can only be length 1 or 2. (see [below for nested schema](#nestedblock--rate_limit--client_identifiers))
-
-Optional:
-
 - `duration` (Number) Duration in seconds for the rate limit.
 - `interval` (Number) Time interval for the rate limit in seconds (60, 600, or 3600 minutes).
 - `signal` (String) Reference ID of the custom singal this rule uses.
@@ -188,8 +185,11 @@ Optional:
 <a id="nestedblock--rate_limit--client_identifiers"></a>
 ### Nested Schema for `rate_limit.client_identifiers`
 
+Required:
+
+- `type` (String) typ for the Client Identifier
+
 Optional:
 
 - `key` (String) Key for the Client Identifier
 - `name` (String) Name for the Client Identifier
-- `type` (String) typ for the Client Identifier

--- a/docs/resources/ngwaf_workspace_rule.md
+++ b/docs/resources/ngwaf_workspace_rule.md
@@ -113,7 +113,7 @@ $ terraform import fastly_ngwaf_workspace_rule.demo <workspaceID>/<ruleID>
 - `action` (Block List, Min: 1) List of actions to perform when the rule matches. (see [below for nested schema](#nestedblock--action))
 - `description` (String) A human-readable description of the rule.
 - `enabled` (Boolean) Whether the rule is currently enabled.
-- `type` (String) The type of the rule (`request`, `signal`, or `templated_signal`).
+- `type` (String) The type of the rule (`request`, `signal`, `rate_limit`, or `templated_signal`).
 - `workspace_id` (String) The ID of the Next-Gen WAF workspace this rule belongs to.
 
 ### Optional
@@ -121,6 +121,7 @@ $ terraform import fastly_ngwaf_workspace_rule.demo <workspaceID>/<ruleID>
 - `condition` (Block List) Flat list of individual conditions. Each must include `field`, `operator`, and `value`. (see [below for nested schema](#nestedblock--condition))
 - `group_condition` (Block List) List of grouped conditions with nested logic. Each group must define a `group_operator` and at least one condition. (see [below for nested schema](#nestedblock--group_condition))
 - `group_operator` (String) Logical operator to apply to group conditions (`any` or `all`).
+- `rate_limit` (Block List, Max: 1) Block specifically for rate_limit rules. (see [below for nested schema](#nestedblock--rate_limit))
 - `request_logging` (String) Logging behavior for matching requests (`sampled` or `none`).
 
 ### Read-Only
@@ -167,3 +168,28 @@ Required:
 - `field` (String) Field to inspect (e.g., `ip`, `path`).
 - `operator` (String) Operator to apply (e.g., `equals`, `contains`).
 - `value` (String) The value to test the field against.
+
+
+
+<a id="nestedblock--rate_limit"></a>
+### Nested Schema for `rate_limit`
+
+Required:
+
+- `client_identifiers` (Block Set, Min: 1) List of client identifiers used for rate limiting. Can only be length 1 or 2. (see [below for nested schema](#nestedblock--rate_limit--client_identifiers))
+
+Optional:
+
+- `duration` (Number) Duration in seconds for the rate limit.
+- `interval` (Number) Time interval for the rate limit in seconds (60, 600, or 3600 minutes).
+- `signal` (String) Reference ID of the custom singal this rule uses.
+- `threshold` (Number) Rate limit threshold (between 1 and 10000).
+
+<a id="nestedblock--rate_limit--client_identifiers"></a>
+### Nested Schema for `rate_limit.client_identifiers`
+
+Optional:
+
+- `key` (String) Key for the Client Identifier
+- `name` (String) Name for the Client Identifier
+- `type` (String) typ for the Client Identifier

--- a/docs/resources/ngwaf_workspace_rule.md
+++ b/docs/resources/ngwaf_workspace_rule.md
@@ -187,7 +187,7 @@ Required:
 
 Required:
 
-- `type` (String) typ for the Client Identifier
+- `type` (String) Type for the Client Identifier
 
 Optional:
 

--- a/fastly/ngwaf_rule_flatten.go
+++ b/fastly/ngwaf_rule_flatten.go
@@ -75,5 +75,12 @@ func flattenNGWAFRuleResponse(d *schema.ResourceData, rule *rules.Rule) error {
 		return fmt.Errorf("error setting group_condition: %w", err)
 	}
 
+	// Flatten rate limit
+	if isWorkspace {
+		if err := d.Set("rate_limit", flattenNGWAFRuleRateLimitGeneric(rule.RateLimit)); err != nil {
+			return fmt.Errorf("error setting rate_limit: %w", err)
+		}
+	}
+
 	return nil
 }

--- a/fastly/ngwaf_rule_helpers.go
+++ b/fastly/ngwaf_rule_helpers.go
@@ -130,3 +130,34 @@ func flattenNGWAFRuleActionsGeneric(actions []rules.Action, isWorkspace bool) []
 
 	return result
 }
+
+func flattenNGWAFRuleRateLimitGeneric(rateLimit *rules.RateLimit) []map[string]any {
+	clientIdentifiers := []map[string]any{}
+
+	if rateLimit == nil {
+		return clientIdentifiers
+	}
+
+	for _, ci := range rateLimit.ClientIdentifiers {
+		m := map[string]any{}
+		if ci.Key != "" {
+			m["key"] = ci.Key
+		}
+		if ci.Name != "" {
+			m["name"] = ci.Name
+		}
+		m["type"] = ci.Type
+
+		clientIdentifiers = append(clientIdentifiers, m)
+	}
+
+	return []map[string]any{
+		{
+			"client_identifiers": clientIdentifiers,
+			"duration":           rateLimit.Duration,
+			"interval":           rateLimit.Interval,
+			"signal":             rateLimit.Signal,
+			"threshold":          rateLimit.Threshold,
+		},
+	}
+}

--- a/fastly/ngwaf_rule_schema.go
+++ b/fastly/ngwaf_rule_schema.go
@@ -129,6 +129,62 @@ func resourceFastlyNGWAFRuleBase() *schema.Resource {
 				Description:      "Logical operator to apply to group conditions (`any` or `all`).",
 				ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice([]string{"any", "all"}, false)),
 			},
+			"rate_limit": {
+				Description: "Block specifically for rate_limit rules.",
+				Type:        schema.TypeList,
+				MaxItems:    1,
+				Optional:    true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"client_identifiers": {
+							Description: "List of client identifiers used for rate limiting. Can only be length 1 or 2.",
+							Type:        schema.TypeSet,
+							Required:    true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"key": {
+										Type:        schema.TypeString,
+										Optional:    true,
+										Description: "Key for the Client Identifier",
+									},
+									"name": {
+										Type:        schema.TypeString,
+										Optional:    true,
+										Description: "Name for the Client Identifier",
+									},
+									"type": {
+										Type:        schema.TypeString,
+										Optional:    true,
+										Description: "typ for the Client Identifier",
+									},
+								},
+							},
+						},
+						"duration": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Description: "Duration in seconds for the rate limit.",
+						},
+						"interval": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							Description:  "Time interval for the rate limit in seconds (60, 600, or 3600 minutes).",
+							ValidateFunc: validation.IntInSlice([]int{60, 600, 3600}),
+						},
+						"signal": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "Reference ID of the custom singal this rule uses.",
+						},
+						"threshold": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							Description:  "Rate limit threshold (between 1 and 10000).",
+							ValidateFunc: validation.IntBetween(1, 10000),
+						},
+					},
+				},
+			},
 			"request_logging": {
 				Type:             schema.TypeString,
 				Optional:         true,

--- a/fastly/ngwaf_rule_schema.go
+++ b/fastly/ngwaf_rule_schema.go
@@ -155,7 +155,7 @@ func resourceFastlyNGWAFRuleBase() *schema.Resource {
 									"type": {
 										Type:        schema.TypeString,
 										Required:    true,
-										Description: "typ for the Client Identifier",
+										Description: "Type for the Client Identifier",
 									},
 								},
 							},

--- a/fastly/ngwaf_rule_schema.go
+++ b/fastly/ngwaf_rule_schema.go
@@ -154,7 +154,7 @@ func resourceFastlyNGWAFRuleBase() *schema.Resource {
 									},
 									"type": {
 										Type:        schema.TypeString,
-										Optional:    true,
+										Required:    true,
 										Description: "typ for the Client Identifier",
 									},
 								},
@@ -162,23 +162,23 @@ func resourceFastlyNGWAFRuleBase() *schema.Resource {
 						},
 						"duration": {
 							Type:        schema.TypeInt,
-							Optional:    true,
+							Required:    true,
 							Description: "Duration in seconds for the rate limit.",
 						},
 						"interval": {
 							Type:         schema.TypeInt,
-							Optional:     true,
+							Required:     true,
 							Description:  "Time interval for the rate limit in seconds (60, 600, or 3600 minutes).",
 							ValidateFunc: validation.IntInSlice([]int{60, 600, 3600}),
 						},
 						"signal": {
 							Type:        schema.TypeString,
-							Optional:    true,
+							Required:    true,
 							Description: "Reference ID of the custom singal this rule uses.",
 						},
 						"threshold": {
 							Type:         schema.TypeInt,
-							Optional:     true,
+							Required:     true,
 							Description:  "Rate limit threshold (between 1 and 10000).",
 							ValidateFunc: validation.IntBetween(1, 10000),
 						},

--- a/fastly/resource_fastly_ngwaf_rule.go
+++ b/fastly/resource_fastly_ngwaf_rule.go
@@ -19,8 +19,8 @@ func resourceFastlyNGWAFWorkspaceRule() *schema.Resource {
 	r.Schema["type"] = &schema.Schema{
 		Type:             schema.TypeString,
 		Required:         true,
-		Description:      "The type of the rule (`request`, `signal`, or `templated_signal`).",
-		ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice([]string{"request", "signal", "templated_signal"}, false)),
+		Description:      "The type of the rule (`request`, `signal`, `rate_limit`, or `templated_signal`).",
+		ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice([]string{"request", "signal", "templated_signal", "rate_limit"}, false)),
 	}
 
 	// Force recreation for templated_signal rules to avoid "templateSignal rules expect no actions"


### PR DESCRIPTION
 All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/go-fastly/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

* [x] Does your submission pass tests? 
* [x] Post the output of your test runs

```
TF_ACC=1 go  test $(go  list ./...) -v -run=TestAccFastlyNGWAFWorkspaceRule_rateLimit -parallel=4 -timeout 360m -ldflags="-X=github.com/fastly/terraform-provider-fastly/version.ProviderVersion=acc"
?       github.com/fastly/terraform-provider-fastly     [no test files]
=== RUN   TestAccFastlyNGWAFWorkspaceRule_rateLimit
=== PAUSE TestAccFastlyNGWAFWorkspaceRule_rateLimit
=== CONT  TestAccFastlyNGWAFWorkspaceRule_rateLimit
--- PASS: TestAccFastlyNGWAFWorkspaceRule_rateLimit (10.14s)
PASS
ok      github.com/fastly/terraform-provider-fastly/fastly      10.552s
?       github.com/fastly/terraform-provider-fastly/fastly/hashcode     [no test files]
?       github.com/fastly/terraform-provider-fastly/version     [no test files]
```