### PR TITLE
Add acceptance test for ngwaf product enablement updates

### DIFF
--- a/fastly/block_fastly_service_product_enablement_test.go
+++ b/fastly/block_fastly_service_product_enablement_test.go
@@ -189,3 +189,91 @@ resource "fastly_service_vcl" "foo" {
 		},
 	})
 }
+
+func TestAccFastlyServiceVCLProductEnablement_ngwafUpdate(t *testing.T) {
+	var service gofastly.ServiceDetail
+	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	domainName := fmt.Sprintf("fastly-test.tf-%s.com", acctest.RandString(10))
+	backendName := fmt.Sprintf("backend-tf-%s", acctest.RandString(10))
+	backendAddress := "httpbin.org"
+
+	initialConfig := fmt.Sprintf(`
+resource "fastly_service_vcl" "foo" {
+  name = "%s"
+
+  domain {
+    name    = "%s"
+    comment = "demo"
+  }
+
+  backend {
+    address = "%s"
+    name    = "%s"
+    port    = 443
+    shield  = "amsterdam-nl"
+  }
+
+  product_enablement {
+    ngwaf {
+      enabled      = true
+      workspace_id = "7JFbo4RNA0OKdFWC04r6B3"
+      traffic_ramp = 100
+    }
+  }
+
+  force_destroy = true
+}
+`, serviceName, domainName, backendAddress, backendName)
+
+	updatedConfig := fmt.Sprintf(`
+resource "fastly_service_vcl" "foo" {
+  name = "%s"
+
+  domain {
+    name    = "%s"
+    comment = "demo"
+  }
+
+  backend {
+    address = "%s"
+    name    = "%s"
+    port    = 443
+    shield  = "amsterdam-nl"
+  }
+
+  product_enablement {
+    ngwaf {
+      enabled      = true
+      workspace_id = "Jf4Vo9RXd00MdTYJ44xY12"
+      traffic_ramp = 80
+    }
+  }
+
+  force_destroy = true
+}
+`, serviceName, domainName, backendAddress, backendName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckServiceVCLDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: initialConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceExists("fastly_service_vcl.foo", &service),
+					resource.TestCheckResourceAttr("fastly_service_vcl.foo", "product_enablement.0.ngwaf.0.workspace_id", "7JFbo4RNA0OKdFWC04r6B3"),
+					resource.TestCheckResourceAttr("fastly_service_vcl.foo", "product_enablement.0.ngwaf.0.traffic_ramp", "100"),
+				),
+			},
+			{
+				Config: updatedConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceExists("fastly_service_vcl.foo", &service),
+					resource.TestCheckResourceAttr("fastly_service_vcl.foo", "product_enablement.0.ngwaf.0.workspace_id", "Jf4Vo9RXd00MdTYJ44xY12"),
+					resource.TestCheckResourceAttr("fastly_service_vcl.foo", "product_enablement.0.ngwaf.0.traffic_ramp", "80"),
+				),
+			},
+		},
+	})
+}


### PR DESCRIPTION
### Change summary

This PR adds an acceptance test to verify that configuration changes to the `ngwaf` block within the `product_enablement` attribute of the `fastly_service_vcl resource` are correctly applied and do not result in persistent diffs.

 All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/terraform-provider-fastly/pulls) for the same update/change?

### New Feature Submissions:

* [x] Does your submission pass tests?
* [x] Post the output of your test runs

```
=== RUN   TestAccFastlyServiceVCLProductEnablement_basic
=== PAUSE TestAccFastlyServiceVCLProductEnablement_basic
=== CONT  TestAccFastlyServiceVCLProductEnablement_basic
--- PASS: TestAccFastlyServiceVCLProductEnablement_basic (16.11s)
```

```
=== RUN   TestAccFastlyServiceVCLProductEnablement_ngwafUpdate
=== PAUSE TestAccFastlyServiceVCLProductEnablement_ngwafUpdate
=== CONT  TestAccFastlyServiceVCLProductEnablement_ngwafUpdate
--- PASS: TestAccFastlyServiceVCLProductEnablement_ngwafUpdate (46.63s)
```

