### PR TITLE
Skip live interface validation for dependabot PRs

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -92,7 +92,7 @@ jobs:
 
   # Branch-based pull request from owner or trusted developer who has WRITE access.
   validate-interface-trusted:
-    if: "!contains(github.event.pull_request.labels.*.name, 'breaking-change') && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository"
+    if: "!contains(github.event.pull_request.labels.*.name, 'breaking-change') && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login != 'dependabot[bot]'"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code


### PR DESCRIPTION
### Change summary

Skip `validate-interface-trusted` for Dependabot PRs.

This job requires `FASTLY_API_KEY` from `secrets.FASTLY_API_TOKEN`, but Dependabot runs can use a different secrets context. In one failing run, the job used `Secret source: Dependabot`, leaving `FASTLY_API_KEY` empty and causing Terraform to fail with:

```text
Error: no API key for Fastly
Error: Terraform exited with code 1.
```

A later run passed when the job used `Secret source: Actions`, where the token was available.

 All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/terraform-provider-fastly/pulls) for the same update/change?