### PR TITLE
feat(service): 'domain' blocks are now optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### ENHANCEMENTS:
 
-- feat(service): 'domain' blocks are now optional ([#XXX](https://github.com/fastly/terraform-provider-fastly/pull/XXX))
+- feat(service): 'domain' blocks are now optional ([#1113](https://github.com/fastly/terraform-provider-fastly/pull/1113))
 
 ### BUG FIXES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### ENHANCEMENTS:
 
+- feat(service): 'domain' blocks are now optional ([#XXX](https://github.com/fastly/terraform-provider-fastly/pull/XXX))
+
 ### BUG FIXES:
 
 ### DEPENDENCIES:

--- a/docs/resources/service_compute.md
+++ b/docs/resources/service_compute.md
@@ -98,7 +98,6 @@ $ terraform import fastly_service_compute.demo xxxxxxxxxxxxxxxxxxxx@2
 
 ### Required
 
-- `domain` (Block Set, Min: 1) A set of Domain names to serve as entry points for your Service (see [below for nested schema](#nestedblock--domain))
 - `name` (String) The unique name for the Service to create
 
 ### Optional
@@ -107,6 +106,7 @@ $ terraform import fastly_service_compute.demo xxxxxxxxxxxxxxxxxxxx@2
 - `backend` (Block Set) (see [below for nested schema](#nestedblock--backend))
 - `comment` (String) Description field for the service. Default `Managed by Terraform`
 - `dictionary` (Block Set) (see [below for nested schema](#nestedblock--dictionary))
+- `domain` (Block Set) A set of Domain names to serve as entry points for your Service (see [below for nested schema](#nestedblock--domain))
 - `force_destroy` (Boolean) Services that are active cannot be destroyed. In order to destroy the Service, set `force_destroy` to `true`. Default `false`
 - `healthcheck` (Block Set) (see [below for nested schema](#nestedblock--healthcheck))
 - `image_optimizer_default_settings` (Block Set, Max: 1) (see [below for nested schema](#nestedblock--image_optimizer_default_settings))
@@ -153,18 +153,6 @@ $ terraform import fastly_service_compute.demo xxxxxxxxxxxxxxxxxxxx@2
 - `id` (String) The ID of this resource.
 - `imported` (Boolean) Used internally by the provider to temporarily indicate if the service is being imported, and is reset to false once the import is finished
 - `staged_version` (Number) The currently staged version of your Fastly Service
-
-<a id="nestedblock--domain"></a>
-### Nested Schema for `domain`
-
-Required:
-
-- `name` (String) The domain that this Service will respond to. It is important to note that changing this attribute will delete and recreate the resource.
-
-Optional:
-
-- `comment` (String) An optional comment about the Domain.
-
 
 <a id="nestedblock--backend"></a>
 ### Nested Schema for `backend`
@@ -216,6 +204,18 @@ Optional:
 Read-Only:
 
 - `dictionary_id` (String) The ID of the dictionary
+
+
+<a id="nestedblock--domain"></a>
+### Nested Schema for `domain`
+
+Required:
+
+- `name` (String) The domain that this Service will respond to. It is important to note that changing this attribute will delete and recreate the resource.
+
+Optional:
+
+- `comment` (String) An optional comment about the Domain.
 
 
 <a id="nestedblock--healthcheck"></a>

--- a/docs/resources/service_vcl.md
+++ b/docs/resources/service_vcl.md
@@ -217,7 +217,6 @@ $ terraform import fastly_service_vcl.demo xxxxxxxxxxxxxxxxxxxx@2
 
 ### Required
 
-- `domain` (Block Set, Min: 1) A set of Domain names to serve as entry points for your Service (see [below for nested schema](#nestedblock--domain))
 - `name` (String) The unique name for the Service to create
 
 ### Optional
@@ -232,6 +231,7 @@ $ terraform import fastly_service_vcl.demo xxxxxxxxxxxxxxxxxxxx@2
 - `default_ttl` (Number) The default Time-to-live (TTL) for requests
 - `dictionary` (Block Set) (see [below for nested schema](#nestedblock--dictionary))
 - `director` (Block Set) (see [below for nested schema](#nestedblock--director))
+- `domain` (Block Set) A set of Domain names to serve as entry points for your Service (see [below for nested schema](#nestedblock--domain))
 - `dynamicsnippet` (Block Set) (see [below for nested schema](#nestedblock--dynamicsnippet))
 - `force_destroy` (Boolean) Services that are active cannot be destroyed. In order to destroy the Service, set `force_destroy` to `true`. Default `false`
 - `gzip` (Block Set) (see [below for nested schema](#nestedblock--gzip))
@@ -287,18 +287,6 @@ $ terraform import fastly_service_vcl.demo xxxxxxxxxxxxxxxxxxxx@2
 - `id` (String) The ID of this resource.
 - `imported` (Boolean) Used internally by the provider to temporarily indicate if the service is being imported, and is reset to false once the import is finished
 - `staged_version` (Number) The currently staged version of your Fastly Service
-
-<a id="nestedblock--domain"></a>
-### Nested Schema for `domain`
-
-Required:
-
-- `name` (String) The domain that this Service will respond to. It is important to note that changing this attribute will delete and recreate the resource.
-
-Optional:
-
-- `comment` (String) An optional comment about the Domain.
-
 
 <a id="nestedblock--acl"></a>
 ### Nested Schema for `acl`
@@ -414,6 +402,18 @@ Optional:
 - `retries` (Number) How many backends to search if it fails. Default `5`
 - `shield` (String) Selected POP to serve as a "shield" for backends. Valid values for `shield` are included in the [`GET /datacenters`](https://developer.fastly.com/reference/api/utils/datacenter/) API response
 - `type` (Number) Type of load balance group to use. Integer, 1 to 4. Values: `1` (random), `3` (hash), `4` (client). Default `1`
+
+
+<a id="nestedblock--domain"></a>
+### Nested Schema for `domain`
+
+Required:
+
+- `name` (String) The domain that this Service will respond to. It is important to note that changing this attribute will delete and recreate the resource.
+
+Optional:
+
+- `comment` (String) An optional comment about the Domain.
 
 
 <a id="nestedblock--dynamicsnippet"></a>

--- a/fastly/block_fastly_service_domain.go
+++ b/fastly/block_fastly_service_domain.go
@@ -34,7 +34,7 @@ func (h *DomainServiceAttributeHandler) Key() string {
 func (h *DomainServiceAttributeHandler) GetSchema() *schema.Schema {
 	return &schema.Schema{
 		Type:        schema.TypeSet,
-		Required:    true,
+		Optional:    true,
 		Description: "A set of Domain names to serve as entry points for your Service",
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{


### PR DESCRIPTION
## Change summary

The Fastly platform now permits services to be activated even if there are no domains linked to them. This change was made to support the new 'versionless domain' feature.

 All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/terraform-provider-fastly/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

* [ ] Does your submission pass tests?
* [ ] Post the output of your test runs (there are no tests for this functionality)