### PR TITLE
[CDTOOL-1199] Correct drift for compute logging blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - fix(logging_https): ensure `response_condition` is applied during updates and add acceptance test coverage ([#1130](https://github.com/fastly/terraform-provider-fastly/pull/1130))
 - fix(backend): preserve optional bool fields (`use_ssl`, `ssl_check_cert`, `prefer_ipv6`, `auto_loadbalance`) during updates and add acceptance test coverage ([#1133](https://github.com/fastly/terraform-provider-fastly/pull/1133))
 - fix(domains_v1/service_link): corrected a behavior where new service links created were not referring to 'domain_id' values correctly ([#1132](https://github.com/fastly/terraform-provider-fastly/pull/1132))
+- fix(logging/compute): corrected drift behavior for some compute logging endpoints where the value of 'period' was not being retained correctly ([#1134](https://github.com/fastly/terraform-provider-fastly/pull/1134))
 
 ### DEPENDENCIES:
 

--- a/fastly/block_fastly_service_logging_blobstorage.go
+++ b/fastly/block_fastly_service_logging_blobstorage.go
@@ -319,6 +319,18 @@ func (h *BlobStorageLoggingServiceAttributeHandler) Delete(ctx context.Context, 
 	return nil
 }
 
+// pruneVCLLoggingAttributes removes VCL-only attributes from Compute service data.
+// For Blob Storage logging, period is not VCL-only, so we preserve it.
+func (h *BlobStorageLoggingServiceAttributeHandler) pruneVCLLoggingAttributes(data map[string]any) {
+	if h.GetServiceMetadata().serviceType == ServiceTypeCompute {
+		delete(data, "format")
+		delete(data, "format_version")
+		delete(data, "placement")
+		delete(data, "response_condition")
+		// Note: period is not deleted for Blob Storage logging as it's available for both VCL and Compute
+	}
+}
+
 // flattenBlobStorages models data into format suitable for saving to Terraform state.
 func flattenBlobStorages(remoteState []*gofastly.BlobStorage, localState []any) []map[string]any {
 	var result []map[string]any

--- a/fastly/block_fastly_service_logging_cloudfiles.go
+++ b/fastly/block_fastly_service_logging_cloudfiles.go
@@ -280,6 +280,18 @@ func (h *CloudfilesServiceAttributeHandler) Delete(ctx context.Context, d *schem
 	return nil
 }
 
+// pruneVCLLoggingAttributes removes VCL-only attributes from Compute service data.
+// For Cloud Files logging, period is not VCL-only, so we preserve it.
+func (h *CloudfilesServiceAttributeHandler) pruneVCLLoggingAttributes(data map[string]any) {
+	if h.GetServiceMetadata().serviceType == ServiceTypeCompute {
+		delete(data, "format")
+		delete(data, "format_version")
+		delete(data, "placement")
+		delete(data, "response_condition")
+		// Note: period is not deleted for Cloud Files logging as it's available for both VCL and Compute
+	}
+}
+
 // flattenCloudfiles models data into format suitable for saving to Terraform state.
 func flattenCloudfiles(remoteState []*gofastly.Cloudfiles, localState []any) []map[string]any {
 	var result []map[string]any

--- a/fastly/block_fastly_service_logging_digitalocean.go
+++ b/fastly/block_fastly_service_logging_digitalocean.go
@@ -279,6 +279,18 @@ func (h *DigitalOceanServiceAttributeHandler) Delete(ctx context.Context, d *sch
 	return nil
 }
 
+// pruneVCLLoggingAttributes removes VCL-only attributes from Compute service data.
+// For DigitalOcean logging, period is not VCL-only, so we preserve it.
+func (h *DigitalOceanServiceAttributeHandler) pruneVCLLoggingAttributes(data map[string]any) {
+	if h.GetServiceMetadata().serviceType == ServiceTypeCompute {
+		delete(data, "format")
+		delete(data, "format_version")
+		delete(data, "placement")
+		delete(data, "response_condition")
+		// Note: period is not deleted for DigitalOcean logging as it's available for both VCL and Compute
+	}
+}
+
 // flattenDigitalOcean models data into format suitable for saving to Terraform state.
 func flattenDigitalOcean(remoteState []*gofastly.DigitalOcean, localState []any) []map[string]any {
 	var result []map[string]any

--- a/fastly/block_fastly_service_logging_ftp.go
+++ b/fastly/block_fastly_service_logging_ftp.go
@@ -282,6 +282,18 @@ func (h *FTPServiceAttributeHandler) Delete(ctx context.Context, d *schema.Resou
 	return nil
 }
 
+// pruneVCLLoggingAttributes removes VCL-only attributes from Compute service data.
+// For FTP logging, period is not VCL-only, so we preserve it.
+func (h *FTPServiceAttributeHandler) pruneVCLLoggingAttributes(data map[string]any) {
+	if h.GetServiceMetadata().serviceType == ServiceTypeCompute {
+		delete(data, "format")
+		delete(data, "format_version")
+		delete(data, "placement")
+		delete(data, "response_condition")
+		// Note: period is not deleted for FTP logging as it's available for both VCL and Compute
+	}
+}
+
 // flattenFTP models data into format suitable for saving to Terraform state.
 func flattenFTP(remoteState []*gofastly.FTP, localState []any) []map[string]any {
 	var result []map[string]any

--- a/fastly/block_fastly_service_logging_gcs.go
+++ b/fastly/block_fastly_service_logging_gcs.go
@@ -322,6 +322,18 @@ func (h *GCSLoggingServiceAttributeHandler) Delete(ctx context.Context, d *schem
 	return nil
 }
 
+// pruneVCLLoggingAttributes removes VCL-only attributes from Compute service data.
+// For GCS logging, period is not VCL-only, so we preserve it.
+func (h *GCSLoggingServiceAttributeHandler) pruneVCLLoggingAttributes(data map[string]any) {
+	if h.GetServiceMetadata().serviceType == ServiceTypeCompute {
+		delete(data, "format")
+		delete(data, "format_version")
+		delete(data, "placement")
+		delete(data, "response_condition")
+		// Note: period is not deleted for GCS logging as it's available for both VCL and Compute
+	}
+}
+
 // flattenGCS models data into format suitable for saving to Terraform state.
 func flattenGCS(remoteState []*gofastly.GCS, state []any) []map[string]any {
 	var result []map[string]any

--- a/fastly/block_fastly_service_logging_openstack.go
+++ b/fastly/block_fastly_service_logging_openstack.go
@@ -282,6 +282,18 @@ func (h *OpenstackServiceAttributeHandler) Delete(ctx context.Context, d *schema
 	return nil
 }
 
+// pruneVCLLoggingAttributes removes VCL-only attributes from Compute service data.
+// For OpenStack logging, period is not VCL-only, so we preserve it.
+func (h *OpenstackServiceAttributeHandler) pruneVCLLoggingAttributes(data map[string]any) {
+	if h.GetServiceMetadata().serviceType == ServiceTypeCompute {
+		delete(data, "format")
+		delete(data, "format_version")
+		delete(data, "placement")
+		delete(data, "response_condition")
+		// Note: period is not deleted for OpenStack logging as it's available for both VCL and Compute
+	}
+}
+
 // flattenOpenstack models data into format suitable for saving to Terraform state.
 func flattenOpenstack(remoteState []*gofastly.Openstack, localState []any) []map[string]any {
 	var result []map[string]any

--- a/fastly/block_fastly_service_logging_s3.go
+++ b/fastly/block_fastly_service_logging_s3.go
@@ -377,6 +377,18 @@ func (h *S3LoggingServiceAttributeHandler) Delete(ctx context.Context, d *schema
 	return nil
 }
 
+// pruneVCLLoggingAttributes removes VCL-only attributes from Compute service data.
+// For S3 logging, period is not VCL-only, so we preserve it.
+func (h *S3LoggingServiceAttributeHandler) pruneVCLLoggingAttributes(data map[string]any) {
+	if h.GetServiceMetadata().serviceType == ServiceTypeCompute {
+		delete(data, "format")
+		delete(data, "format_version")
+		delete(data, "placement")
+		delete(data, "response_condition")
+		// Note: period is not deleted for S3 logging as it's available for both VCL and Compute
+	}
+}
+
 // flattenS3s models data into format suitable for saving to Terraform state.
 func flattenS3s(remoteState []*gofastly.S3, localState []any) []map[string]any {
 	var result []map[string]any

--- a/fastly/block_fastly_service_logging_sftp.go
+++ b/fastly/block_fastly_service_logging_sftp.go
@@ -305,6 +305,18 @@ func (h *SFTPServiceAttributeHandler) Delete(ctx context.Context, d *schema.Reso
 	return nil
 }
 
+// pruneVCLLoggingAttributes removes VCL-only attributes from Compute service data.
+// For SFTP logging, period is not VCL-only, so we preserve it.
+func (h *SFTPServiceAttributeHandler) pruneVCLLoggingAttributes(data map[string]any) {
+	if h.GetServiceMetadata().serviceType == ServiceTypeCompute {
+		delete(data, "format")
+		delete(data, "format_version")
+		delete(data, "placement")
+		delete(data, "response_condition")
+		// Note: period is not deleted for SFTP logging as it's available for both VCL and Compute
+	}
+}
+
 // flattenSFTP models data into format suitable for saving to Terraform state.
 func flattenSFTP(remoteState []*gofastly.SFTP, localState []any) []map[string]any {
 	var result []map[string]any


### PR DESCRIPTION
### Change summary

This PR corrects a bug where the `period` attribute was being pruned from Compute services. By adding a local override per logging endpoint where expected attributes are still pruned, with the exception of 'period', we now see consistent behavior. 

 All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/terraform-provider-fastly/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

* [x] Does your submission pass tests?
* [x] Post the output of your test runs

### Changes to Core Features:

* [ ] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### User Impact

Local drift is now corrected for Compute logging endpoints. 
