### PR TITLE
Ensure that all NGWAF resource documentation pages have the proper heading

### DIFF
--- a/docs/resources/ngwaf_account_rule.md
+++ b/docs/resources/ngwaf_account_rule.md
@@ -6,7 +6,7 @@ description: |-
   Provides a Fastly Next-Gen WAF Account Rule
 ---
 
-# ngwaf_account_rule
+# fastly_ngwaf_account_rule
 
 Provides a Fastly Next-Gen WAF Account Rule.  
 Account-level rules apply across one or more workspaces and are useful for defining shared or global WAF logic.

--- a/docs/resources/ngwaf_account_signal.md
+++ b/docs/resources/ngwaf_account_signal.md
@@ -6,7 +6,7 @@ description: |-
   Provides a Fastly Next-Gen WAF Account Signal
 ---
 
-# ngwaf_account_signal
+# fastly_ngwaf_account_signal
 
 Provides a Fastly Next-Gen WAF Account Signal.  
 Account-level signals apply across one or more workspaces and are useful for defining shared or global WAF logic.

--- a/docs/resources/ngwaf_alert_datadog_integration.md
+++ b/docs/resources/ngwaf_alert_datadog_integration.md
@@ -6,7 +6,7 @@ description: |-
   Provides a Fastly Next-Gen WAF Alert Datadog integration for a Workspace
 ---
 
-# ngwaf_alert_datadog_integration
+# fastly_ngwaf_alert_datadog_integration
 
 Provides Fastly Next-Gen WAF Alert Datadog integrations, which provide a connection to Datadog.
 

--- a/docs/resources/ngwaf_alert_jira_integration.md
+++ b/docs/resources/ngwaf_alert_jira_integration.md
@@ -6,7 +6,7 @@ description: |-
   Provides a Fastly Next-Gen WAF Alert Jira integration for a Workspace
 ---
 
-# ngwaf_alert_jira_integration
+# fastly_ngwaf_alert_jira_integration
 
 Provides Fastly Next-Gen WAF Alert Jira integrations, which provide a connection to Jira.
 

--- a/docs/resources/ngwaf_alert_mailing_list_integration.md
+++ b/docs/resources/ngwaf_alert_mailing_list_integration.md
@@ -6,7 +6,7 @@ description: |-
   Provides a Fastly Next-Gen WAF Alert Mailing List integration for a Workspace
 ---
 
-# ngwaf_alert_mailing_list_integration
+# fastly_ngwaf_alert_mailing_list_integration
 
 Provides Fastly Next-Gen WAF Alert Mailing List integrations, which provide a connection to Mailing List.
 

--- a/docs/resources/ngwaf_alert_microsoft_teams_integration.md
+++ b/docs/resources/ngwaf_alert_microsoft_teams_integration.md
@@ -6,7 +6,7 @@ description: |-
   Provides a Fastly Next-Gen WAF Alert Microsoft Teams integration for a Workspace
 ---
 
-# ngwaf_alert_microsoft_teams_integration
+# fastly_ngwaf_alert_microsoft_teams_integration
 
 Provides Fastly Next-Gen WAF Alert Microsoft Teams integrations, which provide a connection to Microsoft Teams.
 

--- a/docs/resources/ngwaf_alert_opsgenie_integration.md
+++ b/docs/resources/ngwaf_alert_opsgenie_integration.md
@@ -6,7 +6,7 @@ description: |-
   Provides a Fastly Next-Gen WAF Alert Opsgenie integration for a Workspace
 ---
 
-# ngwaf_alert_opsgenie_integration
+# fastly_ngwaf_alert_opsgenie_integration
 
 Provides Fastly Next-Gen WAF Alert Opsgenie integrations, which provide a connection to Opsgenie.
 

--- a/docs/resources/ngwaf_alert_pagerduty_integration.md
+++ b/docs/resources/ngwaf_alert_pagerduty_integration.md
@@ -6,7 +6,7 @@ description: |-
   Provides a Fastly Next-Gen WAF Alert PagerDuty integration for a Workspace
 ---
 
-# ngwaf_alert_pagerduty_integration
+# fastly_ngwaf_alert_pagerduty_integration
 
 Provides Fastly Next-Gen WAF Alert PagerDuty integrations, which provide a connection to PagerDuty.
 

