### PR TITLE
[CDTOOL-1326] Update the Interface Test to Allow Concurrent Runs

### DIFF
--- a/tests/interface/main.tf
+++ b/tests/interface/main.tf
@@ -2,19 +2,24 @@ terraform {
   required_providers {
     fastly = {
       source  = "fastly/fastly"
-      version = ">1.0.0"
+      version = ">= 9.0.0"
     }
   }
+}
+
+variable "service_name" {
+  type    = string
+  default = "interface-test-project"
 }
 
 resource "fastly_service_vcl" "interface-test-project" {
   activate           = true
   comment            = "Fastly Terraform Provider: Interface Test Suite"
-  default_host       = "interface-test-project.fastly-terraform.com"
+  default_host       = "${var.service_name}.fastly-terraform.com"
   default_ttl        = 3600
   force_destroy      = true # Omitted `reuse` as it conflicts
   http3              = false
-  name               = "interface-test-project"
+  name               = var.service_name
   stale_if_error     = false
   stale_if_error_ttl = 43200
   version_comment    = "Fastly Terraform Provider: Version comment example"
@@ -76,7 +81,7 @@ resource "fastly_service_vcl" "interface-test-project" {
 
   domain {
     comment = "demo"
-    name    = "interface-test-project.fastly-terraform.com"
+    name    = "${var.service_name}.fastly-terraform.com"
   }
 
   dynamicsnippet {
@@ -185,7 +190,7 @@ EOT
   request_setting {
     action            = "pass"
     bypass_busy_wait  = true
-    default_host      = "interface-test-project.fastly-terraform.com"
+    default_host      = "${var.service_name}.fastly-terraform.com"
     force_miss        = true
     force_ssl         = false
     hash_keys         = "req.url.path, req.http.host" # Omitted because of error... Syntax error: Expected string variable or constant

--- a/tests/interface/script.sh
+++ b/tests/interface/script.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+RUN_ID="${GITHUB_RUN_ID:-$(date +%s)}"
+export TF_VAR_service_name="interface-test-${RUN_ID}"
+
 cd ./tests/interface/ || exit
 
 echo DEPLOYING USING LATEST TERRAFORM VERSION


### PR DESCRIPTION
### Change summary

This PR updates the Interface test HCL parameters to have dynamic values, ensuring that additional CI jobs do not collide on resource naming. 

 All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/terraform-provider-fastly/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

* [ ] Does your submission pass tests?
* [ ] Post the output of your test runs


### Notes:

We'll need to rewrite this test in the new provider, but this update should help future PR CI checks run smoother in the interim. 