### PR TITLE
fix(service/requestsetting): remove incorrect default value for xff attribute 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - feat(compute acls): add support for compute ACLs ([#1031](https://github.com/fastly/terraform-provider-fastly/pull/1031))
 - refactor(resource_fastly_domain_v1) to use domainmanagement imports and types ([#1074](https://github.com/fastly/terraform-provider-fastly/pull/1074))
 - feat(ngwaf/rules): add support for deception and allow_interactive actions ([#1077](https://github.com/fastly/terraform-provider-fastly/pull/1077))
+- bug(ngwaf/rules): removed a incorrect default value for xff attribute in a request_setting block for a fastly_service_vcl resource  ([#1078](https://github.com/fastly/terraform-provider-fastly/pull/1078))
 
 ### BUG FIXES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 - fix(ngwaf/rules): removes the rate limit block from the account level rules schema. ([#1065](https://github.com/fastly/terraform-provider-fastly/pull/1065))
 - fix(service_vcl/logging_gcs): resolves an issue where project_id was not being updated for GCS logging_gcs. ([#1073](https://github.com/fastly/terraform-provider-fastly/pull/1073))
-- fix(service_vcl/requestsetting): removed a incorrect default value for xff attribute ([#1078](https://github.com/fastly/terraform-provider-fastly/pull/1078))
+- fix(service_vcl/requestsetting): removed a incorrect default value for the xff attribute. ([#1078](https://github.com/fastly/terraform-provider-fastly/pull/1078))
 
 ### DEPENDENCIES:
 - build(deps): `github.com/fastly/go-fastly/v11` from 11.1.1 to 11.2.0 ([#1067](https://github.com/fastly/terraform-provider-fastly/pull/1067))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,12 @@
 - feat(compute acls): add support for compute ACLs ([#1031](https://github.com/fastly/terraform-provider-fastly/pull/1031))
 - refactor(resource_fastly_domain_v1) to use domainmanagement imports and types ([#1074](https://github.com/fastly/terraform-provider-fastly/pull/1074))
 - feat(ngwaf/rules): add support for deception and allow_interactive actions ([#1077](https://github.com/fastly/terraform-provider-fastly/pull/1077))
-- bug(ngwaf/rules): removed a incorrect default value for xff attribute in a request_setting block for a fastly_service_vcl resource  ([#1078](https://github.com/fastly/terraform-provider-fastly/pull/1078))
 
 ### BUG FIXES:
 
 - fix(ngwaf/rules): removes the rate limit block from the account level rules schema. ([#1065](https://github.com/fastly/terraform-provider-fastly/pull/1065))
 - fix(service_vcl/logging_gcs): resolves an issue where project_id was not being updated for GCS logging_gcs. ([#1073](https://github.com/fastly/terraform-provider-fastly/pull/1073))
+- fix(service_vcl/requestsetting): removed a incorrect default value for xff attribute ([#1078](https://github.com/fastly/terraform-provider-fastly/pull/1078))
 
 ### DEPENDENCIES:
 - build(deps): `github.com/fastly/go-fastly/v11` from 11.1.1 to 11.2.0 ([#1067](https://github.com/fastly/terraform-provider-fastly/pull/1067))

--- a/docs/resources/service_vcl.md
+++ b/docs/resources/service_vcl.md
@@ -1244,7 +1244,7 @@ Optional:
 - `max_stale_age` (Number) How old an object is allowed to be to serve `stale-if-error` or `stale-while-revalidate`, in seconds
 - `request_condition` (String) Name of already defined `condition` to determine if this request setting should be applied (should be unique across multiple instances of `request_setting`)
 - `timer_support` (Boolean) Injects the X-Timer info into the request for viewing origin fetch durations
-- `xff` (String) X-Forwarded-For, should be `clear`, `leave`, `append`, `append_all`, or `overwrite`. Default `append`
+- `xff` (String) X-Forwarded-For, should be `clear`, `leave`, `append`, `append_all`, or `overwrite`
 
 
 <a id="nestedblock--response_object"></a>

--- a/fastly/block_fastly_service_requestsetting.go
+++ b/fastly/block_fastly_service_requestsetting.go
@@ -92,8 +92,7 @@ func (h *RequestSettingServiceAttributeHandler) GetSchema() *schema.Schema {
 				"xff": {
 					Type:        schema.TypeString,
 					Optional:    true,
-					Default:     "append",
-					Description: "X-Forwarded-For, should be `clear`, `leave`, `append`, `append_all`, or `overwrite`. Default `append`",
+					Description: "X-Forwarded-For, should be `clear`, `leave`, `append`, `append_all`, or `overwrite`",
 				},
 			},
 		},

--- a/fastly/block_fastly_service_requestsetting_test.go
+++ b/fastly/block_fastly_service_requestsetting_test.go
@@ -67,8 +67,8 @@ func TestAccFastlyServiceVCLRequestSetting_basic(t *testing.T) {
 		XForwardedFor:    gofastly.ToPointer(gofastly.RequestSettingXFFAppend),
 
 		// We only set a few attributes in our TF config (see above).
-		// For all the other attributes (with the exception of `action` and `xff`,
-		// which are only sent to the API if they have a non-zero string value)
+		// For all the other attributes (with the exception of `action`),
+		// which is only sent to the API if they have a non-zero string value)
 		// the default value for their types are still sent to the API
 		// and so the API responds with those default values. Hence we have to set
 		// those defaults below...
@@ -253,6 +253,7 @@ resource "fastly_service_vcl" "foo" {
     name              = "alt_backend"
     request_condition = "serve_alt_backend"
     max_stale_age     = %s
+    xff               = "append"
   }
 
   default_host = "http-me.fastly.dev"


### PR DESCRIPTION
 All Submissions:

### New Feature Submissions:

* [x] Does your submission pass tests? 
* [x] Post the output of your test runs

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### Are there any considerations that need to be addressed for release?

When configuring the `request_setting` block for a `fastly_service_vcl` resource, the XFF field was being set to a default value in which was not intended, not matches the behavior of the API. This PR updates the TF behavior to match that of the API. 

Testing:
```
--- PASS: TestAccFastlyServiceVCLRequestSetting_basic (38.60s)
PASS
ok      github.com/fastly/terraform-provider-fastly/fastly      38.615s
```

Resolves issue https://github.com/fastly/terraform-provider-fastly/issues/67 