### PR TITLE
Fix staticcheck nil dereference warnings in logging schema tests

### DIFF
--- a/fastly/block_fastly_service_logging_bigquery_test.go
+++ b/fastly/block_fastly_service_logging_bigquery_test.go
@@ -226,8 +226,8 @@ func TestBigqueryloggingEnvDefaultFuncAttributes(t *testing.T) {
 		t.Fatalf("Error matching:\nexpected: %#v\ngot: %#v", secretKey, secretkeyResult)
 	}
 
-	formatSchema := loggingResourceSchema["format"]
-	if formatSchema == nil {
+	formatSchema, ok := loggingResourceSchema["format"]
+	if !ok {
 		t.Fatalf("Expected format field to exist in schema")
 	}
 	if formatSchema.Default != LoggingBigQueryDefaultFormat {

--- a/fastly/block_fastly_service_logging_blobstorage_test.go
+++ b/fastly/block_fastly_service_logging_blobstorage_test.go
@@ -223,8 +223,8 @@ func TestBlobstorageloggingEnvDefaultFuncAttributes(t *testing.T) {
 		t.Fatalf("Error matching:\nexpected: %#v\ngot: %#v", token, sasTokenResult)
 	}
 
-	formatSchema := loggingResourceSchema["format"]
-	if formatSchema == nil {
+	formatSchema, ok := loggingResourceSchema["format"]
+	if !ok {
 		t.Fatalf("Expected format field to exist in schema")
 	}
 	if formatSchema.Default != LoggingBlobStorageDefaultFormat {


### PR DESCRIPTION
### Change summary

This PR resolves staticcheck warnings about potential nil pointer dereference in tests for the format field of logging schemas (BigQuery and BlobStorage):

```
fastly/block_fastly_service_logging_bigquery_test.go:230:5: SA5011(related information): this check suggests that the pointer can be nil (staticcheck)
	if formatSchema == nil {
	  ^
fastly/block_fastly_service_logging_bigquery_test.go:233:18: SA5011: possible nil pointer dereference (staticcheck)
	if formatSchema.Default != LoggingBigQueryDefaultFormat {
	               ^
fastly/block_fastly_service_logging_blobstorage_test.go:227:5: SA5011(related information): this check suggests that the pointer can be nil (staticcheck)
	if formatSchema == nil {
	  ^
fastly/block_fastly_service_logging_blobstorage_test.go:230:18: SA5011: possible nil pointer dereference (staticcheck)
	if formatSchema.Default != LoggingBlobStorageDefaultFormat {
	               ^
```

Even though the tests include a t.Fatalf() when formatSchema is nil, the linter cannot prove that execution stops there and still flags the following line (formatSchema.Default) as a possible nil dereference.

This issue was only surfaced when running make lint locally, because our CI lints only changed code using --new-from-patch. Since the affected lines were not touched in the PR, CI did not report the warnings.

 All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/terraform-provider-fastly/pulls) for the same update/change?