### PR TITLE
[CDTOOL-1245] Support for Domain Inspector on Compute Services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### BREAKING:
 
 ### ENHANCEMENTS:
+- feat(product_enablement): Adding support for the `domain_inspector` feature to Compute services ([#1175](https://github.com/fastly/terraform-provider-fastly/pull/1175))
 
 ### BUG FIXES:
 

--- a/docs/resources/service_compute.md
+++ b/docs/resources/service_compute.md
@@ -818,6 +818,7 @@ Optional:
 
 - `api_discovery` (Boolean) Enable API Discovery support
 - `ddos_protection` (Block List, Max: 1) DDoS Protection product (see [below for nested schema](#nestedblock--product_enablement--ddos_protection))
+- `domain_inspector` (Boolean) Enable Domain Inspector support
 - `fanout` (Boolean) Enable Fanout support
 - `log_explorer_insights` (Boolean) Enable Log Explorer & Insights
 - `name` (String) Used by the provider to identify modified settings (changing this value will force the entire block to be deleted, then recreated)

--- a/fastly/block_fastly_service_product_enablement_test.go
+++ b/fastly/block_fastly_service_product_enablement_test.go
@@ -344,10 +344,6 @@ resource "fastly_service_compute" "foo" {
 					resource.TestCheckResourceAttr("fastly_service_compute.foo", "name", serviceName),
 					resource.TestCheckResourceAttr("fastly_service_compute.foo", "product_enablement.0.domain_inspector", "true"),
 				),
-				// Added this flag temporarily until upstream changes
-				// are corrected that are causing hash drifts.
-				// ref: https://fastly.atlassian.net/browse/CDTOOL-1226
-				ExpectNonEmptyPlan: true,
 			},
 		},
 	})

--- a/fastly/block_fastly_service_product_enablement_test.go
+++ b/fastly/block_fastly_service_product_enablement_test.go
@@ -10,7 +10,7 @@ import (
 	gofastly "github.com/fastly/go-fastly/v12/fastly"
 )
 
-func TestAccFastlyServiceVCLProductEnablement_basic(t *testing.T) {
+func TestAccFastlyServiceProductEnablement_vcl_basic(t *testing.T) {
 	var service gofastly.ServiceDetail
 	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	domainName := fmt.Sprintf("fastly-test.tf-%s.com", acctest.RandString(10))
@@ -106,7 +106,7 @@ func TestAccFastlyServiceVCLProductEnablement_basic(t *testing.T) {
 	})
 }
 
-func TestAccFastlyServiceVCLProductEnablement_ddosProtectionModeChange(t *testing.T) {
+func TestAccFastlyServiceProductEnablement_vcl_ddosProtectionModeChange(t *testing.T) {
 	var service gofastly.ServiceDetail
 	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	domainName := fmt.Sprintf("fastly-test.tf-%s.com", acctest.RandString(10))
@@ -190,7 +190,7 @@ resource "fastly_service_vcl" "foo" {
 	})
 }
 
-func TestAccFastlyServiceVCLProductEnablement_ngwafUpdate(t *testing.T) {
+func TestAccFastlyServiceProductEnablement_vcl_ngwafUpdate(t *testing.T) {
 	var service gofastly.ServiceDetail
 	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	domainName := fmt.Sprintf("fastly-test.tf-%s.com", acctest.RandString(10))
@@ -273,6 +273,81 @@ resource "fastly_service_vcl" "foo" {
 					resource.TestCheckResourceAttr("fastly_service_vcl.foo", "product_enablement.0.ngwaf.0.workspace_id", "Jf4Vo9RXd00MdTYJ44xY12"),
 					resource.TestCheckResourceAttr("fastly_service_vcl.foo", "product_enablement.0.ngwaf.0.traffic_ramp", "80"),
 				),
+			},
+		},
+	})
+}
+
+func TestAccFastlyServiceProductEnablement_compute_basic(t *testing.T) {
+	var service gofastly.ServiceDetail
+	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	domainName := fmt.Sprintf("fastly-test.tf-%s.com", acctest.RandString(10))
+
+	config := fmt.Sprintf(`
+data "fastly_package_hash" "example" {
+  filename = "./test_fixtures/package/valid.tar.gz"
+}
+
+resource "fastly_service_compute" "foo" {
+  name = "%s"
+
+  domain {
+    name    = "%s"
+    comment = "demo"
+  }
+
+  backend {
+    address = "httpbin.org"
+    name    = "httpbin"
+  }
+
+  product_enablement {
+    api_discovery         = false
+    domain_inspector      = true
+    fanout                = false
+    log_explorer_insights = false
+    websockets            = false
+
+    ddos_protection {
+      enabled = false
+      mode    = "block"
+    }
+
+    ngwaf {
+      enabled      = false
+      workspace_id = "7JFbo4RNA0OKdFWC04r6B3"
+      traffic_ramp = 100
+    }
+  }
+
+  package {
+    filename = "test_fixtures/package/valid.tar.gz"
+    source_code_hash = data.fastly_package_hash.example.hash
+  }
+
+  force_destroy = true
+  activate = false
+}
+`, serviceName, domainName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckServiceComputeDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceExists("fastly_service_compute.foo", &service),
+					resource.TestCheckResourceAttr("fastly_service_compute.foo", "name", serviceName),
+					resource.TestCheckResourceAttr("fastly_service_compute.foo", "product_enablement.0.domain_inspector", "true"),
+				),
+				// Added this flag temporarily until upstream changes
+				// are corrected that are causing hash drifts.
+				// ref: https://fastly.atlassian.net/browse/CDTOOL-1226
+				ExpectNonEmptyPlan: true,
 			},
 		},
 	})


### PR DESCRIPTION
### Change summary

This PR adds support for the Domain Inspector Product Enablement feature to Compute services. 

 All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/terraform-provider-fastly/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

* [x] Does your submission pass tests?
* [x] Post the output of your test runs

```
=== RUN   TestAccFastlyServiceProductEnablement_compute_basic
=== PAUSE TestAccFastlyServiceProductEnablement_compute_basic
=== CONT  TestAccFastlyServiceProductEnablement_compute_basic
--- PASS: TestAccFastlyServiceProductEnablement_compute_basic (13.53s)
PASS
```

### Changes to Core Features:

* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?