### PR TITLE
Document handling of default values in API attributes

### DIFF
--- a/API_DEFAULTS.md
+++ b/API_DEFAULTS.md
@@ -24,6 +24,10 @@ modifying a resource in the provider.
   match the default value, that value *does appear* in the response
   bodies returned by `GET`, `PUT`, and `PATCH` operations.
 
+## Terraform results
+
+This scenario matches Terraform's expectations.
+
 # Scenario B
 
 * The attribute has a documented default.
@@ -41,6 +45,15 @@ modifying a resource in the provider.
   match the default value, that value *does not appear* in the
   response bodies returned by `GET`, `PUT`, and `PATCH` operations.
 
+## Terraform results
+
+The last item in this scenario does not match Terraform's
+expectations: when the resource is read from the API (during import,
+during planning, or after creation/modification), the attribute will
+be missing. When the user executes `terraform plan` after any of these
+operations, Terraform will propose to set the value again, as it
+believes the value was unset/removed in the resource being managed.
+
 # Scenario C
 
 * The attribute has a documented default.
@@ -52,6 +65,16 @@ modifying a resource in the provider.
 
 * The attribute *always appears* in the response bodies returned by
   `GET`, `PUT`, and `PATCH` operations.
+
+## Terraform results
+
+The last item in this scenario does not match Terraform's
+expectations: when the resource is read from the API (during import,
+during planning, or after creation/modification), the attribute will
+be present even if the user did not include it in their HCL. When the
+user executes `terraform plan` after any of these operations,
+Terraform will propose to remove the value, as it believes the value
+was set in the resource being managed.
 
 # Scenario D
 
@@ -71,6 +94,16 @@ modifying a resource in the provider.
   match the default value, that value *does appear* in the response
   bodies returned by `GET`, `PUT`, and `PATCH` operations.
 
+## Terraform results
+
+The second-to-last item in this scenario does not match Terraform's
+expectations: when the resource is read from the API (during import,
+during planning, or after creation/modification), the attribute will
+be present even if the user did not include it in their HCL. When the
+user executes `terraform plan` after any of these operations,
+Terraform will propose to remove the value, as it believes the value
+was set in the resource being managed.
+
 # Scenario E
 
 * The attribute has a documented default.
@@ -84,3 +117,7 @@ modifying a resource in the provider.
 
 * The attribute *always appears* in the response bodies returned by
   `GET`, `PUT`, and `PATCH` operations.
+
+## Terraform results
+
+This scenario matches Terraform's expectations.

--- a/API_DEFAULTS.md
+++ b/API_DEFAULTS.md
@@ -15,6 +15,14 @@ don't understand why Terraform thinks additional changes are necessary
 when their previous `terraform apply` process completed successfully
 and they haven't made changes to the objects outside of Terraform.
 
+If you are building or modifying a resource or data source in this
+provider and encounter an object attribute with default behavior which
+does not match any of the types listed below, you'll need guidance
+from the Fastly Developer Tools team before proceeding. If you are a
+Fastlyan, ask the team for help in the #customer-dev-tools channel in
+Slack. If you are not a Fastlyan, open an issue in this repository and
+describe the situation you have encountered.
+
 # Type A
 
 * The attribute has a documented default.
@@ -34,6 +42,8 @@ and they haven't made changes to the objects outside of Terraform.
   bodies returned by `GET`, `PUT`, and `PATCH` operations.
 
 ## Examples
+
+TBD
 
 ## Terraform expectations
 
@@ -59,6 +69,8 @@ This type matches Terraform's expectations.
 
 ## Examples
 
+TBD
+
 ## Terraform expectations
 
 The last two items in this type does not match Terraform's
@@ -82,6 +94,8 @@ believes the value was unset/removed in the object being managed.
   `GET`, `PUT`, and `PATCH` operations.
 
 ## Examples
+
+TBD
 
 ## Terraform expectations
 
@@ -113,6 +127,8 @@ was set outside of Terraform in the object being managed.
   bodies returned by `GET`, `PUT`, and `PATCH` operations.
 
 ## Examples
+
+TBD
 
 ## Terraform expectations
 

--- a/API_DEFAULTS.md
+++ b/API_DEFAULTS.md
@@ -1,19 +1,19 @@
 # Handling API default values
 
 The Fastly control plane API is, unfortunately, inconsistent in its
