### PR TITLE
[Pull Request Template] Moved 'User Impact' query to a comment instead of checkbox

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -25,7 +25,7 @@ related discussions (e.g. Slack threads, tickets, documents).
 
 ### User Impact
 
-* [ ] What is the user impact of this change?
+<!-- What is the user impact of this change? -->
 
 ### Are there any considerations that need to be addressed for release?
 


### PR DESCRIPTION
### Change summary

This PR updates the Github Pull Request template from: 

<img width="414" height="86" alt="image" src="https://github.com/user-attachments/assets/cbe3ad9e-534a-453c-af83-626ce8ab1c98" />

To:
 
<img width="581" height="95" alt="image" src="https://github.com/user-attachments/assets/b0ad6e1b-617d-4379-a470-0bbe57386b6b" />


 All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/cli/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### User Impact

* [x] What is the user impact of this change?
As you can see, having a checkbox here doesn't make much sense. Moving this clarification to a comment instead is more logical. 