--- a/docs/resources/ngwaf_alert_slack_integration.md
+++ b/docs/resources/ngwaf_alert_slack_integration.md
@@ -6,7 +6,7 @@ description: |-
   Provides a Fastly Next-Gen WAF Alert Slack integration for a Workspace
 ---
 
-# ngwaf_alert_slack_integration
+# fastly_ngwaf_alert_slack_integration
 
 Provides Fastly Next-Gen WAF Alert Slack integrations, which provide a connection to Slack.
 

--- a/docs/resources/ngwaf_alert_webhook_integration.md
+++ b/docs/resources/ngwaf_alert_webhook_integration.md
@@ -6,7 +6,7 @@ description: |-
   Provides a Fastly Next-Gen WAF Alert Webhook integration for a Workspace
 ---
 
-# ngwaf_alert_webhook_integration
+# fastly_ngwaf_alert_webhook_integration
 
 Provides Fastly Next-Gen WAF Alert Webhook integrations, which provide a connection to Webhooks.
 

--- a/docs/resources/ngwaf_redaction.md
+++ b/docs/resources/ngwaf_redaction.md
@@ -6,7 +6,7 @@ description: |-
   Provides a Fastly Next-Gen WAF Redaction for a Workspace
 ---
 
-# ngwaf_redaction
+# fastly_ngwaf_redaction
 
 Provides a Fastly Next-Gen WAF Redaction, which can automatically redact known patterns of sensitive information.
 

--- a/docs/resources/ngwaf_thresholds.md
+++ b/docs/resources/ngwaf_thresholds.md
@@ -6,7 +6,7 @@ description: |-
   Provides a Fastly Next-Gen WAF Threshold
 ---
 
-# ngwaf_thresholds
+# fastly_ngwaf_thresholds
 
 Provides a Fastly Next-Gen WAF Threshold.  Operations related to managing workspace thresholds.
 

--- a/docs/resources/ngwaf_virtual_patches.md
+++ b/docs/resources/ngwaf_virtual_patches.md
@@ -6,7 +6,7 @@ description: |-
   Provides a Fastly Next-Gen WAF Virtual Patches
 ---
 
-# ngwaf_virtual_patches
+# fastly_ngwaf_virtual_patches
 
 Provides a Fastly Next-Gen WAF Virtual Patch.  Virtual patching 
 rules block or log requests matching specific vulnerabilities.

--- a/docs/resources/ngwaf_workspace.md
+++ b/docs/resources/ngwaf_workspace.md
@@ -6,7 +6,7 @@ description: |-
   Provides a Fastly Next-Gen WAF Workspace
 ---
 
-# ngwaf_workspace
+# fastly_ngwaf_workspace
 
 Provides a Fastly Next-Gen WAF Workspace, representing a container for
 rules, signals, and various other resources that are offered by the

--- a/docs/resources/ngwaf_workspace_rule.md
+++ b/docs/resources/ngwaf_workspace_rule.md
@@ -6,7 +6,7 @@ description: |-
   Provides a Fastly Next-Gen WAF Workspace Rule
 ---
 
-# ngwaf_workspace_rule
+# fastly_ngwaf_workspace_rule
 
 Provides a Fastly Next-Gen WAF Workspace Rule, scoped to a specific NGWAF workspace.  
 These rules define conditions and actions that trigger WAF enforcement at the workspace level.

--- a/docs/resources/ngwaf_workspace_signal.md
+++ b/docs/resources/ngwaf_workspace_signal.md
@@ -6,7 +6,7 @@ description: |-
   Provides a Fastly Next-Gen WAF Workspace Signal
 ---
 
-# ngwaf_workspace_signal
+# fastly_ngwaf_workspace_signal
 
 Provides a Fastly Next-Gen WAF Workspace Signal, scoped to a specific NGWAF workspace.  
 These signals define conditions and actions that trigger WAF enforcement at the workspace level.

--- a/templates/resources/ngwaf_account_rule.md.tmpl
+++ b/templates/resources/ngwaf_account_rule.md.tmpl
@@ -6,7 +6,7 @@ description: |-
   Provides a Fastly Next-Gen WAF Account Rule
 ---
 
