### PR TITLE
[CDTOOL-1646] Skip ACL entry refresh when entries are unmanaged

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,12 @@
 ### BREAKING:
 
 ### ENHANCEMENTS:
+
 - feat(dns): added support for DNS Zones and TSIG Keys ([#1266](https://github.com/fastly/terraform-provider-fastly/pull/1266))
 
 ### BUG FIXES:
+
+- fix(acl-entries): Skip ACL entry refresh when `manage_entries` is false ([#1291](https://github.com/fastly/terraform-provider-fastly/pull/1291))
 
 ### DEPENDENCIES:
 
@@ -14,9 +17,11 @@
 ## 9.2.1 (June 05, 2026)
 
 ### BUG FIXES:
+
 - fix(product_enablement/ngwaf): Restrict `traffic_ramp` field in `ngwaf` block to VCL services only ([#1282](https://github.com/fastly/terraform-provider-fastly/pull/1282))
 
 ### DEPENDENCIES:
+
 - build(deps): `golang.org/x/net` from 0.54.0 to 0.55.0 ([#1276](https://github.com/fastly/terraform-provider-fastly/pull/1276))
 - build(deps): `github.com/fastly/go-fastly/v15` from 15.0.1 to 15.0.2 ([#1280](https://github.com/fastly/terraform-provider-fastly/pull/1280))
 

--- a/fastly/resource_fastly_service_acl_entries.go
+++ b/fastly/resource_fastly_service_acl_entries.go
@@ -107,10 +107,25 @@ func resourceServiceACLEntriesCreate(ctx context.Context, d *schema.ResourceData
 	}
 
 	d.SetId(fmt.Sprintf("%s/%s", serviceID, aclID))
-	return resourceServiceACLEntriesRead(ctx, d, meta)
+
+	if entries.Len() == 0 && !d.Get("manage_entries").(bool) {
+		log.Print("[DEBUG] Skipping ACL entries refresh after create: manage_entries is false and no entries were configured")
+		return nil
+	}
+
+	return refreshServiceACLEntries(ctx, d, meta)
 }
 
 func resourceServiceACLEntriesRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+	if !d.Get("manage_entries").(bool) {
+		log.Print("[DEBUG] Skipping ACL entries refresh: manage_entries is false")
+		return nil
+	}
+
+	return refreshServiceACLEntries(ctx, d, meta)
+}
+
+func refreshServiceACLEntries(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	log.Print("[DEBUG] Refreshing ACL Entries Configuration")
 
 	conn := meta.(*APIClient).conn
@@ -283,6 +298,11 @@ func resourceServiceACLEntriesImport(_ context.Context, d *schema.ResourceData, 
 	}
 
 	err = d.Set("acl_id", aclID)
+	if err != nil {
+		return nil, fmt.Errorf("error importing ACL entries: service %s, ACL %s, %s", serviceID, aclID, err)
+	}
+
+	err = d.Set("manage_entries", true)
 	if err != nil {
 		return nil, fmt.Errorf("error importing ACL entries: service %s, ACL %s, %s", serviceID, aclID, err)
 	}

--- a/fastly/resource_fastly_service_acl_entries_test.go
+++ b/fastly/resource_fastly_service_acl_entries_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
 	gofastly "github.com/fastly/go-fastly/v15/fastly"
@@ -61,6 +62,38 @@ func TestResourceFastlyFlattenAclEntries(t *testing.T) {
 		if !reflect.DeepEqual(out, c.local) {
 			t.Fatalf("Error matching:\nexpected: %#v\ngot: %#v", c.local, out)
 		}
+	}
+}
+
+func TestResourceFastlyServiceACLEntriesReadSkipsRefreshWhenManageEntriesFalse(t *testing.T) {
+	d := schema.TestResourceDataRaw(t, resourceServiceACLEntries().Schema, map[string]any{
+		"service_id":     "service-id",
+		"acl_id":         "acl-id",
+		"manage_entries": false,
+	})
+	d.SetId("service-id/acl-id")
+
+	diags := resourceServiceACLEntriesRead(context.Background(), d, nil)
+	if diags.HasError() {
+		t.Fatalf("expected ACL entries read to be skipped, got diagnostics: %v", diags)
+	}
+}
+
+func TestResourceFastlyServiceACLEntriesImportEnablesManageEntries(t *testing.T) {
+	d := schema.TestResourceDataRaw(t, resourceServiceACLEntries().Schema, map[string]any{})
+	d.SetId("service-id/acl-id")
+
+	result, err := resourceServiceACLEntriesImport(context.Background(), d, nil)
+	if err != nil {
+		t.Fatalf("unexpected import error: %s", err)
+	}
+
+	if len(result) != 1 {
+		t.Fatalf("expected one imported resource, got %d", len(result))
+	}
+
+	if got := result[0].Get("manage_entries").(bool); !got {
+		t.Fatalf("expected manage_entries to be true after import")
 	}
 }
 


### PR DESCRIPTION
### Change summary

Fixes [CDTOOL-1646](https://fastly.atlassian.net/browse/CDTOOL-1646).

This change avoids retrieving all Fastly ACL entries during refresh, plan, and apply when `fastly_service_acl_entries.manage_entries` is set to `false`.

For large ACLs, the previous behavior could page through every ACL entry even though unmanaged entries are intentionally ignored by Terraform. This caused significant performance overhead for ACLs with many entries.

#### Caveat

When `manage_entries = false`, the provider will no longer detect that remote ACL entries changed during refresh.

That is consistent with the documented intent of `manage_entries = false`: externally managed entries should not be reconciled by Terraform.

#### Changes

- Skips ACL entry refresh in `resourceServiceACLEntriesRead` when `manage_entries = false`.
- Preserves the post-create refresh when Terraform created configured `entry` blocks, so computed entry IDs are still populated.
- Skips the post-create refresh when `manage_entries = false` and no entries were configured.
- Preserves existing import behavior by setting `manage_entries = true` during import so imported ACL entries are materialized into state.
- Adds unit coverage for the unmanaged refresh skip.
- Adds unit coverage to verify import enables `manage_entries`.

All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/terraform-provider-fastly/pulls) for the same update/change?

### Changes to Core Features:

* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

```
=== RUN   TestResourceFastlyFlattenAclEntries
--- PASS: TestResourceFastlyFlattenAclEntries (0.00s)
=== RUN   TestResourceFastlyServiceACLEntriesReadSkipsRefreshWhenManageEntriesFalse
2026/06/11 09:44:43 [DEBUG] Skipping ACL entries refresh: manage_entries is false
--- PASS: TestResourceFastlyServiceACLEntriesReadSkipsRefreshWhenManageEntriesFalse (0.00s)
=== RUN   TestResourceFastlyServiceACLEntriesImportEnablesManageEntries
--- PASS: TestResourceFastlyServiceACLEntriesImportEnablesManageEntries (0.00s)
PASS
ok  	github.com/fastly/terraform-provider-fastly/fastly	0.007s
=== RUN   TestAccFastlyServiceAclEntries_manage_entries_false
=== PAUSE TestAccFastlyServiceAclEntries_manage_entries_false
=== CONT  TestAccFastlyServiceAclEntries_manage_entries_false
--- PASS: TestAccFastlyServiceAclEntries_manage_entries_false (37.99s)
PASS
ok  	github.com/fastly/terraform-provider-fastly/fastly	(cached)
=== RUN   TestAccFastlyServiceAclEntries_create
=== PAUSE TestAccFastlyServiceAclEntries_create
=== RUN   TestAccFastlyServiceAclEntries_create_more_than_one_page
=== PAUSE TestAccFastlyServiceAclEntries_create_more_than_one_page
=== RUN   TestAccFastlyServiceAclEntries_create_update
=== PAUSE TestAccFastlyServiceAclEntries_create_update
=== RUN   TestAccFastlyServiceAclEntries_update_additional_fields
=== PAUSE TestAccFastlyServiceAclEntries_update_additional_fields
=== RUN   TestAccFastlyServiceAclEntries_delete
=== PAUSE TestAccFastlyServiceAclEntries_delete
=== CONT  TestAccFastlyServiceAclEntries_create
=== CONT  TestAccFastlyServiceAclEntries_update_additional_fields
=== CONT  TestAccFastlyServiceAclEntries_delete
=== CONT  TestAccFastlyServiceAclEntries_create_more_than_one_page
=== CONT  TestAccFastlyServiceAclEntries_create_update
--- PASS: TestAccFastlyServiceAclEntries_create (17.97s)
--- PASS: TestAccFastlyServiceAclEntries_create_more_than_one_page (38.41s)
--- PASS: TestAccFastlyServiceAclEntries_delete (40.07s)
--- PASS: TestAccFastlyServiceAclEntries_create_update (44.69s)
--- PASS: TestAccFastlyServiceAclEntries_update_additional_fields (45.31s)
PASS
````

### User Impact

This should not introduce a breaking change for users with `manage_entries = true`.

For `manage_entries = false`, Terraform will no longer refresh remote ACL entries into state. That matches the documented intent of the setting: entries are externally managed and should not be reconciled by Terraform.

### Are there any considerations that need to be addressed for release?

no


[CDTOOL-1646]: https://fastly.atlassian.net/browse/CDTOOL-1646?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