### PR TITLE
Limit the number of builds go-releaser does to speed up build times

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -177,7 +177,10 @@ jobs:
         uses: goreleaser/goreleaser-action@v5
         with:
           version: "~> 2"
-          args: build --skip=validate --clean --snapshot # snapshot is needed as local git has no tags
+          args: build --skip=validate --clean --snapshot --id default # snapshot is needed as local git has no tags
+        env:
+          GOOS: linux,darwin,windows
+          GOARCH: amd64,arm
   golangci-latest:
     name: lint-latest (informational)
     runs-on: ubuntu-latest

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -177,10 +177,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v5
         with:
           version: "~> 2"
-          args: build --skip=validate --clean --snapshot --id default # snapshot is needed as local git has no tags
-        env:
-          GOOS: linux,darwin,windows
-          GOARCH: amd64,arm
+          args: build --skip=validate --clean --snapshot --config .goreleaser.pr.yml # snapshot is needed as local git has no tags
   golangci-latest:
     name: lint-latest (informational)
     runs-on: ubuntu-latest

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -169,6 +169,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
       - name: Install Go
         uses: actions/setup-go@v6
         with:

--- a/.goreleaser.pr.yml
+++ b/.goreleaser.pr.yml
@@ -16,7 +16,7 @@ builds:
     - darwin
   goarch:
     - amd64
-    - arm
+    - arm64
   ignore:
     - goos: darwin
       goarch: arm

--- a/.goreleaser.pr.yml
+++ b/.goreleaser.pr.yml
@@ -1,0 +1,34 @@
+version: 2
+before:
+  hooks:
+    - go mod tidy
+builds:
+- env:
+    - CGO_ENABLED=0
+  mod_timestamp: '{{ .CommitTimestamp }}'
+  flags:
+    - -trimpath
+  ldflags:
+    - -s -w -X "github.com/fastly/terraform-provider-fastly/version.ProviderVersion={{.Version}}"
+  goos:
+    - windows
+    - linux
+    - darwin
+  goarch:
+    - amd64
+    - arm
+  ignore:
+    - goos: darwin
+      goarch: arm
+      goarm: '6'
+  binary: '{{ .ProjectName }}_v{{ .Version }}'
+archives:
+- formats: [zip]
+  name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
+checksum:
+  name_template: '{{ .ProjectName }}_{{ .Version }}_SHA256SUMS'
+  algorithm: sha256
+release:
+  disable: true
+changelog:
+  disable: true


### PR DESCRIPTION
### Change summary
limit the number of builds done in PR's to speed up review time

 All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/terraform-provider-fastly/pulls) for the same update/change?