-handling of default values for attributes of resources. Some of the
+handling of default values for attributes of objects. Some of the
 inconsistent behaviors generate unwelcome interactions with
-Terraform's expectations of resource states, so this document provides
+Terraform's expectations of object states, so this document provides
 guidance for how to handle various scenarios when creating or
-modifying a resource in the provider.
+modifying a object in the provider.
 
 The goal of this guide is to eliminate, wherever possible, situations
-where a user of the provider creates or modifies a resource and then
+where a user of the provider creates or modifies a object and then
 immediately sees 'intended changes' when executing `terraform
 plan`. Users are frustrated and confused when this occurs, as they
 don't understand why Terraform thinks additional changes are necessary
 when their previous `terraform apply` process completed successfully
-and they haven't made changes to the resources outside of Terraform.
+and they haven't made changes to the objects outside of Terraform.
 
 # Type A
 
@@ -21,9 +21,9 @@ and they haven't made changes to the resources outside of Terraform.
 
 * The default is applied when the user does not provide a value, or
   provides a value of `null`, for the attribute in a `POST` operation
-  (creating the resource), and when the user sets the attribute's
+  (creating the object), and when the user sets the attribute's
   value to `null` in a `PUT` or `PATCH` operation (updating the
-  resource).
+  object).
 
 * When the default is in effect, the attribute *does not appear* in
   the response bodies returned by `GET`, `PUT`, and `PATCH`
@@ -45,9 +45,9 @@ This type matches Terraform's expectations.
 
 * The default is applied when the user does not provide a value, or
   provides a value of `null`, for the attribute in a `POST` operation
-  (creating the resource), and when the user sets the attribute's
+  (creating the object), and when the user sets the attribute's
   value to `null` in a `PUT` or `PATCH` operation (updating the
-  resource).
+  object).
 
 * When the default is in effect, the attribute *does not appear* in
   the response bodies returned by `GET`, `PUT`, and `PATCH`
@@ -62,11 +62,11 @@ This type matches Terraform's expectations.
 ## Terraform expectations
 
 The last two items in this type does not match Terraform's
-expectations: when the resource is read from the API (during import,
+expectations: when the object is read from the API (during import,
 during planning, or after creation/modification), the attribute will
 be missing. When the user executes `terraform plan` after any of these
 operations, Terraform will propose to set the value again, as it
-believes the value was unset/removed in the resource being managed.
+believes the value was unset/removed in the object being managed.
 
 # Type C
 
@@ -74,9 +74,9 @@ believes the value was unset/removed in the resource being managed.
 
 * The default is applied when the user does not provide a value, or
   provides a value of `null`, for the attribute in a `POST` operation
-  (creating the resource), and when the user sets the attribute's
+  (creating the object), and when the user sets the attribute's
   value to `null` in a `PUT` or `PATCH` operation (updating the
-  resource).
+  object).
 
 * The attribute *always appears* in the response bodies returned by
   `GET`, `PUT`, and `PATCH` operations.
@@ -86,12 +86,12 @@ believes the value was unset/removed in the resource being managed.
 ## Terraform expectations
 
 The last item in this type does not match Terraform's
-expectations: when the resource is read from the API (during import,
+expectations: when the object is read from the API (during import,
 during planning, or after creation/modification), the attribute will
 be present even if the user did not include it in their HCL. When the
 user executes `terraform plan` after any of these operations,
 Terraform will propose to remove the value, as it believes the value
-was set outside of Terraform in the resource being managed.
+was set outside of Terraform in the object being managed.
 
 # Type D
 
@@ -99,9 +99,9 @@ was set outside of Terraform in the resource being managed.
 
 * The default is applied when the user does not provide a value, or
   provides a value of `null`, for the attribute in a `POST` operation
-  (creating the resource), and when the user sets the attribute's
+  (creating the object), and when the user sets the attribute's
   value to `null` in a `PUT` or `PATCH` operation (updating the
-  resource).
+  object).
 
 * When the default is in effect, the attribute *does appear* in the
   response bodies returned by `GET`, `PUT`, and `PATCH` operations,
@@ -117,20 +117,20 @@ was set outside of Terraform in the resource being managed.
 ## Terraform expectations
 
 The second-to-last item in this type does not match Terraform's
