### PR TITLE
[CDTOOL-1286] Correct type assertion for nested single conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### BUG FIXES:
 
+- fix(ngwaf/rules): corrected the condition type assertion for nested single conditions a group condition ([#1198](https://github.com/fastly/terraform-provider-fastly/pull/1198))
+
 ### DEPENDENCIES:
 
 ### DOCUMENTATION:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### BUG FIXES:
 
-- fix(ngwaf/rules): corrected the condition type assertion for nested single conditions a group condition ([#1198](https://github.com/fastly/terraform-provider-fastly/pull/1198))
+- fix(ngwaf/rules): corrected the condition type assertion for nested single conditions in a group condition ([#1198](https://github.com/fastly/terraform-provider-fastly/pull/1198))
 
 ### DEPENDENCIES:
 

--- a/fastly/ngwaf_rule_helpers.go
+++ b/fastly/ngwaf_rule_helpers.go
@@ -53,7 +53,7 @@ func flattenNGWAFRuleConditionsGeneric(items []rules.ConditionItem) ([]map[strin
 				for _, gci := range gc.Conditions {
 					switch gci.Type {
 					case "single":
-						if sc, ok := gci.Fields.(rules.SingleCondition); ok {
+						if sc, ok := gci.Fields.(rules.Condition); ok {
 							conds = append(conds, map[string]any{
 								"field":    sc.Field,
 								"operator": sc.Operator,


### PR DESCRIPTION
### Change summary

This PR correct type assertions for `flattenNGWAFRuleConditionsGeneric` to use `rules.Condition` instead of `rules.SingleCondition` for nested single conditions within GroupConditionItem. 

This incorrect behavior resulted in a Terraform drift that looked similar to the following:
<img width="445" height="573" alt="image" src="https://github.com/user-attachments/assets/9eff735c-aed3-449c-912b-41b0c2a377c7" />


 All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/terraform-provider-fastly/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

* [x] Does your submission pass tests?
* [x] Post the output of your test runs
```
=== RUN   TestFlattenNGWAFRuleResponse
--- PASS: TestFlattenNGWAFRuleResponse (0.00s)
PASS
ok   
```

### Changes to Core Features:

* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### User Impact

Users experiencing drifts with `group_conditions` should no longer have these issues. 

---

_Note: Claude Code was leveraged to help identify this bug_