### PR TITLE
[CDTOOL-1278] Add guide for setting up a new delivery service with a versionless domain and TLS subscription using Certainly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### DOCUMENTATION:
 
 - docs(templates/guides): add a guide for adding a versionless domain to a service using a wildcard tls subscription ([#1194](https://github.com/fastly/terraform-provider-fastly/pull/1194))
+- docs(templates/guides): add a guide for using versionless domains with a Certainly subscription to a new devlivery service ([#1195](https://github.com/fastly/terraform-provider-fastly/pull/1195))
 
 ## 8.7.0 (February 20, 2026)
 

--- a/docs/guides/versionless_domain_with_certainly_subscription.md
+++ b/docs/guides/versionless_domain_with_certainly_subscription.md
@@ -1,0 +1,110 @@
+---
+page_title: Delivery service with a versionless domain and TLS subscription using Certainly
+subcategory: "Guides"
+---
+
+## Creating a Delivery Service with a Certainly TLS Subscription using a versionless domain
+
+The following guide examplifies how to use versionless domains with a Certainly subscription to link to a new delivery service. 
+
+```
+terraform {
+  required_providers {
+    fastly = {
+      source  = "fastly/fastly"
+    }
+  }
+}
+
+provider "fastly" {
+  api_key = "userKey"
+}
+
+resource "fastly_service_vcl" "example_delivery_service" {
+  name = "tls-service-2"
+
+  backend {
+    address = "127.0.0.1"
+    name    = "localhost"
+  }
+
+  force_destroy = true
+}
+
+resource "fastly_domain" "domain_example" {
+  description = "My Fastly example domain"
+  fqdn        = "fastly.example.com"
+  service_id  = fastly_service_vcl.example_delivery_service.id
+}
+
+
+resource "fastly_tls_subscription" "subscription" {
+  domains               = [fastly_domain.domain_example.fqdn]
+  certificate_authority = "certainly"
+  
+  // The 'depends_on' attribute ensures the order of 
+  // operations for domain management is maintained
+  depends_on = [fastly_domain.domain_example]
+}
+
+```
+
+
+## Creating a Delivery Service with a Certainly TLS Subscription for bulk domains
+
+The following guide provides an example of how to bulk manage domains through a Certainly subscription. 
+
+```
+terraform {
+  required_providers {
+    fastly = {
+      source  = "fastly/fastly"
+    }
+  }
+}
+
+provider "fastly" {
+  api_key = "userKey"
+}
+
+locals {
+  subdomains = [
+    "dev.fastly.example.com",
+    "nonprod.fastly.example.com",
+    "prod.fastly.example.com",
+    "staging.fastly.example.com",
+    "staging2.fastly.example.com",
+    "staging3.fastly.example.com"
+  ]
+}
+
+resource "fastly_service_vcl" "bulk_example_delivery_service" {
+  name = "tls-service-2"
+
+  backend {
+    address = "127.0.0.1"
+    name    = "localhost"
+  }
+
+  force_destroy = true
+}
+
+resource "fastly_domain" "bulk_domains" {
+    for_each = toset(local.subdomains)
+
+    description = "Bulk managed Fastly domain"
+    fqdn        = each.value
+    service_id  = fastly_service_vcl.bulk_example_delivery_service.id
+}
+
+resource "fastly_tls_subscription" "subscription" {
+    domains               = local.subdomains
+    certificate_authority = "certainly"
+
+    // The 'depends_on' attribute ensures the order of 
+    // operations for domain management is maintained
+    depends_on = [fastly_domain.bulk_domains]
+}
+
+```
+

--- a/docs/guides/versionless_domain_with_certainly_subscription.md
+++ b/docs/guides/versionless_domain_with_certainly_subscription.md
@@ -5,7 +5,7 @@ subcategory: "Guides"
 
 ## Creating a Delivery Service with a Certainly TLS Subscription using a versionless domain
 
-The following guide examplifies how to use versionless domains with a Certainly subscription to link to a new delivery service. 
+The following guide exemplifies how to use versionless domains with a Certainly subscription to link to a new delivery service. 
 
 ```
 terraform {
@@ -42,8 +42,8 @@ resource "fastly_tls_subscription" "subscription" {
   domains               = [fastly_domain.domain_example.fqdn]
   certificate_authority = "certainly"
   
-  // The 'depends_on' attribute ensures the order of 
-  // operations for domain management is maintained
+  // The 'depends_on' attribute ensures that the 
+  // TLS subscription is created after the domain.
   depends_on = [fastly_domain.domain_example]
 }
 
@@ -101,8 +101,8 @@ resource "fastly_tls_subscription" "subscription" {
     domains               = local.subdomains
     certificate_authority = "certainly"
 
-    // The 'depends_on' attribute ensures the order of 
-    // operations for domain management is maintained
+    // The 'depends_on' attribute ensures that the 
+    // TLS subscription is created after the domain.
     depends_on = [fastly_domain.bulk_domains]
 }
 

--- a/templates/guides/versionless_domain_with_certainly_subscription.md
+++ b/templates/guides/versionless_domain_with_certainly_subscription.md
@@ -1,0 +1,110 @@
+---
+page_title: Delivery service with a versionless domain and TLS subscription using Certainly
+subcategory: "Guides"
+---
+
+## Creating a Delivery Service with a Certainly TLS Subscription using a versionless domain
+
+The following guide examplifies how to use versionless domains with a Certainly subscription to link to a new delivery service. 
+
+```
+terraform {
+  required_providers {
+    fastly = {
+      source  = "fastly/fastly"
+    }
+  }
+}
+
+provider "fastly" {
+  api_key = "userKey"
+}
+
+resource "fastly_service_vcl" "example_delivery_service" {
+  name = "tls-service-2"
+
+  backend {
+    address = "127.0.0.1"
+    name    = "localhost"
+  }
+
+  force_destroy = true
+}
+
+resource "fastly_domain" "domain_example" {
+  description = "My Fastly example domain"
+  fqdn        = "fastly.example.com"
+  service_id  = fastly_service_vcl.example_delivery_service.id
+}
+
+
+resource "fastly_tls_subscription" "subscription" {
+  domains               = [fastly_domain.domain_example.fqdn]
+  certificate_authority = "certainly"
+  
+  // The 'depends_on' attribute ensures the order of 
+  // operations for domain management is maintained
+  depends_on = [fastly_domain.domain_example]
+}
+
+```
+
+
+## Creating a Delivery Service with a Certainly TLS Subscription for bulk domains
+
+The following guide provides an example of how to bulk manage domains through a Certainly subscription. 
+
+```
+terraform {
+  required_providers {
+    fastly = {
+      source  = "fastly/fastly"
+    }
+  }
+}
+
+provider "fastly" {
+  api_key = "userKey"
+}
+
+locals {
+  subdomains = [
+    "dev.fastly.example.com",
+    "nonprod.fastly.example.com",
+    "prod.fastly.example.com",
+    "staging.fastly.example.com",
+    "staging2.fastly.example.com",
+    "staging3.fastly.example.com"
+  ]
+}
+
+resource "fastly_service_vcl" "bulk_example_delivery_service" {
+  name = "tls-service-2"
+
+  backend {
+    address = "127.0.0.1"
+    name    = "localhost"
+  }
+
+  force_destroy = true
+}
+
+resource "fastly_domain" "bulk_domains" {
+    for_each = toset(local.subdomains)
+
+    description = "Bulk managed Fastly domain"
+    fqdn        = each.value
+    service_id  = fastly_service_vcl.bulk_example_delivery_service.id
+}
+
+resource "fastly_tls_subscription" "subscription" {
+    domains               = local.subdomains
+    certificate_authority = "certainly"
+
+    // The 'depends_on' attribute ensures the order of 
+    // operations for domain management is maintained
+    depends_on = [fastly_domain.bulk_domains]
+}
+
+```
+

--- a/templates/guides/versionless_domain_with_certainly_subscription.md
+++ b/templates/guides/versionless_domain_with_certainly_subscription.md
@@ -5,7 +5,7 @@ subcategory: "Guides"
 
 ## Creating a Delivery Service with a Certainly TLS Subscription using a versionless domain
 
-The following guide examplifies how to use versionless domains with a Certainly subscription to link to a new delivery service. 
+The following guide exemplifies how to use versionless domains with a Certainly subscription to link to a new delivery service. 
 
 ```
 terraform {
@@ -42,8 +42,8 @@ resource "fastly_tls_subscription" "subscription" {
   domains               = [fastly_domain.domain_example.fqdn]
   certificate_authority = "certainly"
   
-  // The 'depends_on' attribute ensures the order of 
-  // operations for domain management is maintained
+  // The 'depends_on' attribute ensures that the 
+  // TLS subscription is created after the domain.
   depends_on = [fastly_domain.domain_example]
 }
 
@@ -101,8 +101,8 @@ resource "fastly_tls_subscription" "subscription" {
     domains               = local.subdomains
     certificate_authority = "certainly"
 
-    // The 'depends_on' attribute ensures the order of 
-    // operations for domain management is maintained
+    // The 'depends_on' attribute ensures that the 
+    // TLS subscription is created after the domain.
     depends_on = [fastly_domain.bulk_domains]
 }
 


### PR DESCRIPTION
### Change summary

This PR adds a guide for setting up a new delivery service with versionless domains and TLS subscription using Certainly. 