-expectations: when the resource is read from the API (during import,
+expectations: when the object is read from the API (during import,
 during planning, or after creation/modification), the attribute will
 be present even if the user did not include it in their HCL. When the
 user executes `terraform plan` after any of these operations,
 Terraform will propose to remove the value, as it believes the value
-was set outside of Terraform in the resource being managed.
+was set outside of Terraform in the object being managed.
 
 # Type E
 
 * The attribute has a documented default.
 
 * The attribute is not optional, it must always be included in the
-  request body in `POST` operations (creating the resource), and
-  `PUT`, and `PATCH` operations (updating the resource).
+  request body in `POST` operations (creating the object), and
+  `PUT`, and `PATCH` operations (updating the object).
 
 * The API accepts the 'base' value for the attribute's type (empty
   string for string attributes, zero for numeric attributes) but
@@ -158,11 +158,11 @@ This type matches Terraform's expectations.
   `PATCH` operation).
 
 * When a value for one attribute is provided in the request body of a
-  `POST` operation (creating the resource), the API may set the other
+  `POST` operation (creating the object), the API may set the other
   attribute to a default value derived from the provided value.
 
 * When a value for one attribute is provided in the request body of a
-  `PUT` or `PATCH` operation (updating the resource), the API may
+  `PUT` or `PATCH` operation (updating the object), the API may
   change the value of the other attribute to a value derived from the
   provided value.
 
@@ -177,11 +177,11 @@ This type matches Terraform's expectations.
 ## Terraform expectations
 
 The third and fourth items in this type do not match Terraform's
