### PR TITLE
(doc): Correct 'contentguard' PR# reference in CHANGELOG for v9.0.0 release 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 ## 9.0.0 (April 04, 2026)
 
 ### BREAKING:
-- breaking(product_enablement/bot_management): added support for ContentGuard, which is now requires the `contentguard` and `enabled` parameters ([#1309](https://github.com/fastly/terraform-provider-fastly/pull/1309))
+- breaking(product_enablement/bot_management): added support for ContentGuard, which is now requires the `contentguard` and `enabled` parameters ([#1221](https://github.com/fastly/terraform-provider-fastly/pull/1221))
 
 ### DEPENDENCIES:
 - build(deps): `google.golang.org/grpc` from 1.79.2 to 1.79.3 ([#1216](https://github.com/fastly/terraform-provider-fastly/pull/1216))


### PR DESCRIPTION
### Change summary

This PR corrects the PR # reference for the `breaking(product_enablement/bot_management)` CHANGELOG entry for the `v9.0.0` release. 

 All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/terraform-provider-fastly/pulls) for the same update/change?