### PR TITLE
Collapse Model/NestedModel duplication with embedded struct

### DIFF
--- a/internal/resources/backend/backend_test.go
+++ b/internal/resources/backend/backend_test.go
@@ -191,52 +191,28 @@ func TestFlattenToNestedModel(t *testing.T) {
 	}
 }
 
-func TestApplyNestedToModel(t *testing.T) {
-	src := fullNestedModel()
-	dst := &Model{
-		ID:      types.StringValue("existing-id"),
-		Service: types.StringValue("existing-service"),
-		Version: types.Int64Value(1),
+func TestModelEmbedding(t *testing.T) {
+	nested := fullNestedModel()
+	m := Model{
+		NestedModel: nested,
+		ID:          types.StringValue("test-id"),
+		Service:     types.StringValue("test-service"),
+		Version:     types.Int64Value(1),
 	}
 
-	ApplyNestedToModel(src, dst)
+	// Verify embedded fields are accessible
+	assert.Equal(t, nested.Name, m.Name)
+	assert.Equal(t, nested.Address, m.Address)
+	assert.Equal(t, nested.Port, m.Port)
 
-	// Verify ID/Service/Version are preserved
-	assert.Equal(t, types.StringValue("existing-id"), dst.ID)
-	assert.Equal(t, types.StringValue("existing-service"), dst.Service)
-	assert.Equal(t, types.Int64Value(1), dst.Version)
+	// Verify Model-specific fields
+	assert.Equal(t, types.StringValue("test-id"), m.ID)
+	assert.Equal(t, types.StringValue("test-service"), m.Service)
+	assert.Equal(t, types.Int64Value(1), m.Version)
 
-	// Verify all other fields are copied
-	assert.Equal(t, src.Name, dst.Name)
-	assert.Equal(t, src.Address, dst.Address)
-	assert.Equal(t, src.Port, dst.Port)
-	assert.Equal(t, src.Comment, dst.Comment)
-	assert.Equal(t, src.AutoLoadbalance, dst.AutoLoadbalance)
-	assert.Equal(t, src.BetweenBytesTimeout, dst.BetweenBytesTimeout)
-	assert.Equal(t, src.ConnectTimeout, dst.ConnectTimeout)
-	assert.Equal(t, src.ErrorThreshold, dst.ErrorThreshold)
-	assert.Equal(t, src.FirstByteTimeout, dst.FirstByteTimeout)
-	assert.Equal(t, src.HealthCheck, dst.HealthCheck)
-	assert.Equal(t, src.KeepaliveTime, dst.KeepaliveTime)
-	assert.Equal(t, src.MaxConn, dst.MaxConn)
-	assert.Equal(t, src.MaxLifetime, dst.MaxLifetime)
-	assert.Equal(t, src.MaxTLSVersion, dst.MaxTLSVersion)
-	assert.Equal(t, src.MaxUse, dst.MaxUse)
-	assert.Equal(t, src.MinTLSVersion, dst.MinTLSVersion)
-	assert.Equal(t, src.OverrideHost, dst.OverrideHost)
-	assert.Equal(t, src.PreferIPv6, dst.PreferIPv6)
-	assert.Equal(t, src.RequestCondition, dst.RequestCondition)
-	assert.Equal(t, src.ShareKey, dst.ShareKey)
-	assert.Equal(t, src.Shield, dst.Shield)
-	assert.Equal(t, src.SSLCACert, dst.SSLCACert)
-	assert.Equal(t, src.SSLCertHostname, dst.SSLCertHostname)
-	assert.Equal(t, src.SSLCheckCert, dst.SSLCheckCert)
-	assert.Equal(t, src.SSLCiphers, dst.SSLCiphers)
-	assert.Equal(t, src.SSLClientCert, dst.SSLClientCert)
-	assert.Equal(t, src.SSLClientKey, dst.SSLClientKey)
-	assert.Equal(t, src.SSLSNIHostname, dst.SSLSNIHostname)
-	assert.Equal(t, src.UseSSL, dst.UseSSL)
-	assert.Equal(t, src.Weight, dst.Weight)
+	// Verify NestedModel can be extracted
+	extracted := m.NestedModel
+	assert.Equal(t, nested, extracted)
 }
 
 func TestFlatten(t *testing.T) {
@@ -687,55 +663,25 @@ func TestModelToNested(t *testing.T) {
 	}{
 		{
 			name: "all fields populated",
-			model: func() Model {
-				nested := fullNestedModel()
-				return Model{
-					ID:                  types.StringValue("service-123-5-test"),
-					Service:             types.StringValue("service-123"),
-					Version:             types.Int64Value(5),
-					Name:                nested.Name,
-					Address:             nested.Address,
-					Port:                nested.Port,
-					Comment:             nested.Comment,
-					AutoLoadbalance:     nested.AutoLoadbalance,
-					BetweenBytesTimeout: nested.BetweenBytesTimeout,
-					ConnectTimeout:      nested.ConnectTimeout,
-					ErrorThreshold:      nested.ErrorThreshold,
-					FirstByteTimeout:    nested.FirstByteTimeout,
-					HealthCheck:         nested.HealthCheck,
-					KeepaliveTime:       nested.KeepaliveTime,
-					MaxConn:             nested.MaxConn,
-					MaxLifetime:         nested.MaxLifetime,
-					MaxTLSVersion:       nested.MaxTLSVersion,
-					MaxUse:              nested.MaxUse,
-					MinTLSVersion:       nested.MinTLSVersion,
-					OverrideHost:        nested.OverrideHost,
-					PreferIPv6:          nested.PreferIPv6,
-					RequestCondition:    nested.RequestCondition,
-					ShareKey:            nested.ShareKey,
-					Shield:              nested.Shield,
-					SSLCACert:           nested.SSLCACert,
-					SSLCertHostname:     nested.SSLCertHostname,
-					SSLCheckCert:        nested.SSLCheckCert,
-					SSLCiphers:          nested.SSLCiphers,
-					SSLClientCert:       nested.SSLClientCert,
-					SSLClientKey:        nested.SSLClientKey,
-					SSLSNIHostname:      nested.SSLSNIHostname,
-					UseSSL:              nested.UseSSL,
-					Weight:              nested.Weight,
-				}
-			}(),
+			model: Model{
+				NestedModel: fullNestedModel(),
+				ID:          types.StringValue("service-123-5-test"),
+				Service:     types.StringValue("service-123"),
+				Version:     types.Int64Value(5),
+			},
 			expected: fullNestedModel(),
 		},
 		{
 			name: "minimal fields only",
 			model: Model{
+				NestedModel: NestedModel{
+					Name:    types.StringValue("minimal-backend"),
+					Address: types.StringValue("api.minimal.com"),
+					Port:    types.Int64Value(80),
+				},
 				ID:      types.StringValue("service-456-1-minimal"),
 				Service: types.StringValue("service-456"),
 				Version: types.Int64Value(1),
-				Name:    types.StringValue("minimal-backend"),
-				Address: types.StringValue("api.minimal.com"),
-				Port:    types.Int64Value(80),
 			},
 			expected: NestedModel{
 				Name:    types.StringValue("minimal-backend"),
@@ -746,39 +692,41 @@ func TestModelToNested(t *testing.T) {
 		{
 			name: "null and empty values",
 			model: Model{
-				ID:                  types.StringValue("service-789-2-empty"),
-				Service:             types.StringValue("service-789"),
-				Version:             types.Int64Value(2),
-				Name:                types.StringValue("empty-backend"),
-				Address:             types.StringValue("api.empty.com"),
-				Port:                types.Int64Value(443),
-				Comment:             types.StringNull(),
-				KeepaliveTime:       types.Int64Value(0),
-				MaxTLSVersion:       types.StringValue(""),
-				MinTLSVersion:       types.StringValue(""),
-				OverrideHost:        types.StringValue(""),
-				AutoLoadbalance:     types.BoolValue(false),
-				BetweenBytesTimeout: types.Int64Value(10000),
-				ConnectTimeout:      types.Int64Value(1000),
-				ErrorThreshold:      types.Int64Value(0),
-				FirstByteTimeout:    types.Int64Value(15000),
-				HealthCheck:         types.StringValue(""),
-				MaxConn:             types.Int64Value(200),
-				MaxLifetime:         types.Int64Value(0),
-				MaxUse:              types.Int64Value(0),
-				PreferIPv6:          types.BoolValue(false),
-				RequestCondition:    types.StringValue(""),
-				ShareKey:            types.StringValue(""),
-				Shield:              types.StringValue(""),
-				SSLCACert:           types.StringValue(""),
-				SSLCertHostname:     types.StringValue(""),
-				SSLCheckCert:        types.BoolValue(true),
-				SSLCiphers:          types.StringValue(""),
-				SSLClientCert:       types.StringValue(""),
-				SSLClientKey:        types.StringValue(""),
-				SSLSNIHostname:      types.StringValue(""),
-				UseSSL:              types.BoolValue(false),
-				Weight:              types.Int64Value(100),
+				NestedModel: NestedModel{
+					Name:                types.StringValue("empty-backend"),
+					Address:             types.StringValue("api.empty.com"),
+					Port:                types.Int64Value(443),
+					Comment:             types.StringNull(),
+					KeepaliveTime:       types.Int64Value(0),
+					MaxTLSVersion:       types.StringValue(""),
+					MinTLSVersion:       types.StringValue(""),
+					OverrideHost:        types.StringValue(""),
+					AutoLoadbalance:     types.BoolValue(false),
+					BetweenBytesTimeout: types.Int64Value(10000),
+					ConnectTimeout:      types.Int64Value(1000),
+					ErrorThreshold:      types.Int64Value(0),
+					FirstByteTimeout:    types.Int64Value(15000),
+					HealthCheck:         types.StringValue(""),
+					MaxConn:             types.Int64Value(200),
+					MaxLifetime:         types.Int64Value(0),
+					MaxUse:              types.Int64Value(0),
+					PreferIPv6:          types.BoolValue(false),
+					RequestCondition:    types.StringValue(""),
+					ShareKey:            types.StringValue(""),
+					Shield:              types.StringValue(""),
+					SSLCACert:           types.StringValue(""),
+					SSLCertHostname:     types.StringValue(""),
+					SSLCheckCert:        types.BoolValue(true),
+					SSLCiphers:          types.StringValue(""),
+					SSLClientCert:       types.StringValue(""),
+					SSLClientKey:        types.StringValue(""),
+					SSLSNIHostname:      types.StringValue(""),
+					UseSSL:              types.BoolValue(false),
+					Weight:              types.Int64Value(100),
+				},
+				ID:      types.StringValue("service-789-2-empty"),
+				Service: types.StringValue("service-789"),
+				Version: types.Int64Value(2),
 			},
 			expected: NestedModel{
 				Name:                types.StringValue("empty-backend"),
@@ -817,7 +765,7 @@ func TestModelToNested(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := ModelToNested(tt.model)
+			result := tt.model.NestedModel
 			assert.Equal(t, tt.expected, result)
 		})
 	}

--- a/internal/resources/backend/expand.go
+++ b/internal/resources/backend/expand.go
@@ -111,38 +111,3 @@ func setCreateOnlyNonEmptyStrings(input *fastly.CreateBackendInput, m NestedMode
 	input.SSLClientKey = fastly.NullString(service.StringValue(m.SSLClientKey))
 	input.SSLSNIHostname = fastly.NullString(service.StringValue(m.SSLSNIHostname))
 }
-
-func ModelToNested(m Model) NestedModel {
-	return NestedModel{
-		Name:                m.Name,
-		Address:             m.Address,
-		Port:                m.Port,
-		Comment:             m.Comment,
-		AutoLoadbalance:     m.AutoLoadbalance,
-		BetweenBytesTimeout: m.BetweenBytesTimeout,
-		ConnectTimeout:      m.ConnectTimeout,
-		ErrorThreshold:      m.ErrorThreshold,
-		FirstByteTimeout:    m.FirstByteTimeout,
-		HealthCheck:         m.HealthCheck,
-		KeepaliveTime:       m.KeepaliveTime,
-		MaxConn:             m.MaxConn,
-		MaxLifetime:         m.MaxLifetime,
-		MaxTLSVersion:       m.MaxTLSVersion,
-		MaxUse:              m.MaxUse,
-		MinTLSVersion:       m.MinTLSVersion,
-		OverrideHost:        m.OverrideHost,
-		PreferIPv6:          m.PreferIPv6,
-		RequestCondition:    m.RequestCondition,
-		ShareKey:            m.ShareKey,
-		Shield:              m.Shield,
-		SSLCACert:           m.SSLCACert,
-		SSLCertHostname:     m.SSLCertHostname,
-		SSLCheckCert:        m.SSLCheckCert,
-		SSLCiphers:          m.SSLCiphers,
-		SSLClientCert:       m.SSLClientCert,
-		SSLClientKey:        m.SSLClientKey,
-		SSLSNIHostname:      m.SSLSNIHostname,
-		UseSSL:              m.UseSSL,
-		Weight:              m.Weight,
-	}
-}

--- a/internal/resources/backend/flatten.go
+++ b/internal/resources/backend/flatten.go
@@ -57,39 +57,6 @@ func FlattenToNestedModel(b *fastly.Backend) NestedModel {
 	return m
 }
 
-func ApplyNestedToModel(src NestedModel, dst *Model) {
-	dst.Name = src.Name
-	dst.Address = src.Address
-	dst.Port = src.Port
-	dst.Comment = src.Comment
-	dst.AutoLoadbalance = src.AutoLoadbalance
-	dst.BetweenBytesTimeout = src.BetweenBytesTimeout
-	dst.ConnectTimeout = src.ConnectTimeout
-	dst.ErrorThreshold = src.ErrorThreshold
-	dst.FirstByteTimeout = src.FirstByteTimeout
-	dst.HealthCheck = src.HealthCheck
-	dst.KeepaliveTime = src.KeepaliveTime
-	dst.MaxConn = src.MaxConn
-	dst.MaxLifetime = src.MaxLifetime
-	dst.MaxTLSVersion = src.MaxTLSVersion
-	dst.MaxUse = src.MaxUse
-	dst.MinTLSVersion = src.MinTLSVersion
-	dst.OverrideHost = src.OverrideHost
-	dst.PreferIPv6 = src.PreferIPv6
-	dst.RequestCondition = src.RequestCondition
-	dst.ShareKey = src.ShareKey
-	dst.Shield = src.Shield
-	dst.SSLCACert = src.SSLCACert
-	dst.SSLCertHostname = src.SSLCertHostname
-	dst.SSLCheckCert = src.SSLCheckCert
-	dst.SSLCiphers = src.SSLCiphers
-	dst.SSLClientCert = src.SSLClientCert
-	dst.SSLClientKey = src.SSLClientKey
-	dst.SSLSNIHostname = src.SSLSNIHostname
-	dst.UseSSL = src.UseSSL
-	dst.Weight = src.Weight
-}
-
 func flatten(ctx context.Context, b *fastly.Backend, m *Model) {
 	if b == nil {
 		tflog.Warn(ctx, "flatten called with nil backend")
@@ -101,8 +68,7 @@ func flatten(ctx context.Context, b *fastly.Backend, m *Model) {
 	m.Service = types.StringValue(fastly.ToValue(b.ServiceID))
 	m.Version = types.Int64Value(int64(fastly.ToValue(b.ServiceVersion)))
 
-	backendModel := FlattenToNestedModel(b)
-	ApplyNestedToModel(backendModel, m)
+	m.NestedModel = FlattenToNestedModel(b)
 
 	tflog.Debug(ctx, "Flattened service backend state", map[string]any{
 		"id":      id,

--- a/internal/resources/backend/list.go
+++ b/internal/resources/backend/list.go
@@ -126,11 +126,11 @@ func setResourceAttrs(ctx context.Context, result *list.ListResult, b *fastly.Ba
 	id := serviceID + "-" + fmt.Sprintf("%d", version) + "-" + fastly.ToValue(b.Name)
 
 	model := Model{
-		ID:      types.StringValue(id),
-		Service: types.StringValue(serviceID),
-		Version: types.Int64Value(int64(version)),
+		NestedModel: FlattenToNestedModel(b),
+		ID:          types.StringValue(id),
+		Service:     types.StringValue(serviceID),
+		Version:     types.Int64Value(int64(version)),
 	}
-	ApplyNestedToModel(FlattenToNestedModel(b), &model)
 	diags.Append(result.Resource.Set(ctx, &model)...)
 	return diags
 }

--- a/internal/resources/backend/resource.go
+++ b/internal/resources/backend/resource.go
@@ -31,39 +31,10 @@ func NewResource() resource.Resource {
 }
 
 type Model struct {
-	ID                  types.String `tfsdk:"id"`
-	Service             types.String `tfsdk:"service_id"`
-	Version             types.Int64  `tfsdk:"version"`
-	Name                types.String `tfsdk:"name"`
-	Address             types.String `tfsdk:"address"`
-	Port                types.Int64  `tfsdk:"port"`
-	Comment             types.String `tfsdk:"comment"`
-	AutoLoadbalance     types.Bool   `tfsdk:"auto_loadbalance"`
-	BetweenBytesTimeout types.Int64  `tfsdk:"between_bytes_timeout"`
-	ConnectTimeout      types.Int64  `tfsdk:"connect_timeout"`
-	ErrorThreshold      types.Int64  `tfsdk:"error_threshold"`
-	FirstByteTimeout    types.Int64  `tfsdk:"first_byte_timeout"`
-	HealthCheck         types.String `tfsdk:"healthcheck"`
-	KeepaliveTime       types.Int64  `tfsdk:"keepalive_time"`
-	MaxConn             types.Int64  `tfsdk:"max_conn"`
-	MaxLifetime         types.Int64  `tfsdk:"max_lifetime"`
-	MaxTLSVersion       types.String `tfsdk:"max_tls_version"`
-	MaxUse              types.Int64  `tfsdk:"max_use"`
-	MinTLSVersion       types.String `tfsdk:"min_tls_version"`
-	OverrideHost        types.String `tfsdk:"override_host"`
-	PreferIPv6          types.Bool   `tfsdk:"prefer_ipv6"`
-	RequestCondition    types.String `tfsdk:"request_condition"`
-	ShareKey            types.String `tfsdk:"share_key"`
-	Shield              types.String `tfsdk:"shield"`
-	SSLCACert           types.String `tfsdk:"ssl_ca_cert"`
-	SSLCertHostname     types.String `tfsdk:"ssl_cert_hostname"`
-	SSLCheckCert        types.Bool   `tfsdk:"ssl_check_cert"`
-	SSLCiphers          types.String `tfsdk:"ssl_ciphers"`
-	SSLClientCert       types.String `tfsdk:"ssl_client_cert"`
-	SSLClientKey        types.String `tfsdk:"ssl_client_key"`
-	SSLSNIHostname      types.String `tfsdk:"ssl_sni_hostname"`
-	UseSSL              types.Bool   `tfsdk:"use_ssl"`
-	Weight              types.Int64  `tfsdk:"weight"`
+	NestedModel
+	ID      types.String `tfsdk:"id"`
+	Service types.String `tfsdk:"service_id"`
+	Version types.Int64  `tfsdk:"version"`
 }
 
 type BackendIdentityModel struct {
@@ -115,7 +86,7 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 		return
 	}
 
-	opts := BuildCreateInput(plan.Service.ValueString(), int(plan.Version.ValueInt64()), ModelToNested(plan))
+	opts := BuildCreateInput(plan.Service.ValueString(), int(plan.Version.ValueInt64()), plan.NestedModel)
 
 	b, err := r.providerData.Client.CreateBackend(ctx, opts)
 	if err != nil {
@@ -203,12 +174,11 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 	}
 
 	forceAll := plan.Version.ValueInt64() != state.Version.ValueInt64()
-	stateBackend := ModelToNested(state)
 	opts := BuildUpdateInput(
 		plan.Service.ValueString(),
 		int(plan.Version.ValueInt64()),
-		ModelToNested(plan),
-		&stateBackend,
+		plan.NestedModel,
+		&state.NestedModel,
 		forceAll,
 	)
 

--- a/internal/resources/backend/schema.go
+++ b/internal/resources/backend/schema.go
@@ -77,6 +77,39 @@ type NestedModel struct {
 	Weight              types.Int64  `tfsdk:"weight"`
 }
 
+func (n NestedModel) ModelsEqual(other NestedModel) bool {
+	return service.StringValue(n.Name) == service.StringValue(other.Name) &&
+		service.StringValue(n.Address) == service.StringValue(other.Address) &&
+		service.Int64Value(n.Port) == service.Int64Value(other.Port) &&
+		service.StringValue(n.Comment) == service.StringValue(other.Comment) &&
+		service.BoolValue(n.AutoLoadbalance) == service.BoolValue(other.AutoLoadbalance) &&
+		service.Int64Value(n.BetweenBytesTimeout) == service.Int64Value(other.BetweenBytesTimeout) &&
+		service.Int64Value(n.ConnectTimeout) == service.Int64Value(other.ConnectTimeout) &&
+		service.Int64Value(n.ErrorThreshold) == service.Int64Value(other.ErrorThreshold) &&
+		service.Int64Value(n.FirstByteTimeout) == service.Int64Value(other.FirstByteTimeout) &&
+		service.StringValue(n.HealthCheck) == service.StringValue(other.HealthCheck) &&
+		service.Int64Value(n.KeepaliveTime) == service.Int64Value(other.KeepaliveTime) &&
+		service.Int64Value(n.MaxConn) == service.Int64Value(other.MaxConn) &&
+		service.Int64Value(n.MaxLifetime) == service.Int64Value(other.MaxLifetime) &&
+		service.StringValue(n.MaxTLSVersion) == service.StringValue(other.MaxTLSVersion) &&
+		service.Int64Value(n.MaxUse) == service.Int64Value(other.MaxUse) &&
+		service.StringValue(n.MinTLSVersion) == service.StringValue(other.MinTLSVersion) &&
+		service.StringValue(n.OverrideHost) == service.StringValue(other.OverrideHost) &&
+		service.BoolValue(n.PreferIPv6) == service.BoolValue(other.PreferIPv6) &&
+		service.StringValue(n.RequestCondition) == service.StringValue(other.RequestCondition) &&
+		service.StringValue(n.ShareKey) == service.StringValue(other.ShareKey) &&
+		service.StringValue(n.Shield) == service.StringValue(other.Shield) &&
+		service.StringValue(n.SSLCACert) == service.StringValue(other.SSLCACert) &&
+		service.StringValue(n.SSLCertHostname) == service.StringValue(other.SSLCertHostname) &&
+		service.BoolValue(n.SSLCheckCert) == service.BoolValue(other.SSLCheckCert) &&
+		service.StringValue(n.SSLCiphers) == service.StringValue(other.SSLCiphers) &&
+		service.StringValue(n.SSLClientCert) == service.StringValue(other.SSLClientCert) &&
+		service.StringValue(n.SSLClientKey) == service.StringValue(other.SSLClientKey) &&
+		service.StringValue(n.SSLSNIHostname) == service.StringValue(other.SSLSNIHostname) &&
+		service.BoolValue(n.UseSSL) == service.BoolValue(other.UseSSL) &&
+		service.Int64Value(n.Weight) == service.Int64Value(other.Weight)
+}
+
 func CommonAttributes() map[string]schema.Attribute {
 	return map[string]schema.Attribute{
 		"name": schema.StringAttribute{
@@ -367,7 +400,7 @@ func Reconcile(ctx context.Context, client *fastly.Client, serviceID string, ver
 		}
 
 		remoteModel := FlattenToNestedModel(remoteBackend)
-		if !ModelsEqual(desiredBackend, remoteModel) {
+		if !desiredBackend.ModelsEqual(remoteModel) {
 			input := BuildUpdateInput(serviceID, version, desiredBackend, &remoteModel, false)
 			if _, err := client.UpdateBackend(ctx, input); err != nil {
 				return err
@@ -387,43 +420,10 @@ func Equal(a, b []NestedModel) bool {
 	}
 
 	for i := range a {
-		if !ModelsEqual(a[i], b[i]) {
+		if !a[i].ModelsEqual(b[i]) {
 			return false
 		}
 	}
 
 	return true
-}
-
-func ModelsEqual(a, b NestedModel) bool {
-	return service.StringValue(a.Name) == service.StringValue(b.Name) &&
-		service.StringValue(a.Address) == service.StringValue(b.Address) &&
-		service.Int64Value(a.Port) == service.Int64Value(b.Port) &&
-		service.StringValue(a.Comment) == service.StringValue(b.Comment) &&
-		service.BoolValue(a.AutoLoadbalance) == service.BoolValue(b.AutoLoadbalance) &&
-		service.Int64Value(a.BetweenBytesTimeout) == service.Int64Value(b.BetweenBytesTimeout) &&
-		service.Int64Value(a.ConnectTimeout) == service.Int64Value(b.ConnectTimeout) &&
-		service.Int64Value(a.ErrorThreshold) == service.Int64Value(b.ErrorThreshold) &&
-		service.Int64Value(a.FirstByteTimeout) == service.Int64Value(b.FirstByteTimeout) &&
-		service.StringValue(a.HealthCheck) == service.StringValue(b.HealthCheck) &&
-		service.Int64Value(a.KeepaliveTime) == service.Int64Value(b.KeepaliveTime) &&
-		service.Int64Value(a.MaxConn) == service.Int64Value(b.MaxConn) &&
-		service.Int64Value(a.MaxLifetime) == service.Int64Value(b.MaxLifetime) &&
-		service.StringValue(a.MaxTLSVersion) == service.StringValue(b.MaxTLSVersion) &&
-		service.Int64Value(a.MaxUse) == service.Int64Value(b.MaxUse) &&
-		service.StringValue(a.MinTLSVersion) == service.StringValue(b.MinTLSVersion) &&
-		service.StringValue(a.OverrideHost) == service.StringValue(b.OverrideHost) &&
-		service.BoolValue(a.PreferIPv6) == service.BoolValue(b.PreferIPv6) &&
-		service.StringValue(a.RequestCondition) == service.StringValue(b.RequestCondition) &&
-		service.StringValue(a.ShareKey) == service.StringValue(b.ShareKey) &&
-		service.StringValue(a.Shield) == service.StringValue(b.Shield) &&
-		service.StringValue(a.SSLCACert) == service.StringValue(b.SSLCACert) &&
-		service.StringValue(a.SSLCertHostname) == service.StringValue(b.SSLCertHostname) &&
-		service.BoolValue(a.SSLCheckCert) == service.BoolValue(b.SSLCheckCert) &&
-		service.StringValue(a.SSLCiphers) == service.StringValue(b.SSLCiphers) &&
-		service.StringValue(a.SSLClientCert) == service.StringValue(b.SSLClientCert) &&
-		service.StringValue(a.SSLClientKey) == service.StringValue(b.SSLClientKey) &&
-		service.StringValue(a.SSLSNIHostname) == service.StringValue(b.SSLSNIHostname) &&
-		service.BoolValue(a.UseSSL) == service.BoolValue(b.UseSSL) &&
-		service.Int64Value(a.Weight) == service.Int64Value(b.Weight)
 }


### PR DESCRIPTION
### Change summary

Model now embeds NestedModel directly, eliminating field copying. Benefits:

  - Deleted ModelToNested() — replaced with m.NestedModel property access
  - Deleted ApplyNestedToModel() — replaced with direct assignment
  - Converted ModelsEqual() to a NestedModel method
  - Simplified struct literals using embedded field initialization

 All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/terraform-provider-fastly/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

* [x] Does your submission pass tests?
* [x] Post the output of your test runs
<img width="657" height="859" alt="Screenshot 2026-06-18 at 1 59 10 PM" src="https://github.com/user-attachments/assets/c8dffcee-565b-4f7b-b484-2bae6b3078f0" />

### Changes to Core Features:

* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
