### PR TITLE
[CDTOOL-1658] switch backend and domain nested blocks to SetNestedBlock

### DIFF
--- a/docs/resources/service_cdn_auto.md
+++ b/docs/resources/service_cdn_auto.md
@@ -20,9 +20,9 @@ Automatic-lifecycle Fastly CDN service resource with nested versioned configurat
 
 ### Optional
 
-- `backend` (Block List) Backends attached to this service. (see [below for nested schema](#nestedblock--backend))
+- `backend` (Block Set) Backends attached to this service. (see [below for nested schema](#nestedblock--backend))
 - `comment` (String) Optional service comment.
-- `domain` (Block List) Domains attached to this service. (see [below for nested schema](#nestedblock--domain))
+- `domain` (Block Set) Domains attached to this service. (see [below for nested schema](#nestedblock--domain))
 - `force_destroy` (Boolean) Deactivate the active version before deleting the service. Default `false`.
 - `reuse` (Boolean) Deactivate the active version but do not delete the service, allowing it to be reused/imported elsewhere. Default `false`.
 

--- a/docs/resources/service_compute_auto.md
+++ b/docs/resources/service_compute_auto.md
@@ -20,9 +20,9 @@ Automatic-lifecycle Fastly Compute service resource with nested versioned config
 
 ### Optional
 
-- `backend` (Block List) Backends attached to this service. (see [below for nested schema](#nestedblock--backend))
+- `backend` (Block Set) Backends attached to this service. (see [below for nested schema](#nestedblock--backend))
 - `comment` (String) Optional service comment.
-- `domain` (Block List) Domains attached to this service. (see [below for nested schema](#nestedblock--domain))
+- `domain` (Block Set) Domains attached to this service. (see [below for nested schema](#nestedblock--domain))
 - `force_destroy` (Boolean) Deactivate the active version before deleting the service. Default `false`.
 - `package` (Block List) Compute package attached to this service version. At most one package block is supported. (see [below for nested schema](#nestedblock--package))
 - `reuse` (Boolean) Deactivate the active version but do not delete the service, allowing it to be reused/imported elsewhere. Default `false`.

--- a/internal/resources/backend/schema.go
+++ b/internal/resources/backend/schema.go
@@ -2,7 +2,6 @@ package backend
 
 import (
 	"context"
-	"sort"
 
 	"github.com/fastly/terraform-provider-fastly/internal/service"
 
@@ -248,24 +247,13 @@ func ResourceAttributes() map[string]schema.Attribute {
 	return attrs
 }
 
-func NestedBlockSchema() schema.ListNestedBlock {
-	return schema.ListNestedBlock{
+func NestedBlockSchema() schema.SetNestedBlock {
+	return schema.SetNestedBlock{
 		Description: "Backends attached to this service.",
 		NestedObject: schema.NestedBlockObject{
 			Attributes: CommonAttributes(),
 		},
 	}
-}
-
-func Normalize(input []NestedModel) []NestedModel {
-	out := make([]NestedModel, len(input))
-	copy(out, input)
-
-	sort.Slice(out, func(i, j int) bool {
-		return out[i].Name.ValueString() < out[j].Name.ValueString()
-	})
-
-	return out
 }
 
 func ReadForVersion(ctx context.Context, client *fastly.Client, serviceID string, version int) ([]NestedModel, error) {
@@ -282,7 +270,7 @@ func ReadForVersion(ctx context.Context, client *fastly.Client, serviceID string
 		result = append(result, FlattenToNestedModel(b))
 	}
 
-	return Normalize(result), nil
+	return result, nil
 }
 
 func Reconcile(ctx context.Context, client *fastly.Client, serviceID string, version int, desired []NestedModel) error {
@@ -293,8 +281,6 @@ func Reconcile(ctx context.Context, client *fastly.Client, serviceID string, ver
 	if err != nil {
 		return err
 	}
-
-	desired = Normalize(desired)
 
 	remoteByName := make(map[string]*fastly.Backend, len(remote))
 	for _, b := range remote {
@@ -349,15 +335,18 @@ func Reconcile(ctx context.Context, client *fastly.Client, serviceID string, ver
 }
 
 func Equal(a, b []NestedModel) bool {
-	a = Normalize(a)
-	b = Normalize(b)
-
 	if len(a) != len(b) {
 		return false
 	}
 
-	for i := range a {
-		if !ModelsEqual(a[i], b[i]) {
+	byName := make(map[string]NestedModel, len(a))
+	for _, m := range a {
+		byName[m.Name.ValueString()] = m
+	}
+
+	for _, mb := range b {
+		ma, ok := byName[mb.Name.ValueString()]
+		if !ok || !ModelsEqual(ma, mb) {
 			return false
 		}
 	}

--- a/internal/resources/domain/schema.go
+++ b/internal/resources/domain/schema.go
@@ -2,7 +2,6 @@ package domain
 
 import (
 	"context"
-	"sort"
 
 	fastly "github.com/fastly/go-fastly/v15/fastly"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -48,24 +47,13 @@ func ResourceAttributes() map[string]schema.Attribute {
 	return attrs
 }
 
-func NestedBlockSchema() schema.ListNestedBlock {
-	return schema.ListNestedBlock{
+func NestedBlockSchema() schema.SetNestedBlock {
+	return schema.SetNestedBlock{
 		Description: "Domains attached to this service.",
 		NestedObject: schema.NestedBlockObject{
 			Attributes: CommonAttributes(),
 		},
 	}
-}
-
-func Normalize(input []NestedModel) []NestedModel {
-	out := make([]NestedModel, len(input))
-	copy(out, input)
-
-	sort.Slice(out, func(i, j int) bool {
-		return out[i].Name.ValueString() < out[j].Name.ValueString()
-	})
-
-	return out
 }
 
 func ReadForVersion(ctx context.Context, client *fastly.Client, serviceID string, version int) ([]NestedModel, error) {
@@ -90,7 +78,7 @@ func ReadForVersion(ctx context.Context, client *fastly.Client, serviceID string
 		result = append(result, model)
 	}
 
-	return Normalize(result), nil
+	return result, nil
 }
 
 func Reconcile(ctx context.Context, client *fastly.Client, serviceID string, version int, desired []NestedModel) error {
@@ -101,8 +89,6 @@ func Reconcile(ctx context.Context, client *fastly.Client, serviceID string, ver
 	if err != nil {
 		return err
 	}
-
-	desired = Normalize(desired)
 
 	remoteByName := make(map[string]*fastly.Domain, len(remote))
 	for _, d := range remote {
@@ -178,26 +164,29 @@ func Reconcile(ctx context.Context, client *fastly.Client, serviceID string, ver
 }
 
 func Equal(a, b []NestedModel) bool {
-	a = Normalize(a)
-	b = Normalize(b)
-
 	if len(a) != len(b) {
 		return false
 	}
 
-	for i := range a {
-		if a[i].Name.ValueString() != b[i].Name.ValueString() {
+	byName := make(map[string]NestedModel, len(a))
+	for _, m := range a {
+		byName[m.Name.ValueString()] = m
+	}
+
+	for _, mb := range b {
+		ma, ok := byName[mb.Name.ValueString()]
+		if !ok {
 			return false
 		}
 
 		ac := ""
-		if !a[i].Comment.IsNull() && !a[i].Comment.IsUnknown() {
-			ac = a[i].Comment.ValueString()
+		if !ma.Comment.IsNull() && !ma.Comment.IsUnknown() {
+			ac = ma.Comment.ValueString()
 		}
 
 		bc := ""
-		if !b[i].Comment.IsNull() && !b[i].Comment.IsUnknown() {
-			bc = b[i].Comment.ValueString()
+		if !mb.Comment.IsNull() && !mb.Comment.IsUnknown() {
+			bc = mb.Comment.ValueString()
 		}
 
 		if ac != bc {


### PR DESCRIPTION
### Change summary

This PR switches backend and domain nested blocks from `ListNestedBlock` to `SetNestedBlock`, removing the `Normalize()` sort workaround and all call sites.

`ListNestedBlock` stores elements by position, so API reordering produces spurious diffs. `SetNestedBlock` is the
 framework-idiomatic type for unordered named collections - Terraform handles ordering natively.`Equal()` is
 rewritten as a map lookup keyed by name so it remains order-independent without sorting.

 All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/terraform-provider-fastly/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

* [ ] Does your submission pass tests?
* [ ] Post the output of your test runs

### Changes to Core Features:

* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

### User Impact

`list` and `set` have different state representations, so existing state requires re-import. Landing now before more nested blocks are added to avoid a future migration burden.

