### PR TITLE
[CDTOOL-1233] ensure proper optional bool behavior in request_setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,12 @@
 ### ENHANCEMENTS:
 
 ### BUG FIXES:
+
 - fix(service/backend): corrected a drift issue caused by the `keepalive_time` attribute ([#1156](https://github.com/fastly/terraform-provider-fastly/pull/1156))
+- fix(request_setting): preserve optional bool fields (`force_miss`, `force_ssl`, `bypass_busy_wait`, `timer_support`) during updates and add acceptance test coverage ([#1165](https://github.com/fastly/terraform-provider-fastly/pull/1165))
 
 ### DEPENDENCIES:
+
 - build(deps): `actions/checkout` from 5 to 6 ([#1159](https://github.com/fastly/terraform-provider-fastly/pull/1159))
 
 ### DOCUMENTATION:
@@ -27,6 +30,7 @@
 - fix(product_enablement): ensure `ddos_protection` mode updates are applied ([#1149](https://github.com/fastly/terraform-provider-fastly/pull/1149))
 
 ### DEPENDENCIES:
+
 - build(deps): `golangci/golangci-lint-action` from 8 to 9 ([#1144](https://github.com/fastly/terraform-provider-fastly/pull/1144))
 - build(deps): `golang.org/x/net` from 0.46.0 to 0.47.0 ([#1150](https://github.com/fastly/terraform-provider-fastly/pull/1150))
 - build(deps): `golangci/golangci-lint-action` from 8 to 9 ([#1144](https://github.com/fastly/terraform-provider-fastly/pull/1144))

--- a/fastly/block_fastly_service_requestsetting.go
+++ b/fastly/block_fastly_service_requestsetting.go
@@ -46,6 +46,7 @@ func (h *RequestSettingServiceAttributeHandler) GetSchema() *schema.Schema {
 				"bypass_busy_wait": {
 					Type:        schema.TypeBool,
 					Optional:    true,
+					Default:     false,
 					Description: "Disable collapsed forwarding, so you don't wait for other objects to origin",
 				},
 				"default_host": {
@@ -56,11 +57,13 @@ func (h *RequestSettingServiceAttributeHandler) GetSchema() *schema.Schema {
 				"force_miss": {
 					Type:        schema.TypeBool,
 					Optional:    true,
+					Default:     false,
 					Description: "Force a cache miss for the request. If specified, can be `true` or `false`",
 				},
 				"force_ssl": {
 					Type:        schema.TypeBool,
 					Optional:    true,
+					Default:     false,
 					Description: "Forces the request to use SSL (Redirects a non-SSL request to SSL)",
 				},
 				"hash_keys": {
@@ -87,6 +90,7 @@ func (h *RequestSettingServiceAttributeHandler) GetSchema() *schema.Schema {
 				"timer_support": {
 					Type:        schema.TypeBool,
 					Optional:    true,
+					Default:     false,
 					Description: "Injects the X-Timer info into the request for viewing origin fetch durations",
 				},
 				"xff": {
@@ -145,12 +149,12 @@ func (h *RequestSettingServiceAttributeHandler) Update(ctx context.Context, d *s
 		Name:           resource["name"].(string),
 	}
 
-	if v, ok := modified["force_miss"]; ok {
-		opts.ForceMiss = gofastly.ToPointer(gofastly.Compatibool(v.(bool)))
-	}
-	if v, ok := modified["force_ssl"]; ok {
-		opts.ForceSSL = gofastly.ToPointer(gofastly.Compatibool(v.(bool)))
-	}
+	// Always preserve optional boolean fields
+	opts.ForceMiss = gofastly.ToPointer(gofastly.Compatibool(resource["force_miss"].(bool)))
+	opts.ForceSSL = gofastly.ToPointer(gofastly.Compatibool(resource["force_ssl"].(bool)))
+	opts.BypassBusyWait = gofastly.ToPointer(gofastly.Compatibool(resource["bypass_busy_wait"].(bool)))
+	opts.TimerSupport = gofastly.ToPointer(gofastly.Compatibool(resource["timer_support"].(bool)))
+
 	if v, ok := modified["action"]; ok {
 		switch strings.ToLower(v.(string)) {
 		case "lookup":
@@ -160,9 +164,6 @@ func (h *RequestSettingServiceAttributeHandler) Update(ctx context.Context, d *s
 		default:
 			opts.Action = gofastly.ToPointer(gofastly.RequestSettingActionUnset)
 		}
-	}
-	if v, ok := modified["bypass_busy_wait"]; ok {
-		opts.BypassBusyWait = gofastly.ToPointer(gofastly.Compatibool(v.(bool)))
 	}
 	if v, ok := modified["max_stale_age"]; ok {
 		opts.MaxStaleAge = gofastly.ToPointer(v.(int))
@@ -183,9 +184,6 @@ func (h *RequestSettingServiceAttributeHandler) Update(ctx context.Context, d *s
 		case "overwrite":
 			opts.XForwardedFor = gofastly.ToPointer(gofastly.RequestSettingXFFOverwrite)
 		}
-	}
-	if v, ok := modified["timer_support"]; ok {
-		opts.TimerSupport = gofastly.ToPointer(gofastly.Compatibool(v.(bool)))
 	}
 	if v, ok := modified["default_host"]; ok {
 		opts.DefaultHost = gofastly.ToPointer(v.(string))


### PR DESCRIPTION
### Change summary

This PR resolves an issue related to the `force_miss`, `force_ssl`, `bypass_busy_wait`, and `timer_support` optional boolean fields in the **`request_setting` block**.

In Terraform, `schema.TypeBool` with `Optional: true` cannot distinguish between an unset value and one explicitly set to `false`. As a result, during updates involving unrelated field changes (e.g., `default_host`), these optional booleans could be omitted from the Fastly API update request — leading to unintended resets or configuration drift.

To prevent this, these optional booleans are now **always included** in the update payload, regardless of whether they’ve changed.

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/terraform-provider-fastly/pulls) for the same update/change?

### Testing

- Added new acceptance test for preserving optional bool values:
```
=== RUN TestAccFastlyServiceVCLRequestSetting_PreserveBooleansDuringUpdate
=== PAUSE TestAccFastlyServiceVCLRequestSetting_PreserveBooleansDuringUpdate
=== CONT TestAccFastlyServiceVCLRequestSetting_PreserveBooleansDuringUpdate
--- PASS: TestAccFastlyServiceVCLRequestSetting_PreserveBooleansDuringUpdate (31.03s)
```

- Verified that existing acceptance tests for `request_setting` continue to pass:
```
=== RUN TestAccFastlyServiceVCLRequestSetting_basic
=== PAUSE TestAccFastlyServiceVCLRequestSetting_basic
=== CONT TestAccFastlyServiceVCLRequestSetting_basic
--- PASS: TestAccFastlyServiceVCLRequestSetting_basic (54.55s)
```