-# ngwaf_account_rule
+# fastly_ngwaf_account_rule
 
 Provides a Fastly Next-Gen WAF Account Rule.  
 Account-level rules apply across one or more workspaces and are useful for defining shared or global WAF logic.

--- a/templates/resources/ngwaf_account_signal.md.tmpl
+++ b/templates/resources/ngwaf_account_signal.md.tmpl
@@ -6,7 +6,7 @@ description: |-
   Provides a Fastly Next-Gen WAF Account Signal
 ---
 
-# ngwaf_account_signal
+# fastly_ngwaf_account_signal
 
 Provides a Fastly Next-Gen WAF Account Signal.  
 Account-level signals apply across one or more workspaces and are useful for defining shared or global WAF logic.

--- a/templates/resources/ngwaf_alert_datadog_integration.md.tmpl
+++ b/templates/resources/ngwaf_alert_datadog_integration.md.tmpl
@@ -6,7 +6,7 @@ description: |-
   Provides a Fastly Next-Gen WAF Alert Datadog integration for a Workspace
 ---
 
-# ngwaf_alert_datadog_integration
+# fastly_ngwaf_alert_datadog_integration
 
 Provides Fastly Next-Gen WAF Alert Datadog integrations, which provide a connection to Datadog.
 

--- a/templates/resources/ngwaf_alert_jira_integration.md.tmpl
+++ b/templates/resources/ngwaf_alert_jira_integration.md.tmpl
@@ -6,7 +6,7 @@ description: |-
   Provides a Fastly Next-Gen WAF Alert Jira integration for a Workspace
 ---
 
-# ngwaf_alert_jira_integration
+# fastly_ngwaf_alert_jira_integration
 
 Provides Fastly Next-Gen WAF Alert Jira integrations, which provide a connection to Jira.
 

--- a/templates/resources/ngwaf_alert_mailing_list_integration.md.tmpl
+++ b/templates/resources/ngwaf_alert_mailing_list_integration.md.tmpl
@@ -6,7 +6,7 @@ description: |-
   Provides a Fastly Next-Gen WAF Alert Mailing List integration for a Workspace
 ---
 
-# ngwaf_alert_mailing_list_integration
+# fastly_ngwaf_alert_mailing_list_integration
 
 Provides Fastly Next-Gen WAF Alert Mailing List integrations, which provide a connection to Mailing List.
 

--- a/templates/resources/ngwaf_alert_microsoft_teams_integration.md.tmpl
+++ b/templates/resources/ngwaf_alert_microsoft_teams_integration.md.tmpl
@@ -6,7 +6,7 @@ description: |-
   Provides a Fastly Next-Gen WAF Alert Microsoft Teams integration for a Workspace
 ---
 
-# ngwaf_alert_microsoft_teams_integration
+# fastly_ngwaf_alert_microsoft_teams_integration
 
 Provides Fastly Next-Gen WAF Alert Microsoft Teams integrations, which provide a connection to Microsoft Teams.
 

--- a/templates/resources/ngwaf_alert_opsgenie_integration.md.tmpl
+++ b/templates/resources/ngwaf_alert_opsgenie_integration.md.tmpl
@@ -6,7 +6,7 @@ description: |-
   Provides a Fastly Next-Gen WAF Alert Opsgenie integration for a Workspace
 ---
 
-# ngwaf_alert_opsgenie_integration
+# fastly_ngwaf_alert_opsgenie_integration
 
 Provides Fastly Next-Gen WAF Alert Opsgenie integrations, which provide a connection to Opsgenie.
 

--- a/templates/resources/ngwaf_alert_pagerduty_integration.md.tmpl
+++ b/templates/resources/ngwaf_alert_pagerduty_integration.md.tmpl
@@ -6,7 +6,7 @@ description: |-
   Provides a Fastly Next-Gen WAF Alert PagerDuty integration for a Workspace
 ---
 
-# ngwaf_alert_pagerduty_integration
+# fastly_ngwaf_alert_pagerduty_integration
 
 Provides Fastly Next-Gen WAF Alert PagerDuty integrations, which provide a connection to PagerDuty.
 

