### PR TITLE
[CDTOOL-854] Clarify Bigquery `account_name` field docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 ### DOCUMENTATION:
 
 - docs(ngwaf/rules): provided examples of client_identifiers types for rate limit rules ([#1169](https://github.com/fastly/terraform-provider-fastly/pull/1169))
+- docs(logging/bigquery): updates the details of the `account_name` field to match API requirements ([#1171](https://github.com/fastly/terraform-provider-fastly/pull/1171))
 
 ## 8.5.0 (November 20, 2025)
 

--- a/docs/resources/service_compute.md
+++ b/docs/resources/service_compute.md
@@ -275,7 +275,7 @@ Required:
 
 Optional:
 
-- `account_name` (String) The google account name used to obtain temporary credentials (default none). You may optionally provide this via an environment variable, `FASTLY_GCS_ACCOUNT_NAME`.
+- `account_name` (String) The google account name used to obtain temporary credentials (default none). Not required if 'email' and 'secret_key' are provided. You may optionally provide this via an environment variable, `FASTLY_GCS_ACCOUNT_NAME`.
 - `email` (String, Sensitive) The email for the service account with write access to your BigQuery dataset. If not provided, this will be pulled from a `FASTLY_BQ_EMAIL` environment variable
 - `processing_region` (String) Region where logs will be processed before streaming to BigQuery. Valid values are 'none', 'us' and 'eu'.
 - `secret_key` (String, Sensitive) The secret key associated with the service account that has write access to your BigQuery table. If not provided, this will be pulled from the `FASTLY_BQ_SECRET_KEY` environment variable. Typical format for this is a private key in a string with newlines

--- a/docs/resources/service_vcl.md
+++ b/docs/resources/service_vcl.md
@@ -527,7 +527,7 @@ Required:
 
 Optional:
 
-- `account_name` (String) The google account name used to obtain temporary credentials (default none). You may optionally provide this via an environment variable, `FASTLY_GCS_ACCOUNT_NAME`.
+- `account_name` (String) The google account name used to obtain temporary credentials (default none). Not required if 'email' and 'secret_key' are provided. You may optionally provide this via an environment variable, `FASTLY_GCS_ACCOUNT_NAME`.
 - `email` (String, Sensitive) The email for the service account with write access to your BigQuery dataset. If not provided, this will be pulled from a `FASTLY_BQ_EMAIL` environment variable
 - `format` (String) The logging format desired.
 - `placement` (String) Where in the generated VCL the logging call should be placed.

--- a/fastly/block_fastly_service_logging_bigquery.go
+++ b/fastly/block_fastly_service_logging_bigquery.go
@@ -38,7 +38,7 @@ func (h *BigQueryLoggingServiceAttributeHandler) GetSchema() *schema.Schema {
 			Type:        schema.TypeString,
 			Optional:    true,
 			DefaultFunc: schema.EnvDefaultFunc("FASTLY_GCS_ACCOUNT_NAME", ""),
-			Description: "The google account name used to obtain temporary credentials (default none). You may optionally provide this via an environment variable, `FASTLY_GCS_ACCOUNT_NAME`.",
+			Description: "The google account name used to obtain temporary credentials (default none). Not required if 'email' and 'secret_key' are provided. You may optionally provide this via an environment variable, `FASTLY_GCS_ACCOUNT_NAME`.",
 		},
 		"dataset": {
 			Type:        schema.TypeString,


### PR DESCRIPTION
### Change summary

This PR adds clarification to the `account_name` field for BigQuery logging, specifying that this field is only optional in a specific scenario. This update now ensures that the Terraform docs  correctly match the [API docs](https://www.fastly.com/documentation/reference/api/logging/bigquery/). 

 All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/terraform-provider-fastly/pulls) for the same update/change?
