### PR TITLE
Rename acceptance test functions for logging blocks

### DIFF
--- a/fastly/block_fastly_service_logging_bigquery_test.go
+++ b/fastly/block_fastly_service_logging_bigquery_test.go
@@ -15,7 +15,7 @@ import (
 	gofastly "github.com/fastly/go-fastly/v12/fastly"
 )
 
-func TestAccFastlyServiceVCL_bigquerylogging_basic(t *testing.T) {
+func TestAccFastlyServiceLoggingBigQuery_vcl_basic(t *testing.T) {
 	var service gofastly.ServiceDetail
 	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	email := "email@example.com"
@@ -98,7 +98,7 @@ func TestAccFastlyServiceVCL_bigquerylogging_basic(t *testing.T) {
 	})
 }
 
-func TestAccFastlyServiceVCL_bigquerylogging_basic_compute(t *testing.T) {
+func TestAccFastlyServiceLoggingBigQuery_compute_basic(t *testing.T) {
 	var service gofastly.ServiceDetail
 	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	email := "email@example.com"
@@ -139,7 +139,7 @@ func TestAccFastlyServiceVCL_bigquerylogging_basic_compute(t *testing.T) {
 	})
 }
 
-func TestAccFastlyServiceVCL_bigquerylogging_default(t *testing.T) {
+func TestAccFastlyServiceLoggingBigQuery_vcl_default(t *testing.T) {
 	var service gofastly.ServiceDetail
 	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	email := "email@example.com"

--- a/fastly/block_fastly_service_logging_blobstorage_test.go
+++ b/fastly/block_fastly_service_logging_blobstorage_test.go
@@ -15,7 +15,7 @@ import (
 	gofastly "github.com/fastly/go-fastly/v12/fastly"
 )
 
-func TestAccFastlyServiceVCL_blobstoragelogging_basic(t *testing.T) {
+func TestAccFastlyServiceLoggingBlobstorage_vcl_basic(t *testing.T) {
 	var service gofastly.ServiceDetail
 	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 
@@ -108,7 +108,7 @@ func TestAccFastlyServiceVCL_blobstoragelogging_basic(t *testing.T) {
 	})
 }
 
-func TestAccFastlyServiceVCL_blobstoragelogging_basic_compute(t *testing.T) {
+func TestAccFastlyServiceLoggingBlobstorage_compute_basic(t *testing.T) {
 	var service gofastly.ServiceDetail
 	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 
@@ -148,7 +148,7 @@ func TestAccFastlyServiceVCL_blobstoragelogging_basic_compute(t *testing.T) {
 	})
 }
 
-func TestAccFastlyServiceVCL_blobstoragelogging_default(t *testing.T) {
+func TestAccFastlyServiceLoggingBlobstorage_vcl_default(t *testing.T) {
 	var service gofastly.ServiceDetail
 	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 

--- a/fastly/block_fastly_service_logging_cloudfiles_test.go
+++ b/fastly/block_fastly_service_logging_cloudfiles_test.go
@@ -15,7 +15,7 @@ import (
 	gofastly "github.com/fastly/go-fastly/v12/fastly"
 )
 
-func TestAccFastlyServiceVCL_logging_cloudfiles_basic(t *testing.T) {
+func TestAccFastlyServiceLoggingCloudfiles_vcl_basic(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	domain := fmt.Sprintf("fastly-test.%s.com", name)
@@ -112,7 +112,7 @@ func TestAccFastlyServiceVCL_logging_cloudfiles_basic(t *testing.T) {
 	})
 }
 
-func TestAccFastlyServiceVCL_logging_cloudfiles_basic_compute(t *testing.T) {
+func TestAccFastlyServiceLoggingCloudfiles_compute_basic(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	domain := fmt.Sprintf("fastly-test.%s.com", name)

--- a/fastly/block_fastly_service_logging_datadog_test.go
+++ b/fastly/block_fastly_service_logging_datadog_test.go
@@ -14,7 +14,7 @@ import (
 	gofastly "github.com/fastly/go-fastly/v12/fastly"
 )
 
-func TestAccFastlyServiceVCL_logging_datadog_basic(t *testing.T) {
+func TestAccFastlyServiceLoggingDatadog_vcl_basic(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	domain := fmt.Sprintf("fastly-test.%s.com", name)
@@ -82,7 +82,7 @@ func TestAccFastlyServiceVCL_logging_datadog_basic(t *testing.T) {
 	})
 }
 
-func TestAccFastlyServiceVCL_logging_datadog_basic_compute(t *testing.T) {
+func TestAccFastlyServiceLoggingDatadog_compute_basic(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	domain := fmt.Sprintf("fastly-test.%s.com", name)

--- a/fastly/block_fastly_service_logging_digitalocean_test.go
+++ b/fastly/block_fastly_service_logging_digitalocean_test.go
@@ -14,7 +14,7 @@ import (
 	gofastly "github.com/fastly/go-fastly/v12/fastly"
 )
 
-func TestAccFastlyServiceVCL_logging_digitalocean_basic(t *testing.T) {
+func TestAccFastlyServiceLoggingDigitalOcean_vcl_basic(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	domain := fmt.Sprintf("fastly-test.%s.com", name)
@@ -111,7 +111,7 @@ func TestAccFastlyServiceVCL_logging_digitalocean_basic(t *testing.T) {
 	})
 }
 
-func TestAccFastlyServiceVCL_logging_digitalocean_basic_compute(t *testing.T) {
+func TestAccFastlyServiceLoggingDigitalOcean_compute_basic(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	domain := fmt.Sprintf("fastly-test.%s.com", name)

--- a/fastly/block_fastly_service_logging_elasticsearch_test.go
+++ b/fastly/block_fastly_service_logging_elasticsearch_test.go
@@ -14,7 +14,7 @@ import (
 	gofastly "github.com/fastly/go-fastly/v12/fastly"
 )
 
-func TestAccFastlyServiceVCL_logging_elasticsearch_basic(t *testing.T) {
+func TestAccFastlyServiceLoggingElasticsearch_vcl_basic(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	domain := fmt.Sprintf("fastly-test.%s.com", name)
@@ -116,7 +116,7 @@ func TestAccFastlyServiceVCL_logging_elasticsearch_basic(t *testing.T) {
 	})
 }
 
-func TestAccFastlyServiceVCL_logging_elasticsearch_basic_compute(t *testing.T) {
+func TestAccFastlyServiceLoggingElasticsearch_compute_basic(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	domain := fmt.Sprintf("fastly-test.%s.com", name)

--- a/fastly/block_fastly_service_logging_ftp_test.go
+++ b/fastly/block_fastly_service_logging_ftp_test.go
@@ -14,7 +14,7 @@ import (
 	gofastly "github.com/fastly/go-fastly/v12/fastly"
 )
 
-func TestAccFastlyServiceVCL_logging_ftp_basic(t *testing.T) {
+func TestAccFastlyServiceLoggingFTP_vcl_basic(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	domain := fmt.Sprintf("fastly-test.%s.com", name)
@@ -111,7 +111,7 @@ func TestAccFastlyServiceVCL_logging_ftp_basic(t *testing.T) {
 	})
 }
 
-func TestAccFastlyServiceVCL_logging_ftp_basic_compute(t *testing.T) {
+func TestAccFastlyServiceLoggingFTP_compute_basic(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	domain := fmt.Sprintf("fastly-test.%s.com", name)

--- a/fastly/block_fastly_service_logging_gcs_test.go
+++ b/fastly/block_fastly_service_logging_gcs_test.go
@@ -16,7 +16,7 @@ import (
 	gofastly "github.com/fastly/go-fastly/v12/fastly"
 )
 
-func TestAccFastlyServiceVCL_gcslogging_basic(t *testing.T) {
+func TestAccFastlyServiceLoggingGCS_vcl_basic(t *testing.T) {
 	var service gofastly.ServiceDetail
 	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	secretKey, err := generateKey()
@@ -113,7 +113,7 @@ func TestAccFastlyServiceVCL_gcslogging_basic(t *testing.T) {
 	})
 }
 
-func TestAccFastlyServiceVCL_gcslogging_basic_compute(t *testing.T) {
+func TestAccFastlyServiceLoggingGCS_compute_basic(t *testing.T) {
 	var service gofastly.ServiceDetail
 	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	secretKey, err := generateKey()

--- a/fastly/block_fastly_service_logging_googlepubsub_test.go
+++ b/fastly/block_fastly_service_logging_googlepubsub_test.go
@@ -114,7 +114,7 @@ func TestSecretKeySchemaDefaultFunc(t *testing.T) {
 	}
 }
 
-func TestAccFastlyServiceVCL_googlepubsublogging_basic(t *testing.T) {
+func TestAccFastlyServiceLoggingGooglePubSub_vcl_basic(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	domain := fmt.Sprintf("fastly-test.%s.com", name)
@@ -195,7 +195,7 @@ func TestAccFastlyServiceVCL_googlepubsublogging_basic(t *testing.T) {
 	})
 }
 
-func TestAccFastlyServiceVCL_googlepubsublogging_basic_compute(t *testing.T) {
+func TestAccFastlyServiceLoggingGooglePubSub_compute_basic(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	domain := fmt.Sprintf("fastly-test.%s.com", name)

--- a/fastly/block_fastly_service_logging_grafanacloudlogs_test.go
+++ b/fastly/block_fastly_service_logging_grafanacloudlogs_test.go
@@ -14,7 +14,7 @@ import (
 	gofastly "github.com/fastly/go-fastly/v12/fastly"
 )
 
-func TestAccFastlyServiceVCL_logging_grafanacloudlogs_basic(t *testing.T) {
+func TestAccFastlyServiceLoggingGrafanaCloudLogs_vcl_basic(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	domain := fmt.Sprintf("fastly-test.%s.com", name)
@@ -88,7 +88,7 @@ func TestAccFastlyServiceVCL_logging_grafanacloudlogs_basic(t *testing.T) {
 	})
 }
 
-func TestAccFastlyServiceVCL_logging_grafanacloudlogs_basic_compute(t *testing.T) {
+func TestAccFastlyServiceLoggingGrafanaCloudLogs_compute_basic(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	domain := fmt.Sprintf("fastly-test.%s.com", name)

--- a/fastly/block_fastly_service_logging_heroku_test.go
+++ b/fastly/block_fastly_service_logging_heroku_test.go
@@ -14,7 +14,7 @@ import (
 	gofastly "github.com/fastly/go-fastly/v12/fastly"
 )
 
-func TestAccFastlyServiceVCL_logging_heroku_basic(t *testing.T) {
+func TestAccFastlyServiceLoggingHeroku_vcl_basic(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	domain := fmt.Sprintf("fastly-test.%s.com", name)
@@ -83,7 +83,7 @@ func TestAccFastlyServiceVCL_logging_heroku_basic(t *testing.T) {
 	})
 }
 
-func TestAccFastlyServiceVCL_logging_heroku_basic_compute(t *testing.T) {
+func TestAccFastlyServiceLoggingHeroku_compute_basic(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	domain := fmt.Sprintf("fastly-test.%s.com", name)

--- a/fastly/block_fastly_service_logging_honeycomb_test.go
+++ b/fastly/block_fastly_service_logging_honeycomb_test.go
@@ -14,7 +14,7 @@ import (
 	gofastly "github.com/fastly/go-fastly/v12/fastly"
 )
 
-func TestAccFastlyServiceVCL_logging_honeycomb_basic(t *testing.T) {
+func TestAccFastlyServiceLoggingHoneycomb_vcl_basic(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	domain := fmt.Sprintf("fastly-test.%s.com", name)
@@ -84,7 +84,7 @@ func TestAccFastlyServiceVCL_logging_honeycomb_basic(t *testing.T) {
 	})
 }
 
-func TestAccFastlyServiceVCL_logging_honeycomb_basic_compute(t *testing.T) {
+func TestAccFastlyServiceLoggingHoneycomb_compute_basic(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	domain := fmt.Sprintf("fastly-test.%s.com", name)

--- a/fastly/block_fastly_service_logging_https_test.go
+++ b/fastly/block_fastly_service_logging_https_test.go
@@ -14,7 +14,7 @@ import (
 	gofastly "github.com/fastly/go-fastly/v12/fastly"
 )
 
-func TestAccFastlyServiceVCL_httpslogging_basic(t *testing.T) {
+func TestAccFastlyServiceLoggingHTTPS_vcl_basic(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	domain := fmt.Sprintf("fastly-test.%s.com", name)
@@ -180,7 +180,7 @@ func TestAccFastlyServiceVCL_httpslogging_basic(t *testing.T) {
 	})
 }
 
-func TestAccFastlyServiceVCL_httpslogging_basic_compute(t *testing.T) {
+func TestAccFastlyServiceLoggingHTTPS_compute_basic(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	domain := fmt.Sprintf("fastly-test.%s.com", name)

--- a/fastly/block_fastly_service_logging_kafka_test.go
+++ b/fastly/block_fastly_service_logging_kafka_test.go
@@ -80,7 +80,7 @@ func TestResourceFastlyFlattenKafka(t *testing.T) {
 	}
 }
 
-func TestAccFastlyServiceVCL_kafkalogging_basic(t *testing.T) {
+func TestAccFastlyServiceLoggingKafka_vcl_basic(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	domain := fmt.Sprintf("fastly-test.%s.com", name)
@@ -191,7 +191,7 @@ func TestAccFastlyServiceVCL_kafkalogging_basic(t *testing.T) {
 	})
 }
 
-func TestAccFastlyServiceVCL_kafkalogging_basic_compute(t *testing.T) {
+func TestAccFastlyServiceLoggingKafka_compute_basic(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	domain := fmt.Sprintf("fastly-test.%s.com", name)
@@ -236,7 +236,7 @@ func TestAccFastlyServiceVCL_kafkalogging_basic_compute(t *testing.T) {
 	})
 }
 
-func TestAccFastlyServiceVCL_kafkalogging_PreserveBooleansDuringNameChange(t *testing.T) {
+func TestAccFastlyServiceLoggingKafka_vcl_PreserveBooleansDuringNameChange(t *testing.T) {
 	var service gofastly.ServiceDetail
 	serviceName := acctest.RandomWithPrefix("tf-kafka")
 	domainName := fmt.Sprintf("test.%s.com", acctest.RandString(10))

--- a/fastly/block_fastly_service_logging_kinesis_test.go
+++ b/fastly/block_fastly_service_logging_kinesis_test.go
@@ -16,7 +16,7 @@ import (
 
 const testKinesisIAMRole = "arn:aws:iam::123456789012:role/KinesisAccess"
 
-func TestAccFastlyServiceVCL_logging_kinesis_basic(t *testing.T) {
+func TestAccFastlyServiceLoggingKinesis_vcl_basic(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	domain := fmt.Sprintf("fastly-test.%s.com", name)
@@ -93,7 +93,7 @@ func TestAccFastlyServiceVCL_logging_kinesis_basic(t *testing.T) {
 	})
 }
 
-func TestAccFastlyServiceVCL_logging_kinesis_basic_compute(t *testing.T) {
+func TestAccFastlyServiceLoggingKinesis_compute_basic(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	domain := fmt.Sprintf("fastly-test.%s.com", name)

--- a/fastly/block_fastly_service_logging_logentries_test.go
+++ b/fastly/block_fastly_service_logging_logentries_test.go
@@ -14,7 +14,7 @@ import (
 	gofastly "github.com/fastly/go-fastly/v12/fastly"
 )
 
-func TestAccFastlyServiceVCL_logentries_basic(t *testing.T) {
+func TestAccFastlyServiceLoggingLogentries_vcl_basic(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	domainName1 := fmt.Sprintf("fastly-test.tf-%s.com", acctest.RandString(10))
@@ -77,7 +77,7 @@ func TestAccFastlyServiceVCL_logentries_basic(t *testing.T) {
 	})
 }
 
-func TestAccFastlyServiceVCL_logentries_basic_compute(t *testing.T) {
+func TestAccFastlyServiceLoggingLogentries_compute_basic(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	domainName1 := fmt.Sprintf("fastly-test.tf-%s.com", acctest.RandString(10))
@@ -187,7 +187,7 @@ func testAccCheckFastlyServiceVCLLogentriesAttributes(service *gofastly.ServiceD
 	}
 }
 
-func TestAccFastlyServiceVCL_logentries_formatVersion(t *testing.T) {
+func TestAccFastlyServiceLoggingLogentries_vcl_formatVersion(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	domainName1 := fmt.Sprintf("fastly-test.tf-%s.com", acctest.RandString(10))

--- a/fastly/block_fastly_service_logging_loggly_test.go
+++ b/fastly/block_fastly_service_logging_loggly_test.go
@@ -14,7 +14,7 @@ import (
 	gofastly "github.com/fastly/go-fastly/v12/fastly"
 )
 
-func TestAccFastlyServiceVCL_logging_loggly_basic(t *testing.T) {
+func TestAccFastlyServiceLoggingLoggly_vcl_basic(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	domain := fmt.Sprintf("fastly-test.%s.com", name)
@@ -79,7 +79,7 @@ func TestAccFastlyServiceVCL_logging_loggly_basic(t *testing.T) {
 	})
 }
 
-func TestAccFastlyServiceVCL_logging_loggly_basic_compute(t *testing.T) {
+func TestAccFastlyServiceLoggingLoggly_compute_basic(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	domain := fmt.Sprintf("fastly-test.%s.com", name)

--- a/fastly/block_fastly_service_logging_logshuttle_test.go
+++ b/fastly/block_fastly_service_logging_logshuttle_test.go
@@ -14,7 +14,7 @@ import (
 	gofastly "github.com/fastly/go-fastly/v12/fastly"
 )
 
-func TestAccFastlyServiceVCL_logging_logshuttle_basic(t *testing.T) {
+func TestAccFastlyServiceLoggingLogshuttle_vcl_basic(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	domain := fmt.Sprintf("fastly-test.%s.com", name)
@@ -83,7 +83,7 @@ func TestAccFastlyServiceVCL_logging_logshuttle_basic(t *testing.T) {
 	})
 }
 
-func TestAccFastlyServiceVCL_logging_logshuttle_basic_compute(t *testing.T) {
+func TestAccFastlyServiceLoggingLogshuttle_compute_basic(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	domain := fmt.Sprintf("fastly-test.%s.com", name)

--- a/fastly/block_fastly_service_logging_newrelic_test.go
+++ b/fastly/block_fastly_service_logging_newrelic_test.go
@@ -14,7 +14,7 @@ import (
 	gofastly "github.com/fastly/go-fastly/v12/fastly"
 )
 
-func TestAccFastlyServiceVCL_logging_newrelic_basic(t *testing.T) {
+func TestAccFastlyServiceLoggingNewRelic_vcl_basic(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	domain := fmt.Sprintf("fastly-test.%s.com", name)
@@ -83,7 +83,7 @@ func TestAccFastlyServiceVCL_logging_newrelic_basic(t *testing.T) {
 	})
 }
 
-func TestAccFastlyServiceVCL_logging_newrelic_basic_compute(t *testing.T) {
+func TestAccFastlyServiceLoggingNewRelic_compute_basic(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	domain := fmt.Sprintf("fastly-test.%s.com", name)

--- a/fastly/block_fastly_service_logging_newrelicotlp_test.go
+++ b/fastly/block_fastly_service_logging_newrelicotlp_test.go
@@ -14,7 +14,7 @@ import (
 	gofastly "github.com/fastly/go-fastly/v12/fastly"
 )
 
-func TestAccFastlyServiceVCL_logging_newrelicotlp_basic(t *testing.T) {
+func TestAccFastlyServiceLoggingNewRelicOTLP_vcl_basic(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	domain := fmt.Sprintf("fastly-test.%s.com", name)
@@ -204,7 +204,7 @@ resource "fastly_service_vcl" "foo" {
 `, name, domain, format, format)
 }
 
-func TestAccFastlyServiceVCL_logging_newrelicotlp_basic_compute(t *testing.T) {
+func TestAccFastlyServiceLoggingNewRelicOTLP_compute_basic(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	domain := fmt.Sprintf("fastly-test.%s.com", name)

--- a/fastly/block_fastly_service_logging_openstack_test.go
+++ b/fastly/block_fastly_service_logging_openstack_test.go
@@ -14,7 +14,7 @@ import (
 	gofastly "github.com/fastly/go-fastly/v12/fastly"
 )
 
-func TestAccFastlyServiceVCL_logging_openstack_basic(t *testing.T) {
+func TestAccFastlyServiceLoggingOpenStack_vcl_basic(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	domain := fmt.Sprintf("fastly-test.%s.com", name)
@@ -111,7 +111,7 @@ func TestAccFastlyServiceVCL_logging_openstack_basic(t *testing.T) {
 	})
 }
 
-func TestAccFastlyServiceVCL_logging_openstack_basic_compute(t *testing.T) {
+func TestAccFastlyServiceLoggingOpenStack_compute_basic(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	domain := fmt.Sprintf("fastly-test.%s.com", name)

--- a/fastly/block_fastly_service_logging_papertrail_test.go
+++ b/fastly/block_fastly_service_logging_papertrail_test.go
@@ -13,7 +13,7 @@ import (
 	gofastly "github.com/fastly/go-fastly/v12/fastly"
 )
 
-func TestAccFastlyServiceVCL_papertrail_basic(t *testing.T) {
+func TestAccFastlyServiceLoggingPaperTrail_vcl_basic(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	domainName1 := fmt.Sprintf("fastly-test.tf-%s.com", acctest.RandString(10))
@@ -81,7 +81,7 @@ func TestAccFastlyServiceVCL_papertrail_basic(t *testing.T) {
 	})
 }
 
-func TestAccFastlyServiceVCL_papertrail_basic_compute(t *testing.T) {
+func TestAccFastlyServiceLoggingPaperTrail_compute_basic(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	domainName1 := fmt.Sprintf("fastly-test.tf-%s.com", acctest.RandString(10))

--- a/fastly/block_fastly_service_logging_s3_test.go
+++ b/fastly/block_fastly_service_logging_s3_test.go
@@ -23,7 +23,7 @@ const (
 
 const testS3IAMRole = "arn:aws:iam::123456789012:role/S3Access"
 
-func TestAccFastlyServiceVCL_s3logging_basic(t *testing.T) {
+func TestAccFastlyServiceLoggingS3_vcl_basic(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	domainName1 := fmt.Sprintf("fastly-test.tf-%s.com", acctest.RandString(10))
@@ -132,7 +132,7 @@ func TestAccFastlyServiceVCL_s3logging_basic(t *testing.T) {
 	})
 }
 
-func TestAccFastlyServiceVCL_s3logging_basic_compute(t *testing.T) {
+func TestAccFastlyServiceLoggingS3_compute_basic(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	domainName1 := fmt.Sprintf("fastly-test.tf-%s.com", acctest.RandString(10))
@@ -179,7 +179,7 @@ func TestAccFastlyServiceVCL_s3logging_basic_compute(t *testing.T) {
 	})
 }
 
-func TestAccFastlyServiceVCL_s3logging_domain_default(t *testing.T) {
+func TestAccFastlyServiceLoggingS3_vcl_domain_default(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	domainName1 := fmt.Sprintf("fastly-test.tf-%s.com", acctest.RandString(10))

--- a/fastly/block_fastly_service_logging_scalyr_test.go
+++ b/fastly/block_fastly_service_logging_scalyr_test.go
@@ -14,7 +14,7 @@ import (
 	gofastly "github.com/fastly/go-fastly/v12/fastly"
 )
 
-func TestAccFastlyServiceVCL_scalyrlogging_basic(t *testing.T) {
+func TestAccFastlyServiceLoggingScalyr_vcl_basic(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	domain := fmt.Sprintf("fastly-test.%s.com", name)
@@ -86,7 +86,7 @@ func TestAccFastlyServiceVCL_scalyrlogging_basic(t *testing.T) {
 	})
 }
 
-func TestAccFastlyServiceVCL_scalyrlogging_basic_compute(t *testing.T) {
+func TestAccFastlyServiceLoggingScalyr_compute_basic(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	domain := fmt.Sprintf("fastly-test.%s.com", name)

--- a/fastly/block_fastly_service_logging_sftp_test.go
+++ b/fastly/block_fastly_service_logging_sftp_test.go
@@ -15,7 +15,7 @@ import (
 	gofastly "github.com/fastly/go-fastly/v12/fastly"
 )
 
-func TestAccFastlyServiceVCL_logging_sftp_basic(t *testing.T) {
+func TestAccFastlyServiceLoggingSFTP_vcl_basic(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	domain := fmt.Sprintf("fastly-test.%s.com", name)
@@ -118,7 +118,7 @@ func TestAccFastlyServiceVCL_logging_sftp_basic(t *testing.T) {
 	})
 }
 
-func TestAccFastlyServiceVCL_logging_sftp_basic_compute(t *testing.T) {
+func TestAccFastlyServiceLoggingSFTP_compute_basic(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	domain := fmt.Sprintf("fastly-test.%s.com", name)
@@ -162,7 +162,7 @@ func TestAccFastlyServiceVCL_logging_sftp_basic_compute(t *testing.T) {
 	})
 }
 
-func TestAccFastlyServiceVCL_logging_sftp_password_secret_key(t *testing.T) {
+func TestAccFastlyServiceLoggingSFTP_password_secret_vcl_key(t *testing.T) {
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	domain := fmt.Sprintf("fastly-test.%s.com", name)
 

--- a/fastly/block_fastly_service_logging_splunk_test.go
+++ b/fastly/block_fastly_service_logging_splunk_test.go
@@ -16,7 +16,7 @@ import (
 	gofastly "github.com/fastly/go-fastly/v12/fastly"
 )
 
-func TestAccFastlyServiceVCL_splunk_basic(t *testing.T) {
+func TestAccFastlyServiceLoggingSplunk_vcl_basic(t *testing.T) {
 	var service gofastly.ServiceDetail
 	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 
@@ -109,7 +109,7 @@ func TestAccFastlyServiceVCL_splunk_basic(t *testing.T) {
 	})
 }
 
-func TestAccFastlyServiceVCL_splunk_basic_compute(t *testing.T) {
+func TestAccFastlyServiceLoggingSplunk_compute_basic(t *testing.T) {
 	var service gofastly.ServiceDetail
 	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 

--- a/fastly/block_fastly_service_logging_sumologic_test.go
+++ b/fastly/block_fastly_service_logging_sumologic_test.go
@@ -14,7 +14,7 @@ import (
 	gofastly "github.com/fastly/go-fastly/v12/fastly"
 )
 
-func TestAccFastlyServiceVCL_logging_sumologic_basic(t *testing.T) {
+func TestAccFastlyServiceLoggingSumologic_vcl_basic(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	domain := fmt.Sprintf("fastly-test.%s.com", name)
@@ -82,7 +82,7 @@ func TestAccFastlyServiceVCL_logging_sumologic_basic(t *testing.T) {
 	})
 }
 
-func TestAccFastlyServiceVCL_logging_sumologic_basic_compute(t *testing.T) {
+func TestAccFastlyServiceLoggingSumologic_compute_basic(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	domain := fmt.Sprintf("fastly-test.%s.com", name)

--- a/fastly/block_fastly_service_logging_syslog_test.go
+++ b/fastly/block_fastly_service_logging_syslog_test.go
@@ -15,7 +15,7 @@ import (
 	gofastly "github.com/fastly/go-fastly/v12/fastly"
 )
 
-func TestAccFastlyServiceVCL_logging_syslog_basic(t *testing.T) {
+func TestAccFastlyServiceLoggingSyslog_vcl_basic(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	domainName1 := fmt.Sprintf("fastly-test.tf-%s.com", acctest.RandString(10))
@@ -106,7 +106,7 @@ func TestAccFastlyServiceVCL_logging_syslog_basic(t *testing.T) {
 	})
 }
 
-func TestAccFastlyServiceVCL_logging_syslog_basic_compute(t *testing.T) {
+func TestAccFastlyServiceLoggingSyslog_compute_basic(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	domainName1 := fmt.Sprintf("fastly-test.tf-%s.com", acctest.RandString(10))
@@ -148,7 +148,7 @@ func TestAccFastlyServiceVCL_logging_syslog_basic_compute(t *testing.T) {
 
 // This test should not be run in parallel due to its use of schema.EnvDefaultFunc to set/reset environment variables,
 // which conflicts with other running tests.
-func TestAccFastlyServiceVCL_logging_syslog_useTLS(t *testing.T) {
+func TestAccFastlyServiceLoggingSyslog_vcl_useTLS(t *testing.T) {
 	key, cert, err := generateKeyAndCert()
 	if err != nil {
 		t.Errorf("failed to generate key and cert: %s", err)


### PR DESCRIPTION
### Change summary

All of the acceptance test functions for logging blocks had names which started with the resource name, which did not cause a problem when only one type of resource was being tested. Now that both VCL and Compute resources are being tested, the function names have to be    changed to put that detail in the 'flavor' part of the function name.

 All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/terraform-provider-fastly/pulls) for the same update/change?