### PR TITLE
[CDTOOL-1169] - NGWAF Workspace Thresholds Import Improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - fix(ngwaf/rules): removes the rate limit block from the account level rules schema. ([#1065](https://github.com/fastly/terraform-provider-fastly/pull/1065))
 - fix(service_vcl/logging_gcs): resolves an issue where project_id was not being updated for GCS logging_gcs. ([#1073](https://github.com/fastly/terraform-provider-fastly/pull/1073))
 - fix(service_vcl/requestsetting): removed a incorrect default value for the xff attribute. ([#1078](https://github.com/fastly/terraform-provider-fastly/pull/1078))
+- fix(ngwaf/workspace): corrected zero values being set from workspace imports when attack thresholds are left as default ([#1103](https://github.com/fastly/terraform-provider-fastly/pull/1103))
 
 ### DEPENDENCIES:
 - build(deps): `github.com/fastly/go-fastly/v11` from 11.1.1 to 11.2.0 ([#1067](https://github.com/fastly/terraform-provider-fastly/pull/1067))

--- a/fastly/resource_fastly_ngwaf_workspace.go
+++ b/fastly/resource_fastly_ngwaf_workspace.go
@@ -201,19 +201,39 @@ func resourceFastlyNGWAFWorkspaceRead(ctx context.Context, d *schema.ResourceDat
 
 	log.Printf("[DEBUG] UPDATE: NGWAF workspace attack thresholds get: %#v", workspace.AttackSignalThresholds)
 
-	thresholds := []map[string]any{
-		{
-			"one_minute":  workspace.AttackSignalThresholds.OneMinute,
-			"ten_minutes": workspace.AttackSignalThresholds.TenMinutes,
-			"one_hour":    workspace.AttackSignalThresholds.OneHour,
-			"immediate":   workspace.AttackSignalThresholds.Immediate,
-		},
-	}
-	if err := d.Set("attack_signal_thresholds", thresholds); err != nil {
+	if err := d.Set("attack_signal_thresholds", flattenAttackSignalThresholds(&workspace.AttackSignalThresholds)); err != nil {
 		return diag.FromErr(err)
 	}
 
 	return nil
+}
+
+// Due to the API returning zero values for unset thresholds, we'll need override these with
+// the expected defaults values to avoid conflicts with imports.
+func flattenAttackSignalThresholds(thresholds *ws.AttackSignalThresholds) []map[string]any {
+	oneMinute := thresholds.OneMinute
+	if oneMinute == 0 {
+		oneMinute = 1 // Default from schema
+	}
+
+	tenMinutes := thresholds.TenMinutes
+	if tenMinutes == 0 {
+		tenMinutes = 60 // Default from schema
+	}
+
+	oneHour := thresholds.OneHour
+	if oneHour == 0 {
+		oneHour = 100 // Default from schema
+	}
+
+	return []map[string]any{
+		{
+			"one_minute":  oneMinute,
+			"ten_minutes": tenMinutes,
+			"one_hour":    oneHour,
+			"immediate":   thresholds.Immediate,
+		},
+	}
 }
 
 func resourceFastlyNGWAFWorkspaceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {


### PR DESCRIPTION
### Change summary

When an existing NGWAF Workspace is imported with unmodified `Attack thresholds`  values, the API returns `0` for the `one_minute`, `ten_minutes` and `one_hour` fields. As the value of `0` for this fields is outside the expected parameter for these fields, an error is thrown when a `terraform` plan / apply` is attempted, leading to an unsuccessful import attempt. 

To compensate for this API behavior, we are overriding the `0` value for these fields to the expected defaults in a new flatten function. Any set values (non-zero) by the end user are maintained with this change. 

 All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/terraform-provider-fastly/pulls) for the same update/change?

### New Feature Submissions:

* [x] Does your submission pass tests?
* [x] Post the output of your test runs

### Changes to Core Features:

* [x] Have you successfully run tests with your changes locally?

### User Impact

Users that import will now be unblocked. Users with existing Terraform configurations for a Workspace may have their state file updated from a zero value for the fields in question to the expected the defaults - this shouldn't have any real impact as 0 from the API indicates the default values are being used. 

### Tests:
```
=== RUN   TestAccFastlyNGWAFWorkspace_validate
=== PAUSE TestAccFastlyNGWAFWorkspace_validate
=== CONT  TestAccFastlyNGWAFWorkspace_validate
--- PASS: TestAccFastlyNGWAFWorkspace_validate (8.78s)
PASS
ok      github.com/fastly/terraform-provider-fastly/fastly      8.794s
```

Local tests validate a successful import as well as non-zero values being retained from the API in the new flatten function. 

