### PR TITLE
[CDTOOL-1302] Update Docs to include usage examples for NGWAF Lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 ### DOCUMENTATION:
 
+-docs(ngwaf/lists): updated docs to provide important prefix information for usage with a NGWAF rule. ([#1217](https://github.com/fastly/terraform-provider-fastly/pull/1217))
+
 
 ## 8.8.0 (March 17, 2026)
 

--- a/docs/resources/ngwaf_account_list.md
+++ b/docs/resources/ngwaf_account_list.md
@@ -19,13 +19,37 @@ Basic usage:
 ```terraform
 resource "fastly_ngwaf_account_list" "example" {
   name        = "shared-bot-ip-list"
-  description = "List of known bot IPs shared across workspaces"
+  description = "Account list of known bot IPs shared across workspaces"
   type        = "ip"
   entries     = [
     "1.2.3.4",
     "5.6.7.8",
     "203.0.113.42"
   ]
+}
+
+# Example usage with a rule. 
+resource "fastly_ngwaf_workspace_rule" "example" {
+  workspace_id = fastly_ngwaf_workspace.example.id
+  type = "request"
+  description = "Example usage of a workspace list rule"
+  enabled = true
+  request_logging = "sampled"
+  
+  condition {
+    field = "ip"
+    operator = "not_in_list"
+    # *********************************************
+    # Account lists must be prefixed with 'corp.'
+    # *********************************************
+    value = "corp.${fastly_ngwaf_account_list.example.name}"
+  }
+
+  action {
+    type = "block"
+  }
+
+  depends_on = [ fastly_ngwaf_account_list.example ]
 }
 ```
 

--- a/docs/resources/ngwaf_workspace_list.md
+++ b/docs/resources/ngwaf_workspace_list.md
@@ -43,6 +43,30 @@ resource "fastly_ngwaf_workspace_list" "example" {
     "10.0.0.1"
   ]
 }
+
+# Example usage with a rule. 
+resource "fastly_ngwaf_workspace_rule" "example" {
+  workspace_id = fastly_ngwaf_workspace.example.id
+  type = "request"
+  description = "Example usage of a workspace list rule"
+  enabled = true
+  request_logging = "sampled"
+  
+  condition {
+    field = "ip"
+    operator = "not_in_list"
+    # *********************************************
+    # Workspace lists must be prefixed with 'site.'
+    # *********************************************
+    value = "site.${fastly_ngwaf_workspace_list.example.name}"
+  }
+
+  action {
+    type = "block"
+  }
+
+  depends_on = [ fastly_ngwaf_workspace_list.example ]
+}
 ```
 
 ## Import

--- a/examples/resources/ngwaf_account_list_basic_usage.tf
+++ b/examples/resources/ngwaf_account_list_basic_usage.tf
@@ -1,10 +1,34 @@
 resource "fastly_ngwaf_account_list" "example" {
   name        = "shared-bot-ip-list"
-  description = "List of known bot IPs shared across workspaces"
+  description = "Account list of known bot IPs shared across workspaces"
   type        = "ip"
   entries     = [
     "1.2.3.4",
     "5.6.7.8",
     "203.0.113.42"
   ]
+}
+
+# Example usage with a rule. 
+resource "fastly_ngwaf_workspace_rule" "example" {
+  workspace_id = fastly_ngwaf_workspace.example.id
+  type = "request"
+  description = "Example usage of a workspace list rule"
+  enabled = true
+  request_logging = "sampled"
+  
+  condition {
+    field = "ip"
+    operator = "not_in_list"
+    # *********************************************
+    # Account lists must be prefixed with 'corp.'
+    # *********************************************
+    value = "corp.${fastly_ngwaf_account_list.example.name}"
+  }
+
+  action {
+    type = "block"
+  }
+
+  depends_on = [ fastly_ngwaf_account_list.example ]
 }

--- a/examples/resources/ngwaf_workspace_list_basic_usage.tf
+++ b/examples/resources/ngwaf_workspace_list_basic_usage.tf
@@ -24,3 +24,27 @@ resource "fastly_ngwaf_workspace_list" "example" {
     "10.0.0.1"
   ]
 }
+
+# Example usage with a rule. 
+resource "fastly_ngwaf_workspace_rule" "example" {
+  workspace_id = fastly_ngwaf_workspace.example.id
+  type = "request"
+  description = "Example usage of a workspace list rule"
+  enabled = true
+  request_logging = "sampled"
+  
+  condition {
+    field = "ip"
+    operator = "not_in_list"
+    # *********************************************
+    # Workspace lists must be prefixed with 'site.'
+    # *********************************************
+    value = "site.${fastly_ngwaf_workspace_list.example.name}"
+  }
+
+  action {
+    type = "block"
+  }
+
+  depends_on = [ fastly_ngwaf_workspace_list.example ]
+}


### PR DESCRIPTION
Improved Terraform docs to provide important prefix informations for usage with a NGWAF rule.

### Change summary

This PR proves our Terraform docs to provide important prefix information around the usage of Account and Workspace list with NGWAF rules. 

 All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/terraform-provider-fastly/pulls) for the same update/change?
