### PR TITLE
[CDTOOL-1202] Correct 'TestAccResourceFastlyTLSSubscription_Config'  Failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - fix(backend): preserve optional bool fields (`use_ssl`, `ssl_check_cert`, `prefer_ipv6`, `auto_loadbalance`) during updates and add acceptance test coverage ([#1133](https://github.com/fastly/terraform-provider-fastly/pull/1133))
 - fix(domains_v1/service_link): corrected a behavior where new service links created were not referring to 'domain_id' values correctly ([#1132](https://github.com/fastly/terraform-provider-fastly/pull/1132))
 - fix(logging/compute): corrected drift behavior for some compute logging endpoints where the value of 'period' was not being retained correctly ([#1134](https://github.com/fastly/terraform-provider-fastly/pull/1134))
+- fix(tls/subscriptions): corrects 'common_name' validation for update operations ([#1135](https://github.com/fastly/terraform-provider-fastly/pull/1135))
 
 ### DEPENDENCIES:
 

--- a/fastly/resource_fastly_tls_subscription_test.go
+++ b/fastly/resource_fastly_tls_subscription_test.go
@@ -67,7 +67,7 @@ func TestAccResourceFastlyTLSSubscription_Config(t *testing.T) {
 			},
 			{
 				Config:      testAccResourceFastlyTLSSubscriptionConfigInvalidCommonName(),
-				ExpectError: regexp.MustCompile(`Please add \S+ to an active service to begin TLS enablement`),
+				ExpectError: regexp.MustCompile(`domain specified as common_name .* must also be in domains`),
 			},
 			{
 				Config:      testAccResourceFastlyTLSSubscriptionConfig(name, domain1, domain2Bad, commonName2),


### PR DESCRIPTION
### Change summary

This PR corrects the `resource_fastly_tls_subscription` comparison of the `common_name` field to the list of items in the `domains` field for the `Update` operation. We have replicated the same validation that existed in the `Create` function to fill this gap. 

 All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/terraform-provider-fastly/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

* [x] Does your submission pass tests?
* [x] Post the output of your test runs

### Changes to Core Features:

* [ ] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?