### PR TITLE
[CDTOOL-1185] - Correct HTTPS 'gzip_level' Default Handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### ENHANCEMENTS:
 
 ### BUG FIXES:
+- fix(logging/https): corrected a bug where users that had a HTTPS logging block would recieve 'gzip_level' API errors after upgrading to the to v8.1.0 provider or later ([#1118](https://github.com/fastly/terraform-provider-fastly/pull/1118))
 
 ### DEPENDENCIES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### ENHANCEMENTS:
 
 ### BUG FIXES:
-- fix(logging/https): corrected a bug where users that had a HTTPS logging block would recieve 'gzip_level' API errors after upgrading to the to v8.1.0 provider or later ([#1118](https://github.com/fastly/terraform-provider-fastly/pull/1118))
+- fix(logging/https): corrected a bug where users that had a HTTPS logging block would encounter 'gzip_level' API errors after upgrading to the v8.1.0 provider or later ([#1118](https://github.com/fastly/terraform-provider-fastly/pull/1118))
 
 ### DEPENDENCIES:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,7 +25,7 @@ terraform {
   required_providers {
     fastly = {
       source  = "fastly/fastly"
-      version = ">= 8.2.0"
+      version = ">= 8.3.0"
     }
   }
 }

--- a/fastly/block_fastly_service_logging_blobstorage.go
+++ b/fastly/block_fastly_service_logging_blobstorage.go
@@ -260,7 +260,11 @@ func (h *BlobStorageLoggingServiceAttributeHandler) Update(ctx context.Context, 
 		opts.CompressionCodec = gofastly.ToPointer(v.(string))
 	}
 	if v, ok := modified["gzip_level"]; ok {
-		opts.GzipLevel = gofastly.ToPointer(v.(int))
+		// This condition prevents users on old provider versions from having
+		// compatability issues with the default 'gzip_level' value of `-1` when upgrading to more recent versions.
+		if gl := v.(int); gl != -1 {
+			opts.GzipLevel = gofastly.ToPointer(gl)
+		}
 	}
 	if v, ok := modified["public_key"]; ok {
 		opts.PublicKey = gofastly.ToPointer(v.(string))

--- a/fastly/block_fastly_service_logging_blobstorage.go
+++ b/fastly/block_fastly_service_logging_blobstorage.go
@@ -261,7 +261,7 @@ func (h *BlobStorageLoggingServiceAttributeHandler) Update(ctx context.Context, 
 	}
 	if v, ok := modified["gzip_level"]; ok {
 		// This condition prevents users on old provider versions from having
-		// compatability issues with the default 'gzip_level' value of `-1` when upgrading to more recent versions.
+		// compatibility issues with the default 'gzip_level' value of `-1` when upgrading to more recent versions.
 		if gl := v.(int); gl != -1 {
 			opts.GzipLevel = gofastly.ToPointer(gl)
 		}

--- a/fastly/block_fastly_service_logging_cloudfiles.go
+++ b/fastly/block_fastly_service_logging_cloudfiles.go
@@ -223,7 +223,7 @@ func (h *CloudfilesServiceAttributeHandler) Update(ctx context.Context, d *schem
 	}
 	if v, ok := modified["gzip_level"]; ok {
 		// This condition prevents users on old provider versions from having
-		// compatability issues with the default 'gzip_level' value of `-1` when upgrading to more recent versions.
+		// compatibility issues with the default 'gzip_level' value of `-1` when upgrading to more recent versions.
 		if gl := v.(int); gl != -1 {
 			opts.GzipLevel = gofastly.ToPointer(gl)
 		}

--- a/fastly/block_fastly_service_logging_cloudfiles.go
+++ b/fastly/block_fastly_service_logging_cloudfiles.go
@@ -222,7 +222,11 @@ func (h *CloudfilesServiceAttributeHandler) Update(ctx context.Context, d *schem
 		opts.Period = gofastly.ToPointer(v.(int))
 	}
 	if v, ok := modified["gzip_level"]; ok {
-		opts.GzipLevel = gofastly.ToPointer(v.(int))
+		// This condition prevents users on old provider versions from having
+		// compatability issues with the default 'gzip_level' value of `-1` when upgrading to more recent versions.
+		if gl := v.(int); gl != -1 {
+			opts.GzipLevel = gofastly.ToPointer(gl)
+		}
 	}
 	if v, ok := modified["format"]; ok {
 		opts.Format = gofastly.ToPointer(v.(string))

--- a/fastly/block_fastly_service_logging_digitalocean.go
+++ b/fastly/block_fastly_service_logging_digitalocean.go
@@ -219,7 +219,7 @@ func (h *DigitalOceanServiceAttributeHandler) Update(ctx context.Context, d *sch
 	}
 	if v, ok := modified["gzip_level"]; ok {
 		// This condition prevents users on old provider versions from having
-		// compatability issues with the default 'gzip_level' value of `-1` when upgrading to more recent versions.
+		// compatibility issues with the default 'gzip_level' value of `-1` when upgrading to more recent versions.
 		if gl := v.(int); gl != -1 {
 			opts.GzipLevel = gofastly.ToPointer(gl)
 		}

--- a/fastly/block_fastly_service_logging_digitalocean.go
+++ b/fastly/block_fastly_service_logging_digitalocean.go
@@ -218,7 +218,11 @@ func (h *DigitalOceanServiceAttributeHandler) Update(ctx context.Context, d *sch
 		opts.Period = gofastly.ToPointer(v.(int))
 	}
 	if v, ok := modified["gzip_level"]; ok {
-		opts.GzipLevel = gofastly.ToPointer(v.(int))
+		// This condition prevents users on old provider versions from having
+		// compatability issues with the default 'gzip_level' value of `-1` when upgrading to more recent versions.
+		if gl := v.(int); gl != -1 {
+			opts.GzipLevel = gofastly.ToPointer(gl)
+		}
 	}
 	if v, ok := modified["format"]; ok {
 		opts.Format = gofastly.ToPointer(v.(string))

--- a/fastly/block_fastly_service_logging_ftp.go
+++ b/fastly/block_fastly_service_logging_ftp.go
@@ -234,7 +234,11 @@ func (h *FTPServiceAttributeHandler) Update(ctx context.Context, d *schema.Resou
 		opts.Placement = gofastly.ToPointer(v.(string))
 	}
 	if v, ok := modified["gzip_level"]; ok {
-		opts.GzipLevel = gofastly.ToPointer(v.(int))
+		// This condition prevents users on old provider versions from having
+		// compatability issues with the default 'gzip_level' value of `-1` when upgrading to more recent versions.
+		if gl := v.(int); gl != -1 {
+			opts.GzipLevel = gofastly.ToPointer(gl)
+		}
 	}
 	if v, ok := modified["compression_codec"]; ok {
 		opts.CompressionCodec = gofastly.ToPointer(v.(string))

--- a/fastly/block_fastly_service_logging_ftp.go
+++ b/fastly/block_fastly_service_logging_ftp.go
@@ -235,7 +235,7 @@ func (h *FTPServiceAttributeHandler) Update(ctx context.Context, d *schema.Resou
 	}
 	if v, ok := modified["gzip_level"]; ok {
 		// This condition prevents users on old provider versions from having
-		// compatability issues with the default 'gzip_level' value of `-1` when upgrading to more recent versions.
+		// compatibility issues with the default 'gzip_level' value of `-1` when upgrading to more recent versions.
 		if gl := v.(int); gl != -1 {
 			opts.GzipLevel = gofastly.ToPointer(gl)
 		}

--- a/fastly/block_fastly_service_logging_gcs.go
+++ b/fastly/block_fastly_service_logging_gcs.go
@@ -267,7 +267,7 @@ func (h *GCSLoggingServiceAttributeHandler) Update(ctx context.Context, d *schem
 	}
 	if v, ok := modified["gzip_level"]; ok {
 		// This condition prevents users on old provider versions from having
-		// compatability issues with the default 'gzip_level' value of `-1` when upgrading to more recent versions.
+		// compatibility issues with the default 'gzip_level' value of `-1` when upgrading to more recent versions.
 		if gl := v.(int); gl != -1 {
 			opts.GzipLevel = gofastly.ToPointer(gl)
 		}

--- a/fastly/block_fastly_service_logging_gcs.go
+++ b/fastly/block_fastly_service_logging_gcs.go
@@ -266,7 +266,11 @@ func (h *GCSLoggingServiceAttributeHandler) Update(ctx context.Context, d *schem
 		opts.CompressionCodec = gofastly.ToPointer(v.(string))
 	}
 	if v, ok := modified["gzip_level"]; ok {
-		opts.GzipLevel = gofastly.ToPointer(v.(int))
+		// This condition prevents users on old provider versions from having
+		// compatability issues with the default 'gzip_level' value of `-1` when upgrading to more recent versions.
+		if gl := v.(int); gl != -1 {
+			opts.GzipLevel = gofastly.ToPointer(gl)
+		}
 	}
 	if v, ok := modified["format"]; ok {
 		opts.Format = gofastly.ToPointer(v.(string))

--- a/fastly/block_fastly_service_logging_https.go
+++ b/fastly/block_fastly_service_logging_https.go
@@ -254,7 +254,14 @@ func (h *HTTPSLoggingServiceAttributeHandler) Update(ctx context.Context, d *sch
 		opts.CompressionCodec = gofastly.ToPointer(v.(string))
 	}
 	if v, ok := modified["gzip_level"]; ok {
-		opts.GzipLevel = gofastly.ToPointer(v.(int))
+		// This condition specificlly is added for HTTPS since we only recently
+		// added support for compression on this endpoint in v8.1.0. As such,
+		// users that upgraded were having a default value of `-1` being set up 'gzip_level'
+		// during an Update operation, but had no suppression of sending this `-1` value to
+		// to the API, resulting an errors as `-1` is not a valid value for `gzip_level`.
+		if gl := v.(int); gl != -1 {
+			opts.GzipLevel = gofastly.ToPointer(gl)
+		}
 	}
 	if v, ok := modified["header_name"]; ok {
 		opts.HeaderName = gofastly.ToPointer(v.(string))

--- a/fastly/block_fastly_service_logging_openstack.go
+++ b/fastly/block_fastly_service_logging_openstack.go
@@ -225,7 +225,7 @@ func (h *OpenstackServiceAttributeHandler) Update(ctx context.Context, d *schema
 	}
 	if v, ok := modified["gzip_level"]; ok {
 		// This condition prevents users on old provider versions from having
-		// compatability issues with the default 'gzip_level' value of `-1` when upgrading to more recent versions.
+		// compatibility issues with the default 'gzip_level' value of `-1` when upgrading to more recent versions.
 		if gl := v.(int); gl != -1 {
 			opts.GzipLevel = gofastly.ToPointer(gl)
 		}

--- a/fastly/block_fastly_service_logging_openstack.go
+++ b/fastly/block_fastly_service_logging_openstack.go
@@ -224,7 +224,11 @@ func (h *OpenstackServiceAttributeHandler) Update(ctx context.Context, d *schema
 		opts.CompressionCodec = gofastly.ToPointer(v.(string))
 	}
 	if v, ok := modified["gzip_level"]; ok {
-		opts.GzipLevel = gofastly.ToPointer(v.(int))
+		// This condition prevents users on old provider versions from having
+		// compatability issues with the default 'gzip_level' value of `-1` when upgrading to more recent versions.
+		if gl := v.(int); gl != -1 {
+			opts.GzipLevel = gofastly.ToPointer(gl)
+		}
 	}
 	if v, ok := modified["format"]; ok {
 		opts.Format = gofastly.ToPointer(v.(string))

--- a/fastly/block_fastly_service_logging_s3.go
+++ b/fastly/block_fastly_service_logging_s3.go
@@ -301,7 +301,11 @@ func (h *S3LoggingServiceAttributeHandler) Update(ctx context.Context, d *schema
 		opts.CompressionCodec = gofastly.ToPointer(v.(string))
 	}
 	if v, ok := modified["gzip_level"]; ok {
-		opts.GzipLevel = gofastly.ToPointer(v.(int))
+		// This condition prevents users on old provider versions from having
+		// compatability issues with the default 'gzip_level' value of `-1` when upgrading to more recent versions.
+		if gl := v.(int); gl != -1 {
+			opts.GzipLevel = gofastly.ToPointer(gl)
+		}
 	}
 	if v, ok := modified["format"]; ok {
 		opts.Format = gofastly.ToPointer(v.(string))

--- a/fastly/block_fastly_service_logging_s3.go
+++ b/fastly/block_fastly_service_logging_s3.go
@@ -302,7 +302,7 @@ func (h *S3LoggingServiceAttributeHandler) Update(ctx context.Context, d *schema
 	}
 	if v, ok := modified["gzip_level"]; ok {
 		// This condition prevents users on old provider versions from having
-		// compatability issues with the default 'gzip_level' value of `-1` when upgrading to more recent versions.
+		// compatibility issues with the default 'gzip_level' value of `-1` when upgrading to more recent versions.
 		if gl := v.(int); gl != -1 {
 			opts.GzipLevel = gofastly.ToPointer(gl)
 		}

--- a/fastly/block_fastly_service_logging_sftp.go
+++ b/fastly/block_fastly_service_logging_sftp.go
@@ -250,7 +250,11 @@ func (h *SFTPServiceAttributeHandler) Update(ctx context.Context, d *schema.Reso
 		opts.CompressionCodec = gofastly.ToPointer(v.(string))
 	}
 	if v, ok := modified["gzip_level"]; ok {
-		opts.GzipLevel = gofastly.ToPointer(v.(int))
+		// This condition prevents users on old provider versions from having
+		// compatability issues with the default 'gzip_level' value of `-1` when upgrading to more recent versions.
+		if gl := v.(int); gl != -1 {
+			opts.GzipLevel = gofastly.ToPointer(gl)
+		}
 	}
 	if v, ok := modified["format"]; ok {
 		opts.Format = gofastly.ToPointer(v.(string))

--- a/fastly/block_fastly_service_logging_sftp.go
+++ b/fastly/block_fastly_service_logging_sftp.go
@@ -251,7 +251,7 @@ func (h *SFTPServiceAttributeHandler) Update(ctx context.Context, d *schema.Reso
 	}
 	if v, ok := modified["gzip_level"]; ok {
 		// This condition prevents users on old provider versions from having
-		// compatability issues with the default 'gzip_level' value of `-1` when upgrading to more recent versions.
+		// compatibility issues with the default 'gzip_level' value of `-1` when upgrading to more recent versions.
 		if gl := v.(int); gl != -1 {
 			opts.GzipLevel = gofastly.ToPointer(gl)
 		}


### PR DESCRIPTION
### Change summary

This PR addresses a bug where users upgrading from the Terraform provider prior to `v8.1.0` to >= `8.1.0` will face an issue where HTTPS logging endpoints will throw a `gziip_level` error when no compression attributes are associated. 

 All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/terraform-provider-fastly/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

* [x] Does your submission pass tests?
* [x] Post the output of your test runs

### Changes to Core Features:

* [x] Have you successfully run tests with your changes locally?

### Are there any considerations that need to be addressed for release?

Full description can be found internally [here](https://fastly.slack.com/archives/C01E7FV8P5H/p1760037303399599). 

Essentially we are adding the same exception to the Update operation that the Read operation has, to not push the `gzip_level` value of `-1` (which is a flag) to the API. This will prevent users that are upgrading from another provider without a default `gzip_level` to have the appropriate flag be appended to their state file without sending an invalid payload.

### Additional Notes:
While this fix primarily was for the HTTPS logging endpoint (as this was the only endpoint that recently had support for compression added), the same fix was applied to the 8 other logging endpoints that use compression in case any users were on very old versions of the provider. 