### PR TITLE
[CDTOOL-1211] ensure proper optional bool behavior in header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### BUG FIXES:
 
+- fix(header): preserve optional bool field `ignore_if_set` during updates and add acceptance test coverage ([#1142](https://github.com/fastly/terraform-provider-fastly/pull/1142))
+
 ### DEPENDENCIES:
 
 ### DOCUMENTATION:

--- a/fastly/block_fastly_service_header.go
+++ b/fastly/block_fastly_service_header.go
@@ -165,9 +165,6 @@ func (h *HeaderServiceAttributeHandler) Update(ctx context.Context, d *schema.Re
 	if v, ok := modified["action"]; ok {
 		opts.Action = gofastly.ToPointer(gofastly.HeaderAction(v.(string)))
 	}
-	if v, ok := modified["ignore_if_set"]; ok {
-		opts.IgnoreIfSet = gofastly.ToPointer(gofastly.Compatibool(v.(bool)))
-	}
 	if v, ok := modified["type"]; ok {
 		opts.Type = gofastly.ToPointer(gofastly.HeaderType(v.(string)))
 	}
@@ -195,6 +192,9 @@ func (h *HeaderServiceAttributeHandler) Update(ctx context.Context, d *schema.Re
 	if v, ok := modified["response_condition"]; ok {
 		opts.ResponseCondition = gofastly.ToPointer(v.(string))
 	}
+
+	// Always set optional boolean fields to preserve state
+	opts.IgnoreIfSet = gofastly.ToPointer(gofastly.Compatibool(resource["ignore_if_set"].(bool)))
 
 	log.Printf("[DEBUG] Update Header Opts: %#v", opts)
 	_, err := conn.UpdateHeader(gofastly.NewContextForResourceID(ctx, d.Id()), &opts)


### PR DESCRIPTION
### Change summary

This PR resolves an issue related to the `ignore_if_set` optional boolean field in the **header resource.**
In Terraform, `schema.TypeBool` with `Optional: true` cannot distinguish between unset and explicitly set to false. This causes problems during update operations — if only an unrelated attribute changes (e.g., `name`), optional booleans could be omitted from the Fastly API update request, leading to unintended resets or drift.

 All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/terraform-provider-fastly/pulls) for the same update/change?

### Testing

- Added dedicated acceptance test for `ignore_if_set`:
```
=== RUN   TestAccFastlyServiceVCL_headers_PreserveIgnoreIfSetDuringNameChange
=== PAUSE TestAccFastlyServiceVCL_headers_PreserveIgnoreIfSetDuringNameChange
=== CONT  TestAccFastlyServiceVCL_headers_PreserveIgnoreIfSetDuringNameChange
--- PASS: TestAccFastlyServiceVCL_headers_PreserveIgnoreIfSetDuringNameChange (27.71s).
```

- Verified that existing acceptance tests for backend resources continue to pass.
```
=== RUN   TestAccFastlyServiceVCL_headers_basic
=== PAUSE TestAccFastlyServiceVCL_headers_basic
=== CONT  TestAccFastlyServiceVCL_headers_basic
--- PASS: TestAccFastlyServiceVCL_headers_basic (29.96s)
```
