### PR TITLE
refactor(internal/resources): consolidate 404 checking into errors.IsNotFound

### DIFF
--- a/internal/acceptance_tests/test_helpers.go
+++ b/internal/acceptance_tests/test_helpers.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	"github.com/fastly/go-fastly/v15/fastly"
-	"github.com/fastly/terraform-provider-fastly/internal/errors"
+	"github.com/fastly/terraform-provider-fastly/internal/apierrors"
 	"github.com/fastly/terraform-provider-fastly/internal/provider"
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
@@ -56,7 +56,7 @@ func CheckServiceDestroy(resourceType string) resource.TestCheckFunc {
 				ServiceID: rs.Primary.ID,
 			})
 
-			if errors.IsNotFound(err) {
+			if apierrors.IsNotFound(err) {
 				continue
 			}
 

--- a/internal/acceptance_tests/test_helpers.go
+++ b/internal/acceptance_tests/test_helpers.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/fastly/go-fastly/v15/fastly"
+	"github.com/fastly/terraform-provider-fastly/internal/errors"
 	"github.com/fastly/terraform-provider-fastly/internal/provider"
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
@@ -51,11 +52,11 @@ func CheckServiceDestroy(resourceType string) resource.TestCheckFunc {
 				continue
 			}
 
-			service, err := client.GetService(context.Background(), &fastly.GetServiceInput{
+			svc, err := client.GetService(context.Background(), &fastly.GetServiceInput{
 				ServiceID: rs.Primary.ID,
 			})
 
-			if fastlyErr, ok := err.(*fastly.HTTPError); ok && fastlyErr.StatusCode == 404 {
+			if errors.IsNotFound(err) {
 				continue
 			}
 
@@ -64,7 +65,7 @@ func CheckServiceDestroy(resourceType string) resource.TestCheckFunc {
 			}
 
 			// Service exists - check if it's soft-deleted
-			if service != nil && service.DeletedAt != nil {
+			if svc != nil && svc.DeletedAt != nil {
 				continue
 			}
 

--- a/internal/acceptance_tests/test_helpers.go
+++ b/internal/acceptance_tests/test_helpers.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	"github.com/fastly/go-fastly/v15/fastly"
-	"github.com/fastly/terraform-provider-fastly/internal/apierrors"
+	"github.com/fastly/terraform-provider-fastly/internal/errors"
 	"github.com/fastly/terraform-provider-fastly/internal/provider"
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
@@ -56,7 +56,7 @@ func CheckServiceDestroy(resourceType string) resource.TestCheckFunc {
 				ServiceID: rs.Primary.ID,
 			})
 
-			if apierrors.IsNotFound(err) {
+			if errors.IsNotFound(err) {
 				continue
 			}
 

--- a/internal/apierrors/http.go
+++ b/internal/apierrors/http.go
@@ -1,4 +1,4 @@
-package errors
+package apierrors
 
 import (
 	"errors"

--- a/internal/computepackage/package.go
+++ b/internal/computepackage/package.go
@@ -5,7 +5,7 @@ import (
 	"encoding/base64"
 	"fmt"
 
-	"github.com/fastly/terraform-provider-fastly/internal/apierrors"
+	"github.com/fastly/terraform-provider-fastly/internal/errors"
 
 	fastly "github.com/fastly/go-fastly/v15/fastly"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -177,7 +177,7 @@ func ReadForVersion(ctx context.Context, client *fastly.Client, serviceID string
 		ServiceVersion: version,
 	})
 	if err != nil {
-		if apierrors.IsNotFound(err) {
+		if errors.IsNotFound(err) {
 			return nil, nil
 		}
 		return nil, err

--- a/internal/computepackage/package.go
+++ b/internal/computepackage/package.go
@@ -5,7 +5,7 @@ import (
 	"encoding/base64"
 	"fmt"
 
-	fastlyclient "github.com/fastly/terraform-provider-fastly/internal/client"
+	"github.com/fastly/terraform-provider-fastly/internal/errors"
 
 	fastly "github.com/fastly/go-fastly/v15/fastly"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -177,7 +177,7 @@ func ReadForVersion(ctx context.Context, client *fastly.Client, serviceID string
 		ServiceVersion: version,
 	})
 	if err != nil {
-		if fastlyclient.IsNotFound(err) {
+		if errors.IsNotFound(err) {
 			return nil, nil
 		}
 		return nil, err

--- a/internal/computepackage/package.go
+++ b/internal/computepackage/package.go
@@ -5,7 +5,7 @@ import (
 	"encoding/base64"
 	"fmt"
 
-	"github.com/fastly/terraform-provider-fastly/internal/errors"
+	"github.com/fastly/terraform-provider-fastly/internal/apierrors"
 
 	fastly "github.com/fastly/go-fastly/v15/fastly"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -177,7 +177,7 @@ func ReadForVersion(ctx context.Context, client *fastly.Client, serviceID string
 		ServiceVersion: version,
 	})
 	if err != nil {
-		if errors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return nil, nil
 		}
 		return nil, err

--- a/internal/errors/http.go
+++ b/internal/errors/http.go
@@ -1,4 +1,4 @@
-package apierrors
+package errors
 
 import (
 	"errors"

--- a/internal/errors/http.go
+++ b/internal/errors/http.go
@@ -1,4 +1,4 @@
-package client
+package errors
 
 import (
 	"errors"

--- a/internal/resources/backend/resource.go
+++ b/internal/resources/backend/resource.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"strings"
 
-	"github.com/fastly/terraform-provider-fastly/internal/apierrors"
 	fastlyclient "github.com/fastly/terraform-provider-fastly/internal/client"
+	"github.com/fastly/terraform-provider-fastly/internal/errors"
 	"github.com/fastly/terraform-provider-fastly/internal/importutil"
 	"github.com/fastly/terraform-provider-fastly/internal/service"
 	"github.com/fastly/terraform-provider-fastly/internal/validation"
@@ -156,7 +156,7 @@ func (r *Resource) Read(ctx context.Context, req resource.ReadRequest, resp *res
 		Name:           state.Name.ValueString(),
 	})
 	if err != nil {
-		if apierrors.IsNotFound(err) {
+		if errors.IsNotFound(err) {
 			tflog.Warn(ctx, "Service backend not found, removing from state", map[string]any{
 				"service_id": state.Service.ValueString(),
 				"name":       state.Name.ValueString(),
@@ -251,7 +251,7 @@ func (r *Resource) Delete(ctx context.Context, req resource.DeleteRequest, resp 
 	})
 
 	if err := validation.EnsureServiceTypeSupported(ctx, r.providerData.ServiceTypeChecker, state.Service.ValueString(), "fastly_service_backend", service.TypeVCL, service.TypeCompute); err != nil {
-		if apierrors.IsNotFound(err) {
+		if errors.IsNotFound(err) {
 			return
 		}
 		resp.Diagnostics.AddError("Unsupported Fastly service type", err.Error())
@@ -270,7 +270,7 @@ func (r *Resource) Delete(ctx context.Context, req resource.DeleteRequest, resp 
 		Name:           state.Name.ValueString(),
 	})
 	if err != nil {
-		if apierrors.IsNotFound(err) {
+		if errors.IsNotFound(err) {
 			return
 		}
 		resp.Diagnostics.AddError("Error deleting explicit service backend", err.Error())

--- a/internal/resources/backend/resource.go
+++ b/internal/resources/backend/resource.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	fastlyclient "github.com/fastly/terraform-provider-fastly/internal/client"
+	"github.com/fastly/terraform-provider-fastly/internal/errors"
 	"github.com/fastly/terraform-provider-fastly/internal/importutil"
 	"github.com/fastly/terraform-provider-fastly/internal/service"
 	"github.com/fastly/terraform-provider-fastly/internal/validation"
@@ -155,7 +156,7 @@ func (r *Resource) Read(ctx context.Context, req resource.ReadRequest, resp *res
 		Name:           state.Name.ValueString(),
 	})
 	if err != nil {
-		if fastlyErr, ok := err.(*fastly.HTTPError); ok && fastlyErr.StatusCode == 404 {
+		if errors.IsNotFound(err) {
 			tflog.Warn(ctx, "Service backend not found, removing from state", map[string]any{
 				"service_id": state.Service.ValueString(),
 				"name":       state.Name.ValueString(),
@@ -250,7 +251,7 @@ func (r *Resource) Delete(ctx context.Context, req resource.DeleteRequest, resp 
 	})
 
 	if err := validation.EnsureServiceTypeSupported(ctx, r.providerData.ServiceTypeChecker, state.Service.ValueString(), "fastly_service_backend", service.TypeVCL, service.TypeCompute); err != nil {
-		if fastlyclient.IsNotFound(err) {
+		if errors.IsNotFound(err) {
 			return
 		}
 		resp.Diagnostics.AddError("Unsupported Fastly service type", err.Error())
@@ -269,7 +270,7 @@ func (r *Resource) Delete(ctx context.Context, req resource.DeleteRequest, resp 
 		Name:           state.Name.ValueString(),
 	})
 	if err != nil {
-		if fastlyclient.IsNotFound(err) {
+		if errors.IsNotFound(err) {
 			return
 		}
 		resp.Diagnostics.AddError("Error deleting explicit service backend", err.Error())

--- a/internal/resources/backend/resource.go
+++ b/internal/resources/backend/resource.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"strings"
 
+	"github.com/fastly/terraform-provider-fastly/internal/apierrors"
 	fastlyclient "github.com/fastly/terraform-provider-fastly/internal/client"
-	"github.com/fastly/terraform-provider-fastly/internal/errors"
 	"github.com/fastly/terraform-provider-fastly/internal/importutil"
 	"github.com/fastly/terraform-provider-fastly/internal/service"
 	"github.com/fastly/terraform-provider-fastly/internal/validation"
@@ -156,7 +156,7 @@ func (r *Resource) Read(ctx context.Context, req resource.ReadRequest, resp *res
 		Name:           state.Name.ValueString(),
 	})
 	if err != nil {
-		if errors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			tflog.Warn(ctx, "Service backend not found, removing from state", map[string]any{
 				"service_id": state.Service.ValueString(),
 				"name":       state.Name.ValueString(),
@@ -251,7 +251,7 @@ func (r *Resource) Delete(ctx context.Context, req resource.DeleteRequest, resp 
 	})
 
 	if err := validation.EnsureServiceTypeSupported(ctx, r.providerData.ServiceTypeChecker, state.Service.ValueString(), "fastly_service_backend", service.TypeVCL, service.TypeCompute); err != nil {
-		if errors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return
 		}
 		resp.Diagnostics.AddError("Unsupported Fastly service type", err.Error())
@@ -270,7 +270,7 @@ func (r *Resource) Delete(ctx context.Context, req resource.DeleteRequest, resp 
 		Name:           state.Name.ValueString(),
 	})
 	if err != nil {
-		if errors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return
 		}
 		resp.Diagnostics.AddError("Error deleting explicit service backend", err.Error())

--- a/internal/resources/backend/schema.go
+++ b/internal/resources/backend/schema.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"sort"
 
-	"github.com/fastly/terraform-provider-fastly/internal/apierrors"
+	"github.com/fastly/terraform-provider-fastly/internal/errors"
 	"github.com/fastly/terraform-provider-fastly/internal/service"
 
 	fastly "github.com/fastly/go-fastly/v15/fastly"
@@ -315,7 +315,7 @@ func Reconcile(ctx context.Context, client *fastly.Client, serviceID string, ver
 				ServiceVersion: version,
 				Name:           name,
 			})
-			if apierrors.IsNotFound(err) {
+			if errors.IsNotFound(err) {
 				continue
 			}
 			if err != nil {

--- a/internal/resources/backend/schema.go
+++ b/internal/resources/backend/schema.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"sort"
 
+	"github.com/fastly/terraform-provider-fastly/internal/errors"
 	"github.com/fastly/terraform-provider-fastly/internal/service"
 
 	fastly "github.com/fastly/go-fastly/v15/fastly"
@@ -314,7 +315,7 @@ func Reconcile(ctx context.Context, client *fastly.Client, serviceID string, ver
 				ServiceVersion: version,
 				Name:           name,
 			})
-			if httpErr, ok := err.(*fastly.HTTPError); ok && httpErr.StatusCode == 404 {
+			if errors.IsNotFound(err) {
 				continue
 			}
 			if err != nil {

--- a/internal/resources/backend/schema.go
+++ b/internal/resources/backend/schema.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"sort"
 
-	"github.com/fastly/terraform-provider-fastly/internal/errors"
+	"github.com/fastly/terraform-provider-fastly/internal/apierrors"
 	"github.com/fastly/terraform-provider-fastly/internal/service"
 
 	fastly "github.com/fastly/go-fastly/v15/fastly"
@@ -315,7 +315,7 @@ func Reconcile(ctx context.Context, client *fastly.Client, serviceID string, ver
 				ServiceVersion: version,
 				Name:           name,
 			})
-			if errors.IsNotFound(err) {
+			if apierrors.IsNotFound(err) {
 				continue
 			}
 			if err != nil {

--- a/internal/resources/domain/resource.go
+++ b/internal/resources/domain/resource.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"strings"
 
+	"github.com/fastly/terraform-provider-fastly/internal/apierrors"
 	fastlyclient "github.com/fastly/terraform-provider-fastly/internal/client"
-	"github.com/fastly/terraform-provider-fastly/internal/errors"
 	"github.com/fastly/terraform-provider-fastly/internal/importutil"
 	"github.com/fastly/terraform-provider-fastly/internal/service"
 	"github.com/fastly/terraform-provider-fastly/internal/validation"
@@ -127,7 +127,7 @@ func (r *Resource) Read(ctx context.Context, req resource.ReadRequest, resp *res
 		Name:           state.Name.ValueString(),
 	})
 	if err != nil {
-		if errors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			tflog.Warn(ctx, "Service domain not found, removing from state", map[string]any{
 				"service_id": state.Service.ValueString(),
 				"name":       state.Name.ValueString(),
@@ -210,7 +210,7 @@ func (r *Resource) Delete(ctx context.Context, req resource.DeleteRequest, resp 
 	})
 
 	if err := validation.EnsureServiceTypeSupported(ctx, r.providerData.ServiceTypeChecker, state.Service.ValueString(), "fastly_service_domain", service.TypeVCL, service.TypeCompute); err != nil {
-		if errors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return
 		}
 		resp.Diagnostics.AddError("Unsupported Fastly service type", err.Error())
@@ -229,7 +229,7 @@ func (r *Resource) Delete(ctx context.Context, req resource.DeleteRequest, resp 
 		Name:           state.Name.ValueString(),
 	})
 	if err != nil {
-		if errors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return
 		}
 		resp.Diagnostics.AddError("Error deleting explicit service domain", err.Error())

--- a/internal/resources/domain/resource.go
+++ b/internal/resources/domain/resource.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"strings"
 
-	"github.com/fastly/terraform-provider-fastly/internal/apierrors"
 	fastlyclient "github.com/fastly/terraform-provider-fastly/internal/client"
+	"github.com/fastly/terraform-provider-fastly/internal/errors"
 	"github.com/fastly/terraform-provider-fastly/internal/importutil"
 	"github.com/fastly/terraform-provider-fastly/internal/service"
 	"github.com/fastly/terraform-provider-fastly/internal/validation"
@@ -127,7 +127,7 @@ func (r *Resource) Read(ctx context.Context, req resource.ReadRequest, resp *res
 		Name:           state.Name.ValueString(),
 	})
 	if err != nil {
-		if apierrors.IsNotFound(err) {
+		if errors.IsNotFound(err) {
 			tflog.Warn(ctx, "Service domain not found, removing from state", map[string]any{
 				"service_id": state.Service.ValueString(),
 				"name":       state.Name.ValueString(),
@@ -210,7 +210,7 @@ func (r *Resource) Delete(ctx context.Context, req resource.DeleteRequest, resp 
 	})
 
 	if err := validation.EnsureServiceTypeSupported(ctx, r.providerData.ServiceTypeChecker, state.Service.ValueString(), "fastly_service_domain", service.TypeVCL, service.TypeCompute); err != nil {
-		if apierrors.IsNotFound(err) {
+		if errors.IsNotFound(err) {
 			return
 		}
 		resp.Diagnostics.AddError("Unsupported Fastly service type", err.Error())
@@ -229,7 +229,7 @@ func (r *Resource) Delete(ctx context.Context, req resource.DeleteRequest, resp 
 		Name:           state.Name.ValueString(),
 	})
 	if err != nil {
-		if apierrors.IsNotFound(err) {
+		if errors.IsNotFound(err) {
 			return
 		}
 		resp.Diagnostics.AddError("Error deleting explicit service domain", err.Error())

--- a/internal/resources/domain/resource.go
+++ b/internal/resources/domain/resource.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	fastlyclient "github.com/fastly/terraform-provider-fastly/internal/client"
+	"github.com/fastly/terraform-provider-fastly/internal/errors"
 	"github.com/fastly/terraform-provider-fastly/internal/importutil"
 	"github.com/fastly/terraform-provider-fastly/internal/service"
 	"github.com/fastly/terraform-provider-fastly/internal/validation"
@@ -126,7 +127,7 @@ func (r *Resource) Read(ctx context.Context, req resource.ReadRequest, resp *res
 		Name:           state.Name.ValueString(),
 	})
 	if err != nil {
-		if fastlyErr, ok := err.(*fastly.HTTPError); ok && fastlyErr.StatusCode == 404 {
+		if errors.IsNotFound(err) {
 			tflog.Warn(ctx, "Service domain not found, removing from state", map[string]any{
 				"service_id": state.Service.ValueString(),
 				"name":       state.Name.ValueString(),
@@ -209,7 +210,7 @@ func (r *Resource) Delete(ctx context.Context, req resource.DeleteRequest, resp 
 	})
 
 	if err := validation.EnsureServiceTypeSupported(ctx, r.providerData.ServiceTypeChecker, state.Service.ValueString(), "fastly_service_domain", service.TypeVCL, service.TypeCompute); err != nil {
-		if fastlyclient.IsNotFound(err) {
+		if errors.IsNotFound(err) {
 			return
 		}
 		resp.Diagnostics.AddError("Unsupported Fastly service type", err.Error())
@@ -228,7 +229,7 @@ func (r *Resource) Delete(ctx context.Context, req resource.DeleteRequest, resp 
 		Name:           state.Name.ValueString(),
 	})
 	if err != nil {
-		if fastlyclient.IsNotFound(err) {
+		if errors.IsNotFound(err) {
 			return
 		}
 		resp.Diagnostics.AddError("Error deleting explicit service domain", err.Error())

--- a/internal/resources/domain/schema.go
+++ b/internal/resources/domain/schema.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"sort"
 
-	"github.com/fastly/terraform-provider-fastly/internal/errors"
+	"github.com/fastly/terraform-provider-fastly/internal/apierrors"
 
 	fastly "github.com/fastly/go-fastly/v15/fastly"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -124,7 +124,7 @@ func Reconcile(ctx context.Context, client *fastly.Client, serviceID string, ver
 				ServiceVersion: version,
 				Name:           name,
 			})
-			if errors.IsNotFound(err) {
+			if apierrors.IsNotFound(err) {
 				continue
 			}
 			if err != nil {

--- a/internal/resources/domain/schema.go
+++ b/internal/resources/domain/schema.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"sort"
 
-	"github.com/fastly/terraform-provider-fastly/internal/apierrors"
+	"github.com/fastly/terraform-provider-fastly/internal/errors"
 
 	fastly "github.com/fastly/go-fastly/v15/fastly"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -124,7 +124,7 @@ func Reconcile(ctx context.Context, client *fastly.Client, serviceID string, ver
 				ServiceVersion: version,
 				Name:           name,
 			})
-			if apierrors.IsNotFound(err) {
+			if errors.IsNotFound(err) {
 				continue
 			}
 			if err != nil {

--- a/internal/resources/domain/schema.go
+++ b/internal/resources/domain/schema.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"sort"
 
+	"github.com/fastly/terraform-provider-fastly/internal/errors"
+
 	fastly "github.com/fastly/go-fastly/v15/fastly"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -122,7 +124,7 @@ func Reconcile(ctx context.Context, client *fastly.Client, serviceID string, ver
 				ServiceVersion: version,
 				Name:           name,
 			})
-			if httpErr, ok := err.(*fastly.HTTPError); ok && httpErr.StatusCode == 404 {
+			if errors.IsNotFound(err) {
 				continue
 			}
 			if err != nil {

--- a/internal/resources/servicecdn/resource.go
+++ b/internal/resources/servicecdn/resource.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/fastly/terraform-provider-fastly/internal/apierrors"
 	fastlyclient "github.com/fastly/terraform-provider-fastly/internal/client"
+	"github.com/fastly/terraform-provider-fastly/internal/errors"
 	"github.com/fastly/terraform-provider-fastly/internal/service"
 
 	"github.com/fastly/go-fastly/v15/fastly"
@@ -137,7 +137,7 @@ func (r *Resource) Read(ctx context.Context, req resource.ReadRequest, resp *res
 		ServiceID: state.ID.ValueString(),
 	})
 	if err != nil {
-		if apierrors.IsNotFound(err) {
+		if errors.IsNotFound(err) {
 			resp.State.RemoveResource(ctx)
 			return
 		}

--- a/internal/resources/servicecdn/resource.go
+++ b/internal/resources/servicecdn/resource.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	fastlyclient "github.com/fastly/terraform-provider-fastly/internal/client"
+	"github.com/fastly/terraform-provider-fastly/internal/errors"
 	"github.com/fastly/terraform-provider-fastly/internal/service"
 
 	"github.com/fastly/go-fastly/v15/fastly"
@@ -136,7 +137,7 @@ func (r *Resource) Read(ctx context.Context, req resource.ReadRequest, resp *res
 		ServiceID: state.ID.ValueString(),
 	})
 	if err != nil {
-		if httpErr, ok := err.(*fastly.HTTPError); ok && httpErr.StatusCode == 404 {
+		if errors.IsNotFound(err) {
 			resp.State.RemoveResource(ctx)
 			return
 		}

--- a/internal/resources/servicecdn/resource.go
+++ b/internal/resources/servicecdn/resource.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/fastly/terraform-provider-fastly/internal/apierrors"
 	fastlyclient "github.com/fastly/terraform-provider-fastly/internal/client"
-	"github.com/fastly/terraform-provider-fastly/internal/errors"
 	"github.com/fastly/terraform-provider-fastly/internal/service"
 
 	"github.com/fastly/go-fastly/v15/fastly"
@@ -137,7 +137,7 @@ func (r *Resource) Read(ctx context.Context, req resource.ReadRequest, resp *res
 		ServiceID: state.ID.ValueString(),
 	})
 	if err != nil {
-		if errors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			resp.State.RemoveResource(ctx)
 			return
 		}

--- a/internal/resources/servicecdnauto/resource.go
+++ b/internal/resources/servicecdnauto/resource.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	fastlyclient "github.com/fastly/terraform-provider-fastly/internal/client"
+	"github.com/fastly/terraform-provider-fastly/internal/errors"
 	"github.com/fastly/terraform-provider-fastly/internal/resources/backend"
 	"github.com/fastly/terraform-provider-fastly/internal/resources/domain"
 	"github.com/fastly/terraform-provider-fastly/internal/service"
@@ -188,7 +189,7 @@ func (r *Resource) Read(ctx context.Context, req resource.ReadRequest, resp *res
 		ServiceID: state.ID.ValueString(),
 	})
 	if err != nil {
-		if httpErr, ok := err.(*fastly.HTTPError); ok && httpErr.StatusCode == 404 {
+		if errors.IsNotFound(err) {
 			resp.State.RemoveResource(ctx)
 			return
 		}

--- a/internal/resources/servicecdnauto/resource.go
+++ b/internal/resources/servicecdnauto/resource.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/fastly/terraform-provider-fastly/internal/apierrors"
 	fastlyclient "github.com/fastly/terraform-provider-fastly/internal/client"
+	"github.com/fastly/terraform-provider-fastly/internal/errors"
 	"github.com/fastly/terraform-provider-fastly/internal/resources/backend"
 	"github.com/fastly/terraform-provider-fastly/internal/resources/domain"
 	"github.com/fastly/terraform-provider-fastly/internal/service"
@@ -189,7 +189,7 @@ func (r *Resource) Read(ctx context.Context, req resource.ReadRequest, resp *res
 		ServiceID: state.ID.ValueString(),
 	})
 	if err != nil {
-		if apierrors.IsNotFound(err) {
+		if errors.IsNotFound(err) {
 			resp.State.RemoveResource(ctx)
 			return
 		}

--- a/internal/resources/servicecdnauto/resource.go
+++ b/internal/resources/servicecdnauto/resource.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/fastly/terraform-provider-fastly/internal/apierrors"
 	fastlyclient "github.com/fastly/terraform-provider-fastly/internal/client"
-	"github.com/fastly/terraform-provider-fastly/internal/errors"
 	"github.com/fastly/terraform-provider-fastly/internal/resources/backend"
 	"github.com/fastly/terraform-provider-fastly/internal/resources/domain"
 	"github.com/fastly/terraform-provider-fastly/internal/service"
@@ -189,7 +189,7 @@ func (r *Resource) Read(ctx context.Context, req resource.ReadRequest, resp *res
 		ServiceID: state.ID.ValueString(),
 	})
 	if err != nil {
-		if errors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			resp.State.RemoveResource(ctx)
 			return
 		}

--- a/internal/resources/servicecompute/resource.go
+++ b/internal/resources/servicecompute/resource.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/fastly/terraform-provider-fastly/internal/apierrors"
 	fastlyclient "github.com/fastly/terraform-provider-fastly/internal/client"
+	"github.com/fastly/terraform-provider-fastly/internal/errors"
 	"github.com/fastly/terraform-provider-fastly/internal/service"
 
 	"github.com/fastly/go-fastly/v15/fastly"
@@ -137,7 +137,7 @@ func (r *Resource) Read(ctx context.Context, req resource.ReadRequest, resp *res
 		ServiceID: state.ID.ValueString(),
 	})
 	if err != nil {
-		if apierrors.IsNotFound(err) {
+		if errors.IsNotFound(err) {
 			resp.State.RemoveResource(ctx)
 			return
 		}

--- a/internal/resources/servicecompute/resource.go
+++ b/internal/resources/servicecompute/resource.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	fastlyclient "github.com/fastly/terraform-provider-fastly/internal/client"
+	"github.com/fastly/terraform-provider-fastly/internal/errors"
 	"github.com/fastly/terraform-provider-fastly/internal/service"
 
 	"github.com/fastly/go-fastly/v15/fastly"
@@ -136,7 +137,7 @@ func (r *Resource) Read(ctx context.Context, req resource.ReadRequest, resp *res
 		ServiceID: state.ID.ValueString(),
 	})
 	if err != nil {
-		if httpErr, ok := err.(*fastly.HTTPError); ok && httpErr.StatusCode == 404 {
+		if errors.IsNotFound(err) {
 			resp.State.RemoveResource(ctx)
 			return
 		}

--- a/internal/resources/servicecompute/resource.go
+++ b/internal/resources/servicecompute/resource.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/fastly/terraform-provider-fastly/internal/apierrors"
 	fastlyclient "github.com/fastly/terraform-provider-fastly/internal/client"
-	"github.com/fastly/terraform-provider-fastly/internal/errors"
 	"github.com/fastly/terraform-provider-fastly/internal/service"
 
 	"github.com/fastly/go-fastly/v15/fastly"
@@ -137,7 +137,7 @@ func (r *Resource) Read(ctx context.Context, req resource.ReadRequest, resp *res
 		ServiceID: state.ID.ValueString(),
 	})
 	if err != nil {
-		if errors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			resp.State.RemoveResource(ctx)
 			return
 		}

--- a/internal/resources/servicecomputeauto/resource.go
+++ b/internal/resources/servicecomputeauto/resource.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/fastly/terraform-provider-fastly/internal/apierrors"
 	fastlyclient "github.com/fastly/terraform-provider-fastly/internal/client"
 	"github.com/fastly/terraform-provider-fastly/internal/computepackage"
+	"github.com/fastly/terraform-provider-fastly/internal/errors"
 	"github.com/fastly/terraform-provider-fastly/internal/resources/backend"
 	"github.com/fastly/terraform-provider-fastly/internal/resources/domain"
 	"github.com/fastly/terraform-provider-fastly/internal/service"
@@ -217,7 +217,7 @@ func (r *Resource) Read(ctx context.Context, req resource.ReadRequest, resp *res
 		ServiceID: state.ID.ValueString(),
 	})
 	if err != nil {
-		if apierrors.IsNotFound(err) {
+		if errors.IsNotFound(err) {
 			resp.State.RemoveResource(ctx)
 			return
 		}

--- a/internal/resources/servicecomputeauto/resource.go
+++ b/internal/resources/servicecomputeauto/resource.go
@@ -6,6 +6,7 @@ import (
 
 	fastlyclient "github.com/fastly/terraform-provider-fastly/internal/client"
 	"github.com/fastly/terraform-provider-fastly/internal/computepackage"
+	"github.com/fastly/terraform-provider-fastly/internal/errors"
 	"github.com/fastly/terraform-provider-fastly/internal/resources/backend"
 	"github.com/fastly/terraform-provider-fastly/internal/resources/domain"
 	"github.com/fastly/terraform-provider-fastly/internal/service"
@@ -216,7 +217,7 @@ func (r *Resource) Read(ctx context.Context, req resource.ReadRequest, resp *res
 		ServiceID: state.ID.ValueString(),
 	})
 	if err != nil {
-		if httpErr, ok := err.(*fastly.HTTPError); ok && httpErr.StatusCode == 404 {
+		if errors.IsNotFound(err) {
 			resp.State.RemoveResource(ctx)
 			return
 		}

--- a/internal/resources/servicecomputeauto/resource.go
+++ b/internal/resources/servicecomputeauto/resource.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/fastly/terraform-provider-fastly/internal/apierrors"
 	fastlyclient "github.com/fastly/terraform-provider-fastly/internal/client"
 	"github.com/fastly/terraform-provider-fastly/internal/computepackage"
-	"github.com/fastly/terraform-provider-fastly/internal/errors"
 	"github.com/fastly/terraform-provider-fastly/internal/resources/backend"
 	"github.com/fastly/terraform-provider-fastly/internal/resources/domain"
 	"github.com/fastly/terraform-provider-fastly/internal/service"
@@ -217,7 +217,7 @@ func (r *Resource) Read(ctx context.Context, req resource.ReadRequest, resp *res
 		ServiceID: state.ID.ValueString(),
 	})
 	if err != nil {
-		if errors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			resp.State.RemoveResource(ctx)
 			return
 		}

--- a/internal/service/mutability.go
+++ b/internal/service/mutability.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/fastly/terraform-provider-fastly/internal/errors"
+	"github.com/fastly/terraform-provider-fastly/internal/apierrors"
 
 	"github.com/fastly/go-fastly/v15/fastly"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -113,7 +113,7 @@ func (c *VersionChecker) EnsureMutableForDelete(
 
 	mutability, err := c.GetMutability(ctx, serviceID, version)
 	if err != nil {
-		if errors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return true, diags
 		}
 

--- a/internal/service/mutability.go
+++ b/internal/service/mutability.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/fastly/terraform-provider-fastly/internal/apierrors"
+	"github.com/fastly/terraform-provider-fastly/internal/errors"
 
 	"github.com/fastly/go-fastly/v15/fastly"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -113,7 +113,7 @@ func (c *VersionChecker) EnsureMutableForDelete(
 
 	mutability, err := c.GetMutability(ctx, serviceID, version)
 	if err != nil {
-		if apierrors.IsNotFound(err) {
+		if errors.IsNotFound(err) {
 			return true, diags
 		}
 

--- a/internal/service/mutability.go
+++ b/internal/service/mutability.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/fastly/terraform-provider-fastly/internal/errors"
+
 	"github.com/fastly/go-fastly/v15/fastly"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 )
@@ -111,7 +113,7 @@ func (c *VersionChecker) EnsureMutableForDelete(
 
 	mutability, err := c.GetMutability(ctx, serviceID, version)
 	if err != nil {
-		if isNotFound(err) {
+		if errors.IsNotFound(err) {
 			return true, diags
 		}
 

--- a/internal/service/version.go
+++ b/internal/service/version.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/fastly/terraform-provider-fastly/internal/apierrors"
+	"github.com/fastly/terraform-provider-fastly/internal/errors"
 
 	fastly "github.com/fastly/go-fastly/v15/fastly"
 )
@@ -116,7 +116,7 @@ func DeleteWithPolicy(ctx context.Context, client *fastly.Client, serviceID stri
 		service, err := client.GetServiceDetails(ctx, &fastly.GetServiceDetailsInput{
 			ServiceID: serviceID,
 		})
-		if apierrors.IsNotFound(err) {
+		if errors.IsNotFound(err) {
 			return nil
 		}
 		if err != nil {
@@ -128,7 +128,7 @@ func DeleteWithPolicy(ctx context.Context, client *fastly.Client, serviceID stri
 				ServiceID:      serviceID,
 				ServiceVersion: *service.ActiveVersion.Number,
 			})
-			if err != nil && !apierrors.IsNotFound(err) {
+			if err != nil && !errors.IsNotFound(err) {
 				return err
 			}
 		}
@@ -141,7 +141,7 @@ func DeleteWithPolicy(ctx context.Context, client *fastly.Client, serviceID stri
 	err := client.DeleteService(ctx, &fastly.DeleteServiceInput{
 		ServiceID: serviceID,
 	})
-	if apierrors.IsNotFound(err) {
+	if errors.IsNotFound(err) {
 		return nil
 	}
 	return err

--- a/internal/service/version.go
+++ b/internal/service/version.go
@@ -4,13 +4,10 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/fastly/terraform-provider-fastly/internal/errors"
+
 	fastly "github.com/fastly/go-fastly/v15/fastly"
 )
-
-func isNotFound(err error) bool {
-	httpErr, ok := err.(*fastly.HTTPError)
-	return ok && httpErr.StatusCode == 404
-}
 
 // SelectReadVersion selects the service version that should be used for
 // read-only discovery operations such as terraform query and compatibility
@@ -119,7 +116,7 @@ func DeleteWithPolicy(ctx context.Context, client *fastly.Client, serviceID stri
 		service, err := client.GetServiceDetails(ctx, &fastly.GetServiceDetailsInput{
 			ServiceID: serviceID,
 		})
-		if isNotFound(err) {
+		if errors.IsNotFound(err) {
 			return nil
 		}
 		if err != nil {
@@ -131,7 +128,7 @@ func DeleteWithPolicy(ctx context.Context, client *fastly.Client, serviceID stri
 				ServiceID:      serviceID,
 				ServiceVersion: *service.ActiveVersion.Number,
 			})
-			if err != nil && !isNotFound(err) {
+			if err != nil && !errors.IsNotFound(err) {
 				return err
 			}
 		}
@@ -144,7 +141,7 @@ func DeleteWithPolicy(ctx context.Context, client *fastly.Client, serviceID stri
 	err := client.DeleteService(ctx, &fastly.DeleteServiceInput{
 		ServiceID: serviceID,
 	})
-	if isNotFound(err) {
+	if errors.IsNotFound(err) {
 		return nil
 	}
 	return err

--- a/internal/service/version.go
+++ b/internal/service/version.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/fastly/terraform-provider-fastly/internal/errors"
+	"github.com/fastly/terraform-provider-fastly/internal/apierrors"
 
 	fastly "github.com/fastly/go-fastly/v15/fastly"
 )
@@ -116,7 +116,7 @@ func DeleteWithPolicy(ctx context.Context, client *fastly.Client, serviceID stri
 		service, err := client.GetServiceDetails(ctx, &fastly.GetServiceDetailsInput{
 			ServiceID: serviceID,
 		})
-		if errors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return nil
 		}
 		if err != nil {
@@ -128,7 +128,7 @@ func DeleteWithPolicy(ctx context.Context, client *fastly.Client, serviceID stri
 				ServiceID:      serviceID,
 				ServiceVersion: *service.ActiveVersion.Number,
 			})
-			if err != nil && !errors.IsNotFound(err) {
+			if err != nil && !apierrors.IsNotFound(err) {
 				return err
 			}
 		}
@@ -141,7 +141,7 @@ func DeleteWithPolicy(ctx context.Context, client *fastly.Client, serviceID stri
 	err := client.DeleteService(ctx, &fastly.DeleteServiceInput{
 		ServiceID: serviceID,
 	})
-	if errors.IsNotFound(err) {
+	if apierrors.IsNotFound(err) {
 		return nil
 	}
 	return err


### PR DESCRIPTION
### Change summary

Replace inline *fastly.HTTPError type assertions with wrapped-error-safe
  errors.IsNotFound helper. Move implementation from internal/client to new
  internal/errors package to avoid import cycles.

  Changes:
  - Create internal/errors/http.go with canonical IsNotFound implementation using errors.As
  - Remove internal/client/errors.go (was forwarding wrapper)
  - Delete private service.isNotFound function (used bare type assertion)
  - Update 18 call sites across resources, service, computepackage, and tests to use errors.IsNotFound

 <!--
Briefly describe the changes introduced in this pull request. Include context or
reasoning behind the changes, even if they seem minor. If relevant, link to any
related discussions (e.g. Slack threads, tickets, documents).
-->

 All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/terraform-provider-fastly/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

* [x] Does your submission pass tests?
