### PR TITLE
fix(product_enablement/bot_management): fix schema interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### ENHANCEMENTS:
 
 ### BUG FIXES:
+- fix(product_enablement/bot_management): fix bot_management schema validation  ([#1228](https://github.com/fastly/terraform-provider-fastly/pull/1228))
 
 ### DEPENDENCIES:
 

--- a/fastly/block_fastly_service_product_enablement.go
+++ b/fastly/block_fastly_service_product_enablement.go
@@ -72,7 +72,6 @@ func (h *ProductEnablementServiceAttributeHandler) GetSchema() *schema.Schema {
 			Optional:    true,
 			Description: "Enable Bot Management support",
 			MaxItems:    1,
-			MinItems:    1,
 			Elem: &schema.Resource{
 				Schema: map[string]*schema.Schema{
 					"contentguard": {


### PR DESCRIPTION
### Change summary

This PR fixes the `product_enablement.bot_management` schema validation error:
```
Unexpected block: Blocks of type "bot_management" are not expected here
```

 All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/terraform-provider-fastly/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

* [ ] Does your submission pass tests?
* [ ] Post the output of your test runs

### Changes to Core Features:

* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

### User Impact

Users will no longer see warnings in their IDE about the `bot_management` block not being expected. 

