### PR TITLE
[CDTOOL-1170] - Update NGWF Alerts to use the DisplaySensitiveFields for Sensitive fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### ENHANCEMENTS:
 
+- feat(ngwaf/alerts): add support for the usage of displaying sensitive fields  ([#1106](https://github.com/fastly/terraform-provider-fastly/pull/1106))
+
 ### BUG FIXES:
 
 ### DEPENDENCIES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@
 
 ### ENHANCEMENTS:
 
-- feat(ngwaf/alerts): add support for the usage of displaying sensitive fields  ([#1106](https://github.com/fastly/terraform-provider-fastly/pull/1106))
-
 ### BUG FIXES:
+
+- fix(ngwaf/alerts): Ensure that FASTLY_TF_DISPLAY_SENSITIVE_FIELDS is respected  ([#1106](https://github.com/fastly/terraform-provider-fastly/pull/1106))
 
 ### DEPENDENCIES:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,7 +25,7 @@ terraform {
   required_providers {
     fastly = {
       source  = "fastly/fastly"
-      version = ">= 8.1.0"
+      version = ">= 8.0.0"
     }
   }
 }

--- a/fastly/resource_fastly_ngwaf_alert_datadog_integration.go
+++ b/fastly/resource_fastly_ngwaf_alert_datadog_integration.go
@@ -34,7 +34,7 @@ func resourceFastlyNGWAFAlertDatadogIntegration() *schema.Resource {
 				Required:     true,
 				Type:         schema.TypeString,
 				ValidateFunc: validation.StringLenBetween(9, 9),
-				Sensitive:    true,
+				Sensitive:    !DisplaySensitiveFields,
 			},
 			"site": {
 				Description:  "The Datadog site.",

--- a/fastly/resource_fastly_ngwaf_alert_jira_integration.go
+++ b/fastly/resource_fastly_ngwaf_alert_jira_integration.go
@@ -42,7 +42,7 @@ func resourceFastlyNGWAFAlertJiraIntegration() *schema.Resource {
 				Description: "The Jira key.",
 				Required:    true,
 				Type:        schema.TypeString,
-				Sensitive:   true,
+				Sensitive:   !DisplaySensitiveFields,
 			},
 			"project": {
 				Description: "The Jira project where the issue will be created.",

--- a/fastly/resource_fastly_ngwaf_alert_microsoft_teams_integration.go
+++ b/fastly/resource_fastly_ngwaf_alert_microsoft_teams_integration.go
@@ -32,7 +32,7 @@ func resourceFastlyNGWAFAlertMicrosoftTeamsIntegration() *schema.Resource {
 				Description: "The Microsoft Teams webhook URL.",
 				Required:    true,
 				Type:        schema.TypeString,
-				Sensitive:   true,
+				Sensitive:   !DisplaySensitiveFields,
 			},
 			"workspace_id": {
 				Description: "The ID of the workspace.",

--- a/fastly/resource_fastly_ngwaf_alert_opsgenie_integration.go
+++ b/fastly/resource_fastly_ngwaf_alert_opsgenie_integration.go
@@ -32,7 +32,7 @@ func resourceFastlyNGWAFAlertOpsgenieIntegration() *schema.Resource {
 				Description: "The Opsgenie key.",
 				Required:    true,
 				Type:        schema.TypeString,
-				Sensitive:   true,
+				Sensitive:   !DisplaySensitiveFields,
 			},
 			"workspace_id": {
 				Description: "The ID of the workspace.",

--- a/fastly/resource_fastly_ngwaf_alert_pagerduty_integration.go
+++ b/fastly/resource_fastly_ngwaf_alert_pagerduty_integration.go
@@ -34,7 +34,7 @@ func resourceFastlyNGWAFAlertPagerDutyIntegration() *schema.Resource {
 				Required:     true,
 				Type:         schema.TypeString,
 				ValidateFunc: validation.StringLenBetween(32, 32),
-				Sensitive:    true,
+				Sensitive:    !DisplaySensitiveFields,
 			},
 			"workspace_id": {
 				Description: "The ID of the workspace.",

--- a/fastly/resource_fastly_ngwaf_alert_slack_integration.go
+++ b/fastly/resource_fastly_ngwaf_alert_slack_integration.go
@@ -32,7 +32,7 @@ func resourceFastlyNGWAFAlertSlackIntegration() *schema.Resource {
 				Description: "The Slack webhook URL.",
 				Required:    true,
 				Type:        schema.TypeString,
-				Sensitive:   true,
+				Sensitive:   !DisplaySensitiveFields,
 			},
 			"workspace_id": {
 				Description: "The ID of the workspace.",

--- a/fastly/resource_fastly_ngwaf_alert_webhook_integration.go
+++ b/fastly/resource_fastly_ngwaf_alert_webhook_integration.go
@@ -32,7 +32,7 @@ func resourceFastlyNGWAFAlertWebhookIntegration() *schema.Resource {
 				Description: "The webhook URL.",
 				Required:    true,
 				Type:        schema.TypeString,
-				Sensitive:   true,
+				Sensitive:   !DisplaySensitiveFields,
 			},
 			"workspace_id": {
 				Description: "The ID of the workspace.",


### PR DESCRIPTION
### Change summary

This PR allow the usage of DisplaySensitiveFields for all NGWAF alerts. 

 All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/terraform-provider-fastly/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

* [x] Does your submission pass tests?
* [x] Post the output of your test runs

### Changes to Core Features:

* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
