### PR TITLE
[CDTOOL-1646] Skip dictionary item refresh when items are unmanaged

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,13 @@
 ### BREAKING:
 
 ### ENHANCEMENTS:
+
 - feat(dns): added support for DNS Zones and TSIG Keys ([#1266](https://github.com/fastly/terraform-provider-fastly/pull/1266))
 - feat(ngwaf_thresholds): added support for 'block_immediately' action ([#1292](https://github.com/fastly/terraform-provider-fastly/pull/1292))
 
 ### BUG FIXES:
+
+- fix(dictionary-items): Skip dictionary item refresh when `manage_items` is false ([#1296](https://github.com/fastly/terraform-provider-fastly/pull/1296))
 
 ### DEPENDENCIES:
 
@@ -15,9 +18,11 @@
 ## 9.2.1 (June 05, 2026)
 
 ### BUG FIXES:
+
 - fix(product_enablement/ngwaf): Restrict `traffic_ramp` field in `ngwaf` block to VCL services only ([#1282](https://github.com/fastly/terraform-provider-fastly/pull/1282))
 
 ### DEPENDENCIES:
+
 - build(deps): `golang.org/x/net` from 0.54.0 to 0.55.0 ([#1276](https://github.com/fastly/terraform-provider-fastly/pull/1276))
 - build(deps): `github.com/fastly/go-fastly/v15` from 15.0.1 to 15.0.2 ([#1280](https://github.com/fastly/terraform-provider-fastly/pull/1280))
 

--- a/fastly/resource_fastly_service_dictionary_items.go
+++ b/fastly/resource_fastly_service_dictionary_items.go
@@ -136,6 +136,11 @@ func resourceServiceDictionaryItemsUpdate(ctx context.Context, d *schema.Resourc
 }
 
 func resourceServiceDictionaryItemsRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+	if !d.Get("manage_items").(bool) {
+		log.Print("[DEBUG] Skipping dictionary items refresh: manage_items is false")
+		return nil
+	}
+
 	log.Print("[DEBUG] Refreshing Dictionary Items Configuration")
 
 	conn := meta.(*APIClient).conn
@@ -197,6 +202,11 @@ func resourceServiceDictionaryItemsImport(_ context.Context, d *schema.ResourceD
 	}
 
 	err = d.Set("dictionary_id", dictionaryID)
+	if err != nil {
+		return nil, fmt.Errorf("error importing dictionary items: service %s, dictionary %s, %s", serviceID, dictionaryID, err)
+	}
+
+	err = d.Set("manage_items", true)
 	if err != nil {
 		return nil, fmt.Errorf("error importing dictionary items: service %s, dictionary %s, %s", serviceID, dictionaryID, err)
 	}

--- a/fastly/resource_fastly_service_dictionary_items_test.go
+++ b/fastly/resource_fastly_service_dictionary_items_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
 	gofastly "github.com/fastly/go-fastly/v15/fastly"
@@ -46,6 +47,38 @@ func TestResourceFastlyFlattenDictionaryItems(t *testing.T) {
 		if !reflect.DeepEqual(out, c.local) {
 			t.Fatalf("Error matching:\nexpected: %#v\ngot: %#v", c.local, out)
 		}
+	}
+}
+
+func TestResourceFastlyServiceDictionaryItemsReadSkipsRefreshWhenManageItemsFalse(t *testing.T) {
+	d := schema.TestResourceDataRaw(t, resourceServiceDictionaryItems().Schema, map[string]any{
+		"service_id":    "service-id",
+		"dictionary_id": "dictionary-id",
+		"manage_items":  false,
+	})
+	d.SetId("service-id/dictionary-id")
+
+	diags := resourceServiceDictionaryItemsRead(context.Background(), d, nil)
+	if diags.HasError() {
+		t.Fatalf("expected dictionary items read to be skipped, got diagnostics: %v", diags)
+	}
+}
+
+func TestResourceFastlyServiceDictionaryItemsImportEnablesManageItems(t *testing.T) {
+	d := schema.TestResourceDataRaw(t, resourceServiceDictionaryItems().Schema, map[string]any{})
+	d.SetId("service-id/dictionary-id")
+
+	result, err := resourceServiceDictionaryItemsImport(context.Background(), d, nil)
+	if err != nil {
+		t.Fatalf("unexpected import error: %s", err)
+	}
+
+	if len(result) != 1 {
+		t.Fatalf("expected one imported resource, got %d", len(result))
+	}
+
+	if got := result[0].Get("manage_items").(bool); !got {
+		t.Fatalf("expected manage_items to be true after import")
 	}
 }
 


### PR DESCRIPTION
### Change summary


Fixes dictionary item refresh performance for externally managed service dictionaries.

This change mirrors the ACL entries fix from #1291 for `fastly_service_dictionary_items`.

The provider previously retrieved the full list of dictionary items during refresh, plan, and apply even when `manage_items = false`. For large dictionaries, this can cause unnecessary API calls and slow Terraform operations even though those items are externally managed and otherwise ignored by Terraform.

#### Caveat

When `manage_items = false`, the provider will no longer detect that remote dictionary items changed during refresh.

That is consistent with the documented intent of `manage_items = false`: externally managed items should not be reconciled by Terraform.

#### Changes

- Skips dictionary item refresh in `resourceServiceDictionaryItemsRead` when `manage_items = false`.
- Preserves existing managed behavior when `manage_items = true`.
- Preserves import behavior by setting `manage_items = true` during import so imported dictionary items are materialized into state.
- Adds unit coverage for skipping refresh when `manage_items = false`.
- Adds unit coverage to verify import enables `manage_items`.

 All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/terraform-provider-fastly/pulls) for the same update/change?

### Changes to Core Features:

* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

```
=== RUN   TestResourceFastlyFlattenDictionaryItems
--- PASS: TestResourceFastlyFlattenDictionaryItems (0.00s)
=== RUN   TestResourceFastlyServiceDictionaryItemsReadSkipsRefreshWhenManageItemsFalse
2026/06/12 12:06:16 [DEBUG] Skipping dictionary items refresh: manage_items is false
--- PASS: TestResourceFastlyServiceDictionaryItemsReadSkipsRefreshWhenManageItemsFalse (0.00s)
=== RUN   TestResourceFastlyServiceDictionaryItemsImportEnablesManageItems
--- PASS: TestResourceFastlyServiceDictionaryItemsImportEnablesManageItems (0.00s)
PASS
ok  	github.com/fastly/terraform-provider-fastly/fastly	0.007s
=== RUN   TestAccFastlyServiceDictionaryItem_create
=== PAUSE TestAccFastlyServiceDictionaryItem_create
=== RUN   TestAccFastlyServiceDictionaryItem_create_inactive_service
=== PAUSE TestAccFastlyServiceDictionaryItem_create_inactive_service
=== RUN   TestAccFastlyServiceDictionaryItem_create_dynamic
=== PAUSE TestAccFastlyServiceDictionaryItem_create_dynamic
=== RUN   TestAccFastlyServiceDictionaryItem_update
=== PAUSE TestAccFastlyServiceDictionaryItem_update
=== RUN   TestAccFastlyServiceDictionaryItem_external_item_is_removed
=== PAUSE TestAccFastlyServiceDictionaryItem_external_item_is_removed
=== RUN   TestAccFastlyServiceDictionaryItem_external_item_deleted
=== PAUSE TestAccFastlyServiceDictionaryItem_external_item_deleted
=== RUN   TestAccFastlyServiceDictionaryItem_batch_1001_items
=== PAUSE TestAccFastlyServiceDictionaryItem_batch_1001_items
=== RUN   TestAccFastlyServiceDictionaryItem_manage_items_false
=== PAUSE TestAccFastlyServiceDictionaryItem_manage_items_false
=== CONT  TestAccFastlyServiceDictionaryItem_create
=== CONT  TestAccFastlyServiceDictionaryItem_external_item_is_removed
=== CONT  TestAccFastlyServiceDictionaryItem_create_dynamic
=== CONT  TestAccFastlyServiceDictionaryItem_update
=== CONT  TestAccFastlyServiceDictionaryItem_external_item_deleted
=== CONT  TestAccFastlyServiceDictionaryItem_create_inactive_service
=== CONT  TestAccFastlyServiceDictionaryItem_batch_1001_items
=== CONT  TestAccFastlyServiceDictionaryItem_manage_items_false
--- PASS: TestAccFastlyServiceDictionaryItem_create_inactive_service (14.18s)
--- PASS: TestAccFastlyServiceDictionaryItem_create_dynamic (20.40s)
--- PASS: TestAccFastlyServiceDictionaryItem_create (21.03s)
--- PASS: TestAccFastlyServiceDictionaryItem_external_item_is_removed (27.26s)
--- PASS: TestAccFastlyServiceDictionaryItem_batch_1001_items (37.80s)
--- PASS: TestAccFastlyServiceDictionaryItem_manage_items_false (40.72s)
--- PASS: TestAccFastlyServiceDictionaryItem_external_item_deleted (41.70s)
--- PASS: TestAccFastlyServiceDictionaryItem_update (46.48s)
PASS
```

### User Impact

This should not introduce a breaking change for users with `manage_items = true`.

For `manage_items = false`, Terraform will no longer refresh remote dictionary items into state. That matches the documented intent of the setting: items are externally managed and should not be reconciled by Terraform.

### Are there any considerations that need to be addressed for release?

no