### PR TITLE
Breaking[CDTOOL-1309]  Add support for ContentGuard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## [UNRELEASED]
 
 ### BREAKING:
-- breaking(product_enablement/bot_management): added support for ContentGuard, which is now requires the `contentguard` and `enabled` parameters ([#1216](https://github.com/fastly/terraform-provider-fastly/pull/1216))
+- breaking(product_enablement/bot_management): added support for ContentGuard, which is now requires the `contentguard` and `enabled` parameters ([#1309](https://github.com/fastly/terraform-provider-fastly/pull/1309))
 
 ### ENHANCEMENTS:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [UNRELEASED]
 
 ### BREAKING:
+- breaking(product_enablement/bot_management): added support for ContentGuard, which is now a required parameter ([#1216](https://github.com/fastly/terraform-provider-fastly/pull/1216))
 
 ### ENHANCEMENTS:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## [UNRELEASED]
 
 ### BREAKING:
-- breaking(product_enablement/bot_management): added support for ContentGuard, which is now a required parameter ([#1216](https://github.com/fastly/terraform-provider-fastly/pull/1216))
+- breaking(product_enablement/bot_management): added support for ContentGuard, which is now requires the `contentguard` and `enabled` parameters ([#1216](https://github.com/fastly/terraform-provider-fastly/pull/1216))
 
 ### ENHANCEMENTS:
 

--- a/docs/resources/service_vcl.md
+++ b/docs/resources/service_vcl.md
@@ -1166,7 +1166,7 @@ Optional:
 Optional:
 
 - `api_discovery` (Boolean) Enable API Discovery support
-- `bot_management` (Boolean) Enable Bot Management support
+- `bot_management` (Block List, Max: 1) Enable Bot Management support (see [below for nested schema](#nestedblock--product_enablement--bot_management))
 - `brotli_compression` (Boolean) Enable Brotli Compression support
 - `ddos_protection` (Block List, Max: 1) DDoS Protection product (see [below for nested schema](#nestedblock--product_enablement--ddos_protection))
 - `domain_inspector` (Boolean) Enable Domain Inspector support
@@ -1176,6 +1176,15 @@ Optional:
 - `ngwaf` (Block List, Max: 1) Next-Gen WAF product (see [below for nested schema](#nestedblock--product_enablement--ngwaf))
 - `origin_inspector` (Boolean) Enable Origin Inspector support
 - `websockets` (Boolean) Enable WebSockets support
+
+<a id="nestedblock--product_enablement--bot_management"></a>
+### Nested Schema for `product_enablement.bot_management`
+
+Required:
+
+- `contentguard` (String) ContentGuard status. Can be either `off`, or `on`.
+- `enabled` (Boolean) Enable Bot Management support
+
 
 <a id="nestedblock--product_enablement--ddos_protection"></a>
 ### Nested Schema for `product_enablement.ddos_protection`

--- a/fastly/block_fastly_service_product_enablement.go
+++ b/fastly/block_fastly_service_product_enablement.go
@@ -68,9 +68,29 @@ func (h *ProductEnablementServiceAttributeHandler) GetSchema() *schema.Schema {
 	// These products are supported only on Delivery (VCL) services.
 	if h.GetServiceMetadata().serviceType == ServiceTypeVCL {
 		blockAttributes["bot_management"] = &schema.Schema{
-			Type:        schema.TypeBool,
+			Type:        schema.TypeList,
 			Optional:    true,
 			Description: "Enable Bot Management support",
+			MaxItems:    1,
+			MinItems:    1,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"contentguard": {
+						Type:        schema.TypeString,
+						Required:    true,
+						Description: "ContentGuard status. Can be either `off`, or `on`.",
+						ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice(
+							[]string{"off", "on"},
+							false,
+						)),
+					},
+					"enabled": {
+						Type:        schema.TypeBool,
+						Required:    true,
+						Description: "Enable Bot Management support",
+					},
+				},
+			},
 		}
 		blockAttributes["brotli_compression"] = &schema.Schema{
 			Type:        schema.TypeBool,
@@ -192,11 +212,25 @@ func (h *ProductEnablementServiceAttributeHandler) Create(ctx context.Context, d
 	}
 
 	if h.GetServiceMetadata().serviceType == ServiceTypeVCL {
-		if resource["bot_management"].(bool) {
-			log.Println("[DEBUG] bot_management set")
-			_, err := botmanagement.Enable(gofastly.NewContextForResourceID(ctx, d.Id()), conn, serviceID)
-			if err != nil {
-				return fmt.Errorf("failed to enable bot_management: %w", err)
+		bp := resource["bot_management"].([]any)
+		if len(bp) != 0 {
+			if bp[0].(map[string]any)["enabled"].(bool) {
+				log.Println("[DEBUG] bot_management set")
+				_, err := botmanagement.Enable(gofastly.NewContextForResourceID(ctx, d.Id()), conn, serviceID)
+				if err != nil {
+					return fmt.Errorf("failed to enable bot_management: %w", err)
+				}
+
+				contentguard := bp[0].(map[string]any)["contentguard"].(string)
+				_, err = botmanagement.UpdateConfiguration(
+					gofastly.NewContextForResourceID(ctx, d.Id()),
+					conn,
+					serviceID,
+					botmanagement.ConfigureInput{ContentGuard: contentguard},
+				)
+				if err != nil {
+					return fmt.Errorf("failed to configure bot_management: %w", err)
+				}
 			}
 		}
 		if resource["brotli_compression"].(bool) {
@@ -338,7 +372,21 @@ func (h *ProductEnablementServiceAttributeHandler) Read(ctx context.Context, d *
 
 		if h.GetServiceMetadata().serviceType == ServiceTypeVCL {
 			if _, err := botmanagement.Get(gofastly.NewContextForResourceID(ctx, d.Id()), conn, serviceID); err == nil {
-				result["bot_management"] = true
+				c, err := botmanagement.GetConfiguration(gofastly.NewContextForResourceID(ctx, d.Id()), conn, serviceID)
+				if err != nil {
+					return fmt.Errorf("error looking up Bot Management product configuration for (%s): %s", serviceID, err)
+				}
+
+				bp := []map[string]any{}
+				bp = append(bp, map[string]any{
+					"enabled":      true,
+					"contentguard": *c.Configuration.ContentGuard,
+				})
+
+				result["bot_management"] = bp
+			} else if len(localState) > 0 {
+				bp := localState[0].(map[string]any)["bot_management"].([]any)
+				result["bot_management"] = bp
 			}
 
 			if _, err := brotlicompression.Get(gofastly.NewContextForResourceID(ctx, d.Id()), conn, serviceID); err == nil {
@@ -462,18 +510,31 @@ func (h *ProductEnablementServiceAttributeHandler) Update(ctx context.Context, d
 
 	if h.GetServiceMetadata().serviceType == ServiceTypeVCL {
 		if v, ok := modified["bot_management"]; ok {
-			if v.(bool) {
-				log.Println("[DEBUG] bot_management will be enabled")
-				_, err := botmanagement.Enable(gofastly.NewContextForResourceID(ctx, d.Id()), conn, serviceID)
-				if err != nil {
-					return fmt.Errorf("failed to enable bot_management: %w", err)
-				}
-			} else {
-				log.Println("[DEBUG] bot_management will be disabled")
-				err := botmanagement.Disable(gofastly.NewContextForResourceID(ctx, d.Id()), conn, serviceID)
-				if err != nil {
-					if e := h.checkAPIError(err); e != nil {
-						return e
+			bp := v.([]any)
+			if len(bp) != 0 {
+				if bp[0].(map[string]any)["enabled"].(bool) {
+					log.Println("[DEBUG] bot_management will be enabled")
+					_, err := botmanagement.Enable(gofastly.NewContextForResourceID(ctx, d.Id()), conn, serviceID)
+					if err != nil {
+						return fmt.Errorf("failed to enable bot_management: %w", err)
+					}
+
+					contentguard := bp[0].(map[string]any)["contentguard"].(string)
+					log.Printf("[DEBUG] bot_management contentguard will be set to %s", contentguard)
+					_, err = botmanagement.UpdateConfiguration(
+						gofastly.NewContextForResourceID(ctx, d.Id()), conn, serviceID,
+						botmanagement.ConfigureInput{ContentGuard: contentguard},
+					)
+					if err != nil {
+						return fmt.Errorf("failed to set the configuration of bot_management: %w", err)
+					}
+				} else {
+					log.Println("[DEBUG] bot_management will be disabled")
+					err := botmanagement.Disable(gofastly.NewContextForResourceID(ctx, d.Id()), conn, serviceID)
+					if err != nil {
+						if e := h.checkAPIError(err); e != nil {
+							return e
+						}
 					}
 				}
 			}

--- a/fastly/block_fastly_service_product_enablement.go
+++ b/fastly/block_fastly_service_product_enablement.go
@@ -384,9 +384,6 @@ func (h *ProductEnablementServiceAttributeHandler) Read(ctx context.Context, d *
 				})
 
 				result["bot_management"] = bp
-			} else if len(localState) > 0 {
-				bp := localState[0].(map[string]any)["bot_management"].([]any)
-				result["bot_management"] = bp
 			}
 
 			if _, err := brotlicompression.Get(gofastly.NewContextForResourceID(ctx, d.Id()), conn, serviceID); err == nil {
@@ -426,10 +423,6 @@ func (h *ProductEnablementServiceAttributeHandler) Read(ctx context.Context, d *
 			})
 
 			result["ddos_protection"] = ddp
-		} else if len(localState) > 0 {
-			ddp := localState[0].(map[string]any)["ddos_protection"].([]any)
-			result["ddos_protection"] = ddp
-
 		}
 
 		if _, err := apidiscovery.Get(gofastly.NewContextForResourceID(ctx, d.Id()), conn, serviceID); err == nil {
@@ -455,10 +448,6 @@ func (h *ProductEnablementServiceAttributeHandler) Read(ctx context.Context, d *
 			})
 
 			result["ngwaf"] = ngw
-		} else if len(localState) > 0 {
-			ngw := localState[0].(map[string]any)["ngwaf"].([]any)
-			result["ngwaf"] = ngw
-
 		}
 
 		results := []map[string]any{result}

--- a/fastly/block_fastly_service_product_enablement_test.go
+++ b/fastly/block_fastly_service_product_enablement_test.go
@@ -35,13 +35,17 @@ func TestAccFastlyServiceProductEnablement_vcl_basic(t *testing.T) {
 
     product_enablement {
       api_discovery         = false
-      bot_management        = false
       brotli_compression    = true
       domain_inspector      = false
       image_optimizer       = false
       log_explorer_insights = false
       origin_inspector      = false
       websockets            = false
+
+      bot_management {
+        enabled      = false
+        contentguard = "off"
+      }
 
       ddos_protection {
         enabled = false
@@ -184,6 +188,90 @@ resource "fastly_service_vcl" "foo" {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceExists("fastly_service_vcl.foo", &service),
 					resource.TestCheckResourceAttr("fastly_service_vcl.foo", "product_enablement.0.ddos_protection.0.mode", "log"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccFastlyServiceProductEnablement_vcl_botManagementUpdate(t *testing.T) {
+	var service gofastly.ServiceDetail
+	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	domainName := fmt.Sprintf("fastly-test.tf-%s.com", acctest.RandString(10))
+	backendName := fmt.Sprintf("backend-tf-%s", acctest.RandString(10))
+	backendAddress := "httpbin.org"
+
+	initialConfig := fmt.Sprintf(`
+resource "fastly_service_vcl" "foo" {
+  name = "%s"
+
+  domain {
+    name    = "%s"
+    comment = "demo"
+  }
+
+  backend {
+    address = "%s"
+    name    = "%s"
+    port    = 443
+    shield  = "amsterdam-nl"
+  }
+
+  product_enablement {
+    bot_management {
+      enabled      = true
+      contentguard = "off"
+    }
+  }
+
+  force_destroy = true
+}
+`, serviceName, domainName, backendAddress, backendName)
+
+	updatedConfig := fmt.Sprintf(`
+resource "fastly_service_vcl" "foo" {
+  name = "%s"
+
+  domain {
+    name    = "%s"
+    comment = "demo"
+  }
+
+  backend {
+    address = "%s"
+    name    = "%s"
+    port    = 443
+    shield  = "amsterdam-nl"
+  }
+
+  product_enablement {
+    bot_management {
+      enabled      = true
+      contentguard = "on"
+    }
+  }
+
+  force_destroy = true
+}
+`, serviceName, domainName, backendAddress, backendName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckServiceVCLDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: initialConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceExists("fastly_service_vcl.foo", &service),
+					resource.TestCheckResourceAttr("fastly_service_vcl.foo", "product_enablement.0.bot_management.0.contentguard", "off"),
+				),
+			},
+			{
+				Config: updatedConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceExists("fastly_service_vcl.foo", &service),
+					resource.TestCheckResourceAttr("fastly_service_vcl.foo", "product_enablement.0.bot_management.0.contentguard", "on"),
 				),
 			},
 		},


### PR DESCRIPTION
### Change summary

This PR adds support for ContentGuard to the Bot Management Product Enablement block. 

 All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/terraform-provider-fastly/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

* [x] Does your submission pass tests?
* [x] Post the output of your test runs

```
=== RUN   TestAccFastlyServiceProductEnablement_vcl_botManagementUpdate
=== PAUSE TestAccFastlyServiceProductEnablement_vcl_botManagementUpdate
=== CONT  TestAccFastlyServiceProductEnablement_vcl_botManagementUpdate
--- PASS: TestAccFastlyServiceProductEnablement_vcl_botManagementUpdate (41.55s)
PASS
```

### Changes to Core Features:

* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### User Impact

Users will now need to supply the `contentguard` and `enabled` parameters for the `product_enablement.bot_management` block. 