### PR TITLE
fix(block_fastly_service_product_enablement): remove the vcl check on product enablement for bot management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### BUG FIXES:
 
-- fix(block_fastly_service_product_enablement): remove the vcl check on product enablement for bot management ([#1270](https://github.com/fastly/terraform-provider-fastly/pull/1270))
+- fix(block_fastly_service_product_enablement): Allow `bot_management` to be enabled on Compute services ([#1270](https://github.com/fastly/terraform-provider-fastly/pull/1270))
 
 ### DEPENDENCIES:
 - build(deps): `github.com/hashicorp/terraform-plugin-sdk/v2` from 2.40.0 to 2.40.1 ([#1259](https://github.com/fastly/terraform-provider-fastly/pull/1259))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### BUG FIXES:
 
+- fix(block_fastly_service_product_enablement): remove the vcl check on product enablement for bot management ([#1270](https://github.com/fastly/terraform-provider-fastly/pull/1270))
+
 ### DEPENDENCIES:
 - build(deps): `github.com/hashicorp/terraform-plugin-sdk/v2` from 2.40.0 to 2.40.1 ([#1259](https://github.com/fastly/terraform-provider-fastly/pull/1259))
 - build(deps): `github.com/fastly/go-fastly/v15` from 14.0.2 to 15.0.1([#1260](https://github.com/fastly/terraform-provider-fastly/pull/1260))

--- a/docs/resources/service_compute.md
+++ b/docs/resources/service_compute.md
@@ -819,6 +819,7 @@ Optional:
 Optional:
 
 - `api_discovery` (Boolean) Enable API Discovery support
+- `bot_management` (Block List, Max: 1) Enable Bot Management support (see [below for nested schema](#nestedblock--product_enablement--bot_management))
 - `ddos_protection` (Block List, Max: 1) DDoS Protection product (see [below for nested schema](#nestedblock--product_enablement--ddos_protection))
 - `domain_inspector` (Boolean) Enable Domain Inspector support
 - `fanout` (Boolean) Enable Fanout support
@@ -826,6 +827,15 @@ Optional:
 - `name` (String) Used by the provider to identify modified settings (changing this value will force the entire block to be deleted, then recreated)
 - `ngwaf` (Block List, Max: 1) Next-Gen WAF product (see [below for nested schema](#nestedblock--product_enablement--ngwaf))
 - `websockets` (Boolean) Enable WebSockets support
+
+<a id="nestedblock--product_enablement--bot_management"></a>
+### Nested Schema for `product_enablement.bot_management`
+
+Required:
+
+- `contentguard` (String) ContentGuard status. Can be either `off`, or `on`.
+- `enabled` (Boolean) Enable Bot Management support
+
 
 <a id="nestedblock--product_enablement--ddos_protection"></a>
 ### Nested Schema for `product_enablement.ddos_protection`

--- a/fastly/block_fastly_service_product_enablement.go
+++ b/fastly/block_fastly_service_product_enablement.go
@@ -67,30 +67,6 @@ func (h *ProductEnablementServiceAttributeHandler) GetSchema() *schema.Schema {
 
 	// These products are supported only on Delivery (VCL) services.
 	if h.GetServiceMetadata().serviceType == ServiceTypeVCL {
-		blockAttributes["bot_management"] = &schema.Schema{
-			Type:        schema.TypeList,
-			Optional:    true,
-			Description: "Enable Bot Management support",
-			MaxItems:    1,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"contentguard": {
-						Type:        schema.TypeString,
-						Required:    true,
-						Description: "ContentGuard status. Can be either `off`, or `on`.",
-						ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice(
-							[]string{"off", "on"},
-							false,
-						)),
-					},
-					"enabled": {
-						Type:        schema.TypeBool,
-						Required:    true,
-						Description: "Enable Bot Management support",
-					},
-				},
-			},
-		}
 		blockAttributes["brotli_compression"] = &schema.Schema{
 			Type:        schema.TypeBool,
 			Optional:    true,
@@ -109,6 +85,30 @@ func (h *ProductEnablementServiceAttributeHandler) GetSchema() *schema.Schema {
 	}
 
 	// These products are supported for both Compute (WASM) and Delivery (VCL) services.
+	blockAttributes["bot_management"] = &schema.Schema{
+		Type:        schema.TypeList,
+		Optional:    true,
+		Description: "Enable Bot Management support",
+		MaxItems:    1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"contentguard": {
+					Type:        schema.TypeString,
+					Required:    true,
+					Description: "ContentGuard status. Can be either `off`, or `on`.",
+					ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice(
+						[]string{"off", "on"},
+						false,
+					)),
+				},
+				"enabled": {
+					Type:        schema.TypeBool,
+					Required:    true,
+					Description: "Enable Bot Management support",
+				},
+			},
+		},
+	}
 	blockAttributes["domain_inspector"] = &schema.Schema{
 		Type:        schema.TypeBool,
 		Optional:    true,

--- a/fastly/block_fastly_service_product_enablement_test.go
+++ b/fastly/block_fastly_service_product_enablement_test.go
@@ -391,6 +391,7 @@ resource "fastly_service_compute" "foo" {
 
   product_enablement {
     api_discovery         = false
+    bot_management        = false
     domain_inspector      = true
     fanout                = false
     log_explorer_insights = false

--- a/fastly/redacting_transport_test.go
+++ b/fastly/redacting_transport_test.go
@@ -83,7 +83,8 @@ func TestRedactingTransport_ResponseBodyLogging(t *testing.T) {
 				underlying: http.DefaultTransport,
 				redactKeys: []string{"Fastly-Key"},
 				logf: func(_ context.Context, msg string) {
-					logBuf.WriteString(msg + "\n")
+					logBuf.WriteString(msg)
+					logBuf.WriteString("\n")
 				},
 			}
 


### PR DESCRIPTION
### Change summary

Move bot management outside of the VCL check to allow it on all service types

 All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/terraform-provider-fastly/pulls) for the same update/change?

### New Feature Submissions:

* [x] Does your submission pass tests?

### Changes to Core Features:

* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
