### PR TITLE
[CDTOOL-1655] Refactor store `*client.Data` on `servicecdn` and `servicecompute`

### DIFF
--- a/internal/resources/servicecdn/resource.go
+++ b/internal/resources/servicecdn/resource.go
@@ -19,10 +19,11 @@ import (
 )
 
 type Resource struct {
-	client *fastly.Client
+	providerData *fastlyclient.Data
 }
 
 var _ resource.Resource = &Resource{}
+var _ resource.ResourceWithConfigure = &Resource{}
 var _ resource.ResourceWithImportState = &Resource{}
 var _ resource.ResourceWithIdentity = &Resource{}
 
@@ -83,7 +84,7 @@ func (r *Resource) Configure(_ context.Context, req resource.ConfigureRequest, r
 		return
 	}
 
-	r.client = data.Client
+	r.providerData = data
 }
 
 func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
@@ -98,7 +99,7 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 		"comment": plan.Comment.ValueString(),
 	})
 
-	created, err := r.client.CreateService(ctx, &fastly.CreateServiceInput{
+	created, err := r.providerData.Client.CreateService(ctx, &fastly.CreateServiceInput{
 		Name:    fastly.ToPointer(plan.Name.ValueString()),
 		Comment: fastly.ToPointer(plan.Comment.ValueString()),
 		Type:    fastly.ToPointer(service.TypeVCL),
@@ -132,7 +133,7 @@ func (r *Resource) Read(ctx context.Context, req resource.ReadRequest, resp *res
 		return
 	}
 
-	details, err := r.client.GetServiceDetails(ctx, &fastly.GetServiceDetailsInput{
+	details, err := r.providerData.Client.GetServiceDetails(ctx, &fastly.GetServiceDetailsInput{
 		ServiceID: state.ID.ValueString(),
 	})
 	if err != nil {
@@ -185,7 +186,7 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 		return
 	}
 
-	_, err := r.client.UpdateService(ctx, &fastly.UpdateServiceInput{
+	_, err := r.providerData.Client.UpdateService(ctx, &fastly.UpdateServiceInput{
 		ServiceID: state.ID.ValueString(),
 		Name:      fastly.ToPointer(plan.Name.ValueString()),
 		Comment:   fastly.ToPointer(plan.Comment.ValueString()),
@@ -206,7 +207,7 @@ func (r *Resource) Delete(ctx context.Context, req resource.DeleteRequest, resp 
 		return
 	}
 
-	if err := service.DeleteWithPolicy(ctx, r.client, state.ID.ValueString(), service.BoolValue(state.ForceDestroy), service.BoolValue(state.Reuse)); err != nil {
+	if err := service.DeleteWithPolicy(ctx, r.providerData.Client, state.ID.ValueString(), service.BoolValue(state.ForceDestroy), service.BoolValue(state.Reuse)); err != nil {
 		resp.Diagnostics.AddError("Error deleting Fastly CDN service", err.Error())
 	}
 }

--- a/internal/resources/servicecompute/resource.go
+++ b/internal/resources/servicecompute/resource.go
@@ -19,10 +19,11 @@ import (
 )
 
 type Resource struct {
-	client *fastly.Client
+	providerData *fastlyclient.Data
 }
 
 var _ resource.Resource = &Resource{}
+var _ resource.ResourceWithConfigure = &Resource{}
 var _ resource.ResourceWithImportState = &Resource{}
 var _ resource.ResourceWithIdentity = &Resource{}
 
@@ -83,7 +84,7 @@ func (r *Resource) Configure(_ context.Context, req resource.ConfigureRequest, r
 		return
 	}
 
-	r.client = data.Client
+	r.providerData = data
 }
 
 func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
@@ -98,7 +99,7 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 		"comment": plan.Comment.ValueString(),
 	})
 
-	created, err := r.client.CreateService(ctx, &fastly.CreateServiceInput{
+	created, err := r.providerData.Client.CreateService(ctx, &fastly.CreateServiceInput{
 		Name:    fastly.ToPointer(plan.Name.ValueString()),
 		Comment: fastly.ToPointer(plan.Comment.ValueString()),
 		Type:    fastly.ToPointer(service.TypeCompute),
@@ -132,7 +133,7 @@ func (r *Resource) Read(ctx context.Context, req resource.ReadRequest, resp *res
 		return
 	}
 
-	details, err := r.client.GetServiceDetails(ctx, &fastly.GetServiceDetailsInput{
+	details, err := r.providerData.Client.GetServiceDetails(ctx, &fastly.GetServiceDetailsInput{
 		ServiceID: state.ID.ValueString(),
 	})
 	if err != nil {
@@ -185,7 +186,7 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 		return
 	}
 
-	_, err := r.client.UpdateService(ctx, &fastly.UpdateServiceInput{
+	_, err := r.providerData.Client.UpdateService(ctx, &fastly.UpdateServiceInput{
 		ServiceID: state.ID.ValueString(),
 		Name:      fastly.ToPointer(plan.Name.ValueString()),
 		Comment:   fastly.ToPointer(plan.Comment.ValueString()),
@@ -206,7 +207,7 @@ func (r *Resource) Delete(ctx context.Context, req resource.DeleteRequest, resp 
 		return
 	}
 
-	if err := service.DeleteWithPolicy(ctx, r.client, state.ID.ValueString(), service.BoolValue(state.ForceDestroy), service.BoolValue(state.Reuse)); err != nil {
+	if err := service.DeleteWithPolicy(ctx, r.providerData.Client, state.ID.ValueString(), service.BoolValue(state.ForceDestroy), service.BoolValue(state.Reuse)); err != nil {
 		resp.Diagnostics.AddError("Error deleting Fastly Compute service", err.Error())
 	}
 }


### PR DESCRIPTION
### Change summary

`servicecdn` and `servicecompute` were storing only the bare `*fastly.Client` from provider data, discarding the `VersionChecker` and `ServiceTypeChecker`. This PR replaces the client field with `providerData *fastlyclient.Data` on both resources, matching the pattern already established by `servicecdnauto`, `servicecomputeauto`, `backend`, and `domain`. All six resources now have uniform access to shared provider helpers. A `ResourceWithConfigure` interface guard is also added to each struct.

 All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/terraform-provider-fastly/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

* [x] Does your submission pass tests?
* [x] Post the output of your test runs

```
==> Running acceptance tests...
    Note: This requires FASTLY_API_TOKEN to be set
=== RUN   TestAccFastlyServiceBackend_importBasic
--- PASS: TestAccFastlyServiceBackend_importBasic (12.02s)
=== RUN   TestAccFastlyServiceBackend_importWithNameSlashes
--- PASS: TestAccFastlyServiceBackend_importWithNameSlashes (9.68s)
=== RUN   TestAccFastlyServiceDomain_importBasic
--- PASS: TestAccFastlyServiceDomain_importBasic (9.79s)
=== RUN   TestAccFastlyServiceDomain_importWithSubdomain
--- PASS: TestAccFastlyServiceDomain_importWithSubdomain (13.11s)
=== RUN   TestAccProvider_ConfigureWithAPIToken
--- PASS: TestAccProvider_ConfigureWithAPIToken (11.33s)
=== RUN   TestAccProvider_ConfigureWithEnvVar
--- PASS: TestAccProvider_ConfigureWithEnvVar (9.15s)
=== RUN   TestAccProvider_MissingToken
--- PASS: TestAccProvider_MissingToken (0.24s)
=== RUN   TestAccProvider_InvalidToken
--- PASS: TestAccProvider_InvalidToken (0.39s)
=== RUN   TestAccProvider_ExplicitTokenOverridesEnvVar
--- PASS: TestAccProvider_ExplicitTokenOverridesEnvVar (8.96s)
=== RUN   TestAccFastlyServiceCDNAuto_basic
--- PASS: TestAccFastlyServiceCDNAuto_basic (12.94s)
=== RUN   TestAccFastlyServiceCDNAuto_withBackend
--- PASS: TestAccFastlyServiceCDNAuto_withBackend (20.16s)
=== RUN   TestAccFastlyServiceCDNAuto_update
--- PASS: TestAccFastlyServiceCDNAuto_update (23.48s)
=== RUN   TestAccFastlyServiceCDNAuto_multipleBackends
--- PASS: TestAccFastlyServiceCDNAuto_multipleBackends (19.94s)
=== RUN   TestAccFastlyServiceCDNAuto_import
--- PASS: TestAccFastlyServiceCDNAuto_import (16.05s)
=== RUN   TestAccFastlyServiceCDN_basic
--- PASS: TestAccFastlyServiceCDN_basic (4.27s)
=== RUN   TestAccFastlyServiceCDN_withComment
--- PASS: TestAccFastlyServiceCDN_withComment (4.17s)
=== RUN   TestAccFastlyServiceCDN_update
--- PASS: TestAccFastlyServiceCDN_update (7.02s)
=== RUN   TestAccFastlyServiceCDN_withDomain
--- PASS: TestAccFastlyServiceCDN_withDomain (7.27s)
=== RUN   TestAccFastlyServiceCDN_withBackend
--- PASS: TestAccFastlyServiceCDN_withBackend (8.26s)
=== RUN   TestAccFastlyServiceCDN_import
--- PASS: TestAccFastlyServiceCDN_import (6.15s)
=== RUN   TestAccFastlyServiceComputeAuto_basic
--- PASS: TestAccFastlyServiceComputeAuto_basic (20.55s)
=== RUN   TestAccFastlyServiceComputeAuto_withBackend
--- PASS: TestAccFastlyServiceComputeAuto_withBackend (18.64s)
=== RUN   TestAccFastlyServiceComputeAuto_update
--- PASS: TestAccFastlyServiceComputeAuto_update (31.45s)
=== RUN   TestAccFastlyServiceComputeAuto_multipleBackends
--- PASS: TestAccFastlyServiceComputeAuto_multipleBackends (21.36s)
=== RUN   TestAccFastlyServiceComputeAuto_import
--- PASS: TestAccFastlyServiceComputeAuto_import (20.29s)
=== RUN   TestAccFastlyServiceCompute_basic
--- PASS: TestAccFastlyServiceCompute_basic (5.54s)
=== RUN   TestAccFastlyServiceCompute_withComment
--- PASS: TestAccFastlyServiceCompute_withComment (6.22s)
=== RUN   TestAccFastlyServiceCompute_update
--- PASS: TestAccFastlyServiceCompute_update (10.49s)
=== RUN   TestAccFastlyServiceCompute_import
--- PASS: TestAccFastlyServiceCompute_import (5.53s)
PASS
ok      github.com/fastly/terraform-provider-fastly/internal/acceptance_tests   344.473s
```

### Changes to Core Features:

* [ ] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
