### PR TITLE
Remove vcl check for bot management in actual functions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,8 +68,9 @@ clean_test:
 		TEST_PARALLELISM=8 make testacc; \
 	fi
 
-fmt:
-	golangci-lint fmt
+fmt: install-linter check-linter-version
+	@echo "==> Running golangci-lint --fix"
+	@$(GOLANGCI_LINT) run --fix
 
 
 test-compile:

--- a/fastly/block_fastly_service_product_enablement.go
+++ b/fastly/block_fastly_service_product_enablement.go
@@ -211,27 +211,6 @@ func (h *ProductEnablementServiceAttributeHandler) Create(ctx context.Context, d
 	}
 
 	if h.GetServiceMetadata().serviceType == ServiceTypeVCL {
-		bp := resource["bot_management"].([]any)
-		if len(bp) != 0 {
-			if bp[0].(map[string]any)["enabled"].(bool) {
-				log.Println("[DEBUG] bot_management set")
-				_, err := botmanagement.Enable(gofastly.NewContextForResourceID(ctx, d.Id()), conn, serviceID)
-				if err != nil {
-					return fmt.Errorf("failed to enable bot_management: %w", err)
-				}
-
-				contentguard := bp[0].(map[string]any)["contentguard"].(string)
-				_, err = botmanagement.UpdateConfiguration(
-					gofastly.NewContextForResourceID(ctx, d.Id()),
-					conn,
-					serviceID,
-					botmanagement.ConfigureInput{ContentGuard: contentguard},
-				)
-				if err != nil {
-					return fmt.Errorf("failed to configure bot_management: %w", err)
-				}
-			}
-		}
 		if resource["brotli_compression"].(bool) {
 			log.Println("[DEBUG] brotli_compression set")
 			_, err := brotlicompression.Enable(gofastly.NewContextForResourceID(ctx, d.Id()), conn, serviceID)
@@ -253,6 +232,28 @@ func (h *ProductEnablementServiceAttributeHandler) Create(ctx context.Context, d
 			_, err := origininspector.Enable(gofastly.NewContextForResourceID(ctx, d.Id()), conn, serviceID)
 			if err != nil {
 				return fmt.Errorf("failed to enable origin_inspector: %w", err)
+			}
+		}
+	}
+
+	bp := resource["bot_management"].([]any)
+	if len(bp) != 0 {
+		if bp[0].(map[string]any)["enabled"].(bool) {
+			log.Println("[DEBUG] bot_management set")
+			_, err := botmanagement.Enable(gofastly.NewContextForResourceID(ctx, d.Id()), conn, serviceID)
+			if err != nil {
+				return fmt.Errorf("failed to enable bot_management: %w", err)
+			}
+
+			contentguard := bp[0].(map[string]any)["contentguard"].(string)
+			_, err = botmanagement.UpdateConfiguration(
+				gofastly.NewContextForResourceID(ctx, d.Id()),
+				conn,
+				serviceID,
+				botmanagement.ConfigureInput{ContentGuard: contentguard},
+			)
+			if err != nil {
+				return fmt.Errorf("failed to configure bot_management: %w", err)
 			}
 		}
 	}
@@ -370,28 +371,6 @@ func (h *ProductEnablementServiceAttributeHandler) Read(ctx context.Context, d *
 		}
 
 		if h.GetServiceMetadata().serviceType == ServiceTypeVCL {
-			if _, err := botmanagement.Get(gofastly.NewContextForResourceID(ctx, d.Id()), conn, serviceID); err == nil {
-				c, err := botmanagement.GetConfiguration(gofastly.NewContextForResourceID(ctx, d.Id()), conn, serviceID)
-				if err != nil {
-					return fmt.Errorf("error looking up Bot Management product configuration for (%s): %s", serviceID, err)
-				}
-
-				bp := []map[string]any{}
-				bp = append(bp, map[string]any{
-					"enabled":      true,
-					"contentguard": *c.Configuration.ContentGuard,
-				})
-
-				result["bot_management"] = bp
-			} else if len(localState) > 0 {
-				// Preserve explicitly disabled nested blocks from config to prevent drift
-				if localMap, ok := localState[0].(map[string]any); ok {
-					if bm, ok := localMap["bot_management"].([]any); ok && len(bm) > 0 {
-						result["bot_management"] = bm
-					}
-				}
-			}
-
 			if _, err := brotlicompression.Get(gofastly.NewContextForResourceID(ctx, d.Id()), conn, serviceID); err == nil {
 				result["brotli_compression"] = true
 			}
@@ -402,6 +381,27 @@ func (h *ProductEnablementServiceAttributeHandler) Read(ctx context.Context, d *
 
 			if _, err := origininspector.Get(gofastly.NewContextForResourceID(ctx, d.Id()), conn, serviceID); err == nil {
 				result["origin_inspector"] = true
+			}
+		}
+		if _, err := botmanagement.Get(gofastly.NewContextForResourceID(ctx, d.Id()), conn, serviceID); err == nil {
+			c, err := botmanagement.GetConfiguration(gofastly.NewContextForResourceID(ctx, d.Id()), conn, serviceID)
+			if err != nil {
+				return fmt.Errorf("error looking up Bot Management product configuration for (%s): %s", serviceID, err)
+			}
+
+			bp := []map[string]any{}
+			bp = append(bp, map[string]any{
+				"enabled":      true,
+				"contentguard": *c.Configuration.ContentGuard,
+			})
+
+			result["bot_management"] = bp
+		} else if len(localState) > 0 {
+			// Preserve explicitly disabled nested blocks from config to prevent drift
+			if localMap, ok := localState[0].(map[string]any); ok {
+				if bm, ok := localMap["bot_management"].([]any); ok && len(bm) > 0 {
+					result["bot_management"] = bm
+				}
 			}
 		}
 		if _, err := domaininspector.Get(gofastly.NewContextForResourceID(ctx, d.Id()), conn, serviceID); err == nil {
@@ -518,37 +518,6 @@ func (h *ProductEnablementServiceAttributeHandler) Update(ctx context.Context, d
 	}
 
 	if h.GetServiceMetadata().serviceType == ServiceTypeVCL {
-		if v, ok := modified["bot_management"]; ok {
-			bp := v.([]any)
-			if len(bp) != 0 {
-				if bp[0].(map[string]any)["enabled"].(bool) {
-					log.Println("[DEBUG] bot_management will be enabled")
-					_, err := botmanagement.Enable(gofastly.NewContextForResourceID(ctx, d.Id()), conn, serviceID)
-					if err != nil {
-						return fmt.Errorf("failed to enable bot_management: %w", err)
-					}
-
-					contentguard := bp[0].(map[string]any)["contentguard"].(string)
-					log.Printf("[DEBUG] bot_management contentguard will be set to %s", contentguard)
-					_, err = botmanagement.UpdateConfiguration(
-						gofastly.NewContextForResourceID(ctx, d.Id()), conn, serviceID,
-						botmanagement.ConfigureInput{ContentGuard: contentguard},
-					)
-					if err != nil {
-						return fmt.Errorf("failed to set the configuration of bot_management: %w", err)
-					}
-				} else {
-					log.Println("[DEBUG] bot_management will be disabled")
-					err := botmanagement.Disable(gofastly.NewContextForResourceID(ctx, d.Id()), conn, serviceID)
-					if err != nil {
-						if e := h.checkAPIError(err); e != nil {
-							return e
-						}
-					}
-				}
-			}
-		}
-
 		if v, ok := modified["brotli_compression"]; ok {
 			if v.(bool) {
 				log.Println("[DEBUG] brotli_compression will be enabled")
@@ -595,6 +564,36 @@ func (h *ProductEnablementServiceAttributeHandler) Update(ctx context.Context, d
 			} else {
 				log.Println("[DEBUG] origin_inspector will be disabled")
 				err := origininspector.Disable(gofastly.NewContextForResourceID(ctx, d.Id()), conn, serviceID)
+				if err != nil {
+					if e := h.checkAPIError(err); e != nil {
+						return e
+					}
+				}
+			}
+		}
+	}
+	if v, ok := modified["bot_management"]; ok {
+		bp := v.([]any)
+		if len(bp) != 0 {
+			if bp[0].(map[string]any)["enabled"].(bool) {
+				log.Println("[DEBUG] bot_management will be enabled")
+				_, err := botmanagement.Enable(gofastly.NewContextForResourceID(ctx, d.Id()), conn, serviceID)
+				if err != nil {
+					return fmt.Errorf("failed to enable bot_management: %w", err)
+				}
+
+				contentguard := bp[0].(map[string]any)["contentguard"].(string)
+				log.Printf("[DEBUG] bot_management contentguard will be set to %s", contentguard)
+				_, err = botmanagement.UpdateConfiguration(
+					gofastly.NewContextForResourceID(ctx, d.Id()), conn, serviceID,
+					botmanagement.ConfigureInput{ContentGuard: contentguard},
+				)
+				if err != nil {
+					return fmt.Errorf("failed to set the configuration of bot_management: %w", err)
+				}
+			} else {
+				log.Println("[DEBUG] bot_management will be disabled")
+				err := botmanagement.Disable(gofastly.NewContextForResourceID(ctx, d.Id()), conn, serviceID)
 				if err != nil {
 					if e := h.checkAPIError(err); e != nil {
 						return e
@@ -781,16 +780,8 @@ func (h *ProductEnablementServiceAttributeHandler) Delete(ctx context.Context, d
 	}
 
 	if h.GetServiceMetadata().serviceType == ServiceTypeVCL {
-		log.Println("[DEBUG] disable bot_management")
-		err := botmanagement.Disable(gofastly.NewContextForResourceID(ctx, d.Id()), conn, serviceID)
-		if err != nil {
-			if e := h.checkAPIError(err); e != nil {
-				return e
-			}
-		}
-
 		log.Println("[DEBUG] disable brotli_compression")
-		err = brotlicompression.Disable(gofastly.NewContextForResourceID(ctx, d.Id()), conn, serviceID)
+		err := brotlicompression.Disable(gofastly.NewContextForResourceID(ctx, d.Id()), conn, serviceID)
 		if err != nil {
 			if e := h.checkAPIError(err); e != nil {
 				return e
@@ -814,8 +805,16 @@ func (h *ProductEnablementServiceAttributeHandler) Delete(ctx context.Context, d
 		}
 	}
 
+	log.Println("[DEBUG] disable bot_management")
+	err := botmanagement.Disable(gofastly.NewContextForResourceID(ctx, d.Id()), conn, serviceID)
+	if err != nil {
+		if e := h.checkAPIError(err); e != nil {
+			return e
+		}
+	}
+
 	log.Println("[DEBUG] disable domain_inspector")
-	err := domaininspector.Disable(gofastly.NewContextForResourceID(ctx, d.Id()), conn, serviceID)
+	err = domaininspector.Disable(gofastly.NewContextForResourceID(ctx, d.Id()), conn, serviceID)
 	if err != nil {
 		if e := h.checkAPIError(err); e != nil {
 			return e

--- a/fastly/block_fastly_service_product_enablement_test.go
+++ b/fastly/block_fastly_service_product_enablement_test.go
@@ -391,11 +391,15 @@ resource "fastly_service_compute" "foo" {
 
   product_enablement {
     api_discovery         = false
-    bot_management        = false
     domain_inspector      = true
     fanout                = false
     log_explorer_insights = false
     websockets            = false
+
+    bot_management {
+      enabled       = false
+      contentguard  = "off"
+    }
 
     ddos_protection {
       enabled = false


### PR DESCRIPTION
### Change summary

I had missed the extra checks in the CRUD operations for VCL, removing those as well

 All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/terraform-provider-fastly/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

* [x] Does your submission pass tests?
* [x] Post the output of your test runs

<img width="851" height="497" alt="Screenshot 2026-05-20 at 10 14 11 AM" src="https://github.com/user-attachments/assets/3a850eac-d748-4be8-932b-6cd540b83158" />

### Changes to Core Features:

* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
