### PR TITLE
Removes the rate limit block from the account level rules schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### BUG FIXES:
 
+- fix(ngwaf/rules): removes the rate limit block from the account level rules schema.  ([#1065](https://github.com/fastly/terraform-provider-fastly/pull/1065))
+
 ### DEPENDENCIES:
 
 ## 8.0.0 (August 5, 2025)

--- a/docs/resources/ngwaf_account_rule.md
+++ b/docs/resources/ngwaf_account_rule.md
@@ -70,7 +70,6 @@ $ terraform import fastly_ngwaf_account_rule.demo <ruleID>
 - `condition` (Block List) Flat list of individual conditions. Each must include `field`, `operator`, and `value`. (see [below for nested schema](#nestedblock--condition))
 - `group_condition` (Block List) List of grouped conditions with nested logic. Each group must define a `group_operator` and at least one condition. (see [below for nested schema](#nestedblock--group_condition))
 - `group_operator` (String) Logical operator to apply to group conditions. Accepted values are `any` and `all`.
-- `rate_limit` (Block List, Max: 1) Block specifically for rate_limit rules. (see [below for nested schema](#nestedblock--rate_limit))
 - `request_logging` (String) Logging behavior for matching requests. Accepted values are `sampled` and `none`.
 
 ### Read-Only
@@ -115,28 +114,3 @@ Required:
 - `field` (String) Field to inspect (e.g., `ip`, `path`).
 - `operator` (String) Operator to apply (e.g., `equals`, `contains`).
 - `value` (String) The value to test the field against.
-
-
-
-<a id="nestedblock--rate_limit"></a>
-### Nested Schema for `rate_limit`
-
-Required:
-
-- `client_identifiers` (Block Set, Min: 1) List of client identifiers used for rate limiting. Can only be length 1 or 2. (see [below for nested schema](#nestedblock--rate_limit--client_identifiers))
-- `duration` (Number) Duration in seconds for the rate limit.
-- `interval` (Number) Time interval for the rate limit in seconds. Accepted values are 60, 600, and 3600.
-- `signal` (String) Reference ID of the custom signal this rule uses to count requests.
-- `threshold` (Number) Rate limit threshold. Minimum 1 and maximum 10,000.
-
-<a id="nestedblock--rate_limit--client_identifiers"></a>
-### Nested Schema for `rate_limit.client_identifiers`
-
-Required:
-
-- `type` (String) Type of the Client Identifier.
-
-Optional:
-
-- `key` (String) Key for the Client Identifier.
-- `name` (String) Name for the Client Identifier.

--- a/fastly/ngwaf_rule_schema.go
+++ b/fastly/ngwaf_rule_schema.go
@@ -130,62 +130,6 @@ func resourceFastlyNGWAFRuleBase() *schema.Resource {
 				Description:      "Logical operator to apply to group conditions. Accepted values are `any` and `all`.",
 				ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice([]string{"any", "all"}, false)),
 			},
-			"rate_limit": {
-				Description: "Block specifically for rate_limit rules.",
-				Type:        schema.TypeList,
-				MaxItems:    1,
-				Optional:    true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"client_identifiers": {
-							Description: "List of client identifiers used for rate limiting. Can only be length 1 or 2.",
-							Type:        schema.TypeSet,
-							Required:    true,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"key": {
-										Type:        schema.TypeString,
-										Optional:    true,
-										Description: "Key for the Client Identifier.",
-									},
-									"name": {
-										Type:        schema.TypeString,
-										Optional:    true,
-										Description: "Name for the Client Identifier.",
-									},
-									"type": {
-										Type:        schema.TypeString,
-										Required:    true,
-										Description: "Type of the Client Identifier.",
-									},
-								},
-							},
-						},
-						"duration": {
-							Type:        schema.TypeInt,
-							Required:    true,
-							Description: "Duration in seconds for the rate limit.",
-						},
-						"interval": {
-							Type:         schema.TypeInt,
-							Required:     true,
-							Description:  "Time interval for the rate limit in seconds. Accepted values are 60, 600, and 3600.",
-							ValidateFunc: validation.IntInSlice([]int{60, 600, 3600}),
-						},
-						"signal": {
-							Type:        schema.TypeString,
-							Required:    true,
-							Description: "Reference ID of the custom signal this rule uses to count requests.",
-						},
-						"threshold": {
-							Type:         schema.TypeInt,
-							Required:     true,
-							Description:  "Rate limit threshold. Minimum 1 and maximum 10,000.",
-							ValidateFunc: validation.IntBetween(1, 10000),
-						},
-					},
-				},
-			},
 			"request_logging": {
 				Type:             schema.TypeString,
 				Optional:         true,

--- a/fastly/resource_fastly_ngwaf_rule.go
+++ b/fastly/resource_fastly_ngwaf_rule.go
@@ -45,6 +45,63 @@ func resourceFastlyNGWAFWorkspaceRule() *schema.Resource {
 		Description: "The ID of the workspace.",
 	}
 
+	r.Schema["rate_limit"] = &schema.Schema{
+		Description: "Block specifically for rate_limit rules.",
+		Type:        schema.TypeList,
+		MaxItems:    1,
+		Optional:    true,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"client_identifiers": {
+					Description: "List of client identifiers used for rate limiting. Can only be length 1 or 2.",
+					Type:        schema.TypeSet,
+					Required:    true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"key": {
+								Type:        schema.TypeString,
+								Optional:    true,
+								Description: "Key for the Client Identifier.",
+							},
+							"name": {
+								Type:        schema.TypeString,
+								Optional:    true,
+								Description: "Name for the Client Identifier.",
+							},
+							"type": {
+								Type:        schema.TypeString,
+								Required:    true,
+								Description: "Type of the Client Identifier.",
+							},
+						},
+					},
+				},
+				"duration": {
+					Type:        schema.TypeInt,
+					Required:    true,
+					Description: "Duration in seconds for the rate limit.",
+				},
+				"interval": {
+					Type:         schema.TypeInt,
+					Required:     true,
+					Description:  "Time interval for the rate limit in seconds. Accepted values are 60, 600, and 3600.",
+					ValidateFunc: validation.IntInSlice([]int{60, 600, 3600}),
+				},
+				"signal": {
+					Type:        schema.TypeString,
+					Required:    true,
+					Description: "Reference ID of the custom signal this rule uses to count requests.",
+				},
+				"threshold": {
+					Type:         schema.TypeInt,
+					Required:     true,
+					Description:  "Rate limit threshold. Minimum 1 and maximum 10,000.",
+					ValidateFunc: validation.IntBetween(1, 10000),
+				},
+			},
+		},
+	}
+
 	return r
 }
 


### PR DESCRIPTION
#All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/go-fastly/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

* [x] Does your submission pass tests? 
* [x] Post the output of your test runs
```
➜  terraform-provider-fastly git:(main) ✗ make testacc TESTARGS='-run=TestAccFastlyNGWAFWorkspaceRule_rateLimit'
golangci-lint run --verbose
INFO golangci-lint has version v2.1.6 built with go1.24.2 from (unknown, modified: ?, mod sum: "h1:LXqShFfAGM5BDzEOWD2SL1IzJAgUOqES/HRBsfKjI+w=") on (unknown) 
INFO [config_reader] Config search paths: [./ /Users/anthonygomez/src/fastly/terraform-provider-fastly /Users/anthonygomez/src/fastly /Users/anthonygomez/src /Users/anthonygomez /Users /] 
INFO [config_reader] Used config file .golangci.yml 
INFO [config_reader] Module name "github.com/fastly/terraform-provider-fastly" 
INFO maxprocs: Leaving GOMAXPROCS=12: CPU quota undefined 
INFO [goenv] Read go env for 7.671709ms: map[string]string{"GOCACHE":"/Users/anthonygomez/Library/Caches/go-build", "GOROOT":"/Users/anthonygomez/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.2.darwin-arm64"} 
INFO [lintersdb] Active 19 linters: [durationcheck errcheck exhaustive gocritic godot gofumpt goimports gosec govet ineffassign makezero misspell nilerr predeclared revive staticcheck unconvert unparam unused] 
INFO [loader] Go packages loading at mode 8767 (imports|types_sizes|deps|name|compiled_files|exports_file|files) took 2.815365667s 
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 35.167417ms 
INFO [linters_context/goanalysis] analyzers took 23.211044892s with top 10 stages: goimports: 6.601922666s, the_only_name: 3.161648584s, buildir: 1.661609792s, gosec: 1.174050125s, gofumpt: 1.1455125s, gocritic: 600.145583ms, S1038: 572.291709ms, unused: 570.049542ms, misspell: 509.123875ms, unparam: 478.565418ms 
INFO [runner/exclusion_paths] Skipped 0 issues by pattern "third_party$" 
INFO [runner/exclusion_paths] Skipped 0 issues by pattern "builtin$" 
INFO [runner/exclusion_paths] Skipped 0 issues by pattern "examples$" 
INFO [runner/exclusion_rules] Skipped 0 issues by rules: [Path: "third_party$", Linters: "gofumpt, goimports"] 
INFO [runner/exclusion_rules] Skipped 0 issues by rules: [Path: "builtin$", Linters: "gofumpt, goimports"] 
INFO [runner/exclusion_rules] Skipped 0 issues by rules: [Path: "examples$", Linters: "gofumpt, goimports"] 
INFO [runner] Issues before processing: 13, after processing: 0 
INFO [runner] Processors filtering stat (in/out): path_relativity: 13/13, invalid_issue: 13/13, exclusion_paths: 13/13, exclusion_rules: 13/2, cgo: 13/13, filename_unadjuster: 13/13, path_absoluter: 13/13, generated_file_filter: 13/13, nolint_filter: 2/0 
INFO [runner] processing took 809.374µs with stages: nolint_filter: 442µs, generated_file_filter: 252.626µs, exclusion_rules: 62.958µs, exclusion_paths: 26.083µs, path_relativity: 10.833µs, invalid_issue: 6.292µs, cgo: 3µs, sort_results: 1.958µs, filename_unadjuster: 1.458µs, path_absoluter: 584ns, max_same_issues: 375ns, fixer: 333ns, diff: 167ns, path_prettifier: 166ns, path_shortener: 125ns, uniq_by_line: 125ns, source_code: 125ns, max_from_linter: 83ns, max_per_file_from_linter: 42ns, severity-rules: 41ns 
INFO [runner] linters took 7.411126167s with stages: goanalysis_metalinter: 7.410240917s 
0 issues.
INFO File cache stats: 0 entries of total size 0B 
INFO Memory: 104 samples, avg is 475.9MB, max is 732.1MB 
INFO Execution took 10.269974667s                 
go  tool -modfile=tools.mod tfproviderlintx -R001=false -R018=false -R019=false -XR001=false -XAT001=false  ./...
golangci-lint fmt
TF_ACC=1 go  test $(go  list ./...) -v -run=TestAccFastlyNGWAFWorkspaceRule_rateLimit -parallel=4 -timeout 360m -ldflags="-X=github.com/fastly/terraform-provider-fastly/version.ProviderVersion=acc"
?       github.com/fastly/terraform-provider-fastly     [no test files]
=== RUN   TestAccFastlyNGWAFWorkspaceRule_rateLimit
=== PAUSE TestAccFastlyNGWAFWorkspaceRule_rateLimit
=== CONT  TestAccFastlyNGWAFWorkspaceRule_rateLimit
--- PASS: TestAccFastlyNGWAFWorkspaceRule_rateLimit (11.09s)
PASS
ok      github.com/fastly/terraform-provider-fastly/fastly      11.852s
?       github.com/fastly/terraform-provider-fastly/fastly/hashcode     [no test files]
?       github.com/fastly/terraform-provider-fastly/version     [no test files]
```
