### PR TITLE
[CDTOOL-1212] ensure proper optional bool behavior in image optimizer default settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### BUG FIXES:
 
 - fix(header): preserve optional bool field `ignore_if_set` during updates and add acceptance test coverage ([#1142](https://github.com/fastly/terraform-provider-fastly/pull/1142))
+- fix(image_optimizer_default_settings): preserve optional bool fields (`allow_video`, `webp`, `upscale`) during updates and add acceptance test coverage ([#1145](https://github.com/fastly/terraform-provider-fastly/pull/1145))
 
 ### DEPENDENCIES:
 

--- a/fastly/block_fastly_service_image_optimizer_default_settings.go
+++ b/fastly/block_fastly_service_image_optimizer_default_settings.go
@@ -181,7 +181,8 @@ func (h *ImageOptimizerDefaultSettingsServiceAttributeHandler) Read(ctx context.
 func (h *ImageOptimizerDefaultSettingsServiceAttributeHandler) Update(
 	ctx context.Context,
 	d *schema.ResourceData,
-	resource, modified map[string]any,
+	resource,
+	modified map[string]any,
 	serviceVersion int,
 	conn *gofastly.Client,
 ) error {


### PR DESCRIPTION
### Change summary

This PR resolves an issue related to the `allow_video`, `webp`, and `upscale` optional boolean fields in the **`image_optimizer_default_settings` block**.

In Terraform, `schema.TypeBool` with `Optional: true` cannot distinguish between an unset value and one explicitly set to `false`. As a result, during updates involving unrelated field changes (e.g., `jpeg_quality`), these optional booleans could be omitted from the Fastly API update request — leading to unintended resets or configuration drift.

To prevent this, these optional booleans are now **always included** in the update payload, regardless of whether they’ve changed.

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/terraform-provider-fastly/pulls) for the same update/change?

### Testing

- Added new acceptance test for preserving optional bool values:
```
=== RUN   TestAccFastlyServiceImageOptimizerDefaultSettings_basic
=== PAUSE TestAccFastlyServiceImageOptimizerDefaultSettings_basic
=== CONT  TestAccFastlyServiceImageOptimizerDefaultSettings_basic
--- PASS: TestAccFastlyServiceImageOptimizerDefaultSettings_basic (41.18s)
```

- Verified that existing acceptance tests for `image_optimizer_default_settings` continue to pass:
```
=== RUN   TestAccFastlyServiceImageOptimizerDefaultSettings_PreserveBooleansDuringUnrelatedChange
=== PAUSE TestAccFastlyServiceImageOptimizerDefaultSettings_PreserveBooleansDuringUnrelatedChange
=== CONT  TestAccFastlyServiceImageOptimizerDefaultSettings_PreserveBooleansDuringUnrelatedChange
--- PASS: TestAccFastlyServiceImageOptimizerDefaultSettings_PreserveBooleansDuringUnrelatedChange (44.65s)
```