### PR TITLE
[CDTOOL-1164] - Support for Multival NGWAF Rule Condition Types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### ENHANCEMENTS:
 
+- feat(ngwaf/rules): add support for multival type conditions ([#1100](https://github.com/fastly/terraform-provider-fastly/pull/1100))
+
 ### BUG FIXES:
 
 - fix(ngwaf/alerts): Ensure that FASTLY_TF_DISPLAY_SENSITIVE_FIELDS is respected ([#1106](https://github.com/fastly/terraform-provider-fastly/pull/1106))

--- a/docs/resources/ngwaf_account_rule.md
+++ b/docs/resources/ngwaf_account_rule.md
@@ -70,6 +70,7 @@ $ terraform import fastly_ngwaf_account_rule.demo <ruleID>
 - `condition` (Block List) Flat list of individual conditions. Each must include `field`, `operator`, and `value`. (see [below for nested schema](#nestedblock--condition))
 - `group_condition` (Block List) List of grouped conditions with nested logic. Each group must define a `group_operator` and at least one condition. (see [below for nested schema](#nestedblock--group_condition))
 - `group_operator` (String) Logical operator to apply to group conditions. Accepted values are `any` and `all`.
+- `multival_condition` (Block List) List of multival conditions with nested logic. Each multival list must define a `field, operator, group_operator` and at least one condition. (see [below for nested schema](#nestedblock--multival_condition))
 - `request_logging` (String) Logging behavior for matching requests. Accepted values are `sampled` and `none`.
 
 ### Read-Only
@@ -112,5 +113,26 @@ Required:
 Required:
 
 - `field` (String) Field to inspect (e.g., `ip`, `path`).
+- `operator` (String) Operator to apply (e.g., `equals`, `contains`).
+- `value` (String) The value to test the field against.
+
+
+
+<a id="nestedblock--multival_condition"></a>
+### Nested Schema for `multival_condition`
+
+Required:
+
+- `condition` (Block List, Min: 1) A list of nested conditions in this list. (see [below for nested schema](#nestedblock--multival_condition--condition))
+- `field` (String) Enums for multival condition field.. Accepted values are `post_parameter`, `query_parameter`, `request_cookie`, `request_header`, `response_header`, and `signal`.
+- `group_operator` (String) Logical operator for the group. Accepted values are `any` and `all`.
+- `operator` (String) Indicates whether the supplied conditions will check for existence or non-existence of matching field values. Accepted values are `exists` and `does_not_exist`.
+
+<a id="nestedblock--multival_condition--condition"></a>
+### Nested Schema for `multival_condition.condition`
+
+Required:
+
+- `field` (String) Field to inspect (e.g., `name`, `value`, `signal_id`).
 - `operator` (String) Operator to apply (e.g., `equals`, `contains`).
 - `value` (String) The value to test the field against.

--- a/docs/resources/ngwaf_workspace_rule.md
+++ b/docs/resources/ngwaf_workspace_rule.md
@@ -121,6 +121,7 @@ $ terraform import fastly_ngwaf_workspace_rule.demo <workspaceID>/<ruleID>
 - `condition` (Block List) Flat list of individual conditions. Each must include `field`, `operator`, and `value`. (see [below for nested schema](#nestedblock--condition))
 - `group_condition` (Block List) List of grouped conditions with nested logic. Each group must define a `group_operator` and at least one condition. (see [below for nested schema](#nestedblock--group_condition))
 - `group_operator` (String) Logical operator to apply to group conditions. Accepted values are `any` and `all`.
+- `multival_condition` (Block List) List of multival conditions with nested logic. Each multival list must define a `field, operator, group_operator` and at least one condition. (see [below for nested schema](#nestedblock--multival_condition))
 - `rate_limit` (Block List, Max: 1) Block specifically for rate_limit rules. (see [below for nested schema](#nestedblock--rate_limit))
 - `request_logging` (String) Logging behavior for matching requests. Accepted values are `sampled` and `none`.
 
@@ -168,6 +169,27 @@ Required:
 Required:
 
 - `field` (String) Field to inspect (e.g., `ip`, `path`).
+- `operator` (String) Operator to apply (e.g., `equals`, `contains`).
+- `value` (String) The value to test the field against.
+
+
+
+<a id="nestedblock--multival_condition"></a>
+### Nested Schema for `multival_condition`
+
+Required:
+
+- `condition` (Block List, Min: 1) A list of nested conditions in this list. (see [below for nested schema](#nestedblock--multival_condition--condition))
+- `field` (String) Enums for multival condition field.. Accepted values are `post_parameter`, `query_parameter`, `request_cookie`, `request_header`, `response_header`, and `signal`.
+- `group_operator` (String) Logical operator for the group. Accepted values are `any` and `all`.
+- `operator` (String) Indicates whether the supplied conditions will check for existence or non-existence of matching field values. Accepted values are `exists` and `does_not_exist`.
+
+<a id="nestedblock--multival_condition--condition"></a>
+### Nested Schema for `multival_condition.condition`
+
+Required:
+
+- `field` (String) Field to inspect (e.g., `name`, `value`, `signal_id`).
 - `operator` (String) Operator to apply (e.g., `equals`, `contains`).
 - `value` (String) The value to test the field against.
 

--- a/fastly/ngwaf_rule_expand.go
+++ b/fastly/ngwaf_rule_expand.go
@@ -37,19 +37,11 @@ func expandNGWAFRuleCreateInput(d *schema.ResourceData, s *scope.Scope) *rules.C
 	return &rules.CreateInput{
 		Type:               gofastly.ToPointer(d.Get("type").(string)),
 		Description:        gofastly.ToPointer(d.Get("description").(string)),
-<<<<<<< HEAD
 		Scope:              s,
 		Enabled:            gofastly.ToPointer(d.Get("enabled").(bool)),
 		GroupOperator:      gofastly.ToPointer(d.Get("group_operator").(string)),
 		RequestLogging:     gofastly.ToPointer(d.Get("request_logging").(string)),
 		Actions:            expandNGWAFRuleCreateActions(actionRaw, string(s.Type)),
-=======
-		Scope:              scope,
-		Enabled:            gofastly.ToPointer(d.Get("enabled").(bool)),
-		GroupOperator:      gofastly.ToPointer(d.Get("group_operator").(string)),
-		RequestLogging:     gofastly.ToPointer(d.Get("request_logging").(string)),
-		Actions:            expandNGWAFRuleCreateActions(actionRaw, string(scope.Type)),
->>>>>>> a5d12edb (multival support)
 		Conditions:         expandNGWAFRuleCreateConditions(conditionRaw),
 		GroupConditions:    expandNGWAFRuleGroupCreateConditions(groupRaw),
 		MultivalConditions: expandNGWAFRuleMultiValCreateConditions(multivalRaw),

--- a/fastly/ngwaf_rule_expand.go
+++ b/fastly/ngwaf_rule_expand.go
@@ -24,22 +24,29 @@ func expandNGWAFRuleCreateInput(d *schema.ResourceData, s *scope.Scope) *rules.C
 		groupRaw = v.([]any)
 	}
 
+	var multivalRaw []any
+	if v, ok := d.GetOk("multival_condition"); ok {
+		multivalRaw = v.([]any)
+	}
+
 	var rateLimitRaw []any
 	if v, ok := d.GetOk("rate_limit"); ok {
 		rateLimitRaw = v.([]any)
 	}
 
 	return &rules.CreateInput{
-		Type:            gofastly.ToPointer(d.Get("type").(string)),
-		Description:     gofastly.ToPointer(d.Get("description").(string)),
-		Scope:           s,
-		Enabled:         gofastly.ToPointer(d.Get("enabled").(bool)),
-		GroupOperator:   gofastly.ToPointer(d.Get("group_operator").(string)),
-		RequestLogging:  gofastly.ToPointer(d.Get("request_logging").(string)),
-		Actions:         expandNGWAFRuleCreateActions(actionRaw, string(s.Type)),
-		Conditions:      expandNGWAFRuleCreateConditions(conditionRaw),
-		GroupConditions: expandNGWAFRuleGroupCreateConditions(groupRaw),
-		RateLimit:       expandNGWAFRuleCreateRateLimit(rateLimitRaw),
+
+		Type:               gofastly.ToPointer(d.Get("type").(string)),
+		Description:        gofastly.ToPointer(d.Get("description").(string)),
+		Scope:              s,
+		Enabled:            gofastly.ToPointer(d.Get("enabled").(bool)),
+		GroupOperator:      gofastly.ToPointer(d.Get("group_operator").(string)),
+		RequestLogging:     gofastly.ToPointer(d.Get("request_logging").(string)),
+		Actions:            expandNGWAFRuleCreateActions(actionRaw, string(s.Type)),
+		Conditions:         expandNGWAFRuleCreateConditions(conditionRaw),
+		GroupConditions:    expandNGWAFRuleGroupCreateConditions(groupRaw),
+		MultivalConditions: expandNGWAFRuleMultiValCreateConditions(multivalRaw),
+		RateLimit:          expandNGWAFRuleCreateRateLimit(rateLimitRaw),
 	}
 }
 
@@ -59,22 +66,28 @@ func expandNGWAFRuleUpdateInput(d *schema.ResourceData, s *scope.Scope) *rules.U
 		groupRaw = v.([]any)
 	}
 
+	var multivalRaw []any
+	if v, ok := d.GetOk("multival_condition"); ok {
+		multivalRaw = v.([]any)
+	}
+
 	var rateLimitRaw []any
 	if v, ok := d.GetOk("rate_limit"); ok {
 		rateLimitRaw = v.([]any)
 	}
 
 	updateInput := &rules.UpdateInput{
-		RuleID:          gofastly.ToPointer(d.Id()),
-		Scope:           s,
-		Type:            gofastly.ToPointer(d.Get("type").(string)),
-		Description:     gofastly.ToPointer(d.Get("description").(string)),
-		Enabled:         gofastly.ToPointer(d.Get("enabled").(bool)),
-		GroupOperator:   gofastly.ToPointer(d.Get("group_operator").(string)),
-		RequestLogging:  gofastly.ToPointer(d.Get("request_logging").(string)),
-		Conditions:      expandNGWAFRuleUpdateConditions(conditionRaw),
-		GroupConditions: expandNGWAFRuleGroupUpdateConditions(groupRaw),
-		RateLimit:       expandNGWAFRuleUpdateRateLimit(rateLimitRaw),
+		RuleID:             gofastly.ToPointer(d.Id()),
+		Scope:              s,
+		Type:               gofastly.ToPointer(d.Get("type").(string)),
+		Description:        gofastly.ToPointer(d.Get("description").(string)),
+		Enabled:            gofastly.ToPointer(d.Get("enabled").(bool)),
+		GroupOperator:      gofastly.ToPointer(d.Get("group_operator").(string)),
+		RequestLogging:     gofastly.ToPointer(d.Get("request_logging").(string)),
+		Conditions:         expandNGWAFRuleUpdateConditions(conditionRaw),
+		GroupConditions:    expandNGWAFRuleGroupUpdateConditions(groupRaw),
+		MultivalConditions: expandNGWAFRuleMultiValUpdateConditions(multivalRaw),
+		RateLimit:          expandNGWAFRuleUpdateRateLimit(rateLimitRaw),
 	}
 
 	// templated_signal rules don't allow actions in update requests
@@ -253,6 +266,96 @@ func expandNGWAFRuleGroupUpdateConditions(raw []any) []*rules.UpdateGroupConditi
 	}
 
 	return result
+}
+
+func expandNGWAFRuleMultiValCreateConditions(raw []any) []*rules.CreateMultivalCondition {
+	if raw == nil {
+		return nil
+	}
+
+	var MultivalConditions []*rules.CreateMultivalCondition
+	for _, item := range raw {
+		m, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		// Extract top level fields.
+		field := m["field"].(string)
+		operator := m["operator"].(string)
+		groupOperator := m["group_operator"].(string)
+
+		// Extract nested conditions.
+		rawConditions, ok := m["condition"].([]any)
+		if !ok || len(rawConditions) == 0 {
+			continue
+		}
+
+		var conditions []*rules.CreateConditionMult
+		for _, c := range rawConditions {
+			cm, ok := c.(map[string]any)
+			if !ok {
+				continue
+			}
+			conditions = append(conditions, &rules.CreateConditionMult{
+				Field:    gofastly.ToPointer(cm["field"].(string)),
+				Operator: gofastly.ToPointer(cm["operator"].(string)),
+				Value:    gofastly.ToPointer(cm["value"].(string)),
+			})
+		}
+		MultivalConditions = append(MultivalConditions, &rules.CreateMultivalCondition{
+			Field:         gofastly.ToPointer(field),
+			Operator:      gofastly.ToPointer(operator),
+			GroupOperator: gofastly.ToPointer(groupOperator),
+			Conditions:    conditions,
+		})
+	}
+
+	return MultivalConditions
+}
+
+func expandNGWAFRuleMultiValUpdateConditions(raw []any) []*rules.UpdateMultivalCondition {
+	if raw == nil {
+		return nil
+	}
+
+	var MultivalConditions []*rules.UpdateMultivalCondition
+	for _, item := range raw {
+		m, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		// Extract top level fields.
+		field := m["field"].(string)
+		operator := m["operator"].(string)
+		groupOperator := m["group_operator"].(string)
+
+		// Extract nested conditions.
+		rawConditions, ok := m["condition"].([]any)
+		if !ok || len(rawConditions) == 0 {
+			continue
+		}
+
+		var conditions []*rules.UpdateConditionMult
+		for _, c := range rawConditions {
+			cm, ok := c.(map[string]any)
+			if !ok {
+				continue
+			}
+			conditions = append(conditions, &rules.UpdateConditionMult{
+				Field:    gofastly.ToPointer(cm["field"].(string)),
+				Operator: gofastly.ToPointer(cm["operator"].(string)),
+				Value:    gofastly.ToPointer(cm["value"].(string)),
+			})
+		}
+		MultivalConditions = append(MultivalConditions, &rules.UpdateMultivalCondition{
+			Field:         gofastly.ToPointer(field),
+			Operator:      gofastly.ToPointer(operator),
+			GroupOperator: gofastly.ToPointer(groupOperator),
+			Conditions:    conditions,
+		})
+	}
+
+	return MultivalConditions
 }
 
 func expandNGWAFRuleCreateRateLimit(raw []any) *rules.CreateRateLimit {

--- a/fastly/ngwaf_rule_expand.go
+++ b/fastly/ngwaf_rule_expand.go
@@ -37,11 +37,19 @@ func expandNGWAFRuleCreateInput(d *schema.ResourceData, s *scope.Scope) *rules.C
 	return &rules.CreateInput{
 		Type:               gofastly.ToPointer(d.Get("type").(string)),
 		Description:        gofastly.ToPointer(d.Get("description").(string)),
+<<<<<<< HEAD
 		Scope:              s,
 		Enabled:            gofastly.ToPointer(d.Get("enabled").(bool)),
 		GroupOperator:      gofastly.ToPointer(d.Get("group_operator").(string)),
 		RequestLogging:     gofastly.ToPointer(d.Get("request_logging").(string)),
 		Actions:            expandNGWAFRuleCreateActions(actionRaw, string(s.Type)),
+=======
+		Scope:              scope,
+		Enabled:            gofastly.ToPointer(d.Get("enabled").(bool)),
+		GroupOperator:      gofastly.ToPointer(d.Get("group_operator").(string)),
+		RequestLogging:     gofastly.ToPointer(d.Get("request_logging").(string)),
+		Actions:            expandNGWAFRuleCreateActions(actionRaw, string(scope.Type)),
+>>>>>>> a5d12edb (multival support)
 		Conditions:         expandNGWAFRuleCreateConditions(conditionRaw),
 		GroupConditions:    expandNGWAFRuleGroupCreateConditions(groupRaw),
 		MultivalConditions: expandNGWAFRuleMultiValCreateConditions(multivalRaw),

--- a/fastly/ngwaf_rule_expand.go
+++ b/fastly/ngwaf_rule_expand.go
@@ -35,7 +35,6 @@ func expandNGWAFRuleCreateInput(d *schema.ResourceData, s *scope.Scope) *rules.C
 	}
 
 	return &rules.CreateInput{
-
 		Type:               gofastly.ToPointer(d.Get("type").(string)),
 		Description:        gofastly.ToPointer(d.Get("description").(string)),
 		Scope:              s,

--- a/fastly/ngwaf_rule_flatten.go
+++ b/fastly/ngwaf_rule_flatten.go
@@ -65,7 +65,7 @@ func flattenNGWAFRuleResponse(d *schema.ResourceData, rule *rules.Rule) error {
 	}
 
 	// Flatten conditions
-	singles, groups := flattenNGWAFRuleConditionsGeneric(rule.Conditions)
+	singles, groups, multivals := flattenNGWAFRuleConditionsGeneric(rule.Conditions)
 
 	if err := d.Set("condition", singles); err != nil {
 		return fmt.Errorf("error setting condition: %w", err)
@@ -73,6 +73,10 @@ func flattenNGWAFRuleResponse(d *schema.ResourceData, rule *rules.Rule) error {
 
 	if err := d.Set("group_condition", groups); err != nil {
 		return fmt.Errorf("error setting group_condition: %w", err)
+	}
+
+	if err := d.Set("multival_condition", multivals); err != nil {
+		return fmt.Errorf("error setting multival_condition: %w", err)
 	}
 
 	// Flatten rate limit

--- a/fastly/ngwaf_rule_schema.go
+++ b/fastly/ngwaf_rule_schema.go
@@ -177,7 +177,7 @@ func resourceFastlyNGWAFRuleBase() *schema.Resource {
 							Type:             schema.TypeString,
 							Required:         true,
 							Description:      "Enums for multival condition field.. Accepted values are `post_parameter`, `query_parameter`, `request_cookie`, `request_header`, `response_header`, and `signal`.",
-							ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice([]string{"post_parameter", "query_parameter", "request_cookie", "request_header", "response_header,", "signal"}, false)),
+							ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice([]string{"post_parameter", "query_parameter", "request_cookie", "request_header", "response_header", "signal"}, false)),
 						},
 						"group_operator": {
 							Type:             schema.TypeString,

--- a/fastly/ngwaf_rule_schema.go
+++ b/fastly/ngwaf_rule_schema.go
@@ -140,6 +140,60 @@ func resourceFastlyNGWAFRuleBase() *schema.Resource {
 				Description:      "Logical operator to apply to group conditions. Accepted values are `any` and `all`.",
 				ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice([]string{"any", "all"}, false)),
 			},
+			"multival_condition": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Description: "List of multival conditions with nested logic. Each multival list must define a `field, operator, group_operator` and at least one condition.",
+				Elem: &schema.Resource{
+					Description: "Group of conditions using logical operators.",
+					Schema: map[string]*schema.Schema{
+						"condition": {
+							Type:        schema.TypeList,
+							Required:    true,
+							MinItems:    1,
+							Description: "A list of nested conditions in this list.",
+							Elem: &schema.Resource{
+								Description: "Nested condition inside a group.",
+								Schema: map[string]*schema.Schema{
+									"field": {
+										Type:        schema.TypeString,
+										Required:    true,
+										Description: "Field to inspect (e.g., `name`, `value`, `signal_id`).",
+									},
+									"operator": {
+										Type:        schema.TypeString,
+										Required:    true,
+										Description: "Operator to apply (e.g., `equals`, `contains`).",
+									},
+									"value": {
+										Type:        schema.TypeString,
+										Required:    true,
+										Description: "The value to test the field against.",
+									},
+								},
+							},
+						},
+						"field": {
+							Type:             schema.TypeString,
+							Required:         true,
+							Description:      "Enums for multival condition field.. Accepted values are `post_parameter`, `query_parameter`, `request_cookie`, `request_header`, `response_header`, and `signal`.",
+							ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice([]string{"post_parameter", "query_parameter", "request_cookie", "request_header", "response_header,", "signal"}, false)),
+						},
+						"group_operator": {
+							Type:             schema.TypeString,
+							Required:         true,
+							Description:      "Logical operator for the group. Accepted values are `any` and `all`.",
+							ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice([]string{"any", "all"}, false)),
+						},
+						"operator": {
+							Type:             schema.TypeString,
+							Required:         true,
+							Description:      "Indicates whether the supplied conditions will check for existence or non-existence of matching field values. Accepted values are `exists` and `does_not_exist`.",
+							ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice([]string{"exists", "does_not_exist"}, false)),
+						},
+					},
+				},
+			},
 			"request_logging": {
 				Type:             schema.TypeString,
 				Optional:         true,

--- a/fastly/resource_fastly_ngwaf_account_rule_test.go
+++ b/fastly/resource_fastly_ngwaf_account_rule_test.go
@@ -30,6 +30,15 @@ func TestAccFastlyNGWAFAccountRule_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("fastly_ngwaf_account_rule.example", "request_logging", "sampled"),
 					resource.TestCheckResourceAttr("fastly_ngwaf_account_rule.example", "group_operator", "all"),
 					resource.TestCheckResourceAttr("fastly_ngwaf_account_rule.example", "action.0.type", "block"),
+					resource.TestCheckResourceAttr("fastly_ngwaf_account_rule.example", "multival_condition.0.field", "request_header"),
+					resource.TestCheckResourceAttr("fastly_ngwaf_account_rule.example", "multival_condition.0.operator", "exists"),
+					resource.TestCheckResourceAttr("fastly_ngwaf_account_rule.example", "multival_condition.0.group_operator", "any"),
+					resource.TestCheckResourceAttr("fastly_ngwaf_account_rule.example", "multival_condition.0.condition.0.field", "name"),
+					resource.TestCheckResourceAttr("fastly_ngwaf_account_rule.example", "multival_condition.0.condition.0.operator", "contains"),
+					resource.TestCheckResourceAttr("fastly_ngwaf_account_rule.example", "multival_condition.0.condition.0.value", "Header-Sample"),
+					resource.TestCheckResourceAttr("fastly_ngwaf_account_rule.example", "multival_condition.0.condition.1.field", "name"),
+					resource.TestCheckResourceAttr("fastly_ngwaf_account_rule.example", "multival_condition.0.condition.1.operator", "equals"),
+					resource.TestCheckResourceAttr("fastly_ngwaf_account_rule.example", "multival_condition.0.condition.1.value", "X-API-Key"),
 				),
 			},
 			{
@@ -82,6 +91,24 @@ resource "fastly_ngwaf_account_rule" "example" {
       value    = "POST"
     }
   }
+
+  multival_condition {
+    field          = "request_header"
+    operator       = "exists"
+    group_operator = "any"
+
+    condition {
+      field    = "name"
+      operator = "contains"
+      value    = "Header-Sample"
+    }
+
+    condition {
+      field    = "name"
+      operator = "equals"
+      value    = "X-API-Key"
+    }
+  }
 }
 `, description)
 }
@@ -113,6 +140,24 @@ resource "fastly_ngwaf_account_rule" "example" {
       field    = "method"
       operator = "equals"
       value    = "GET"
+    }
+  }
+
+  multival_condition {
+    field          = "request_header"
+    operator       = "exists"
+    group_operator = "any"
+
+    condition {
+      field    = "name"
+      operator = "equals"
+      value    = "Header-Sample-Updated"
+    }
+
+    condition {
+      field    = "name"
+      operator = "contains"
+      value    = "X-API-Key-Updated"
     }
   }
 }


### PR DESCRIPTION
### Change summary

This PR introduces support for Multival NGWAF Rule Condition Types which is required for certain condition fields. 

 All Submissions:

### New Feature Submissions:

* [x] Does your submission pass tests?
* [x] Post the output of your test runs

### Changes to Core Features:

* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### Are there any considerations that need to be addressed for release?

While the condition `type` field has been removed from structs, it's still supported upstream in go-fastly with internal handlers introduced in https://github.com/fastly/go-fastly/pull/755. 

### Tests:
```
=== RUN   TestAccFastlyNGWAFWorkspaceRule_rateLimit
=== PAUSE TestAccFastlyNGWAFWorkspaceRule_rateLimit
=== CONT  TestAccFastlyNGWAFWorkspaceRule_rateLimit
--- PASS: TestAccFastlyNGWAFWorkspaceRule_rateLimit (8.51s)
PASS
```
```
=== RUN   TestAccFastlyNGWAFWorkspaceRule_basic
=== PAUSE TestAccFastlyNGWAFWorkspaceRule_basic
=== CONT  TestAccFastlyNGWAFWorkspaceRule_basic
--- PASS: TestAccFastlyNGWAFWorkspaceRule_basic (8.16s)
PASS
ok      github.com/fastly/terraform-provider-fastly/fastly      8.175s
```
```
=== RUN   TestFlattenNGWAFRuleResponse
--- PASS: TestFlattenNGWAFRuleResponse (0.00s)
PASS
ok      github.com/fastly/terraform-provider-fastly/fastly      0.008s
```

All local testing works as intended. 