### PR TITLE
Update v1 Domains Data Source to user correct terminology

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### ENHANCEMENTS:
 
+- feat(domainsv1/data source): add support for the v1 domains data source ([#1112](https://github.com/fastly/terraform-provider-fastly/pull/1112))
+- feat(domainsv1/data source): corrected terminology in docs to use 'versionless domain' ([#1114](https://github.com/fastly/terraform-provider-fastly/pull/1114))
+
 ### BUG FIXES:
 
 ### DEPENDENCIES:
@@ -15,7 +18,6 @@
 ### ENHANCEMENTS:
 
 - feat(ngwaf/rules): add support for multival type conditions ([#1100](https://github.com/fastly/terraform-provider-fastly/pull/1100))
-- feat(domainsv1/data source): add support for the v1 domains data source ([#1112](https://github.com/fastly/terraform-provider-fastly/pull/1112))
 
 ### BUG FIXES:
 

--- a/docs/data-sources/domains_v1.md
+++ b/docs/data-sources/domains_v1.md
@@ -3,12 +3,12 @@ layout: "fastly"
 page_title: "Fastly: fastly_domains_v1"
 sidebar_current: "docs-fastly-datasource-fastly_domains_v1"
 description: |-
-  Get information on Fastly domains.
+  Get information on versionless domains.
 ---
 
 # fastly_domains_v1
 
-Use this data source to get information about Fastly domains.
+Use this data source to get information about versionless domains.
 
 ## Example Usage
 
@@ -16,13 +16,12 @@ Use this data source to get information about Fastly domains.
 data "fastly_domains_v1" "example" {
 }
 
-  output "all_domains" {
+output "all_domains" {
   value = data.fastly_domains_v1.example.domains
 }
 
 output "total_domains" {
   value = data.fastly_domains_v1.example.total
-  
 }
 ```
 

--- a/examples/data-sources/fastly_domains_v1.tf
+++ b/examples/data-sources/fastly_domains_v1.tf
@@ -1,11 +1,10 @@
 data "fastly_domains_v1" "example" {
 }
 
-  output "all_domains" {
+output "all_domains" {
   value = data.fastly_domains_v1.example.domains
 }
 
 output "total_domains" {
   value = data.fastly_domains_v1.example.total
-  
 }

--- a/templates/data-sources/domains_v1.md.tmpl
+++ b/templates/data-sources/domains_v1.md.tmpl
@@ -3,12 +3,12 @@ layout: "fastly"
 page_title: "Fastly: fastly_domains_v1"
 sidebar_current: "docs-fastly-datasource-fastly_domains_v1"
 description: |-
-  Get information on Fastly domains.
+  Get information on versionless domains.
 ---
 
 # fastly_domains_v1
 
-Use this data source to get information about Fastly domains.
+Use this data source to get information about versionless domains.
 
 ## Example Usage
 


### PR DESCRIPTION
### Change summary

 We need to use the term `versionless domain` to refer to results from this endpoint.  

 All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/terraform-provider-fastly/pulls) for the same update/change?