### PR TITLE
feat(product_enablement): adds state upgrader for bot management so users can plan and apply without changing state manually

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### BREAKING:
 
 ### ENHANCEMENTS:
+- feat(product_enablement): add state upgrader for bot_management schema change from v9.0.0 - automatically migrates existing boolean values to new list structure with contentguard attribute ([#1226](https://github.com/fastly/terraform-provider-fastly/pull/1226))
 
 ### BUG FIXES:
 
@@ -21,7 +22,7 @@
 
 ### DOCUMENTATION:
 
--docs(ngwaf/lists): updated docs to provide important prefix information for usage with a NGWAF rule. ([#1217](https://github.com/fastly/terraform-provider-fastly/pull/1217))
+-docs(ngwaf/lists): updated docs to provide important prefix information for usage with a NGWAF rule ([#1217](https://github.com/fastly/terraform-provider-fastly/pull/1217))
 
 ## 8.8.0 (March 17, 2026)
 

--- a/docs/guides/state_upgrader_bot_management.md
+++ b/docs/guides/state_upgrader_bot_management.md
@@ -6,7 +6,7 @@ This document describes the state upgrader implemented for the breaking change i
 
 ## The Change state_upgrader_bot_management
 
-### Old Schema (v0)
+### Old Schema
 ```hcl
 resource "fastly_service_vcl" "example" {
   # ...
@@ -17,7 +17,7 @@ resource "fastly_service_vcl" "example" {
 }
 ```
 
-### New Schema (v1)
+### New Schema
 ```hcl
 resource "fastly_service_vcl" "example" {
   # ...

--- a/docs/guides/state_upgrader_bot_management.md
+++ b/docs/guides/state_upgrader_bot_management.md
@@ -1,0 +1,62 @@
+# State Upgrader for bot_management Schema Change
+
+## Overview
+
+This document describes the state upgrader implemented for the breaking change introduced in v9.0.0, where the `bot_management` attribute in the `product_enablement` block was changed from a boolean to a list block with nested attributes.
+
+## The Change state_upgrader_bot_management
+
+### Old Schema (v0)
+```hcl
+resource "fastly_service_vcl" "example" {
+  # ...
+  
+  product_enablement {
+    bot_management = true  # or false
+  }
+}
+```
+
+### New Schema (v1)
+```hcl
+resource "fastly_service_vcl" "example" {
+  # ...
+  
+  product_enablement {
+    bot_management {
+      enabled      = true
+      contentguard = "off"  # or "on"
+    }
+  }
+}
+```
+
+## Implementation
+
+The state upgrader automatically handles the migration of existing Terraform state files from the old schema to the new schema. This allows users to upgrade to version 9.0.0+ without manually editing their state files.
+
+## Migration Logic
+
+The upgrader performs the following conversions:
+
+| Old State Value | New State Value |
+|----------------|-----------------|
+| `bot_management = true` | `bot_management { enabled = true, contentguard = "off" }` |
+| `bot_management = false` | `bot_management = []` (empty list) |
+| Already in new format | No change (idempotent) |
+
+### Default Values
+
+When migrating from `bot_management = true`, the upgrader sets:
+- `enabled = true` (preserves the intent)
+- `contentguard = "off"` (safe default, can be changed by user)
+
+## Usage
+
+The state upgrader runs automatically when users:
+
+1. Upgrade to Terraform Provider Fastly v9.0.0+
+2. Run `terraform plan` or `terraform apply`
+3. Have existing state with the old `bot_management` boolean format
+
+No manual intervention is required. Terraform will automatically detect that the state schema version is 0 and apply the upgrader to bring it to version 1.

--- a/fastly/resource_fastly_service_vcl.go
+++ b/fastly/resource_fastly_service_vcl.go
@@ -65,5 +65,17 @@ var vclService = &BaseServiceDefinition{
 }
 
 func resourceServiceVCL() *schema.Resource {
-	return resourceService(vclService)
+	resource := resourceService(vclService)
+
+	// Add schema version and state upgraders for bot_management breaking change (v9.0.0)
+	resource.SchemaVersion = 1
+	resource.StateUpgraders = []schema.StateUpgrader{
+		{
+			Version: 0,
+			Type:    serviceVCLStateUpgraderV0().CoreConfigSchema().ImpliedType(),
+			Upgrade: upgradeServiceVCLStateV0toV1,
+		},
+	}
+
+	return resource
 }

--- a/fastly/resource_fastly_service_vcl_state_upgrade.go
+++ b/fastly/resource_fastly_service_vcl_state_upgrade.go
@@ -1,0 +1,108 @@
+package fastly
+
+import (
+	"context"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// upgradeServiceVCLStateV0toV1 upgrades the state schema from version 0 to version 1.
+// This handles the breaking change in v9.0.0 where bot_management was changed from
+// a boolean to a list block with nested enabled and contentguard attributes.
+func upgradeServiceVCLStateV0toV1(_ context.Context, rawState map[string]any, _ any) (map[string]any, error) {
+	if rawState == nil {
+		return rawState, nil
+	}
+
+	log.Println("[DEBUG] Upgrading fastly_service_vcl state from v0 to v1")
+
+	// Check if product_enablement block exists
+	// In rawState, Sets and Lists are both represented as []any
+	productEnablementRaw, ok := rawState["product_enablement"]
+	if !ok {
+		return rawState, nil
+	}
+
+	// Product_enablement is a Set in the schema, but in rawState it's a []any
+	productEnablementList, ok := productEnablementRaw.([]any)
+	if !ok {
+		log.Printf("[DEBUG] product_enablement has unexpected type: %T", productEnablementRaw)
+		return rawState, nil
+	}
+
+	if len(productEnablementList) == 0 {
+		return rawState, nil
+	}
+
+	// Get the product_enablement block
+	productEnablement, ok := productEnablementList[0].(map[string]any)
+	if !ok {
+		log.Printf("[DEBUG] product_enablement element has unexpected type: %T", productEnablementList[0])
+		return rawState, nil
+	}
+
+	// Check if bot_management exists and needs migration
+	botManagementRaw, exists := productEnablement["bot_management"]
+	if !exists {
+		return rawState, nil
+	}
+
+	switch botManagement := botManagementRaw.(type) {
+	case bool:
+		log.Printf("[DEBUG] Migrating bot_management from bool (%v) to list block", botManagement)
+
+		// Convert boolean to new list structure
+		// If bot_management was true, set enabled=true and contentguard="off" (default)
+		// If bot_management was false, remove the block entirely (empty list)
+		if botManagement {
+			productEnablement["bot_management"] = []any{
+				map[string]any{
+					"enabled":      true,
+					"contentguard": "off",
+				},
+			}
+		} else {
+			// If bot_management was false, set it to an empty list
+			productEnablement["bot_management"] = []any{}
+		}
+
+	case []any:
+		// Already in new format, no migration needed
+		log.Println("[DEBUG] bot_management already in list format, skipping migration")
+
+	default:
+		log.Printf("[DEBUG] Unexpected bot_management type: %T", botManagement)
+	}
+
+	return rawState, nil
+}
+
+// serviceVCLStateUpgraderV0 returns the schema for version 0 of the service VCL resource.
+// This represents the schema before the bot_management change in v9.0.0.
+func serviceVCLStateUpgraderV0() *schema.Resource {
+	// Return a resource with the old schema (v0) where bot_management was a boolean
+	// We only need to define the parts of the schema that are relevant to the upgrade
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"product_enablement": {
+				Type:        schema.TypeList,
+				Description: "Product Enablement",
+				Optional:    true,
+				MaxItems:    1,
+				MinItems:    1,
+				Elem: &schema.Resource{
+					Description: "Product Enablement values",
+					Schema: map[string]*schema.Schema{
+						"bot_management": {
+							Description: "Bot management enablement",
+							Type:        schema.TypeBool,
+							Optional:    true,
+						},
+						// Other fields are omitted as they don't affect the upgrade
+					},
+				},
+			},
+		},
+	}
+}

--- a/fastly/resource_fastly_service_vcl_state_upgrade_test.go
+++ b/fastly/resource_fastly_service_vcl_state_upgrade_test.go
@@ -1,0 +1,190 @@
+package fastly
+
+import (
+	"context"
+	"testing"
+)
+
+func TestUpgradeServiceVCLStateV0toV1_BotManagementTrue(t *testing.T) {
+	// Test upgrading when bot_management was true
+	// In rawState, Sets are represented as []any slices
+	rawState := map[string]any{
+		"product_enablement": []any{
+			map[string]any{
+				"bot_management": true,
+			},
+		},
+	}
+
+	upgraded, err := upgradeServiceVCLStateV0toV1(context.Background(), rawState, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	peUpgraded, ok := upgraded["product_enablement"].([]any)
+	if !ok {
+		t.Fatalf("expected product_enablement to be []any, got %T", upgraded["product_enablement"])
+	}
+
+	if len(peUpgraded) == 0 {
+		t.Fatal("expected product_enablement to have items")
+	}
+
+	pe, ok := peUpgraded[0].(map[string]any)
+	if !ok {
+		t.Fatalf("expected product_enablement element to be map[string]any, got %T", peUpgraded[0])
+	}
+
+	botManagement, ok := pe["bot_management"].([]any)
+	if !ok {
+		t.Fatalf("expected bot_management to be []any, got %T", pe["bot_management"])
+	}
+
+	if len(botManagement) != 1 {
+		t.Fatalf("expected bot_management to have 1 item, got %d", len(botManagement))
+	}
+
+	bmBlock, ok := botManagement[0].(map[string]any)
+	if !ok {
+		t.Fatalf("expected bot_management element to be map[string]any, got %T", botManagement[0])
+	}
+
+	if enabled, ok := bmBlock["enabled"].(bool); !ok || !enabled {
+		t.Errorf("expected enabled to be true, got %v", bmBlock["enabled"])
+	}
+
+	if contentguard, ok := bmBlock["contentguard"].(string); !ok || contentguard != "off" {
+		t.Errorf("expected contentguard to be 'off', got %v", bmBlock["contentguard"])
+	}
+}
+
+func TestUpgradeServiceVCLStateV0toV1_BotManagementFalse(t *testing.T) {
+	// Test upgrading when bot_management was false
+	rawState := map[string]any{
+		"product_enablement": []any{
+			map[string]any{
+				"bot_management": false,
+			},
+		},
+	}
+
+	upgraded, err := upgradeServiceVCLStateV0toV1(context.Background(), rawState, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	peUpgraded, ok := upgraded["product_enablement"].([]any)
+	if !ok {
+		t.Fatalf("expected product_enablement to be []any, got %T", upgraded["product_enablement"])
+	}
+
+	if len(peUpgraded) == 0 {
+		t.Fatal("expected product_enablement to have items")
+	}
+
+	pe, ok := peUpgraded[0].(map[string]any)
+	if !ok {
+		t.Fatalf("expected product_enablement element to be map[string]any, got %T", peUpgraded[0])
+	}
+
+	botManagement, ok := pe["bot_management"].([]any)
+	if !ok {
+		t.Fatalf("expected bot_management to be []any, got %T", pe["bot_management"])
+	}
+
+	// When bot_management was false, it should be converted to an empty list
+	if len(botManagement) != 0 {
+		t.Fatalf("expected bot_management to be empty, got %d items", len(botManagement))
+	}
+}
+
+func TestUpgradeServiceVCLStateV0toV1_AlreadyUpgraded(t *testing.T) {
+	// Test that already upgraded state (bot_management as []any) is not modified
+	// This simulates a state that's already been upgraded or is in transition
+	rawState := map[string]any{
+		"product_enablement": []any{
+			map[string]any{
+				"bot_management": []any{
+					map[string]any{
+						"enabled":      true,
+						"contentguard": "on",
+					},
+				},
+			},
+		},
+	}
+
+	upgraded, err := upgradeServiceVCLStateV0toV1(context.Background(), rawState, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	peUpgraded, ok := upgraded["product_enablement"].([]any)
+	if !ok {
+		t.Fatalf("expected product_enablement to be []any, got %T", upgraded["product_enablement"])
+	}
+
+	if len(peUpgraded) == 0 {
+		t.Fatal("expected product_enablement to have items")
+	}
+
+	pe, ok := peUpgraded[0].(map[string]any)
+	if !ok {
+		t.Fatalf("expected product_enablement element to be map[string]any, got %T", peUpgraded[0])
+	}
+
+	botManagement, ok := pe["bot_management"].([]any)
+	if !ok {
+		t.Fatalf("expected bot_management to be []any, got %T", pe["bot_management"])
+	}
+
+	if len(botManagement) != 1 {
+		t.Fatalf("expected bot_management to have 1 item, got %d", len(botManagement))
+	}
+
+	bmBlock, ok := botManagement[0].(map[string]any)
+	if !ok {
+		t.Fatalf("expected bot_management element to be map[string]any, got %T", botManagement[0])
+	}
+
+	if enabled, ok := bmBlock["enabled"].(bool); !ok || !enabled {
+		t.Errorf("expected enabled to be true, got %v", bmBlock["enabled"])
+	}
+
+	// Should remain "on" since it was already upgraded
+	if contentguard, ok := bmBlock["contentguard"].(string); !ok || contentguard != "on" {
+		t.Errorf("expected contentguard to remain 'on', got %v", bmBlock["contentguard"])
+	}
+}
+
+func TestUpgradeServiceVCLStateV0toV1_NoProductEnablement(t *testing.T) {
+	// Test that state without product_enablement is not modified
+	rawState := map[string]any{
+		"name": "test-service",
+	}
+
+	upgraded, err := upgradeServiceVCLStateV0toV1(context.Background(), rawState, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if _, exists := upgraded["product_enablement"]; exists {
+		t.Error("expected product_enablement to not be present in upgraded state")
+	}
+
+	if name := upgraded["name"]; name != "test-service" {
+		t.Errorf("expected name to remain 'test-service', got %v", name)
+	}
+}
+
+func TestUpgradeServiceVCLStateV0toV1_NilState(t *testing.T) {
+	// Test that nil state returns nil without error
+	upgraded, err := upgradeServiceVCLStateV0toV1(context.Background(), nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if upgraded != nil {
+		t.Error("expected nil state to remain nil")
+	}
+}

--- a/templates/guides/state_upgrader_bot_management.md
+++ b/templates/guides/state_upgrader_bot_management.md
@@ -6,7 +6,7 @@ This document describes the state upgrader implemented for the breaking change i
 
 ## The Change state_upgrader_bot_management
 
-### Old Schema (v0)
+### Old Schema
 ```hcl
 resource "fastly_service_vcl" "example" {
   # ...
@@ -17,7 +17,7 @@ resource "fastly_service_vcl" "example" {
 }
 ```
 
-### New Schema (v1)
+### New Schema
 ```hcl
 resource "fastly_service_vcl" "example" {
   # ...

--- a/templates/guides/state_upgrader_bot_management.md
+++ b/templates/guides/state_upgrader_bot_management.md
@@ -1,0 +1,62 @@
+# State Upgrader for bot_management Schema Change
+
+## Overview
+
+This document describes the state upgrader implemented for the breaking change introduced in v9.0.0, where the `bot_management` attribute in the `product_enablement` block was changed from a boolean to a list block with nested attributes.
+
+## The Change state_upgrader_bot_management
+
+### Old Schema (v0)
+```hcl
+resource "fastly_service_vcl" "example" {
+  # ...
+  
+  product_enablement {
+    bot_management = true  # or false
+  }
+}
+```
+
+### New Schema (v1)
+```hcl
+resource "fastly_service_vcl" "example" {
+  # ...
+  
+  product_enablement {
+    bot_management {
+      enabled      = true
+      contentguard = "off"  # or "on"
+    }
+  }
+}
+```
+
+## Implementation
+
+The state upgrader automatically handles the migration of existing Terraform state files from the old schema to the new schema. This allows users to upgrade to version 9.0.0+ without manually editing their state files.
+
+## Migration Logic
+
+The upgrader performs the following conversions:
+
+| Old State Value | New State Value |
+|----------------|-----------------|
+| `bot_management = true` | `bot_management { enabled = true, contentguard = "off" }` |
+| `bot_management = false` | `bot_management = []` (empty list) |
+| Already in new format | No change (idempotent) |
+
+### Default Values
+
+When migrating from `bot_management = true`, the upgrader sets:
+- `enabled = true` (preserves the intent)
+- `contentguard = "off"` (safe default, can be changed by user)
+
+## Usage
+
+The state upgrader runs automatically when users:
+
+1. Upgrade to Terraform Provider Fastly v9.0.0+
+2. Run `terraform plan` or `terraform apply`
+3. Have existing state with the old `bot_management` boolean format
+
+No manual intervention is required. Terraform will automatically detect that the state schema version is 0 and apply the upgrader to bring it to version 1.


### PR DESCRIPTION
### Change summary
 Adds a state updater so users don't have to manually modify state or otherwise deal with the upgrade in state

 All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/terraform-provider-fastly/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

* [x] Does your submission pass tests?
* [x] Post the output of your test runs

main.tf v8.8.1
<img width="480" height="302" alt="Screenshot 2026-04-07 at 3 42 19 PM" src="https://github.com/user-attachments/assets/72f55e6d-1298-4d14-8d6c-4baf628ecc46" />

main.tf v9.0.0
<img width="377" height="364" alt="Screenshot 2026-04-07 at 3 41 20 PM" src="https://github.com/user-attachments/assets/6eab67c3-c9ea-4263-8d64-c8a917a066fb" />

`terraform plan` output
<img width="1269" height="243" alt="Screenshot 2026-04-07 at 3 41 03 PM" src="https://github.com/user-attachments/assets/b186351e-61fa-485f-8196-ae585bac6884" />


### Changes to Core Features:

* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
