### PR TITLE
add parallel capability to most tests

### DIFF
--- a/internal/acceptance_tests/backend_import_test.go
+++ b/internal/acceptance_tests/backend_import_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestAccFastlyServiceBackend_importBasic(t *testing.T) {
+	t.Parallel()
 	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	domainName := fmt.Sprintf("%s.example.com", acctest.RandString(10))
 	backendName := fmt.Sprintf("backend-%s", acctest.RandString(10))
@@ -56,6 +57,7 @@ func TestAccFastlyServiceBackend_importBasic(t *testing.T) {
 }
 
 func TestAccFastlyServiceBackend_importWithNameSlashes(t *testing.T) {
+	t.Parallel()
 	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	domainName := fmt.Sprintf("%s.example.com", acctest.RandString(10))
 	// Backend name with slashes to test SplitN behavior

--- a/internal/acceptance_tests/domain_import_test.go
+++ b/internal/acceptance_tests/domain_import_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestAccFastlyServiceDomain_importBasic(t *testing.T) {
+	t.Parallel()
 	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	domainName := fmt.Sprintf("%s.example.com", acctest.RandString(10))
 	additionalDomainName := fmt.Sprintf("www.%s.example.com", acctest.RandString(10))
@@ -54,6 +55,7 @@ func TestAccFastlyServiceDomain_importBasic(t *testing.T) {
 }
 
 func TestAccFastlyServiceDomain_importWithSubdomain(t *testing.T) {
+	t.Parallel()
 	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	domainName := fmt.Sprintf("%s.example.com", acctest.RandString(10))
 	// Domain with multiple levels to ensure proper parsing

--- a/internal/acceptance_tests/provider_test.go
+++ b/internal/acceptance_tests/provider_test.go
@@ -13,6 +13,7 @@ import (
 
 // TestAccProvider_ConfigureWithAPIToken tests provider configuration with explicit api_token
 func TestAccProvider_ConfigureWithAPIToken(t *testing.T) {
+	t.Parallel()
 	if os.Getenv("TF_ACC") == "" {
 		t.Skip("Acceptance tests skipped unless env 'TF_ACC' is set")
 	}
@@ -38,6 +39,7 @@ func TestAccProvider_ConfigureWithAPIToken(t *testing.T) {
 
 // TestAccProvider_ConfigureWithEnvVar tests provider configuration via FASTLY_API_TOKEN env var
 func TestAccProvider_ConfigureWithEnvVar(t *testing.T) {
+	t.Parallel()
 	if os.Getenv("TF_ACC") == "" {
 		t.Skip("Acceptance tests skipped unless env 'TF_ACC' is set")
 	}
@@ -67,6 +69,7 @@ func TestAccProvider_ConfigureWithEnvVar(t *testing.T) {
 }
 
 // TestAccProvider_MissingToken tests provider error handling when no token is provided
+// NOTE: This test modifies the FASTLY_API_TOKEN environment variable, so it cannot run in parallel
 func TestAccProvider_MissingToken(t *testing.T) {
 	if os.Getenv("TF_ACC") == "" {
 		t.Skip("Acceptance tests skipped unless env 'TF_ACC' is set")
@@ -99,6 +102,7 @@ func TestAccProvider_MissingToken(t *testing.T) {
 
 // TestAccProvider_InvalidToken tests provider error handling with an invalid token
 func TestAccProvider_InvalidToken(t *testing.T) {
+	t.Parallel()
 	if os.Getenv("TF_ACC") == "" {
 		t.Skip("Acceptance tests skipped unless env 'TF_ACC' is set")
 	}
@@ -118,6 +122,7 @@ func TestAccProvider_InvalidToken(t *testing.T) {
 }
 
 // TestAccProvider_ExplicitTokenOverridesEnvVar tests that explicit api_token takes precedence over env var
+// NOTE: This test modifies the FASTLY_API_TOKEN environment variable, so it cannot run in parallel
 func TestAccProvider_ExplicitTokenOverridesEnvVar(t *testing.T) {
 	if os.Getenv("TF_ACC") == "" {
 		t.Skip("Acceptance tests skipped unless env 'TF_ACC' is set")

--- a/internal/acceptance_tests/service_cdn_auto_test.go
+++ b/internal/acceptance_tests/service_cdn_auto_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestAccFastlyServiceCDNAuto_basic(t *testing.T) {
+	t.Parallel()
 	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	domainName := fmt.Sprintf("%s.example.com", acctest.RandString(10))
 
@@ -38,6 +39,7 @@ func TestAccFastlyServiceCDNAuto_basic(t *testing.T) {
 }
 
 func TestAccFastlyServiceCDNAuto_withBackend(t *testing.T) {
+	t.Parallel()
 	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	domainName := fmt.Sprintf("%s.example.com", acctest.RandString(10))
 	backendName := fmt.Sprintf("backend-%s", acctest.RandString(10))
@@ -79,6 +81,7 @@ func TestAccFastlyServiceCDNAuto_withBackend(t *testing.T) {
 }
 
 func TestAccFastlyServiceCDNAuto_update(t *testing.T) {
+	t.Parallel()
 	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	serviceNameUpdated := fmt.Sprintf("tf-test-updated-%s", acctest.RandString(10))
 	domainName := fmt.Sprintf("%s.example.com", acctest.RandString(10))
@@ -130,6 +133,7 @@ func TestAccFastlyServiceCDNAuto_update(t *testing.T) {
 }
 
 func TestAccFastlyServiceCDNAuto_multipleBackends(t *testing.T) {
+	t.Parallel()
 	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	domainName := fmt.Sprintf("%s.example.com", acctest.RandString(10))
 
@@ -167,6 +171,7 @@ func TestAccFastlyServiceCDNAuto_multipleBackends(t *testing.T) {
 }
 
 func TestAccFastlyServiceCDNAuto_import(t *testing.T) {
+	t.Parallel()
 	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	domainName := fmt.Sprintf("%s.example.com", acctest.RandString(10))
 

--- a/internal/acceptance_tests/service_cdn_test.go
+++ b/internal/acceptance_tests/service_cdn_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestAccFastlyServiceCDN_basic(t *testing.T) {
+	t.Parallel()
 	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 
 	resource.Test(t, resource.TestCase{
@@ -32,6 +33,7 @@ func TestAccFastlyServiceCDN_basic(t *testing.T) {
 }
 
 func TestAccFastlyServiceCDN_withComment(t *testing.T) {
+	t.Parallel()
 	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 
 	resource.Test(t, resource.TestCase{
@@ -52,6 +54,7 @@ func TestAccFastlyServiceCDN_withComment(t *testing.T) {
 }
 
 func TestAccFastlyServiceCDN_update(t *testing.T) {
+	t.Parallel()
 	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	serviceNameUpdated := fmt.Sprintf("tf-test-updated-%s", acctest.RandString(10))
 
@@ -79,6 +82,7 @@ func TestAccFastlyServiceCDN_update(t *testing.T) {
 }
 
 func TestAccFastlyServiceCDN_withDomain(t *testing.T) {
+	t.Parallel()
 	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	domainName := fmt.Sprintf("%s.example.com", acctest.RandString(10))
 
@@ -101,6 +105,7 @@ func TestAccFastlyServiceCDN_withDomain(t *testing.T) {
 }
 
 func TestAccFastlyServiceCDN_withBackend(t *testing.T) {
+	t.Parallel()
 	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	domainName := fmt.Sprintf("%s.example.com", acctest.RandString(10))
 	backendName := fmt.Sprintf("backend-%s", acctest.RandString(10))
@@ -126,6 +131,7 @@ func TestAccFastlyServiceCDN_withBackend(t *testing.T) {
 }
 
 func TestAccFastlyServiceCDN_import(t *testing.T) {
+	t.Parallel()
 	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 
 	resource.Test(t, resource.TestCase{

--- a/internal/acceptance_tests/service_compute_auto_test.go
+++ b/internal/acceptance_tests/service_compute_auto_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestAccFastlyServiceComputeAuto_basic(t *testing.T) {
+	t.Parallel()
 	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	domainName := fmt.Sprintf("%s.example.com", acctest.RandString(10))
 
@@ -38,6 +39,7 @@ func TestAccFastlyServiceComputeAuto_basic(t *testing.T) {
 }
 
 func TestAccFastlyServiceComputeAuto_withBackend(t *testing.T) {
+	t.Parallel()
 	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	domainName := fmt.Sprintf("%s.example.com", acctest.RandString(10))
 	backendName := fmt.Sprintf("backend-%s", acctest.RandString(10))
@@ -67,6 +69,7 @@ func TestAccFastlyServiceComputeAuto_withBackend(t *testing.T) {
 }
 
 func TestAccFastlyServiceComputeAuto_update(t *testing.T) {
+	t.Parallel()
 	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	serviceNameUpdated := fmt.Sprintf("tf-test-updated-%s", acctest.RandString(10))
 	domainName := fmt.Sprintf("%s.example.com", acctest.RandString(10))
@@ -105,6 +108,7 @@ func TestAccFastlyServiceComputeAuto_update(t *testing.T) {
 }
 
 func TestAccFastlyServiceComputeAuto_multipleBackends(t *testing.T) {
+	t.Parallel()
 	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	domainName := fmt.Sprintf("%s.example.com", acctest.RandString(10))
 
@@ -127,6 +131,7 @@ func TestAccFastlyServiceComputeAuto_multipleBackends(t *testing.T) {
 }
 
 func TestAccFastlyServiceComputeAuto_import(t *testing.T) {
+	t.Parallel()
 	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	domainName := fmt.Sprintf("%s.example.com", acctest.RandString(10))
 

--- a/internal/acceptance_tests/service_compute_test.go
+++ b/internal/acceptance_tests/service_compute_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestAccFastlyServiceCompute_basic(t *testing.T) {
+	t.Parallel()
 	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 
 	resource.Test(t, resource.TestCase{
@@ -32,6 +33,7 @@ func TestAccFastlyServiceCompute_basic(t *testing.T) {
 }
 
 func TestAccFastlyServiceCompute_withComment(t *testing.T) {
+	t.Parallel()
 	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 
 	resource.Test(t, resource.TestCase{
@@ -52,6 +54,7 @@ func TestAccFastlyServiceCompute_withComment(t *testing.T) {
 }
 
 func TestAccFastlyServiceCompute_update(t *testing.T) {
+	t.Parallel()
 	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	serviceNameUpdated := fmt.Sprintf("tf-test-updated-%s", acctest.RandString(10))
 
@@ -79,6 +82,7 @@ func TestAccFastlyServiceCompute_update(t *testing.T) {
 }
 
 func TestAccFastlyServiceCompute_import(t *testing.T) {
+	t.Parallel()
 	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 
 	resource.Test(t, resource.TestCase{


### PR DESCRIPTION
### Change summary

brings ACC test timing down from 316 seconds to 137 seconds

 All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/terraform-provider-fastly/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

* [x] Does your submission pass tests?
* [x] Post the output of your test runs
<img width="710" height="624" alt="Screenshot 2026-06-18 at 3 16 07 PM" src="https://github.com/user-attachments/assets/4a742c82-c2b5-4877-bf24-2e17380d6d89" />