-expectations: when the resource is read from the API (during import,
+expectations: when the object is read from the API (during import,
 during planning, or after creation/modification), one or both of the
 attributes will be present even if the user did not include them in
 their HCL. In addition, the value of one of the attributes may have
 changed since the last time it was read. When the user executes
 `terraform plan` after any of these operations, Terraform will propose
 to change or remove the value, as it believes the value was modified
-(outside of Terraform) in the resource being managed.
+(outside of Terraform) in the object being managed.

--- a/API_DEFAULTS.md
+++ b/API_DEFAULTS.md
@@ -7,14 +7,23 @@ Terraform's expectations of resource states, so this document provides
 guidance for how to handle various scenarios when creating or
 modifying a resource in the provider.
 
-# Scenario A
+The goal of this guide is to eliminate, wherever possible, situations
+where a user of the provider creates or modifies a resource and then
+immediately sees 'intended changes' when executing `terraform
+plan`. Users are frustrated and confused when this occurs, as they
+don't understand why Terraform thinks additional changes are necessary
+when their previous `terraform apply` process completed successfully
+and they haven't made changes to the resources outside of Terraform.
+
+# Type A
 
 * The attribute has a documented default.
 
-* That default is applied when the user does not provide a value for
-  the attribute in a `POST` operation (creating the resource), and
-  when the user sets the attribute's value to `null` in a `PUT` or
-  `PATCH` operation (updating the resource).
+* The default is applied when the user does not provide a value, or
+  provides a value of `null`, for the attribute in a `POST` operation
+  (creating the resource), and when the user sets the attribute's
+  value to `null` in a `PUT` or `PATCH` operation (updating the
+  resource).
 
 * When the default is in effect, the attribute *does not appear* in
   the response bodies returned by `GET`, `PUT`, and `PATCH`
@@ -24,18 +33,21 @@ modifying a resource in the provider.
   match the default value, that value *does appear* in the response
   bodies returned by `GET`, `PUT`, and `PATCH` operations.
 
-## Terraform results
+## Examples
 
-This scenario matches Terraform's expectations.
+## Terraform expectations
 
-# Scenario B
+This type matches Terraform's expectations.
+
+# Type B
 
 * The attribute has a documented default.
 
-* That default is applied when the user does not provide a value for
-  the attribute in a `POST` operation (creating the resource), and
-  when the user sets the attribute's value to `null` in a `PUT` or
-  `PATCH` operation (updating the resource).
+* The default is applied when the user does not provide a value, or
+  provides a value of `null`, for the attribute in a `POST` operation
+  (creating the resource), and when the user sets the attribute's
+  value to `null` in a `PUT` or `PATCH` operation (updating the
+  resource).
 
 * When the default is in effect, the attribute *does not appear* in
   the response bodies returned by `GET`, `PUT`, and `PATCH`
@@ -45,45 +57,51 @@ This scenario matches Terraform's expectations.
   match the default value, that value *does not appear* in the
   response bodies returned by `GET`, `PUT`, and `PATCH` operations.
 
-## Terraform results
+## Examples
 
-The last item in this scenario does not match Terraform's
+## Terraform expectations
+
+The last two items in this type does not match Terraform's
 expectations: when the resource is read from the API (during import,
 during planning, or after creation/modification), the attribute will
 be missing. When the user executes `terraform plan` after any of these
 operations, Terraform will propose to set the value again, as it
 believes the value was unset/removed in the resource being managed.
 
-# Scenario C
+# Type C
 
 * The attribute has a documented default.
 
-* That default is applied when the user does not provide a value for
-  the attribute in a `POST` operation (creating the resource), and
-  when the user sets the attribute's value to `null` in a `PUT` or
-  `PATCH` operation (updating the resource).
+* The default is applied when the user does not provide a value, or
+  provides a value of `null`, for the attribute in a `POST` operation
+  (creating the resource), and when the user sets the attribute's
+  value to `null` in a `PUT` or `PATCH` operation (updating the
+  resource).
 
 * The attribute *always appears* in the response bodies returned by
   `GET`, `PUT`, and `PATCH` operations.
 
-## Terraform results
+## Examples
 
-The last item in this scenario does not match Terraform's
+## Terraform expectations
+
+The last item in this type does not match Terraform's
 expectations: when the resource is read from the API (during import,
 during planning, or after creation/modification), the attribute will
 be present even if the user did not include it in their HCL. When the
 user executes `terraform plan` after any of these operations,
 Terraform will propose to remove the value, as it believes the value
-was set in the resource being managed.
+was set outside of Terraform in the resource being managed.
 
-# Scenario D
+# Type D
 
 * The attribute has a documented default.
 
-* That default is applied when the user does not provide a value for
-  the attribute in a `POST` operation (creating the resource), and
-  when the user sets the attribute's value to `null` in a `PUT` or
-  `PATCH` operation (updating the resource).
+* The default is applied when the user does not provide a value, or
+  provides a value of `null`, for the attribute in a `POST` operation
+  (creating the resource), and when the user sets the attribute's
+  value to `null` in a `PUT` or `PATCH` operation (updating the
+  resource).
 
 * When the default is in effect, the attribute *does appear* in the
   response bodies returned by `GET`, `PUT`, and `PATCH` operations,
@@ -94,30 +112,76 @@ was set in the resource being managed.
   match the default value, that value *does appear* in the response
   bodies returned by `GET`, `PUT`, and `PATCH` operations.
 
-## Terraform results
+## Examples
 
-The second-to-last item in this scenario does not match Terraform's
+## Terraform expectations
+
+The second-to-last item in this type does not match Terraform's
 expectations: when the resource is read from the API (during import,
 during planning, or after creation/modification), the attribute will
 be present even if the user did not include it in their HCL. When the
 user executes `terraform plan` after any of these operations,
 Terraform will propose to remove the value, as it believes the value
-was set in the resource being managed.
+was set outside of Terraform in the resource being managed.
 
-# Scenario E
+# Type E
 
 * The attribute has a documented default.
 
 * The attribute is not optional, it must always be included in the
-  request body in `POST`, `PUT`, and `PATCH` operations.
+  request body in `POST` operations (creating the resource), and
+  `PUT`, and `PATCH` operations (updating the resource).
 
 * The API accepts the 'base' value for the attribute's type (empty
   string for string attributes, zero for numeric attributes) but
   treats that as equivalent to the default value.
 
 * The attribute *always appears* in the response bodies returned by
+  `GET`, `PUT`, and `PATCH` operations. The returned value is the
+  value provided by the user.
+
+## Examples
+
+* The `period` attribute in HTTPS Logging endpoints.
+
+## Terraform expectations
+
+This type matches Terraform's expectations.
+
+# Type F
+
+* There are two attributes with documented defaults.
+
+* Both attributes are optional, and the API is documented to consider
+  them mutually exclusive (it is documented to return an error if both
+  attributes are included in the request body of a `POST`, `PUT`, or
+  `PATCH` operation).
+
+* When a value for one attribute is provided in the request body of a
+  `POST` operation (creating the resource), the API may set the other
+  attribute to a default value derived from the provided value.
+
+* When a value for one attribute is provided in the request body of a
+  `PUT` or `PATCH` operation (updating the resource), the API may
+  change the value of the other attribute to a value derived from the
+  provided value.
+
+* The attributes *always appear* in the response bodies returned by
   `GET`, `PUT`, and `PATCH` operations.
 
