### PR TITLE
[CDTOOL-1241] Improve `client_identifiers` doc for Rate Limit Rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - build(deps): `actions/checkout` from 5 to 6 ([#1159](https://github.com/fastly/terraform-provider-fastly/pull/1159))
 
 ### DOCUMENTATION:
+- docs(ngwaf/rules): provided examples of client_identifiers types for rate limit rules ([#1169](https://github.com/fastly/terraform-provider-fastly/pull/1169))
 
 ## 8.5.0 (November 20, 2025)
 

--- a/docs/resources/ngwaf_workspace_rule.md
+++ b/docs/resources/ngwaf_workspace_rule.md
@@ -411,7 +411,7 @@ Required:
 
 Required:
 
-- `type` (String) Type of the Client Identifier.
+- `type` (String) Type of the Client Identifier. Accepted values are `ip`, `post_parameter`, `request_cookie`, `request_header`, and `signal_payload`.
 
 Optional:
 

--- a/fastly/resource_fastly_ngwaf_rule.go
+++ b/fastly/resource_fastly_ngwaf_rule.go
@@ -71,7 +71,7 @@ func resourceFastlyNGWAFWorkspaceRule() *schema.Resource {
 							"type": {
 								Type:        schema.TypeString,
 								Required:    true,
-								Description: "Type of the Client Identifier.",
+								Description: "Type of the Client Identifier. Accepted values are `ip`, `post_parameter`, `request_cookie`, `request_header`, and `signal_payload`.",
 							},
 						},
 					},


### PR DESCRIPTION
### Change summary

This PR provides the possible types for the `client_identifiers` field for rate limit rules to the Terraform Provider docs.  

 All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/terraform-provider-fastly/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->