### PR TITLE
fix(product_enablement): preserve disabled nested blocks in state

### DIFF
--- a/fastly/block_fastly_service_product_enablement.go
+++ b/fastly/block_fastly_service_product_enablement.go
@@ -384,6 +384,13 @@ func (h *ProductEnablementServiceAttributeHandler) Read(ctx context.Context, d *
 				})
 
 				result["bot_management"] = bp
+			} else if len(localState) > 0 {
+				// Preserve explicitly disabled nested blocks from config to prevent drift
+				if localMap, ok := localState[0].(map[string]any); ok {
+					if bm, ok := localMap["bot_management"].([]any); ok && len(bm) > 0 {
+						result["bot_management"] = bm
+					}
+				}
 			}
 
 			if _, err := brotlicompression.Get(gofastly.NewContextForResourceID(ctx, d.Id()), conn, serviceID); err == nil {
@@ -423,6 +430,13 @@ func (h *ProductEnablementServiceAttributeHandler) Read(ctx context.Context, d *
 			})
 
 			result["ddos_protection"] = ddp
+		} else if len(localState) > 0 {
+			// Preserve explicitly disabled nested blocks from config to prevent drift
+			if localMap, ok := localState[0].(map[string]any); ok {
+				if ddp, ok := localMap["ddos_protection"].([]any); ok && len(ddp) > 0 {
+					result["ddos_protection"] = ddp
+				}
+			}
 		}
 
 		if _, err := apidiscovery.Get(gofastly.NewContextForResourceID(ctx, d.Id()), conn, serviceID); err == nil {
@@ -448,6 +462,13 @@ func (h *ProductEnablementServiceAttributeHandler) Read(ctx context.Context, d *
 			})
 
 			result["ngwaf"] = ngw
+		} else if len(localState) > 0 {
+			// Preserve explicitly disabled nested blocks from config to prevent drift
+			if localMap, ok := localState[0].(map[string]any); ok {
+				if ngw, ok := localMap["ngwaf"].([]any); ok && len(ngw) > 0 {
+					result["ngwaf"] = ngw
+				}
+			}
 		}
 
 		results := []map[string]any{result}

--- a/tests/interface/main.tf
+++ b/tests/interface/main.tf
@@ -149,12 +149,16 @@ EOT
   }
 
   product_enablement {
-    bot_management     = false
     brotli_compression = true
     domain_inspector   = false
     image_optimizer    = false
     origin_inspector   = false
     websockets         = false
+
+    bot_management {
+      enabled      = false
+      contentguard = "off"
+    }
   }
 
   rate_limiter {


### PR DESCRIPTION
### Change summary

This PR partially reverts commit [235a633](https://github.com/fastly/terraform-provider-fastly/pull/1221/commits/235a633e31a42e8febeeb35a8e2a0013e9b9b6ba). While there was a previously concern about assertion panic, removing the fallbacks was not the correct step. Instead we are simply adding additional safety around these lookups. 

 All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/terraform-provider-fastly/pulls) for the same update/change?

```
=== RUN   TestAccFastlyServiceProductEnablement_vcl_basic
=== PAUSE TestAccFastlyServiceProductEnablement_vcl_basic
=== CONT  TestAccFastlyServiceProductEnablement_vcl_basic
--- PASS: TestAccFastlyServiceProductEnablement_vcl_basic (16.23s)
PASS
```

The above test is now passing with this correction. 