### PR TITLE
[CDTOOL-1203] Add cidr validation to compute ACL entries prefixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - feat(ngwaf/lists): added support for NGWAF Lists to data sources ([#1124](https://github.com/fastly/terraform-provider-fastly/pull/1124))
 - feat(ngwaf/rules): added support for NGWAF Rules to data sources ([#1124](https://github.com/fastly/terraform-provider-fastly/pull/1124))
 - feat(ngwaf/signals): added support for NGWAF Signals to data sources ([#1124](https://github.com/fastly/terraform-provider-fastly/pull/1124))
+- feat(compute_acl_entries): add CIDR validation ([#1136](https://github.com/fastly/terraform-provider-fastly/pull/1136))
 
 ### BUG FIXES:
 


### PR DESCRIPTION
### Change summary

This PR adds client-side validation for the `entries` map in the `fastly_compute_acl_entries` resource to ensure that all prefixes are valid CIDR notations.

Previously, invalid CIDR strings (e.g. `"bad_cidr"`) would only trigger an error during `terraform apply`, returned by the Fastly API as:

```
400 - Bad Request: entry 1: missing prefix separator
```

This change introduces validation at the Terraform provider layer using Go’s `net.ParseCIDR()` to catch invalid prefixes earlier, during plan or validate. This results in better feedback and a smoother user experience.

The same input will now fail earlier with:

```
Error: invalid prefix "bad_cidr": expected valid CIDR notation
```

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/terraform-provider-fastly/pulls) for the same update/change?

### New Feature Submissions:

* [x] Does your submission pass tests?
* [x] Post the output of your test runs

### Test output:
```
=== RUN   TestAccFastlyComputeACLEntries_invalidPrefix
=== PAUSE TestAccFastlyComputeACLEntries_invalidPrefix
=== CONT  TestAccFastlyComputeACLEntries_invalidPrefix
--- PASS: TestAccFastlyComputeACLEntries_invalidPrefix (0.11s)
```

