### PR TITLE
[CDTOOL-1167] - Update NGWAF rule action types to use correct API syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 ### DOCUMENTATION:
 
 - docs(ngwaf/rules): add rule action types documentation ([#1069](https://github.com/fastly/terraform-provider-fastly/pull/1069))
+- docs(ngwaf/rules): updated rule action type references ([#1098](https://github.com/fastly/terraform-provider-fastly/pull/1098))
 
 ## 8.0.0 (August 5, 2025)
 

--- a/docs/resources/ngwaf_account_rule.md
+++ b/docs/resources/ngwaf_account_rule.md
@@ -81,7 +81,7 @@ $ terraform import fastly_ngwaf_account_rule.demo <ruleID>
 
 Required:
 
-- `type` (String) The action type. One of: `addSignal`, `allow`, `block`, `browserChallenge`, `dynamicChallenge`, `excludeSignal`, `verifyToken` or for rate limit rule valid values: `logRequest`, `blockSignal`, `browserChallenge`, `verifyToken`
+- `type` (String) The action type. One of: `add_signal`, `allow`, `block`, `browserChallenge`, `dynamicChallenge`, `excludeSignal`, `verifyToken` or for rate limit rule valid values: `logRequest`, `blockSignal`, `browserChallenge`, `verifyToken`
 
 Optional:
 

--- a/docs/resources/ngwaf_account_rule.md
+++ b/docs/resources/ngwaf_account_rule.md
@@ -81,7 +81,7 @@ $ terraform import fastly_ngwaf_account_rule.demo <ruleID>
 
 Required:
 
-- `type` (String) The action type. One of: `add_signal`, `allow`, `block`, `browserChallenge`, `dynamicChallenge`, `excludeSignal`, `verifyToken` or for rate limit rule valid values: `logRequest`, `blockSignal`, `browserChallenge`, `verifyToken`
+- `type` (String) The action type. One of: `add_signal`, `allow`, `block`, `browser_challenge`, `dynamic_challenge`, `exclude_signal`, `verify_token` or for rate limit rule valid values: `log_request`, `block_signal`, `browser_challenge`, `verify_token`
 
 Optional:
 

--- a/docs/resources/ngwaf_workspace_rule.md
+++ b/docs/resources/ngwaf_workspace_rule.md
@@ -133,7 +133,7 @@ $ terraform import fastly_ngwaf_workspace_rule.demo <workspaceID>/<ruleID>
 
 Required:
 
-- `type` (String) The action type. One of: `addSignal`, `allow`, `block`, `browserChallenge`, `dynamicChallenge`, `excludeSignal`, `verifyToken` or for rate limit rule valid values: `logRequest`, `blockSignal`, `browserChallenge`, `verifyToken`
+- `type` (String) The action type. One of: `add_signal`, `allow`, `block`, `browserChallenge`, `dynamicChallenge`, `excludeSignal`, `verifyToken` or for rate limit rule valid values: `logRequest`, `blockSignal`, `browserChallenge`, `verifyToken`
 
 Optional:
 

--- a/docs/resources/ngwaf_workspace_rule.md
+++ b/docs/resources/ngwaf_workspace_rule.md
@@ -133,7 +133,7 @@ $ terraform import fastly_ngwaf_workspace_rule.demo <workspaceID>/<ruleID>
 
 Required:
 
-- `type` (String) The action type. One of: `add_signal`, `allow`, `block`, `browserChallenge`, `dynamicChallenge`, `excludeSignal`, `verifyToken` or for rate limit rule valid values: `logRequest`, `blockSignal`, `browserChallenge`, `verifyToken`
+- `type` (String) The action type. One of: `add_signal`, `allow`, `block`, `browser_challenge`, `dynamic_challenge`, `exclude_signal`, `verify_token` or for rate limit rule valid values: `log_request`, `block_signal`, `browser_challenge`, `verify_token`
 
 Optional:
 

--- a/fastly/ngwaf_rule_schema.go
+++ b/fastly/ngwaf_rule_schema.go
@@ -52,7 +52,7 @@ func resourceFastlyNGWAFRuleBase() *schema.Resource {
 						"type": {
 							Type:        schema.TypeString,
 							Required:    true,
-							Description: "The action type. One of: `add_signal`, `allow`, `block`, `browserChallenge`, `dynamicChallenge`, `excludeSignal`, `verifyToken` or for rate limit rule valid values: `logRequest`, `blockSignal`, `browserChallenge`, `verifyToken`",
+							Description: "The action type. One of: `add_signal`, `allow`, `block`, `browser_challenge`, `dynamic_challenge`, `exclude_signal`, `verify_token` or for rate limit rule valid values: `log_request`, `block_signal`, `browser_challenge`, `verify_token`",
 						},
 					},
 				},

--- a/fastly/ngwaf_rule_schema.go
+++ b/fastly/ngwaf_rule_schema.go
@@ -52,7 +52,7 @@ func resourceFastlyNGWAFRuleBase() *schema.Resource {
 						"type": {
 							Type:        schema.TypeString,
 							Required:    true,
-							Description: "The action type. One of: `addSignal`, `allow`, `block`, `browserChallenge`, `dynamicChallenge`, `excludeSignal`, `verifyToken` or for rate limit rule valid values: `logRequest`, `blockSignal`, `browserChallenge`, `verifyToken`",
+							Description: "The action type. One of: `add_signal`, `allow`, `block`, `browserChallenge`, `dynamicChallenge`, `excludeSignal`, `verifyToken` or for rate limit rule valid values: `logRequest`, `blockSignal`, `browserChallenge`, `verifyToken`",
 						},
 					},
 				},


### PR DESCRIPTION
### Change summary

For NGWAF rule actions, we incorrectly document the usage of the usage of of  'addSignal' instead of 'add_signal'. This PR fixes this. 

 All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/terraform-provider-fastly/pulls) for the same update/change?

### User Impact

* [x] What is the user impact of this change?

This is only a docs update. 

Internal discussion on this:
https://fastly.slack.com/archives/C07LTJ32282/p1757688069019109 