### PR TITLE
`FASTLY_TF_DISPLAY_SENSITIVE_FIELDS` has no effect on service schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### BUG FIXES:
 
+- fix(provider): `FASTLY_TF_DISPLAY_SENSITIVE_FIELDS` env var now takes effect on service schemas. Previously the value was read too late, after the schema vars had already been initialized. ([#1219](https://github.com/fastly/terraform-provider-fastly/pull/1219))
+
 ### DEPENDENCIES:
 - build(deps): `google.golang.org/grpc` from 1.79.2 to 1.79.3 ([#1216](https://github.com/fastly/terraform-provider-fastly/pull/1216))
 

--- a/fastly/provider.go
+++ b/fastly/provider.go
@@ -17,12 +17,11 @@ import (
 const TerraformProviderProductUserAgent = "terraform-provider-fastly"
 
 // This value can be set to allow terraform output to display sensitive info.
-var DisplaySensitiveFields = false
+// Read at package init time so it is available before service schema vars are built.
+var DisplaySensitiveFields = os.Getenv("FASTLY_TF_DISPLAY_SENSITIVE_FIELDS") == "true"
 
 // Provider returns a *schema.Provider.
 func Provider() *schema.Provider {
-	DisplaySensitiveFields = os.Getenv("FASTLY_TF_DISPLAY_SENSITIVE_FIELDS") == "true"
-
 	provider := &schema.Provider{
 		Schema: map[string]*schema.Schema{
 			"api_key": {


### PR DESCRIPTION
### Change summary

The `FASTLY_TF_DISPLAY_SENSITIVE_FIELDS` env var was read inside Provider(), but the package-level vars vclService and computeService (which build schemas referencing DisplaySensitiveFields) were already initialized at package load time. Move the env var read to the var declaration so it is evaluated before the service schema vars are constructed.

 All Submissions:

* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/terraform-provider-fastly/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

* [ ] Does your submission pass tests?
* [ ] Post the output of your test runs

### Changes to Core Features:

* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

### User Impact

<!-- What is the user impact of this change? -->

### Are there any considerations that need to be addressed for release?

<!-- Any breaking changes, etc -->
