### PR TITLE
Add guide for migrating delivery service classic domain to a versionless domain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - docs(templates/guides): add a guide for adding a versionless domain to a service using a wildcard tls subscription ([#1194](https://github.com/fastly/terraform-provider-fastly/pull/1194))
 - docs(templates/guides): add a guide for using versionless domains with a Certainly subscription to a new devlivery service ([#1195](https://github.com/fastly/terraform-provider-fastly/pull/1195))
+- docs(templates/guides): add guide for migrating delivery service classic domain to a versionless domain ([#1196](https://github.com/fastly/terraform-provider-fastly/pull/1196))
 
 ## 8.7.0 (February 20, 2026)
 

--- a/docs/guides/versionless_domain_migration.md
+++ b/docs/guides/versionless_domain_migration.md
@@ -18,7 +18,7 @@ resource "fastly_service_vcl" "vcl_example" {
 }
 ```
 
-Once you [use the control panel to migrate this domain to a versionless domain](https://www.fastly.com/documentation/guides/getting-started/domains/working-with-domains/migrating-classic-domains/), you will need to update your HCL to look something like this.
+Once you [use the control panel to migrate this domain to a versionless domain](https://www.fastly.com/documentation/guides/getting-started/domains/working-with-domains/migrating-classic-domains/), you will need to update your HCL to match the pattern below.
 You can find the documentation on versionless domain patterns here: https://registry.terraform.io/providers/fastly/fastly/latest/docs/resources/domain. Do not apply your changes before running the import step below, as that will result in an error.
 
 ```
@@ -32,7 +32,7 @@ resource "fastly_domain" "domain_example" {
 }
 ```
 
-Before making other changes you will need to import domain using terraform. The Domain ID can using the Fastly CLI by running `fastly domain list --fqdn=foo.example.com` and using the Domain ID fromt the record.
+Before making other changes you will need to import domain using terraform. The Domain ID can using the Fastly CLI by running `fastly domain list --fqdn=foo.example.com` and using the Domain ID from the record.
 
 ```
 terraform import fastly_domain.domain_example YOUR_DOMAIN_ID

--- a/docs/guides/versionless_domain_migration.md
+++ b/docs/guides/versionless_domain_migration.md
@@ -32,7 +32,7 @@ resource "fastly_domain" "domain_example" {
 }
 ```
 
-Before making other changes you will need to import domain using terraform. The Domain ID can using the Fastly CLI by running `fastly domain list --fqdn=foo.example.com` and using the Domain ID from the record.
+Before making other changes you will need to import domain using terraform. The Domain ID can using [the Fastly CLI](https://www.fastly.com/documentation/reference/tools/cli/) by running `fastly domain list --fqdn=foo.example.com` and using the Domain ID from the record.
 
 ```
 terraform import fastly_domain.domain_example YOUR_DOMAIN_ID

--- a/docs/guides/versionless_domain_migration.md
+++ b/docs/guides/versionless_domain_migration.md
@@ -19,7 +19,7 @@ resource "fastly_service_vcl" "vcl_example" {
 ```
 
 Once you [use the control panel to migrate this domain to a versionless domain](https://www.fastly.com/documentation/guides/getting-started/domains/working-with-domains/migrating-classic-domains/), you will need to update your HCL to match the pattern below.
-You can find the documentation on versionless domain patterns here: https://registry.terraform.io/providers/fastly/fastly/latest/docs/resources/domain. Do not apply your changes before running the import step below, as that will result in an error.
+You can find the documentation on versionless domain patterns here: https://registry.terraform.io/providers/fastly/fastly/latest/docs/resources/domain. Do not apply your changes before running the import in the next step, as that will result in an error.
 
 ```
 resource "fastly_service_vcl" "vcl_example" {

--- a/docs/guides/versionless_domain_migration.md
+++ b/docs/guides/versionless_domain_migration.md
@@ -31,6 +31,7 @@ resource "fastly_service_vcl" "vcl_example" {
 ```
 
 Once you [use the control panel to migrate this domain to a versionless domain](https://www.fastly.com/documentation/guides/getting-started/domains/working-with-domains/migrating-classic-domains/), you will need to update your HCL to look something like this.
+[Here are the versionless domain docs.](https://registry.terraform.io/providers/fastly/fastly/latest/docs/resources/domain)
 
 ```
 terraform {

--- a/docs/guides/versionless_domain_migration.md
+++ b/docs/guides/versionless_domain_migration.md
@@ -60,7 +60,7 @@ resource "fastly_domain" "domain_example" {
 Before making other changes you will need to import domain using terraform.
 
 ```
-terraform import fastly_domain.domain_example <domain_id>
+terraform import fastly_domain.domain_example YOUR_DOMAIN_ID
 ```
 
-After that, running `terraform plan` should result in no changes
+After importing, running `terraform plan` should result in no changes.

--- a/docs/guides/versionless_domain_migration.md
+++ b/docs/guides/versionless_domain_migration.md
@@ -56,3 +56,11 @@ resource "fastly_domain" "domain_example" {
   service_id = fastly_service_vcl.vcl_example.id
 }
 ```
+
+Before making other changes you will need to import domain using terraform.
+
+```
+terraform import fastly_domain.domain_example <domain_id>
+```
+
+After that, running `terraform plan` should result in no changes

--- a/docs/guides/versionless_domain_migration.md
+++ b/docs/guides/versionless_domain_migration.md
@@ -8,18 +8,6 @@ subcategory: "Guides"
 Before migrating, your HCL will look something like this, with a domain block inside of your service.
 
 ```
-terraform {
-  required_providers {
-    fastly = {
-      source  = "fastly/fastly"
-    }
-  }
-}
-
-provider "fastly" {
-  api_key = "userKey"
-}
-
 resource "fastly_service_vcl" "vcl_example" {
   name = "versionlessdomainexample"
   domain {
@@ -31,21 +19,44 @@ resource "fastly_service_vcl" "vcl_example" {
 ```
 
 Once you [use the control panel to migrate this domain to a versionless domain](https://www.fastly.com/documentation/guides/getting-started/domains/working-with-domains/migrating-classic-domains/), you will need to update your HCL to look something like this.
-[Here are the versionless domain docs.](https://registry.terraform.io/providers/fastly/fastly/latest/docs/resources/domain)
+You can find the documentation on versionless domain patterns here: https://registry.terraform.io/providers/fastly/fastly/latest/docs/resources/domain. Do not apply your changes before running the import step below, as that will result in an error.
 
 ```
-terraform {
-  required_providers {
-    fastly = {
-      source  = "fastly/fastly"
-    }
-  }
+resource "fastly_service_vcl" "vcl_example" {
+  name = "versionlessdomainexample"
+  force_destroy = true
 }
 
-provider "fastly" {
-  api_key = "userKey"
+resource "fastly_domain" "domain_example" {
+  fqdn       = "demo.example.com"
 }
+```
 
+Before making other changes you will need to import domain using terraform. The Domain ID can using the Fastly CLI by running `fastly domain list --fqdn=foo.example.com` and using the Domain ID fromt the record.
+
+```
+terraform import fastly_domain.domain_example YOUR_DOMAIN_ID
+```
+
+Terraform should produce a message similar to the following.
+
+```
+fastly_domain.example: Importing from ID "YOUR_DOMAIN_ID"...
+fastly_domain.example: Import prepared!
+  Prepared fastly_domain for import
+fastly_domain.example: Refreshing state... [id=YOUR_DOMAIN_ID]
+
+Import successful!
+
+The resources that were imported are shown above. These resources are now in
+your Terraform state and will henceforth be managed by Terraform.
+```
+
+After importing, running `terraform plan` should result in no changes.
+
+Once the import has run successfully, you can assign the domain to a service using the `service_id` field of the domain and then plan and apply.
+
+```
 resource "fastly_service_vcl" "vcl_example" {
   name = "versionlessdomainexample"
   force_destroy = true
@@ -56,11 +67,3 @@ resource "fastly_domain" "domain_example" {
   service_id = fastly_service_vcl.vcl_example.id
 }
 ```
-
-Before making other changes you will need to import domain using terraform.
-
-```
-terraform import fastly_domain.domain_example YOUR_DOMAIN_ID
-```
-
-After importing, running `terraform plan` should result in no changes.

--- a/docs/guides/versionless_domain_migration.md
+++ b/docs/guides/versionless_domain_migration.md
@@ -1,0 +1,57 @@
+---
+page_title: Migrate a Delivery service with a classic domain to a versionless domain
+subcategory: "Guides"
+---
+
+## Migrate a Delivery service with a classic domain to a versionless domain
+
+Before migrating, your HCL will look something like this, with a domain block inside of your service.
+
+```
+terraform {
+  required_providers {
+    fastly = {
+      source  = "fastly/fastly"
+    }
+  }
+}
+
+provider "fastly" {
+  api_key = "userKey"
+}
+
+resource "fastly_service_vcl" "vcl_example" {
+  name = "versionlessdomainexample"
+  domain {
+    name    = "demo.example.com"
+    comment = "demo"
+  }
+  force_destroy = true
+}
+```
+
+Once you [use the control panel to migrate this domain to a versionless domain](https://www.fastly.com/documentation/guides/getting-started/domains/working-with-domains/migrating-classic-domains/), you will need to update your HCL to look something like this.
+
+```
+terraform {
+  required_providers {
+    fastly = {
+      source  = "fastly/fastly"
+    }
+  }
+}
+
+provider "fastly" {
+  api_key = "userKey"
+}
+
+resource "fastly_service_vcl" "vcl_example" {
+  name = "versionlessdomainexample"
+  force_destroy = true
+}
+
+resource "fastly_domain" "domain_example" {
+  fqdn       = "demo.example.com"
+  service_id = fastly_service_vcl.vcl_example.id
+}
+```

--- a/docs/guides/versionless_domain_with_wildcard_tls_subscription.md
+++ b/docs/guides/versionless_domain_with_wildcard_tls_subscription.md
@@ -21,7 +21,7 @@ provider "fastly" {
 }
 
 data "fastly_tls_subscription" "subscription" {
-  domains               = ["*.fastlyversionlessdomain.com"]
+  domains               = ["*.example.com"]
   certificate_authority = "certainly"
 }
 
@@ -31,7 +31,7 @@ resource "fastly_service_vcl" "vcl_example" {
 }
 
 resource "fastly_domain" "domain_example" {
-  fqdn       = "example.fastlyversionlessdomain.com"
+  fqdn       = "example.example.com"
   service_id = fastly_service_vcl.vcl_example.id
 }
 ```

--- a/templates/guides/versionless_domain_migration.md
+++ b/templates/guides/versionless_domain_migration.md
@@ -56,3 +56,11 @@ resource "fastly_domain" "domain_example" {
   service_id = fastly_service_vcl.vcl_example.id
 }
 ```
+
+Before making other changes you will need to import domain using terraform.
+
+```
+terraform import fastly_domain.domain_example <domain_id>
+```
+
+After importing, running `terraform plan` should result in no changes.

--- a/templates/guides/versionless_domain_migration.md
+++ b/templates/guides/versionless_domain_migration.md
@@ -18,7 +18,7 @@ resource "fastly_service_vcl" "vcl_example" {
 }
 ```
 
-Once you [use the control panel to migrate this domain to a versionless domain](https://www.fastly.com/documentation/guides/getting-started/domains/working-with-domains/migrating-classic-domains/), you will need to update your HCL to look something like this.
+Once you [use the control panel to migrate this domain to a versionless domain](https://www.fastly.com/documentation/guides/getting-started/domains/working-with-domains/migrating-classic-domains/), you will need to update your HCL to match the pattern below.
 You can find the documentation on versionless domain patterns here: https://registry.terraform.io/providers/fastly/fastly/latest/docs/resources/domain. Do not apply your changes before running the import step below, as that will result in an error.
 
 ```
@@ -32,7 +32,7 @@ resource "fastly_domain" "domain_example" {
 }
 ```
 
-Before making other changes you will need to import domain using terraform. The Domain ID can using the Fastly CLI by running `fastly domain list --fqdn=foo.example.com` and using the Domain ID fromt the record.
+Before making other changes you will need to import domain using terraform. The Domain ID can using the Fastly CLI by running `fastly domain list --fqdn=foo.example.com` and using the Domain ID from the record.
 
 ```
 terraform import fastly_domain.domain_example YOUR_DOMAIN_ID

--- a/templates/guides/versionless_domain_migration.md
+++ b/templates/guides/versionless_domain_migration.md
@@ -32,7 +32,7 @@ resource "fastly_domain" "domain_example" {
 }
 ```
 
-Before making other changes you will need to import domain using terraform. The Domain ID can using the Fastly CLI by running `fastly domain list --fqdn=foo.example.com` and using the Domain ID from the record.
+Before making other changes you will need to import domain using terraform. The Domain ID can using [the Fastly CLI](https://www.fastly.com/documentation/reference/tools/cli/) by running `fastly domain list --fqdn=foo.example.com` and using the Domain ID from the record.
 
 ```
 terraform import fastly_domain.domain_example YOUR_DOMAIN_ID

--- a/templates/guides/versionless_domain_migration.md
+++ b/templates/guides/versionless_domain_migration.md
@@ -60,7 +60,7 @@ resource "fastly_domain" "domain_example" {
 Before making other changes you will need to import domain using terraform.
 
 ```
-terraform import fastly_domain.domain_example <domain_id>
+terraform import fastly_domain.domain_example YOUR_DOMAIN_ID
 ```
 
 After importing, running `terraform plan` should result in no changes.

--- a/templates/guides/versionless_domain_migration.md
+++ b/templates/guides/versionless_domain_migration.md
@@ -19,7 +19,7 @@ resource "fastly_service_vcl" "vcl_example" {
 ```
 
 Once you [use the control panel to migrate this domain to a versionless domain](https://www.fastly.com/documentation/guides/getting-started/domains/working-with-domains/migrating-classic-domains/), you will need to update your HCL to match the pattern below.
-You can find the documentation on versionless domain patterns here: https://registry.terraform.io/providers/fastly/fastly/latest/docs/resources/domain. Do not apply your changes before running the import step below, as that will result in an error.
+You can find the documentation on versionless domain patterns here: https://registry.terraform.io/providers/fastly/fastly/latest/docs/resources/domain. Do not apply your changes before running the import in the next step, as that will result in an error.
 
 ```
 resource "fastly_service_vcl" "vcl_example" {

--- a/templates/guides/versionless_domain_migration.md
+++ b/templates/guides/versionless_domain_migration.md
@@ -31,6 +31,7 @@ resource "fastly_service_vcl" "vcl_example" {
 ```
 
 Once you [use the control panel to migrate this domain to a versionless domain](https://www.fastly.com/documentation/guides/getting-started/domains/working-with-domains/migrating-classic-domains/), you will need to update your HCL to look something like this.
+[Here are the versionless domain docs.](https://registry.terraform.io/providers/fastly/fastly/latest/docs/resources/domain)
 
 ```
 terraform {

--- a/templates/guides/versionless_domain_migration.md
+++ b/templates/guides/versionless_domain_migration.md
@@ -8,18 +8,6 @@ subcategory: "Guides"
 Before migrating, your HCL will look something like this, with a domain block inside of your service.
 
 ```
-terraform {
-  required_providers {
-    fastly = {
-      source  = "fastly/fastly"
-    }
-  }
-}
-
-provider "fastly" {
-  api_key = "userKey"
-}
-
 resource "fastly_service_vcl" "vcl_example" {
   name = "versionlessdomainexample"
   domain {
@@ -31,21 +19,44 @@ resource "fastly_service_vcl" "vcl_example" {
 ```
 
 Once you [use the control panel to migrate this domain to a versionless domain](https://www.fastly.com/documentation/guides/getting-started/domains/working-with-domains/migrating-classic-domains/), you will need to update your HCL to look something like this.
-[Here are the versionless domain docs.](https://registry.terraform.io/providers/fastly/fastly/latest/docs/resources/domain)
+You can find the documentation on versionless domain patterns here: https://registry.terraform.io/providers/fastly/fastly/latest/docs/resources/domain. Do not apply your changes before running the import step below, as that will result in an error.
 
 ```
-terraform {
-  required_providers {
-    fastly = {
-      source  = "fastly/fastly"
-    }
-  }
+resource "fastly_service_vcl" "vcl_example" {
+  name = "versionlessdomainexample"
+  force_destroy = true
 }
 
-provider "fastly" {
-  api_key = "userKey"
+resource "fastly_domain" "domain_example" {
+  fqdn       = "demo.example.com"
 }
+```
 
+Before making other changes you will need to import domain using terraform. The Domain ID can using the Fastly CLI by running `fastly domain list --fqdn=foo.example.com` and using the Domain ID fromt the record.
+
+```
+terraform import fastly_domain.domain_example YOUR_DOMAIN_ID
+```
+
+Terraform should produce a message similar to the following.
+
+```
+fastly_domain.example: Importing from ID "YOUR_DOMAIN_ID"...
+fastly_domain.example: Import prepared!
+  Prepared fastly_domain for import
+fastly_domain.example: Refreshing state... [id=YOUR_DOMAIN_ID]
+
+Import successful!
+
+The resources that were imported are shown above. These resources are now in
+your Terraform state and will henceforth be managed by Terraform.
+```
+
+After importing, running `terraform plan` should result in no changes.
+
+Once the import has run successfully, you can assign the domain to a service using the `service_id` field of the domain and then plan and apply.
+
+```
 resource "fastly_service_vcl" "vcl_example" {
   name = "versionlessdomainexample"
   force_destroy = true
@@ -56,11 +67,3 @@ resource "fastly_domain" "domain_example" {
   service_id = fastly_service_vcl.vcl_example.id
 }
 ```
-
-Before making other changes you will need to import domain using terraform.
-
-```
-terraform import fastly_domain.domain_example YOUR_DOMAIN_ID
-```
-
-After importing, running `terraform plan` should result in no changes.

--- a/templates/guides/versionless_domain_migration.md
+++ b/templates/guides/versionless_domain_migration.md
@@ -1,0 +1,57 @@
+---
+page_title: Migrate a Delivery service with a classic domain to a versionless domain
+subcategory: "Guides"
+---
+
+## Migrate a Delivery service with a classic domain to a versionless domain
+
+Before migrating, your HCL will look something like this, with a domain block inside of your service.
+
+```
+terraform {
+  required_providers {
+    fastly = {
+      source  = "fastly/fastly"
+    }
+  }
+}
+
+provider "fastly" {
+  api_key = "userKey"
+}
+
+resource "fastly_service_vcl" "vcl_example" {
+  name = "versionlessdomainexample"
+  domain {
+    name    = "demo.example.com"
+    comment = "demo"
+  }
+  force_destroy = true
+}
+```
+
+Once you [use the control panel to migrate this domain to a versionless domain](https://www.fastly.com/documentation/guides/getting-started/domains/working-with-domains/migrating-classic-domains/), you will need to update your HCL to look something like this.
+
+```
+terraform {
+  required_providers {
+    fastly = {
+      source  = "fastly/fastly"
+    }
+  }
+}
+
+provider "fastly" {
+  api_key = "userKey"
+}
+
+resource "fastly_service_vcl" "vcl_example" {
+  name = "versionlessdomainexample"
+  force_destroy = true
+}
+
+resource "fastly_domain" "domain_example" {
+  fqdn       = "demo.example.com"
+  service_id = fastly_service_vcl.vcl_example.id
+}
+```

--- a/templates/guides/versionless_domain_with_wildcard_tls_subscription.md
+++ b/templates/guides/versionless_domain_with_wildcard_tls_subscription.md
@@ -21,7 +21,7 @@ provider "fastly" {
 }
 
 data "fastly_tls_subscription" "subscription" {
-  domains               = ["*.fastlyversionlessdomain.com"]
+  domains               = ["*.example.com"]
   certificate_authority = "certainly"
 }
 
@@ -31,7 +31,7 @@ resource "fastly_service_vcl" "vcl_example" {
 }
 
 resource "fastly_domain" "domain_example" {
-  fqdn       = "example.fastlyversionlessdomain.com"
+  fqdn       = "example.example.com"
   service_id = fastly_service_vcl.vcl_example.id
 }
 ```


### PR DESCRIPTION
### Change summary

Add docs for migrating classic domains attached to a service to versionless domains
 
All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/terraform-provider-fastly/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
