### PR TITLE
Compute ACL entry CIDR validation still needs to be released

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### ENHANCEMENTS:
 
+- feat(compute_acl_entries): add CIDR validation ([#1136](https://github.com/fastly/terraform-provider-fastly/pull/1136))
+
 ### BUG FIXES:
 
 ### DEPENDENCIES:
@@ -17,7 +19,6 @@
 - feat(ngwaf/lists): added support for NGWAF Lists to data sources ([#1124](https://github.com/fastly/terraform-provider-fastly/pull/1124))
 - feat(ngwaf/rules): added support for NGWAF Rules to data sources ([#1124](https://github.com/fastly/terraform-provider-fastly/pull/1124))
 - feat(ngwaf/signals): added support for NGWAF Signals to data sources ([#1124](https://github.com/fastly/terraform-provider-fastly/pull/1124))
-- feat(compute_acl_entries): add CIDR validation ([#1136](https://github.com/fastly/terraform-provider-fastly/pull/1136))
 
 ### BUG FIXES:
 


### PR DESCRIPTION
### Change summary

#1136 does not belong to `v8.4.0` and still needs to be released. This PR moves the entry back to the unreleased block.

 All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/terraform-provider-fastly/pulls) for the same update/change?