### PR TITLE
[CDTOOL-1303] Improve Issue Template Routing

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,3 +1,23 @@
+---
+name: Bug report
+about: Tell us about a bug to help us improve
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+<!-- 
+  **Note**:  Please keep in mind that if your issue requires troubleshooting that will require any details that you aren't comfortable disclosing in this public forum (such as service IDs), you will need to open a Fastly support ticket instead: https://support.fastly.com. 
+  
+  Bug reports opened here:
+    - Do not have an SLA
+    - Should not be a duplicate of an existing support ticket that you have already created, or vice versa
+    - May take longer to solve compared to our dedicated support team
+
+  More details on submitting issues can be found here: https://github.com/fastly/terraform-provider-fastly/blob/main/ISSUES.md 
+-->
+
 ### Terraform Version
 
 ```shell

--- a/.github/ISSUE_TEMPLATE/config.yaml
+++ b/.github/ISSUE_TEMPLATE/config.yaml
@@ -1,0 +1,2 @@
+# Disable blank issues for non-maintainers. 
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,29 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: feature request
+assignees: ''
+
+---
+<!-- 
+  **Note**:  Please keep in mind that if your feature request discusses any details that you aren't comfortable disclosing in this public forum (such as service IDs), you will need to open a Fastly support ticket instead: https://support.fastly.com. 
+  
+  Feature requests opened here:
+    - Do not have an SLA nor are guaranteed to be implemented
+    - Should not be a duplicate of an existing support ticket that you have already created, or vice versa
+
+  More details on submitting issues can be found here: https://github.com/fastly/terraform-provider-fastly/blob/main/ISSUES.md 
+-->
+
+### Is your feature request related to a problem? Please describe
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+### Describe the solution you'd like
+A clear and concise description of what you want to happen.
+
+### Describe alternatives you've considered
+A clear and concise description of any alternative solutions or features you've considered.
+
+### Additional context
+Add any other context or screenshots about the feature request here.

--- a/ISSUES.md
+++ b/ISSUES.md
@@ -1,0 +1,34 @@
+<div align="center">
+  <h3 align="center">Fastly Terraform Provider Issues</h3>
+  <p align="center">Best practices for submitting an issue to the Fastly Terraform Provider repository.</p>
+</div>
+
+## Issue Type: Bug
+
+Issues related to the Fastly Terraform Provider behavior not working as intended. 
+
+- The Terraform Provider crashes or exits with an unexpected error
+- An item in the Terraform Provider documentation is incorrect
+- I am experiencing a drift after a `terraform apply` when I made no configuration changes
+
+**Example:** "The provider crashes after I run a `terraform import`."
+
+## Issue Type: Feature Request
+
+Issues related to suggesting improvements to the Fastly Terraform Provider:
+
+- Add support for an existing Fastly API endpoint / feature that doesn't exist in the provider
+- Improved error messages or user experience
+- Improved documentation around a specific feature
+
+**Example:** "Add support for a LogABC resource and data source, which already exists in the Fastly API."
+
+## Fastly Support
+
+Fastly Terraform Provider behavior specific to your environment or service / account should be routed to the Fastly support team @ support.fastly.com or support@fastly.com. 
+
+- A feature is missing from your account / service
+- Partial content is returned that you may not have access to with your current Fastly account role
+- My site is not loading after a configuration change
+
+**Example:** After running `terraform apply`, an error is thrown that a given version can't be activated.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 - Website: https://www.terraform.io
 - Documentation: https://registry.terraform.io/providers/fastly/fastly/latest/docs
+- Issues: https://github.com/fastly/terraform-provider-fastly/blob/main/ISSUES.md 
 - Mailing list: http://groups.google.com/group/terraform-tool
 - [![Gitter chat](https://badges.gitter.im/hashicorp-terraform/Lobby.png)](https://gitter.im/hashicorp-terraform/Lobby)
 


### PR DESCRIPTION
### Change summary

This PR adds support docs and notes to existing templates clarifying when to reach out to support and general best practices around issue submitting. A separate template has been added for feature requests, which did not exist in the prior template. 

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/terraform-provider-fastly/pulls) for the same update/change?

### User Impact

Users are now forced to select an issue type of `Bug` or `Feature Request` request when opening an issue in this repository. 

### Notes

We have moved the issue template from an older pattern to the Github suggest pattern of utilizing individual issue type templates, which we currently leverage in our CLI repo. 