### PR TITLE
Update Datadog key validation and threshold duration defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### ENHANCEMENTS:
 
+- Expands the allowed length for Datadog keys from exactly 9 to between 9 and 99 characters.
+- Makes the 'duration' field in NGWAF thresholds optional with a default of 86400 seconds, and ensures a default is set when reading if the value is zero. The NGWAF API does not return the field for duration when doing a read operation if the default value is used (1 day or 86400 seconds). This update allows the Terraform provider to gracefully set the default value to allow for a successful Terraform import when the default value is used for a site alert.
+
 ### BUG FIXES:
 
 - fix(ngwaf/alerts): Ensure that FASTLY_TF_DISPLAY_SENSITIVE_FIELDS is respected ([#1106](https://github.com/fastly/terraform-provider-fastly/pull/1106))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,10 @@
 
 ### ENHANCEMENTS:
 
-- Expands the allowed length for Datadog keys from exactly 9 to between 9 and 99 characters.
-- Makes the 'duration' field in NGWAF thresholds optional with a default of 86400 seconds, and ensures a default is set when reading if the value is zero. The NGWAF API does not return the field for duration when doing a read operation if the default value is used (1 day or 86400 seconds). This update allows the Terraform provider to gracefully set the default value to allow for a successful Terraform import when the default value is used for a site alert.
-
 ### BUG FIXES:
 
+- fix(ngwaf/thresholds): Make duration optional and set default when missing ([#1107](https://github.com/fastly/terraform-provider-fastly/pull/1107))
+- fix(ngwaf/alert_datadog_integration): Expand allowed Datadog key length ([#1107](https://github.com/fastly/terraform-provider-fastly/pull/1107))
 - fix(ngwaf/alerts): Ensure that FASTLY_TF_DISPLAY_SENSITIVE_FIELDS is respected ([#1106](https://github.com/fastly/terraform-provider-fastly/pull/1106))
 
 ### DEPENDENCIES:

--- a/docs/resources/ngwaf_thresholds.md
+++ b/docs/resources/ngwaf_thresholds.md
@@ -43,13 +43,16 @@ $ terraform import fastly_ngwaf_threshold.example <workspace_id>/<threshold_id>
 
 - `action` (String) Action to take when threshold is exceeded.
 - `dont_notify` (Boolean) Whether to silence notifications when action is taken.
-- `duration` (Number) Duration the action is in place, in seconds. Minimum 1 and maximum 31,556,900.
 - `enabled` (Boolean) Whether this threshold is active.
 - `interval` (Number) Threshold interval in seconds. Accepted values are `60`, `600`, and `3600`.
 - `limit` (Number) Threshold limit. Minimum 1 and maximum 10,000.
 - `name` (String) The name of the threshold.
 - `signal` (String) The name of the signal this threshold is acting on.
 - `workspace_id` (String) The ID of the workspace.
+
+### Optional
+
+- `duration` (Number) Duration the action is in place, in seconds. Minimum 1 and maximum 31,556,900.
 
 ### Read-Only
 

--- a/fastly/resource_fastly_ngwaf_alert_datadog_integration.go
+++ b/fastly/resource_fastly_ngwaf_alert_datadog_integration.go
@@ -33,7 +33,7 @@ func resourceFastlyNGWAFAlertDatadogIntegration() *schema.Resource {
 				Description:  "The Datadog key.",
 				Required:     true,
 				Type:         schema.TypeString,
-				ValidateFunc: validation.StringLenBetween(9, 9),
+				ValidateFunc: validation.StringLenBetween(9, 99),
 				Sensitive:    !DisplaySensitiveFields,
 			},
 			"site": {

--- a/fastly/resource_fastly_ngwaf_thresholds.go
+++ b/fastly/resource_fastly_ngwaf_thresholds.go
@@ -38,7 +38,9 @@ func resourceFastlyNGWAFThresholds() *schema.Resource {
 			"duration": {
 				Type:             schema.TypeInt,
 				Description:      "Duration the action is in place, in seconds. Minimum 1 and maximum 31,556,900.",
-				Required:         true,
+				Required:         false,
+				Optional:         true,
+				Default:          86400,
 				ValidateDiagFunc: validation.ToDiagFunc(validation.IntBetween(1, 31556900)),
 			},
 			"enabled": {
@@ -137,7 +139,11 @@ func resourceFastlyNGWAFThresholdsRead(ctx context.Context, d *schema.ResourceDa
 	if err := d.Set("dont_notify", threshold.DontNotify); err != nil {
 		return diag.FromErr(err)
 	}
-	if err := d.Set("duration", threshold.Duration); err != nil {
+	var durationVal any = threshold.Duration
+	if threshold.Duration == 0 {
+		durationVal = 86400
+	}
+	if err := d.Set("duration", durationVal); err != nil {
 		return diag.FromErr(err)
 	}
 	if err := d.Set("enabled", threshold.Enabled); err != nil {

--- a/fastly/resource_fastly_ngwaf_thresholds.go
+++ b/fastly/resource_fastly_ngwaf_thresholds.go
@@ -38,7 +38,6 @@ func resourceFastlyNGWAFThresholds() *schema.Resource {
 			"duration": {
 				Type:             schema.TypeInt,
 				Description:      "Duration the action is in place, in seconds. Minimum 1 and maximum 31,556,900.",
-				Required:         false,
 				Optional:         true,
 				Default:          86400,
 				ValidateDiagFunc: validation.ToDiagFunc(validation.IntBetween(1, 31556900)),


### PR DESCRIPTION

### Change summary

Expands the allowed length for Datadog keys from exactly 9 to between 9 and 99 characters. Makes the 'duration' field in NGWAF thresholds optional with a default of 86400 seconds, and ensures a default is set when reading if the value is zero. The NGWAF API does not return the field for duration when doing a read operation if the the default value is used (1 day or 86400 seconds). This update allows the Terraform provider to gracefully set the default value to allow for a successful Terraform import when the default value is used for a site alert.


 All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/terraform-provider-fastly/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

* [ ] Does your submission pass tests?
* [ ] Post the output of your test runs

### Changes to Core Features:

* [ ] Have you written new tests for your core changes, as applicable? No.
* [x] Have you successfully run tests with your changes locally? Yes. See below

### User Impact

* [x] What is the user impact of this change?
Fixing bugs

### Are there any considerations that need to be addressed for release?

No breaking changes that I am aware of.

### Testing

Below is how I have tested.

```bash
! terraform plan -generate-config-out=generated.tf
╷
│ Warning: Provider development overrides are in effect
│ 
│ The following provider development overrides are set in the CLI configuration:
│  - fastly/fastly in /Users/brookscunningham/Documents/mygit/terraform-provider-fastly/bin
│ 
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published
│ releases.
╵
fastly_ngwaf_thresholds.terraform_ngwaf_site_rl_key_alert_tf_6650b787160b8299a955ac1c: Preparing import... [id=terraform_ngwaf_site/6650b787160b8299a955ac1c]
fastly_ngwaf_thresholds.terraform_ngwaf_site_api_key_rl_site_alert_tf_7gs08jncvevxvwllrkijwj: Preparing import... [id=terraform_ngwaf_site/7gs08JNcVEvxvWllrkIjWJ]
fastly_ngwaf_thresholds.terraform_ngwaf_site_any_attack_alert_1_min_tf_660ff12249483e78d92d1989: Preparing import... [id=terraform_ngwaf_site/660ff12249483e78d92d1989]
fastly_ngwaf_thresholds.terraform_ngwaf_site_any_system_attack_alert_10_min_tf_660ff12166dd7b84d6e58983: Preparing import... [id=terraform_ngwaf_site/660ff12166dd7b84d6e58983]
fastly_ngwaf_thresholds.terraform_ngwaf_site_any_system_attack_alert_60_min_tf_660ff12166dd7b84d6e58992: Preparing import... [id=terraform_ngwaf_site/660ff12166dd7b84d6e58992]
fastly_ngwaf_thresholds.terraform_ngwaf_site_any_system_attack_alert_60_min_tf_660ff12166dd7b84d6e58992: Refreshing state... [id=660ff12166dd7b84d6e58992]
fastly_ngwaf_thresholds.terraform_ngwaf_site_any_attack_alert_1_min_tf_660ff12249483e78d92d1989: Refreshing state... [id=660ff12249483e78d92d1989]
fastly_ngwaf_thresholds.terraform_ngwaf_site_rl_key_alert_tf_6650b787160b8299a955ac1c: Refreshing state... [id=6650b787160b8299a955ac1c]
fastly_ngwaf_thresholds.terraform_ngwaf_site_api_key_rl_site_alert_tf_7gs08jncvevxvwllrkijwj: Refreshing state... [id=7gs08JNcVEvxvWllrkIjWJ]
fastly_ngwaf_thresholds.terraform_ngwaf_site_any_system_attack_alert_10_min_tf_660ff12166dd7b84d6e58983: Refreshing state... [id=660ff12166dd7b84d6e58983]

Terraform will perform the following actions:

  # fastly_ngwaf_thresholds.terraform_ngwaf_site_any_attack_alert_1_min_tf_660ff12249483e78d92d1989 will be imported
  # (config will be generated)
    resource "fastly_ngwaf_thresholds" "terraform_ngwaf_site_any_attack_alert_1_min_tf_660ff12249483e78d92d1989" {
        action       = "log"
        dont_notify  = true
        duration     = 21600
        enabled      = true
        id           = "660ff12249483e78d92d1989"
        interval     = 60
        limit        = 50
        name         = "Any attack alert 1 min"
        signal       = "corp.system-attack"
        workspace_id = "terraform_ngwaf_site"
    }

  # fastly_ngwaf_thresholds.terraform_ngwaf_site_any_system_attack_alert_10_min_tf_660ff12166dd7b84d6e58983 will be imported
  # (config will be generated)
    resource "fastly_ngwaf_thresholds" "terraform_ngwaf_site_any_system_attack_alert_10_min_tf_660ff12166dd7b84d6e58983" {
        action       = "log"
        dont_notify  = true
        duration     = 86400
        enabled      = true
        id           = "660ff12166dd7b84d6e58983"
        interval     = 600
        limit        = 350
        name         = "Any system attack alert 10 min"
        signal       = "corp.system-attack"
        workspace_id = "terraform_ngwaf_site"
    }

  # fastly_ngwaf_thresholds.terraform_ngwaf_site_any_system_attack_alert_60_min_tf_660ff12166dd7b84d6e58992 will be imported
  # (config will be generated)
    resource "fastly_ngwaf_thresholds" "terraform_ngwaf_site_any_system_attack_alert_60_min_tf_660ff12166dd7b84d6e58992" {
        action       = "log"
        dont_notify  = true
        duration     = 86400
        enabled      = true
        id           = "660ff12166dd7b84d6e58992"
        interval     = 3600
        limit        = 1800
        name         = "Any system attack alert 60 min"
        signal       = "corp.system-attack"
        workspace_id = "terraform_ngwaf_site"
    }

  # fastly_ngwaf_thresholds.terraform_ngwaf_site_api_key_rl_site_alert_tf_7gs08jncvevxvwllrkijwj will be imported
  # (config will be generated)
    resource "fastly_ngwaf_thresholds" "terraform_ngwaf_site_api_key_rl_site_alert_tf_7gs08jncvevxvwllrkijwj" {
        action       = "log"
        dont_notify  = false
        duration     = 600
        enabled      = true
        id           = "7gs08JNcVEvxvWllrkIjWJ"
        interval     = 60
        limit        = 10
        name         = "api-key-rl-site-alert"
        signal       = "site.api-key-rl"
        workspace_id = "terraform_ngwaf_site"
    }

  # fastly_ngwaf_thresholds.terraform_ngwaf_site_rl_key_alert_tf_6650b787160b8299a955ac1c will be imported
  # (config will be generated)
    resource "fastly_ngwaf_thresholds" "terraform_ngwaf_site_rl_key_alert_tf_6650b787160b8299a955ac1c" {
        action       = "log"
        dont_notify  = false
        duration     = 86400
        enabled      = true
        id           = "6650b787160b8299a955ac1c"
        interval     = 600
        limit        = 10
        name         = "rl-key-alert"
        signal       = "site.rl-key-tracker"
        workspace_id = "terraform_ngwaf_site"
    }

Plan: 5 to import, 0 to add, 0 to change, 0 to destroy.
╷
│ Warning: Config generation is experimental
│ 
│ Generating configuration during import is currently experimental, and the generated configuration format may change in future versions.
╵

───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

Terraform has generated configuration and written it to generated.tf. Please review the configuration and edit it as necessary before adding it to version control.

Note: You didn't use the -out option to save this plan, so Terraform can't guarantee to take exactly these actions if you run "terraform apply" now.
(base) H6VDC24PHQ:fastly-terraformer brookscunningham$ 
! 
```
