### PR TITLE
object_storage_access_key: properly set access_key_id

### DIFF
--- a/fastly/resource_fastly_object_storage_access_key.go
+++ b/fastly/resource_fastly_object_storage_access_key.go
@@ -131,7 +131,7 @@ func resourceObjectStorageAccessKeyRead(ctx context.Context, resourceData *schem
 		}
 	}
 	if readAK.AccessKeyID != "" {
-		err = resourceData.Set("access_key_id", readAK.SecretKey)
+		err = resourceData.Set("access_key_id", readAK.AccessKeyID)
 		if err != nil {
 			return diag.FromErr(err)
 		}


### PR DESCRIPTION
### Change summary

`access_key_id` was being set using the secret key instead of the key identifier.

 All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/terraform-provider-fastly/pulls) for the same update/change?

* [ ] Have you written new tests for your core changes, as applicable?
* [X] Have you successfully run tests with your changes locally?

### User Impact

The key identifier is now properly  returned.


