### PR TITLE
[CDTOOL-1192] Virtual Patch Doc Fix

### DIFF
--- a/docs/resources/ngwaf_virtual_patches.md
+++ b/docs/resources/ngwaf_virtual_patches.md
@@ -16,7 +16,7 @@ rules block or log requests matching specific vulnerabilities.
 Basic usage:
 
 ```terraform
-resource "fastly_ngwaf_virtual_patch" "demo" {
+resource "fastly_ngwaf_virtual_patches" "demo" {
   action            = "block"
   enabled           = true
   virtual_patch_id    = "CVE-2017-5638"

--- a/examples/resources/ngwaf_virtual_patches_basic_usage.tf
+++ b/examples/resources/ngwaf_virtual_patches_basic_usage.tf
@@ -1,4 +1,4 @@
-resource "fastly_ngwaf_virtual_patch" "demo" {
+resource "fastly_ngwaf_virtual_patches" "demo" {
   action            = "block"
   enabled           = true
   virtual_patch_id    = "CVE-2017-5638"


### PR DESCRIPTION
### Change summary

This PR fixes a typo in the Virtual Patch docs - we are updating the doc reference from `fastly_ngwaf_virtual_patch` to `fastly_ngwaf_virtual_patches`, as this is what the resource is defined as. 

 All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/terraform-provider-fastly/pulls) for the same update/change?

### Are there any considerations that need to be addressed for release?

As the plural definition wasn't corrected prior to the release, we can't change this now without a breaking change. Instead, we'll have to maintain the `patches` suffix. 