### PR TITLE
Add templated_signal example to the doc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### BREAKING:
 
 ### ENHANCEMENTS:
-- feat(ngwaf/workspace): add `templated_signal` example
+- feat(ngwaf/rules): add `templated_signal` example
 - feat(ngwaf/lists): added support for NGWAF Lists to data sources ([#1124](https://github.com/fastly/terraform-provider-fastly/pull/1124))
 - feat(ngwaf/rules): added support for NGWAF Rules to data sources ([#1124](https://github.com/fastly/terraform-provider-fastly/pull/1124))
 - feat(ngwaf/signals): added support for NGWAF Signals to data sources ([#1124](https://github.com/fastly/terraform-provider-fastly/pull/1124))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### BREAKING:
 
 ### ENHANCEMENTS:
+- feat(ngwaf/workspace): add `templated_signal` example
 - feat(ngwaf/lists): added support for NGWAF Lists to data sources ([#1124](https://github.com/fastly/terraform-provider-fastly/pull/1124))
 - feat(ngwaf/rules): added support for NGWAF Rules to data sources ([#1124](https://github.com/fastly/terraform-provider-fastly/pull/1124))
 - feat(ngwaf/signals): added support for NGWAF Signals to data sources ([#1124](https://github.com/fastly/terraform-provider-fastly/pull/1124))

--- a/docs/resources/ngwaf_workspace_rule.md
+++ b/docs/resources/ngwaf_workspace_rule.md
@@ -95,6 +95,30 @@ resource "fastly_ngwaf_workspace_rule" "example" {
     }
   }
 }
+
+resource "fastly_ngwaf_workspace_rule" "LOGINATTEMPT" {
+  workspace_id   = fastly_ngwaf_workspace.waf.id
+  type           = "templated_signal"
+  enabled        = true
+  group_operator = "all"
+  description    = ""
+
+  condition {
+    field    = "method"
+    operator = "equals"
+    value    = "POST"
+  }
+  condition {
+    field    = "path"
+    operator = "equals"
+    value    = "/login"
+  }
+
+  action {
+    type   = "templated_signal"
+    signal = "LOGINATTEMPT"
+  }
+}
 ```
 
 ## Import

--- a/examples/resources/ngwaf_workspace_rule_basic_usage.tf
+++ b/examples/resources/ngwaf_workspace_rule_basic_usage.tf
@@ -77,3 +77,27 @@ resource "fastly_ngwaf_workspace_rule" "example" {
     }
   }
 }
+
+resource "fastly_ngwaf_workspace_rule" "LOGINATTEMPT" {
+  workspace_id   = fastly_ngwaf_workspace.waf.id
+  type           = "templated_signal"
+  enabled        = true
+  group_operator = "all"
+  description    = ""
+
+  condition {
+    field    = "method"
+    operator = "equals"
+    value    = "POST"
+  }
+  condition {
+    field    = "path"
+    operator = "equals"
+    value    = "/login"
+  }
+
+  action {
+    type   = "templated_signal"
+    signal = "LOGINATTEMPT"
+  }
+}


### PR DESCRIPTION
This PR amends the doc with a `templated_signal` sample rule and I've validated the fix with v8.3.2.

All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/go-fastly/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

* [x] Does your submission pass tests? 
* [x] Post the output of your test runs

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?

### Are there any considerations that need to be addressed for release?

<!-- Any breaking changes, etc -->
