### PR TITLE
Add default_redirect_url to workspaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### ENHANCEMENTS:
 
+- feat(ngwaf/workspace): add default_redirect_url to workspaces. ([#1068](https://github.com/fastly/terraform-provider-fastly/pull/1068))
+
 ### BUG FIXES:
 
 - fix(ngwaf/rules): removes the rate limit block from the account level rules schema.  ([#1065](https://github.com/fastly/terraform-provider-fastly/pull/1065))

--- a/docs/resources/ngwaf_workspace.md
+++ b/docs/resources/ngwaf_workspace.md
@@ -46,6 +46,7 @@ $ terraform import fastly_ngwaf_workspace.demo xxxxxxxxxxxxxxxxxxxx
 
 - `client_ip_headers` (List of String) Specifies the request headers containing the client IP address. Maximum of 10 header names.
 - `default_blocking_response_code` (Number) The status code returned when a request is blocked. This configuration is applied at the workspace but can be overwritten in rules. Accepted values are [`301`, `302`, `400..599`]. Default value `406`.
+- `default_redirect_url` (String) URL to redirect to when blocking with a '301' or '302' HTTP status code
 - `ip_anonymization` (String) Agents will anonymize IP addresses according to the option selected. Accepted value is `hashed`.
 
 ### Read-Only

--- a/docs/resources/ngwaf_workspace.md
+++ b/docs/resources/ngwaf_workspace.md
@@ -46,7 +46,7 @@ $ terraform import fastly_ngwaf_workspace.demo xxxxxxxxxxxxxxxxxxxx
 
 - `client_ip_headers` (List of String) Specifies the request headers containing the client IP address. Maximum of 10 header names.
 - `default_blocking_response_code` (Number) The status code returned when a request is blocked. This configuration is applied at the workspace but can be overwritten in rules. Accepted values are [`301`, `302`, `400..599`]. Default value `406`.
-- `default_redirect_url` (String) URL to redirect to when blocking with a '301' or '302' HTTP status code
+- `default_redirect_url` (String) The redirect URL used if default_blocking_response_code is `301` or `302`.
 - `ip_anonymization` (String) Agents will anonymize IP addresses according to the option selected. Accepted value is `hashed`.
 
 ### Read-Only

--- a/fastly/resource_fastly_ngwaf_workspace.go
+++ b/fastly/resource_fastly_ngwaf_workspace.go
@@ -76,7 +76,7 @@ func resourceFastlyNGWAFWorkspace() *schema.Resource {
 			"default_redirect_url": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Description: "URL to redirect to when blocking with a '301' or '302' HTTP status code",
+				Description: "The redirect URL used if default_blocking_response_code is `301` or `302`.",
 			},
 			"description": {
 				Type:        schema.TypeString,

--- a/fastly/resource_fastly_ngwaf_workspace.go
+++ b/fastly/resource_fastly_ngwaf_workspace.go
@@ -73,6 +73,11 @@ func resourceFastlyNGWAFWorkspace() *schema.Resource {
 				Description:      "The status code returned when a request is blocked. This configuration is applied at the workspace but can be overwritten in rules. Accepted values are [`301`, `302`, `400..599`]. Default value `406`.",
 				ValidateDiagFunc: validation.ToDiagFunc(validation.Any(validation.IntBetween(400, 599), validation.IntInSlice([]int{301, 302}))),
 			},
+			"default_redirect_url": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "URL to redirect to when blocking with a '301' or '302' HTTP status code",
+			},
 			"description": {
 				Type:        schema.TypeString,
 				Required:    true,
@@ -124,6 +129,11 @@ func resourceFastlyNGWAFWorkspaceCreate(ctx context.Context, d *schema.ResourceD
 	if d.HasChange("default_blocking_response_code") || d.Get("default_blocking_response_code") != 406 {
 		code := d.Get("default_blocking_response_code").(int)
 		i.DefaultBlockingResponseCode = &code
+	}
+
+	if d.HasChange("default_redirect_url") || d.Get("default_redirect_url") != "" {
+		url := d.Get("default_redirect_url").(string)
+		i.DefaultRedirectURL = &url
 	}
 
 	if v, ok := d.GetOk("attack_signal_thresholds"); ok && len(v.([]any)) > 0 {
@@ -185,6 +195,9 @@ func resourceFastlyNGWAFWorkspaceRead(ctx context.Context, d *schema.ResourceDat
 	if err := d.Set("default_blocking_response_code", workspace.DefaultBlockingResponseCode); err != nil {
 		return diag.FromErr(err)
 	}
+	if err := d.Set("default_redirect_url", workspace.DefaultRedirectURL); err != nil {
+		return diag.FromErr(err)
+	}
 
 	log.Printf("[DEBUG] UPDATE: NGWAF workspace attack thresholds get: %#v", workspace.AttackSignalThresholds)
 
@@ -226,6 +239,11 @@ func resourceFastlyNGWAFWorkspaceUpdate(ctx context.Context, d *schema.ResourceD
 	if d.HasChange("default_blocking_response_code") || d.Get("default_blocking_response_code") != 406 {
 		code := d.Get("default_blocking_response_code").(int)
 		i.DefaultBlockingResponseCode = &code
+	}
+
+	if d.HasChange("default_redirect_url") || d.Get("default_redirect_url") != "" {
+		url := d.Get("default_redirect_url").(string)
+		i.DefaultRedirectURL = &url
 	}
 
 	if v, ok := d.GetOk("attack_signal_thresholds"); ok && len(v.([]any)) > 0 {

--- a/fastly/resource_fastly_ngwaf_workspace_test.go
+++ b/fastly/resource_fastly_ngwaf_workspace_test.go
@@ -63,7 +63,8 @@ func TestAccFastlyNGWAFWorkspace_validate(t *testing.T) {
 					resource.TestCheckResourceAttr("fastly_ngwaf_workspace.example", "mode", "log"),
 					resource.TestCheckResourceAttr("fastly_ngwaf_workspace.example", "ip_anonymization", "hashed"),
 					resource.TestCheckResourceAttr("fastly_ngwaf_workspace.example", "client_ip_headers.0", "True-Client-IP"),
-					resource.TestCheckResourceAttr("fastly_ngwaf_workspace.example", "default_blocking_response_code", "406"),
+					resource.TestCheckResourceAttr("fastly_ngwaf_workspace.example", "default_blocking_response_code", "301"),
+					resource.TestCheckResourceAttr("fastly_ngwaf_workspace.example", "default_redirect_url", "www.test.com"),
 					resource.TestCheckResourceAttr("fastly_ngwaf_workspace.example", "attack_signal_thresholds.0.one_minute", "200"),
 					resource.TestCheckResourceAttr("fastly_ngwaf_workspace.example", "attack_signal_thresholds.0.ten_minutes", "1000"),
 					resource.TestCheckResourceAttr("fastly_ngwaf_workspace.example", "attack_signal_thresholds.0.one_hour", "2000"),
@@ -148,7 +149,8 @@ resource "fastly_ngwaf_workspace" "example" {
   mode                           = "log"
   ip_anonymization               = "hashed"
   client_ip_headers              = ["True-Client-IP"]
-  default_blocking_response_code = 406
+  default_blocking_response_code = 301
+  default_redirect_url           = "www.test.com"
 
   attack_signal_thresholds {
     one_minute  = 200


### PR DESCRIPTION
 All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/go-fastly/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

* [x] Does your submission pass tests? 
* [x] Post the output of your test runs
```
  terraform-provider-fastly git:(main) ✗ make testacc TESTARGS='-run=TestAccFastlyNGWAFWorkspace_validate'
golangci-lint run --verbose
INFO golangci-lint has version v2.1.6 built with go1.24.2 from (unknown, modified: ?, mod sum: "h1:LXqShFfAGM5BDzEOWD2SL1IzJAgUOqES/HRBsfKjI+w=") on (unknown) 
INFO [config_reader] Config search paths: [./ /Users/anthonygomez/src/fastly/terraform-provider-fastly /Users/anthonygomez/src/fastly /Users/anthonygomez/src /Users/anthonygomez /Users /] 
INFO [config_reader] Used config file .golangci.yml 
INFO [config_reader] Module name "github.com/fastly/terraform-provider-fastly" 
INFO maxprocs: Leaving GOMAXPROCS=12: CPU quota undefined 
INFO [goenv] Read go env for 7.791584ms: map[string]string{"GOCACHE":"/Users/anthonygomez/Library/Caches/go-build", "GOROOT":"/Users/anthonygomez/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.2.darwin-arm64"} 
INFO [lintersdb] Active 19 linters: [durationcheck errcheck exhaustive gocritic godot gofumpt goimports gosec govet ineffassign makezero misspell nilerr predeclared revive staticcheck unconvert unparam unused] 
INFO [loader] Go packages loading at mode 8767 (files|imports|name|types_sizes|compiled_files|deps|exports_file) took 2.607906208s 
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 36.385667ms 
INFO [linters_context/goanalysis] analyzers took 30.357865807s with top 10 stages: goimports: 7.214857416s, the_only_name: 3.778937625s, buildir: 1.702779386s, gosec: 1.554045916s, gofumpt: 1.398117583s, gocritic: 863.57825ms, unused: 834.95475ms, S1038: 704.452458ms, QF1004: 679.912626ms, buildssa: 661.314083ms 
INFO [runner/exclusion_paths] Skipped 0 issues by pattern "third_party$" 
INFO [runner/exclusion_paths] Skipped 0 issues by pattern "builtin$" 
INFO [runner/exclusion_paths] Skipped 0 issues by pattern "examples$" 
INFO [runner/exclusion_rules] Skipped 0 issues by rules: [Path: "third_party$", Linters: "gofumpt, goimports"] 
INFO [runner/exclusion_rules] Skipped 0 issues by rules: [Path: "builtin$", Linters: "gofumpt, goimports"] 
INFO [runner/exclusion_rules] Skipped 0 issues by rules: [Path: "examples$", Linters: "gofumpt, goimports"] 
INFO [runner] Issues before processing: 13, after processing: 0 
INFO [runner] Processors filtering stat (in/out): exclusion_paths: 13/13, invalid_issue: 13/13, path_relativity: 13/13, generated_file_filter: 13/13, exclusion_rules: 13/2, path_absoluter: 13/13, cgo: 13/13, filename_unadjuster: 13/13, nolint_filter: 2/0 
INFO [runner] processing took 706.252µs with stages: nolint_filter: 409.417µs, generated_file_filter: 192.417µs, exclusion_rules: 52.709µs, exclusion_paths: 31.459µs, path_relativity: 9.624µs, cgo: 3.542µs, invalid_issue: 2.291µs, sort_results: 2.126µs, filename_unadjuster: 458ns, max_same_issues: 417ns, path_absoluter: 375ns, fixer: 292ns, source_code: 250ns, diff: 209ns, uniq_by_line: 208ns, path_shortener: 125ns, path_prettifier: 125ns, severity-rules: 125ns, max_from_linter: 83ns, max_per_file_from_linter: 0s 
INFO [runner] linters took 7.98452525s with stages: goanalysis_metalinter: 7.983756292s 
0 issues.
INFO File cache stats: 0 entries of total size 0B 
INFO Memory: 108 samples, avg is 493.0MB, max is 720.4MB 
INFO Execution took 10.637140959s                 
go  tool -modfile=tools.mod tfproviderlintx -R001=false -R018=false -R019=false -XR001=false -XAT001=false  ./...
golangci-lint fmt
TF_ACC=1 go  test $(go  list ./...) -v -run=TestAccFastlyNGWAFWorkspace_validate -parallel=4 -timeout 360m -ldflags="-X=github.com/fastly/terraform-provider-fastly/version.ProviderVersion=acc"
?       github.com/fastly/terraform-provider-fastly     [no test files]
=== RUN   TestAccFastlyNGWAFWorkspace_validate
=== PAUSE TestAccFastlyNGWAFWorkspace_validate
=== CONT  TestAccFastlyNGWAFWorkspace_validate
--- PASS: TestAccFastlyNGWAFWorkspace_validate (9.54s)
PASS
ok      github.com/fastly/terraform-provider-fastly/fastly      10.278s
?       github.com/fastly/terraform-provider-fastly/fastly/hashcode     [no test files]
?       github.com/fastly/terraform-provider-fastly/version     [no test files]
```
