### PR TITLE
CDTOOL-1336: Add support for 'block_immediately' action in NGWAF thresholds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### ENHANCEMENTS:
 - feat(dns): added support for DNS Zones and TSIG Keys ([#1266](https://github.com/fastly/terraform-provider-fastly/pull/1266))
-- feat(ngwaf_thresholds): added support for 'block_immediately' action ([#XXX](https://github.com/fastly/terraform-provider-fastly/pull/XXX))
+- feat(ngwaf_thresholds): added support for 'block_immediately' action ([#1292](https://github.com/fastly/terraform-provider-fastly/pull/1292))
 
 ### BUG FIXES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### ENHANCEMENTS:
 - feat(dns): added support for DNS Zones and TSIG Keys ([#1266](https://github.com/fastly/terraform-provider-fastly/pull/1266))
+- feat(ngwaf_thresholds): added support for 'block_immediately' action ([#XXX](https://github.com/fastly/terraform-provider-fastly/pull/XXX))
 
 ### BUG FIXES:
 

--- a/fastly/resource_fastly_ngwaf_thresholds.go
+++ b/fastly/resource_fastly_ngwaf_thresholds.go
@@ -28,7 +28,7 @@ func resourceFastlyNGWAFThresholds() *schema.Resource {
 				Type:             schema.TypeString,
 				Description:      "Action to take when threshold is exceeded.",
 				Required:         true,
-				ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice([]string{"block", "log"}, false)),
+				ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice([]string{"block", "block_immediately", "log"}, false)),
 			},
 			"dont_notify": {
 				Type:        schema.TypeBool,

--- a/fastly/resource_fastly_ngwaf_thresholds_test.go
+++ b/fastly/resource_fastly_ngwaf_thresholds_test.go
@@ -71,7 +71,7 @@ func TestAccFastlyNGWAFThresholds_validate(t *testing.T) {
 					resource.TestCheckResourceAttr("fastly_ngwaf_thresholds.sample", "interval", "600"),
 					resource.TestCheckResourceAttr("fastly_ngwaf_thresholds.sample", "limit", "50"),
 					resource.TestCheckResourceAttr("fastly_ngwaf_thresholds.sample", "name", thresholdName),
-					resource.TestCheckResourceAttr("fastly_ngwaf_thresholds.sample", "signal", "BHH"),
+					resource.TestCheckResourceAttr("fastly_ngwaf_thresholds.sample", "signal", "XXE"),
 					resource.TestCheckResourceAttrPair("fastly_ngwaf_thresholds.sample", "workspace_id", "fastly_ngwaf_workspace.example", "id"),
 					testAccNGWAFThresholdsExists("fastly_ngwaf_thresholds.sample"),
 				),
@@ -172,7 +172,7 @@ resource "fastly_ngwaf_thresholds" "sample" {
     interval     = 600
     limit        = 50
     name         = "%s"
-    signal       = "BHH"
+    signal       = "XXE"
     workspace_id = fastly_ngwaf_workspace.example.id
   }
   `, testAccNGWAFWorkspaceConfig("Test Thresholds WS"), thresholdName)

--- a/fastly/resource_fastly_ngwaf_thresholds_test.go
+++ b/fastly/resource_fastly_ngwaf_thresholds_test.go
@@ -32,7 +32,7 @@ func TestAccFastlyNGWAFThresholds_validate(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccNGWAFThresholdsConfig(thresholdName),
+				Config: testAccNGWAFThresholdsConfigBlock(thresholdName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("fastly_ngwaf_thresholds.sample", "action", "block"),
 					resource.TestCheckResourceAttr("fastly_ngwaf_thresholds.sample", "dont_notify", "false"),
@@ -47,9 +47,24 @@ func TestAccFastlyNGWAFThresholds_validate(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccNGWAFThresholdsConfigUpdate(thresholdName),
+				Config: testAccNGWAFThresholdsConfigLog(thresholdName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("fastly_ngwaf_thresholds.sample", "action", "log"),
+					resource.TestCheckResourceAttr("fastly_ngwaf_thresholds.sample", "dont_notify", "true"),
+					resource.TestCheckResourceAttr("fastly_ngwaf_thresholds.sample", "duration", "43200"),
+					resource.TestCheckResourceAttr("fastly_ngwaf_thresholds.sample", "enabled", "false"),
+					resource.TestCheckResourceAttr("fastly_ngwaf_thresholds.sample", "interval", "600"),
+					resource.TestCheckResourceAttr("fastly_ngwaf_thresholds.sample", "limit", "50"),
+					resource.TestCheckResourceAttr("fastly_ngwaf_thresholds.sample", "name", thresholdName),
+					resource.TestCheckResourceAttr("fastly_ngwaf_thresholds.sample", "signal", "BHH"),
+					resource.TestCheckResourceAttrPair("fastly_ngwaf_thresholds.sample", "workspace_id", "fastly_ngwaf_workspace.example", "id"),
+					testAccNGWAFThresholdsExists("fastly_ngwaf_thresholds.sample"),
+				),
+			},
+			{
+				Config: testAccNGWAFThresholdsConfigBlockImmediately(thresholdName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("fastly_ngwaf_thresholds.sample", "action", "block_immediately"),
 					resource.TestCheckResourceAttr("fastly_ngwaf_thresholds.sample", "dont_notify", "true"),
 					resource.TestCheckResourceAttr("fastly_ngwaf_thresholds.sample", "duration", "43200"),
 					resource.TestCheckResourceAttr("fastly_ngwaf_thresholds.sample", "enabled", "false"),
@@ -109,7 +124,7 @@ func testAccNGWAFThresholdsExists(n string) resource.TestCheckFunc {
 	}
 }
 
-func testAccNGWAFThresholdsConfig(thresholdName string) string {
+func testAccNGWAFThresholdsConfigBlock(thresholdName string) string {
 	return fmt.Sprintf(`
 %s
 
@@ -127,12 +142,30 @@ resource "fastly_ngwaf_thresholds" "sample" {
   `, testAccNGWAFWorkspaceConfig("Test Thresholds WS"), thresholdName)
 }
 
-func testAccNGWAFThresholdsConfigUpdate(thresholdName string) string {
+func testAccNGWAFThresholdsConfigLog(thresholdName string) string {
 	return fmt.Sprintf(`
 %s
 
 resource "fastly_ngwaf_thresholds" "sample" {
     action       = "log"
+    dont_notify  = true
+    duration     = 43200
+    enabled      = false
+    interval     = 600
+    limit        = 50
+    name         = "%s"
+    signal       = "BHH"
+    workspace_id = fastly_ngwaf_workspace.example.id
+  }
+  `, testAccNGWAFWorkspaceConfig("Test Thresholds WS"), thresholdName)
+}
+
+func testAccNGWAFThresholdsConfigBlockImmediately(thresholdName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "fastly_ngwaf_thresholds" "sample" {
+    action       = "block_immediately"
     dont_notify  = true
     duration     = 43200
     enabled      = false


### PR DESCRIPTION
### Change summary

Adds 'block_immediately' action for thresholds.

 All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/terraform-provider-fastly/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

* [ ] Does your submission pass tests?
* [ ] Post the output of your test runs

### Changes to Core Features:

* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