--- a/templates/resources/ngwaf_alert_slack_integration.md.tmpl
+++ b/templates/resources/ngwaf_alert_slack_integration.md.tmpl
@@ -6,7 +6,7 @@ description: |-
   Provides a Fastly Next-Gen WAF Alert Slack integration for a Workspace
 ---
 
-# ngwaf_alert_slack_integration
+# fastly_ngwaf_alert_slack_integration
 
 Provides Fastly Next-Gen WAF Alert Slack integrations, which provide a connection to Slack.
 

--- a/templates/resources/ngwaf_alert_webhook_integration.md.tmpl
+++ b/templates/resources/ngwaf_alert_webhook_integration.md.tmpl
@@ -6,7 +6,7 @@ description: |-
   Provides a Fastly Next-Gen WAF Alert Webhook integration for a Workspace
 ---
 
-# ngwaf_alert_webhook_integration
+# fastly_ngwaf_alert_webhook_integration
 
 Provides Fastly Next-Gen WAF Alert Webhook integrations, which provide a connection to Webhooks.
 

--- a/templates/resources/ngwaf_redaction.md.tmpl
+++ b/templates/resources/ngwaf_redaction.md.tmpl
@@ -6,7 +6,7 @@ description: |-
   Provides a Fastly Next-Gen WAF Redaction for a Workspace
 ---
 
-# ngwaf_redaction
+# fastly_ngwaf_redaction
 
 Provides a Fastly Next-Gen WAF Redaction, which can automatically redact known patterns of sensitive information.
 

--- a/templates/resources/ngwaf_thresholds.md.tmpl
+++ b/templates/resources/ngwaf_thresholds.md.tmpl
@@ -6,7 +6,7 @@ description: |-
   Provides a Fastly Next-Gen WAF Threshold
 ---
 
-# ngwaf_thresholds
+# fastly_ngwaf_thresholds
 
 Provides a Fastly Next-Gen WAF Threshold.  Operations related to managing workspace thresholds.
 

--- a/templates/resources/ngwaf_virtual_patches.md.tmpl
+++ b/templates/resources/ngwaf_virtual_patches.md.tmpl
@@ -6,7 +6,7 @@ description: |-
   Provides a Fastly Next-Gen WAF Virtual Patches
 ---
 
-# ngwaf_virtual_patches
+# fastly_ngwaf_virtual_patches
 
 Provides a Fastly Next-Gen WAF Virtual Patch.  Virtual patching 
 rules block or log requests matching specific vulnerabilities.

--- a/templates/resources/ngwaf_workspace.md.tmpl
+++ b/templates/resources/ngwaf_workspace.md.tmpl
@@ -6,7 +6,7 @@ description: |-
   Provides a Fastly Next-Gen WAF Workspace
 ---
 
-# ngwaf_workspace
+# fastly_ngwaf_workspace
 
 Provides a Fastly Next-Gen WAF Workspace, representing a container for
 rules, signals, and various other resources that are offered by the

--- a/templates/resources/ngwaf_workspace_rule.md.tmpl
+++ b/templates/resources/ngwaf_workspace_rule.md.tmpl
@@ -6,7 +6,7 @@ description: |-
   Provides a Fastly Next-Gen WAF Workspace Rule
 ---
 
-# ngwaf_workspace_rule
+# fastly_ngwaf_workspace_rule
 
 Provides a Fastly Next-Gen WAF Workspace Rule, scoped to a specific NGWAF workspace.  
 These rules define conditions and actions that trigger WAF enforcement at the workspace level.

--- a/templates/resources/ngwaf_workspace_signal.md.tmpl
+++ b/templates/resources/ngwaf_workspace_signal.md.tmpl
@@ -6,7 +6,7 @@ description: |-
   Provides a Fastly Next-Gen WAF Workspace Signal
 ---
 
-# ngwaf_workspace_signal
+# fastly_ngwaf_workspace_signal
 
 Provides a Fastly Next-Gen WAF Workspace Signal, scoped to a specific NGWAF workspace.  
 These signals define conditions and actions that trigger WAF enforcement at the workspace level.


### PR DESCRIPTION
### Change summary

The resource names all begin with `fastly_` so that should be included in the heading.

 All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/terraform-provider-fastly/pulls) for the same update/change?