### PR TITLE
[CDTOOL-1196] ensure proper optional bool behavior in backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,12 @@
 ### BUG FIXES:
 
 - fix(logging_https): ensure `response_condition` is applied during updates and add acceptance test coverage ([#1130](https://github.com/fastly/terraform-provider-fastly/pull/1130))
+- fix(backend): preserve optional bool fields (`use_ssl`, `ssl_check_cert`, `prefer_ipv6`, `auto_loadbalance`) during updates and add acceptance test coverage ([#1133](https://github.com/fastly/terraform-provider-fastly/pull/1133))
 
 ### DEPENDENCIES:
 
 ### DOCUMENTATION:
+
 - docs(ngwaf/rules): imroved usage examples of various NGWAF Rule patterns ([#1128](https://github.com/fastly/terraform-provider-fastly/pull/1128))
 
 ## 8.3.2 (October 16, 2025)

--- a/fastly/block_fastly_service_backend.go
+++ b/fastly/block_fastly_service_backend.go
@@ -372,9 +372,6 @@ func (h *BackendServiceAttributeHandler) buildUpdateBackendInput(serviceID strin
 	if v, ok := modified["port"]; ok {
 		opts.Port = gofastly.ToPointer(v.(int))
 	}
-	if v, ok := modified["prefer_ipv6"]; ok {
-		opts.PreferIPv6 = gofastly.ToPointer(gofastly.Compatibool(v.(bool)))
-	}
 	if v, ok := modified["override_host"]; ok {
 		opts.OverrideHost = gofastly.ToPointer(v.(string))
 	}
@@ -396,11 +393,6 @@ func (h *BackendServiceAttributeHandler) buildUpdateBackendInput(serviceID strin
 	if v, ok := modified["between_bytes_timeout"]; ok {
 		opts.BetweenBytesTimeout = gofastly.ToPointer(v.(int))
 	}
-	if v, ok := modified["auto_loadbalance"]; ok {
-		if h.GetServiceMetadata().serviceType == ServiceTypeVCL {
-			opts.AutoLoadbalance = gofastly.ToPointer(gofastly.Compatibool(v.(bool)))
-		}
-	}
 	if v, ok := modified["weight"]; ok {
 		opts.Weight = gofastly.ToPointer(v.(int))
 	}
@@ -419,12 +411,6 @@ func (h *BackendServiceAttributeHandler) buildUpdateBackendInput(serviceID strin
 	}
 	if v, ok := modified["shield"]; ok {
 		opts.Shield = gofastly.ToPointer(v.(string))
-	}
-	if v, ok := modified["use_ssl"]; ok {
-		opts.UseSSL = gofastly.ToPointer(gofastly.Compatibool(v.(bool)))
-	}
-	if v, ok := modified["ssl_check_cert"]; ok {
-		opts.SSLCheckCert = gofastly.ToPointer(gofastly.Compatibool(v.(bool)))
 	}
 	if v, ok := modified["ssl_ca_cert"]; ok {
 		opts.SSLCACert = gofastly.ToPointer(v.(string))
@@ -449,6 +435,13 @@ func (h *BackendServiceAttributeHandler) buildUpdateBackendInput(serviceID strin
 	}
 	if v, ok := modified["ssl_ciphers"]; ok {
 		opts.SSLCiphers = gofastly.ToPointer(v.(string))
+	}
+	// Always set optional boolean values to preserve state
+	opts.UseSSL = gofastly.ToPointer(gofastly.Compatibool(resource["use_ssl"].(bool)))
+	opts.SSLCheckCert = gofastly.ToPointer(gofastly.Compatibool(resource["ssl_check_cert"].(bool)))
+	opts.PreferIPv6 = gofastly.ToPointer(gofastly.Compatibool(resource["prefer_ipv6"].(bool)))
+	if h.GetServiceMetadata().serviceType == ServiceTypeVCL {
+		opts.AutoLoadbalance = gofastly.ToPointer(gofastly.Compatibool(resource["auto_loadbalance"].(bool)))
 	}
 
 	return opts


### PR DESCRIPTION
## Change summary

This PR addresses a long-standing issue with `schema.TypeBool` fields marked as `Optional: true` in the **backend resource**. In Terraform, optional booleans cannot naturally distinguish between "unset" and "explicitly set to false". This has historically led to state drift, where unrelated updates caused boolean fields to revert to their defaults.

### Testing
- Added dedicated acceptance test for backend booleans.
```
=== RUN   TestAccFastlyServiceVCLBackend_PreserveBooleansDuringNameChange
=== PAUSE TestAccFastlyServiceVCLBackend_PreserveBooleansDuringNameChange
=== CONT  TestAccFastlyServiceVCLBackend_PreserveBooleansDuringNameChange
--- PASS: TestAccFastlyServiceVCLBackend_PreserveBooleansDuringNameChange (27.06s)
```
- Verified that existing acceptance tests for backend resources continue to pass.
```
=== RUN   TestAccFastlyServiceVCLBackend_basic
=== PAUSE TestAccFastlyServiceVCLBackend_basic
=== CONT  TestAccFastlyServiceVCLBackend_basic
--- PASS: TestAccFastlyServiceVCLBackend_basic (27.72s)
```

## Outcome
- Optional boolean values are now reliably preserved during updates in the backend resource.
- Reduced risk of Terraform plan churn and unexpected resource diffs.

 All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/terraform-provider-fastly/pulls) for the same update/change?