### PR TITLE
Ensure that mode updates are always sent when ddos_protection is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - fix(header): preserve optional bool field `ignore_if_set` during updates and add acceptance test coverage ([#1142](https://github.com/fastly/terraform-provider-fastly/pull/1142))
 - fix(image_optimizer_default_settings): preserve optional bool fields (`allow_video`, `webp`, `upscale`) during updates and add acceptance test coverage ([#1145](https://github.com/fastly/terraform-provider-fastly/pull/1145))
 - fix(logging_kafka): preserve optional bool fields (`use_tls`, `parse_log_keyvals`) during updates and add acceptance test coverage ([#1147](https://github.com/fastly/terraform-provider-fastly/pull/1147))
+- fix(product_enablement): ensure `ddos_protection` mode updates are applied ([#1149](https://github.com/fastly/terraform-provider-fastly/pull/1149))
 
 ### DEPENDENCIES:
 

--- a/fastly/block_fastly_service_product_enablement.go
+++ b/fastly/block_fastly_service_product_enablement.go
@@ -607,16 +607,14 @@ func (h *ProductEnablementServiceAttributeHandler) Update(ctx context.Context, d
 					return fmt.Errorf("failed to enable ddos_protection: %w", err)
 				}
 
-				// The operation mode is set by default to "log"
 				mode := ddp[0].(map[string]any)["mode"].(string)
-				if mode != "log" {
-					log.Println("[DEBUG] ddos_protection mode will be updated")
-					_, err := ddosprotection.UpdateConfiguration(gofastly.NewContextForResourceID(ctx, d.Id()), conn, serviceID, ddosprotection.ConfigureInput{
-						Mode: mode,
-					})
-					if err != nil {
-						return fmt.Errorf("failed to set the configuration of ddos_protection: %w", err)
-					}
+				log.Printf("[DEBUG] ddos_protection mode will be set to %s", mode)
+				_, err = ddosprotection.UpdateConfiguration(
+					gofastly.NewContextForResourceID(ctx, d.Id()), conn, serviceID,
+					ddosprotection.ConfigureInput{Mode: mode},
+				)
+				if err != nil {
+					return fmt.Errorf("failed to set the configuration of ddos_protection: %w", err)
 				}
 			} else {
 				log.Println("[DEBUG] ddos_protection will be disabled")


### PR DESCRIPTION
### Change summary

Fixes #1148.

Previously, changes to ddos_protection.mode (e.g. from "block" to "log") were not sent to the Fastly API if the target mode was "log", due to a conditional check that skipped the update. This caused persistent diffs and unexpected behavior.

This pull request removes the conditional check and ensures that mode updates are always sent when ddos_protection is enabled.

 All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/terraform-provider-fastly/pulls) for the same update/change?

### Changes to Core Features:

* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

```
=== RUN   TestAccFastlyServiceVCLProductEnablement_basic
=== PAUSE TestAccFastlyServiceVCLProductEnablement_basic
=== CONT  TestAccFastlyServiceVCLProductEnablement_basic
--- PASS: TestAccFastlyServiceVCLProductEnablement_basic (14.98s)
```

```
=== RUN   TestAccFastlyServiceVCLProductEnablement_ddosProtectionModeChange
=== PAUSE TestAccFastlyServiceVCLProductEnablement_ddosProtectionModeChange
=== CONT  TestAccFastlyServiceVCLProductEnablement_ddosProtectionModeChange
--- PASS: TestAccFastlyServiceVCLProductEnablement_ddosProtectionModeChange (41.45s)
```
