### PR TITLE
Have optional boolean be fetched by getOkExists instead of getOK, which could not set a boolean value if false is supplied

### DIFF
--- a/fastly/data_source_fastly_tls_configuration.go
+++ b/fastly/data_source_fastly_tls_configuration.go
@@ -174,7 +174,8 @@ func getTLSConfigurationFilters(d *schema.ResourceData) []func(*fastly.CustomTLS
 			return !c.Bulk
 		})
 	}
-	if v, ok := d.GetOk("default"); ok {
+	//nolint:staticcheck
+	if v, ok := d.GetOkExists("default"); ok {
 		filters = append(filters, func(c *fastly.CustomTLSConfiguration) bool {
 			return c.Default == v.(bool)
 		})


### PR DESCRIPTION

 All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/go-fastly/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

* [x] Does your submission pass tests? 
* [x] Post the output of your test runs
```
TF_ACC=1 go  test $(go  list ./...) -v -run=TestAccFastlyDataSourceTLSConfiguration_basic -parallel=4 -timeout 360m -ldflags="-X=github.com/fastly/terraform-provider-fastly/version.ProviderVersion=acc"
?       github.com/fastly/terraform-provider-fastly     [no test files]
=== RUN   TestAccFastlyDataSourceTLSConfiguration_basic
=== PAUSE TestAccFastlyDataSourceTLSConfiguration_basic
=== CONT  TestAccFastlyDataSourceTLSConfiguration_basic
--- PASS: TestAccFastlyDataSourceTLSConfiguration_basic (3.43s)
PASS
ok      github.com/fastly/terraform-provider-fastly/fastly      4.235s
?       github.com/fastly/terraform-provider-fastly/fastly/hashcode     [no test files]
?       github.com/fastly/terraform-provider-fastly/version     [no test files]
```
