### PR TITLE
[CDTOOL-1225] Correct `keepalive_time` Drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### ENHANCEMENTS:
 
 ### BUG FIXES:
+- fix(service/backend): corrected a drift issue caused by the `keepalive_time` attribute ([#1156](https://github.com/fastly/terraform-provider-fastly/pull/1156))
 
 ### DEPENDENCIES:
 

--- a/fastly/block_fastly_service_backend.go
+++ b/fastly/block_fastly_service_backend.go
@@ -71,6 +71,7 @@ func (h *BackendServiceAttributeHandler) GetSchema() *schema.Schema {
 		"keepalive_time": {
 			Type:        schema.TypeInt,
 			Optional:    true,
+			Computed:    true,
 			Description: "How long in seconds to keep a persistent connection to the backend between requests.",
 		},
 		"max_conn": {


### PR DESCRIPTION
### Change summary

This PR fixes a bug where the `keepalive_time` backend attribute was incorrectly being set to `0` in state when a value wasn't being set. 

A more in depth explanation can be found here: https://fastly.atlassian.net/browse/CDTOOL-1225 

 All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/terraform-provider-fastly/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

* [x] Does your submission pass tests?
* [x] Post the output of your test runs

```
--- PASS: TestAccFastlyServiceVCLBackend_Minimal (9.28s)
PASS
ok   
```

### Changes to Core Features:

* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### User Impact

* [x] What is the user impact of this change?

Users should not longer see drift when updating backend objects in Terraform due to inconsistency between the `keepalive_time` attribute being changed from `0 -> null`. 
