### PR TITLE
[CDTOOL-1198] Correct Service Link Read Behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### BUG FIXES:
 
 - fix(logging_https): ensure `response_condition` is applied during updates and add acceptance test coverage ([#1130](https://github.com/fastly/terraform-provider-fastly/pull/1130))
+- fix(domains_v1/service_link): corrected a behavior where new service links created were not referring to 'domain_id' values correctly ([#1132](https://github.com/fastly/terraform-provider-fastly/pull/1132))
 
 ### DEPENDENCIES:
 

--- a/fastly/resource_fastly_domain_v1_service_link.go
+++ b/fastly/resource_fastly_domain_v1_service_link.go
@@ -41,7 +41,7 @@ func resourceFastlyDomainV1ServiceLinkRead(ctx context.Context, d *schema.Resour
 	conn := meta.(*APIClient).conn
 
 	input := &domains.GetInput{
-		DomainID: gofastly.ToPointer(d.Id()),
+		DomainID: gofastly.ToPointer(d.Get("domain_id").(string)),
 	}
 
 	data, err := domains.Get(gofastly.NewContextForResourceID(ctx, d.Get("domain_id").(string)), conn, input)

--- a/fastly/resource_fastly_domain_v1_service_link_test.go
+++ b/fastly/resource_fastly_domain_v1_service_link_test.go
@@ -69,6 +69,45 @@ func TestAccFastlyDomainV1ServiceLink_Basic(t *testing.T) {
 	})
 }
 
+// TestAccFastlyDomainV1ServiceLink_Create tests resource creation from scratch (without import).
+// This ensures the Create → Read flow works correctly, as import can mask certain behaviors where
+// setting d.Id() before Read is called. [CDTOOL-1198]
+func TestAccFastlyDomainV1ServiceLink_Create(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckDomainV1ServiceLinkDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+				resource "fastly_domain_v1_service_link" "example" {
+				    domain_id = "%s"
+					service_id = "%s"
+				}
+				`, domainID, serviceID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("fastly_domain_v1_service_link.example", "domain_id", domainID),
+					resource.TestCheckResourceAttr("fastly_domain_v1_service_link.example", "service_id", serviceID),
+				),
+			},
+			{
+				Config: fmt.Sprintf(`
+				resource "fastly_domain_v1_service_link" "example" {
+				    domain_id = "%s"
+					service_id = "%s"
+				}
+				`, domainID, serviceID2),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("fastly_domain_v1_service_link.example", "domain_id", domainID),
+					resource.TestCheckResourceAttr("fastly_domain_v1_service_link.example", "service_id", serviceID2),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckDomainV1ServiceLinkDestroy(s *terraform.State) error {
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "fastly_domain_v1_service_link" {

--- a/fastly/resource_fastly_domain_v1_service_link_test.go
+++ b/fastly/resource_fastly_domain_v1_service_link_test.go
@@ -71,7 +71,7 @@ func TestAccFastlyDomainV1ServiceLink_Basic(t *testing.T) {
 
 // TestAccFastlyDomainV1ServiceLink_Create tests resource creation from scratch (without import).
 // This ensures the Create → Read flow works correctly, as import can mask certain behaviors where
-// setting d.Id() before Read is called. [CDTOOL-1198]
+// setting d.Id() before Read is called [CDTOOL-1198].
 func TestAccFastlyDomainV1ServiceLink_Create(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {


### PR DESCRIPTION
### Change summary

This PR fixes a bug where creating a `fastly_domain_v1_service_link` resource would fail when referring to a `domain_id` from a data source, such as `fastly_domains_v1`. 
IE:
```
locals {
  a2_domain = [
    for domain in data.fastly_domains_v1.example.domains :
    domain if domain.fqdn == "mySpecialDomain.com"
  ][0]
}

output "all_domains" {
  value = data.fastly_domains_v1.example.domains
}

resource "fastly_domain_v1_service_link" "svc_link" {
  domain_id  = local.a2_domain.id
  service_id = fastly_service_vcl.test.id
}

------>

  Error: Provider produced inconsistent result after apply
  Root object was present, but now absent.
```

This was caused by the `resourceFastlyDomainV1ServiceLinkRead` function that was reading from an internal resource ID (`d.Id`) that was not yet set. This has been corrected by replacing this reference with `domain_id` instead directly from the Terraform configuration. 

 All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/terraform-provider-fastly/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

* [x] Does your submission pass tests?
* [x] Post the output of your test runs

### Changes to Core Features:

* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### User Impact

Bug fix. 

### Are there any considerations that need to be addressed for release?

The previous test didn't capture this as we were using an 'import' block, which masked the scenario where 'd.Id' was not set. Another test was creating without this import to ensure we capture this scenario going forward. 
