### PR TITLE
Remove integration from state when read returns 404

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,10 @@
 ### BUG FIXES:
 
 - fix(block_fastly_service_product_enablement): Allow `bot_management` to be enabled on Compute services ([#1270](https://github.com/fastly/terraform-provider-fastly/pull/1270))
+- fix(resource_fastly_integration): recreate integrations deleted outside of Terraform ([#1273](https://github.com/fastly/terraform-provider-fastly/pull/1273))
 
 ### DEPENDENCIES:
+
 - build(deps): `github.com/hashicorp/terraform-plugin-sdk/v2` from 2.40.0 to 2.40.1 ([#1259](https://github.com/fastly/terraform-provider-fastly/pull/1259))
 - build(deps): `github.com/fastly/go-fastly/v15` from 14.0.2 to 15.0.1([#1260](https://github.com/fastly/terraform-provider-fastly/pull/1260))
 - build(deps): `golang.org/x/net` from 0.53.0 to 0.54.0 ([#1267](https://github.com/fastly/terraform-provider-fastly/pull/1267))
@@ -24,6 +26,7 @@
 - fix(ngwaf/rules): updated validation to allow the maximum value of rate limit rule thresholds to `1000000` ([#1236](https://github.com/fastly/terraform-provider-fastly/pull/1236))
 
 ### DEPENDENCIES:
+
 - build(deps): `actions/github-script` from 8 to 9 ([#1232](https://github.com/fastly/terraform-provider-fastly/pull/1232))
 - build(deps): `github.com/fastly/go-fastly/v14` from 14.0.0 to 14.2.0 ([#1231](https://github.com/fastly/terraform-provider-fastly/pull/1231))
 - build(deps): `golang.org/x/net` from 0.52.0 to 0.53.0 ([#1231](https://github.com/fastly/terraform-provider-fastly/pull/1231))

--- a/fastly/resource_fastly_integration.go
+++ b/fastly/resource_fastly_integration.go
@@ -83,6 +83,12 @@ func resourceFastlyIntegrationRead(ctx context.Context, d *schema.ResourceData, 
 		ID: d.Id(),
 	})
 	if err != nil {
+		if e, ok := err.(*gofastly.HTTPError); ok && e.IsNotFound() {
+			log.Printf("[WARN] Integration not found (%s); removing from state", d.Id())
+			d.SetId("")
+			return nil
+		}
+
 		return diag.FromErr(err)
 	}
 
@@ -149,6 +155,10 @@ func resourceFastlyIntegrationDelete(ctx context.Context, d *schema.ResourceData
 		ID: d.Id(),
 	})
 	if err != nil {
+		if e, ok := err.(*gofastly.HTTPError); ok && e.IsNotFound() {
+			return nil
+		}
+
 		return diag.FromErr(err)
 	}
 

--- a/fastly/resource_fastly_integration_test.go
+++ b/fastly/resource_fastly_integration_test.go
@@ -135,6 +135,45 @@ func TestAccFastlyIntegration_webhook(t *testing.T) {
 	testAccFastlyIntegration(createIntegration, updateIntegration, t)
 }
 
+func TestAccFastlyIntegration_recreateAfterManualDelete(t *testing.T) {
+	var integrationID string
+
+	integration := gofastly.Integration{
+		Config: map[string]string{
+			"webhook": fmt.Sprintf("https://foo.com/bar-%s", acctest.RandString(10)),
+		},
+		Description: gofastly.ToPointer("my description"),
+		Name:        gofastly.ToPointer(fmt.Sprintf("integration %s", acctest.RandString(10))),
+		Type:        gofastly.ToPointer("slack"),
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckIntegrationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIntegrationConfig(integration),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFastlyIntegrationsRemoteState(integration),
+					testAccCaptureFastlyIntegrationID("fastly_integration.foo", &integrationID),
+				),
+			},
+			{
+				PreConfig: func() {
+					testAccDeleteFastlyIntegrationByID(t, integrationID)
+				},
+				Config: testAccIntegrationConfig(integration),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFastlyIntegrationsRemoteState(integration),
+				),
+			},
+		},
+	})
+}
+
 func testAccFastlyIntegration(createIntegration, updateIntegration gofastly.Integration, t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
@@ -228,6 +267,43 @@ func testAccCheckIntegrationDestroy(s *terraform.State) error {
 		}
 	}
 	return nil
+}
+
+func testAccCaptureFastlyIntegrationID(resourceName string, integrationID *string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("resource not found in state: %s", resourceName)
+		}
+
+		if rs.Primary == nil || rs.Primary.ID == "" {
+			return fmt.Errorf("resource %s has no ID in state", resourceName)
+		}
+
+		*integrationID = rs.Primary.ID
+
+		return nil
+	}
+}
+
+func testAccDeleteFastlyIntegrationByID(t *testing.T, integrationID string) {
+	t.Helper()
+
+	if integrationID == "" {
+		t.Fatal("integration ID is not set")
+	}
+
+	conn := testAccProvider.Meta().(*APIClient).conn
+	err := conn.DeleteIntegration(context.TODO(), &gofastly.DeleteIntegrationInput{
+		ID: integrationID,
+	})
+	if err != nil {
+		if e, ok := err.(*gofastly.HTTPError); ok && e.IsNotFound() {
+			return
+		}
+
+		t.Fatalf("error deleting integration out of band (%s): %s", integrationID, err)
+	}
 }
 
 func testAccIntegrationConfig(integration gofastly.Integration) string {


### PR DESCRIPTION
### Change summary

Updates the `fastly_integration` resource so Terraform can recover when an integration has been manually deleted outside of Terraform.

Previously, if the Fastly API returned a 404 during `Read`, the provider returned the error directly. This caused refresh, plan, or apply to fail with `could not retrieve integration`, leaving Terraform state out of sync.

With this change, a 404 from `Read` is treated as a missing remote resource. The provider clears the resource ID from state and returns successfully, allowing Terraform to plan the integration for recreation.

This also aligns `fastly_integration` with the behavior already used by other resources in the provider.

 All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/terraform-provider-fastly/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes to Core Features:

* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

```
=== RUN   TestAccFastlyIntegration_recreateAfterManualDelete
=== PAUSE TestAccFastlyIntegration_recreateAfterManualDelete
=== CONT  TestAccFastlyIntegration_recreateAfterManualDelete
--- PASS: TestAccFastlyIntegration_recreateAfterManualDelete (3.95s)
```