-## Terraform results
+## Examples
 
-This scenario matches Terraform's expectations.
+* The `compression_codec` and `gzip_level` attributes in various
+  Logging endpoints (HTTPS, S3, and others).
+
+## Terraform expectations
+
+The third and fourth items in this type do not match Terraform's
+expectations: when the resource is read from the API (during import,
+during planning, or after creation/modification), one or both of the
+attributes will be present even if the user did not include them in
+their HCL. In addition, the value of one of the attributes may have
+changed since the last time it was read. When the user executes
+`terraform plan` after any of these operations, Terraform will propose
+to change or remove the value, as it believes the value was modified
+(outside of Terraform) in the resource being managed.

--- a/API_DEFAULTS.md
+++ b/API_DEFAULTS.md
@@ -1,0 +1,86 @@
+# Handling API default values
+
+The Fastly control plane API is, unfortunately, inconsistent in its
+handling of default values for attributes of resources. Some of the
+inconsistent behaviors generate unwelcome interactions with
+Terraform's expectations of resource states, so this document provides
+guidance for how to handle various scenarios when creating or
+modifying a resource in the provider.
+
+# Scenario A
+
+* The attribute has a documented default.
+
+* That default is applied when the user does not provide a value for
+  the attribute in a `POST` operation (creating the resource), and
+  when the user sets the attribute's value to `null` in a `PUT` or
+  `PATCH` operation (updating the resource).
+
+* When the default is in effect, the attribute *does not appear* in
+  the response bodies returned by `GET`, `PUT`, and `PATCH`
+  operations.
+
+* When the user provides a value for the attribute which happens to
+  match the default value, that value *does appear* in the response
+  bodies returned by `GET`, `PUT`, and `PATCH` operations.
+
+# Scenario B
+
+* The attribute has a documented default.
+
+* That default is applied when the user does not provide a value for
+  the attribute in a `POST` operation (creating the resource), and
+  when the user sets the attribute's value to `null` in a `PUT` or
+  `PATCH` operation (updating the resource).
+
+* When the default is in effect, the attribute *does not appear* in
+  the response bodies returned by `GET`, `PUT`, and `PATCH`
+  operations.
+
+* When the user provides a value for the attribute which happens to
+  match the default value, that value *does not appear* in the
+  response bodies returned by `GET`, `PUT`, and `PATCH` operations.
+
+# Scenario C
+
+* The attribute has a documented default.
+
+* That default is applied when the user does not provide a value for
+  the attribute in a `POST` operation (creating the resource), and
+  when the user sets the attribute's value to `null` in a `PUT` or
+  `PATCH` operation (updating the resource).
+
+* The attribute *always appears* in the response bodies returned by
+  `GET`, `PUT`, and `PATCH` operations.
+
+# Scenario D
+
+* The attribute has a documented default.
+
+* That default is applied when the user does not provide a value for
+  the attribute in a `POST` operation (creating the resource), and
+  when the user sets the attribute's value to `null` in a `PUT` or
+  `PATCH` operation (updating the resource).
+
+* When the default is in effect, the attribute *does appear* in the
+  response bodies returned by `GET`, `PUT`, and `PATCH` operations,
+  however its value is the 'base' value for the attribute's type
+  (empty string for string attributes, zero for numeric attributes).
+
+* When the user provides a value for the attribute which happens to
+  match the default value, that value *does appear* in the response
+  bodies returned by `GET`, `PUT`, and `PATCH` operations.
+
+# Scenario E
+
+* The attribute has a documented default.
+
+* The attribute is not optional, it must always be included in the
+  request body in `POST`, `PUT`, and `PATCH` operations.
+
+* The API accepts the 'base' value for the attribute's type (empty
+  string for string attributes, zero for numeric attributes) but
+  treats that as equivalent to the default value.
+
+* The attribute *always appears* in the response bodies returned by
+  `GET`, `PUT`, and `PATCH` operations.


### PR DESCRIPTION
### Change summary

This PR provides documentation on how developers working on this provider should address the behavior of the Fastly API when dealing with default values for resource attributes.

 All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/terraform-provider-fastly/pulls) for the same update/change?
