### PR TITLE
Log error response bodies in redactingTransport and make logging testable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### ENHANCEMENTS:
 
 - feat(provider): redact `Fastly-Key` from `TF_LOG=DEBUG` output ([#1167](https://github.com/fastly/terraform-provider-fastly/pull/1167))
+- feat(provider): log response body for HTTP error responses (≥400) in `TF_LOG=DEBUG` output ([#1170](https://github.com/fastly/terraform-provider-fastly/pull/1170))
 
 ### BUG FIXES:
 
@@ -12,11 +13,13 @@
 - fix(request_setting): preserve optional bool fields (`force_miss`, `force_ssl`, `bypass_busy_wait`, `timer_support`) during updates and add acceptance test coverage ([#1165](https://github.com/fastly/terraform-provider-fastly/pull/1165))
 
 ### DEPENDENCIES:
+
 - build(deps): `actions/checkout` from 5 to 6 ([#1159](https://github.com/fastly/terraform-provider-fastly/pull/1159))
 - build(deps): `golang.org/x/net` from 0.47.0 to 0.48.0 ([#1166](https://github.com/fastly/terraform-provider-fastly/pull/1166))
 - build(deps): `actions/checkout` from 5 to 6 ([#1159](https://github.com/fastly/terraform-provider-fastly/pull/1159))
 
 ### DOCUMENTATION:
+
 - docs(ngwaf/rules): provided examples of client_identifiers types for rate limit rules ([#1169](https://github.com/fastly/terraform-provider-fastly/pull/1169))
 
 ## 8.5.0 (November 20, 2025)

--- a/fastly/redacting_transport_test.go
+++ b/fastly/redacting_transport_test.go
@@ -1,6 +1,14 @@
 package fastly
 
-import "testing"
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
 
 func TestShouldRedact(t *testing.T) {
 	rt := redactingTransport{
@@ -21,5 +29,83 @@ func TestShouldRedact(t *testing.T) {
 		if result != test.expected {
 			t.Errorf("expected redaction for %s to be %v, got %v", test.header, test.expected, result)
 		}
+	}
+}
+
+func TestRedactingTransport_ResponseBodyLogging(t *testing.T) {
+	tests := []struct {
+		name          string
+		statusCode    int
+		expectLogged  bool
+		expectedInLog string
+	}{
+		{
+			name:         "200 OK does not log response body",
+			statusCode:   http.StatusOK,
+			expectLogged: false,
+		},
+		{
+			name:          "400 Bad Request logs response body",
+			statusCode:    http.StatusBadRequest,
+			expectLogged:  true,
+			expectedInLog: "error: bad request",
+		},
+		{
+			name:          "500 Internal Server Error logs response body",
+			statusCode:    http.StatusInternalServerError,
+			expectLogged:  true,
+			expectedInLog: "error: internal server error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var logBuf bytes.Buffer
+			ctx := context.Background()
+
+			// Simulated body content
+			body := tt.expectedInLog
+			if body == "" {
+				body = "ok"
+			}
+
+			// Set up mock HTTP server
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tt.statusCode)
+				_, _ = w.Write([]byte(body))
+			}))
+			defer ts.Close()
+
+			// Create transport with injected logger
+			rt := &redactingTransport{
+				ctx:        ctx,
+				name:       "Fastly",
+				underlying: http.DefaultTransport,
+				redactKeys: []string{"Fastly-Key"},
+				logf: func(_ context.Context, msg string) {
+					logBuf.WriteString(msg + "\n")
+				},
+			}
+
+			client := &http.Client{Transport: rt}
+			resp, err := client.Get(ts.URL)
+			if err != nil {
+				t.Fatalf("request failed: %v", err)
+			}
+			defer resp.Body.Close()
+			_, _ = io.ReadAll(resp.Body)
+
+			logOutput := logBuf.String()
+
+			if tt.expectLogged {
+				if !strings.Contains(logOutput, tt.expectedInLog) {
+					t.Errorf("expected log to contain %q, but it did not.\nFull log output:\n%s", tt.expectedInLog, logOutput)
+				}
+			} else {
+				if strings.Contains(logOutput, body) {
+					t.Errorf("did not expect log to contain %q, but it was found.\nFull log output:\n%s", body, logOutput)
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION
### Change summary

This PR improves observability of API interactions by ensuring that response bodies for HTTP errors (status ≥ 400) are logged by the `redactingTransport`.

- Refactored `redactingTransport` to allow injection of custom logging via an optional `logf` function.
- Updated `RoundTrip()` to log the response body (up to 300 chars) when status is ≥ 400.
- Wrote focused tests (`TestRedactingTransport_ResponseBodyLogging`) to verify logging behavior for 200, 400, and 500 status codes without relying on `tflog`.
- Preserved compatibility with the Terraform SDK framework (`terraform-plugin-sdk/v2`) — no dependency on the Plugin Framework.

### Review Notes

Terraform Plugin SDK (`terraform-plugin-sdk/v2`) does not provide test hooks for `tflog` out of the box (unlike the newer Plugin Framework), making it hard to test log output directly. 

Instead of trying to extract logs from `tflog`, this PR injects a logger for test purposes only, preserving production behavior while enabling fine-grained assertions in unit tests.

### Example log output

```
2025-12-15T11:34:10.077-0500 [DEBUG] provider.terraform-provider-fastly_v8.5.0-13-g1da19cd5: Fastly <-- 404 Not Found: tf_provider_addr=provider tf_req_id=14ac201a-efd3-f711-adb8-ab00479deb8e tf_rpc=Configure @caller=/home/philipp/src/fastly/terraform-provider-fastly/fastly/redacting_transport.go:27 @module=provider timestamp=2025-12-15T11:34:10.077-0500
2025-12-15T11:34:10.077-0500 [DEBUG] provider.terraform-provider-fastly_v8.5.0-13-g1da19cd5: Fastly Response Header: X-Served-By: cache-chi-klot8100143-CHI: tf_provider_addr=provider tf_req_id=14ac201a-efd3-f711-adb8-ab00479deb8e tf_rpc=Configure @caller=/home/philipp/src/fastly/terraform-provider-fastly/fastly/redacting_transport.go:27 @module=provider timestamp=2025-12-15T11:34:10.077-0500
2025-12-15T11:34:10.077-0500 [DEBUG] provider.terraform-provider-fastly_v8.5.0-13-g1da19cd5: Fastly Response Header: Vary: Accept-Encoding: @module=provider tf_provider_addr=provider tf_req_id=14ac201a-efd3-f711-adb8-ab00479deb8e tf_rpc=Configure @caller=/home/philipp/src/fastly/terraform-provider-fastly/fastly/redacting_transport.go:27 timestamp=2025-12-15T11:34:10.077-0500
2025-12-15T11:34:10.077-0500 [DEBUG] provider.terraform-provider-fastly_v8.5.0-13-g1da19cd5: Fastly Response Header: Pragma: no-cache: @caller=/home/philipp/src/fastly/terraform-provider-fastly/fastly/redacting_transport.go:27 @module=provider tf_provider_addr=provider tf_req_id=14ac201a-efd3-f711-adb8-ab00479deb8e tf_rpc=Configure timestamp=2025-12-15T11:34:10.077-0500
2025-12-15T11:34:10.077-0500 [DEBUG] provider.terraform-provider-fastly_v8.5.0-13-g1da19cd5: Fastly Response Header: Content-Type: application/json: tf_provider_addr=provider tf_req_id=14ac201a-efd3-f711-adb8-ab00479deb8e tf_rpc=Configure @caller=/home/philipp/src/fastly/terraform-provider-fastly/fastly/redacting_transport.go:27 @module=provider timestamp=2025-12-15T11:34:10.077-0500
2025-12-15T11:34:10.077-0500 [DEBUG] provider.terraform-provider-fastly_v8.5.0-13-g1da19cd5: Fastly Response Header: Status: 404 Not Found: tf_provider_addr=provider tf_req_id=14ac201a-efd3-f711-adb8-ab00479deb8e tf_rpc=Configure @caller=/home/philipp/src/fastly/terraform-provider-fastly/fastly/redacting_transport.go:27 @module=provider timestamp=2025-12-15T11:34:10.077-0500
2025-12-15T11:34:10.077-0500 [DEBUG] provider.terraform-provider-fastly_v8.5.0-13-g1da19cd5: Fastly Response Header: Accept-Ranges: bytes: tf_req_id=14ac201a-efd3-f711-adb8-ab00479deb8e tf_rpc=Configure @caller=/home/philipp/src/fastly/terraform-provider-fastly/fastly/redacting_transport.go:27 @module=provider tf_provider_addr=provider timestamp=2025-12-15T11:34:10.077-0500
2025-12-15T11:34:10.077-0500 [DEBUG] provider.terraform-provider-fastly_v8.5.0-13-g1da19cd5: Fastly Response Header: Age: 0: @module=provider tf_provider_addr=provider tf_req_id=14ac201a-efd3-f711-adb8-ab00479deb8e tf_rpc=Configure @caller=/home/philipp/src/fastly/terraform-provider-fastly/fastly/redacting_transport.go:27 timestamp=2025-12-15T11:34:10.077-0500
2025-12-15T11:34:10.077-0500 [DEBUG] provider.terraform-provider-fastly_v8.5.0-13-g1da19cd5: Fastly Response Header: Via: 1.1 varnish: tf_req_id=14ac201a-efd3-f711-adb8-ab00479deb8e tf_rpc=Configure @caller=/home/philipp/src/fastly/terraform-provider-fastly/fastly/redacting_transport.go:27 @module=provider tf_provider_addr=provider timestamp=2025-12-15T11:34:10.077-0500
2025-12-15T11:34:10.077-0500 [DEBUG] provider.terraform-provider-fastly_v8.5.0-13-g1da19cd5: Fastly Response Header: X-Cache: MISS: tf_provider_addr=provider tf_req_id=14ac201a-efd3-f711-adb8-ab00479deb8e tf_rpc=Configure @caller=/home/philipp/src/fastly/terraform-provider-fastly/fastly/redacting_transport.go:27 @module=provider timestamp=2025-12-15T11:34:10.077-0500
2025-12-15T11:34:10.077-0500 [DEBUG] provider.terraform-provider-fastly_v8.5.0-13-g1da19cd5: Fastly Response Header: X-Timer: S1765816450.031329,VS0,VE91: tf_req_id=14ac201a-efd3-f711-adb8-ab00479deb8e tf_rpc=Configure @caller=/home/philipp/src/fastly/terraform-provider-fastly/fastly/redacting_transport.go:27 @module=provider tf_provider_addr=provider timestamp=2025-12-15T11:34:10.077-0500
2025-12-15T11:34:10.077-0500 [DEBUG] provider.terraform-provider-fastly_v8.5.0-13-g1da19cd5: Fastly Response Header: Cache-Control: no-store: @module=provider tf_provider_addr=provider tf_req_id=14ac201a-efd3-f711-adb8-ab00479deb8e tf_rpc=Configure @caller=/home/philipp/src/fastly/terraform-provider-fastly/fastly/redacting_transport.go:27 timestamp=2025-12-15T11:34:10.077-0500
2025-12-15T11:34:10.077-0500 [DEBUG] provider.terraform-provider-fastly_v8.5.0-13-g1da19cd5: Fastly Response Header: X-Cache-Hits: 0: tf_provider_addr=provider tf_req_id=14ac201a-efd3-f711-adb8-ab00479deb8e tf_rpc=Configure @caller=/home/philipp/src/fastly/terraform-provider-fastly/fastly/redacting_transport.go:27 @module=provider timestamp=2025-12-15T11:34:10.077-0500
2025-12-15T11:34:10.077-0500 [DEBUG] provider.terraform-provider-fastly_v8.5.0-13-g1da19cd5: Fastly Response Header: Server: fastly: @module=provider tf_provider_addr=provider tf_req_id=14ac201a-efd3-f711-adb8-ab00479deb8e tf_rpc=Configure @caller=/home/philipp/src/fastly/terraform-provider-fastly/fastly/redacting_transport.go:27 timestamp=2025-12-15T11:34:10.077-0500
2025-12-15T11:34:10.077-0500 [DEBUG] provider.terraform-provider-fastly_v8.5.0-13-g1da19cd5: Fastly Response Header: Date: Mon, 15 Dec 2025 16:34:10 GMT: tf_provider_addr=provider tf_req_id=14ac201a-efd3-f711-adb8-ab00479deb8e tf_rpc=Configure @caller=/home/philipp/src/fastly/terraform-provider-fastly/fastly/redacting_transport.go:27 @module=provider timestamp=2025-12-15T11:34:10.077-0500
2025-12-15T11:34:10.077-0500 [DEBUG] provider.terraform-provider-fastly_v8.5.0-13-g1da19cd5: Fastly Response Header: Strict-Transport-Security: max-age=31536000: tf_req_id=14ac201a-efd3-f711-adb8-ab00479deb8e tf_rpc=Configure @caller=/home/philipp/src/fastly/terraform-provider-fastly/fastly/redacting_transport.go:27 @module=provider tf_provider_addr=provider timestamp=2025-12-15T11:34:10.077-0500
2025-12-15T11:34:10.077-0500 [DEBUG] provider.terraform-provider-fastly_v8.5.0-13-g1da19cd5: Fastly Response Body: {"msg":"Not found"}: tf_provider_addr=provider tf_req_id=14ac201a-efd3-f711-adb8-ab00479deb8e tf_rpc=Configure @caller=/home/philipp/src/fastly/terraform-provider-fastly/fastly/redacting_transport.go:27 @module=provider timestamp=2025-12-15T11:34:10.077-0500
```

 ### All Submissions

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/terraform-provider-fastly/pulls) for the same update/change?

### New Feature Submissions

* [x] Does your submission pass tests?

```
=== RUN   TestShouldRedact
--- PASS: TestShouldRedact (0.00s)
```

```
=== RUN   TestRedactingTransport_ResponseBodyLogging
=== RUN   TestRedactingTransport_ResponseBodyLogging/200_OK_does_not_log_response_body
=== RUN   TestRedactingTransport_ResponseBodyLogging/400_Bad_Request_logs_response_body
=== RUN   TestRedactingTransport_ResponseBodyLogging/500_Internal_Server_Error_logs_response_body
--- PASS: TestRedactingTransport_ResponseBodyLogging (0.00s)
    --- PASS: TestRedactingTransport_ResponseBodyLogging/200_OK_does_not_log_response_body (0.00s)
    --- PASS: TestRedactingTransport_ResponseBodyLogging/400_Bad_Request_logs_response_body (0.00s)
    --- PASS: TestRedactingTransport_ResponseBodyLogging/500_Internal_Server_Error_logs_response_body (0.00s)
```


