### PR TITLE
Remove per-field diffing from update input builders

### DIFF
--- a/internal/resources/backend/backend_test.go
+++ b/internal/resources/backend/backend_test.go
@@ -421,12 +421,10 @@ func TestBuildUpdateInput(t *testing.T) {
 		serviceID string
 		version   int
 		plan      NestedModel
-		state     *NestedModel
-		forceAll  bool
 		validate  func(t *testing.T, input *fastly.UpdateBackendInput)
 	}{
 		{
-			name:      "update with forceAll true",
+			name:      "update with all fields",
 			serviceID: "service-123",
 			version:   6,
 			plan: func() NestedModel {
@@ -439,13 +437,6 @@ func TestBuildUpdateInput(t *testing.T) {
 				m.ConnectTimeout = types.Int64Value(2000)
 				return m
 			}(),
-			state: func() *NestedModel {
-				m := defaultNestedModel()
-				m.Name = types.StringValue("test-backend")
-				m.Address = types.StringValue("api.example.com")
-				return &m
-			}(),
-			forceAll: true,
 			validate: func(t *testing.T, input *fastly.UpdateBackendInput) {
 				assert.Equal(t, "service-123", input.ServiceID)
 				assert.Equal(t, 6, input.ServiceVersion)
@@ -459,7 +450,7 @@ func TestBuildUpdateInput(t *testing.T) {
 			},
 		},
 		{
-			name:      "update only changed fields",
+			name:      "update with changed address",
 			serviceID: "service-456",
 			version:   10,
 			plan: func() NestedModel {
@@ -469,36 +460,20 @@ func TestBuildUpdateInput(t *testing.T) {
 				m.Port = types.Int64Value(8080)
 				return m
 			}(),
-			state: func() *NestedModel {
-				m := defaultNestedModel()
-				m.Name = types.StringValue("backend-2")
-				m.Address = types.StringValue("api.original.com")
-				return &m
-			}(),
-			forceAll: false,
 			validate: func(t *testing.T, input *fastly.UpdateBackendInput) {
 				assert.Equal(t, "service-456", input.ServiceID)
 				assert.Equal(t, 10, input.ServiceVersion)
 				assert.Equal(t, "backend-2", input.Name)
-
-				// Changed fields should be present
 				assert.NotNil(t, input.Address)
 				assert.Equal(t, "api.changed.com", *input.Address)
 				assert.NotNil(t, input.Port)
 				assert.Equal(t, 8080, *input.Port)
-
-				// Unchanged fields should be nil (not sent in update payload)
-				assert.Nil(t, input.UseSSL)
-				assert.Nil(t, input.Weight)
-				assert.Nil(t, input.ConnectTimeout)
-				assert.Nil(t, input.BetweenBytesTimeout)
-				assert.Nil(t, input.MaxConn)
-				assert.Nil(t, input.AutoLoadbalance)
-				assert.Nil(t, input.SSLCheckCert)
+				assert.NotNil(t, input.UseSSL)
+				assert.NotNil(t, input.Weight)
 			},
 		},
 		{
-			name:      "update with nil state forces all fields",
+			name:      "update with new backend",
 			serviceID: "service-789",
 			version:   1,
 			plan: func() NestedModel {
@@ -508,8 +483,6 @@ func TestBuildUpdateInput(t *testing.T) {
 				m.Port = types.Int64Value(443)
 				return m
 			}(),
-			state:    nil,
-			forceAll: false,
 			validate: func(t *testing.T, input *fastly.UpdateBackendInput) {
 				assert.Equal(t, "service-789", input.ServiceID)
 				assert.Equal(t, 1, input.ServiceVersion)
@@ -530,14 +503,6 @@ func TestBuildUpdateInput(t *testing.T) {
 				m.Comment = types.StringValue("New comment")
 				return m
 			}(),
-			state: func() *NestedModel {
-				m := defaultNestedModel()
-				m.Name = types.StringValue("commented-backend")
-				m.Address = types.StringValue("api.test.com")
-				m.Comment = types.StringValue("Old comment")
-				return &m
-			}(),
-			forceAll: false,
 			validate: func(t *testing.T, input *fastly.UpdateBackendInput) {
 				assert.NotNil(t, input.Comment)
 				assert.Equal(t, "New comment", *input.Comment)
@@ -547,7 +512,7 @@ func TestBuildUpdateInput(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			input := BuildUpdateInput(tt.serviceID, tt.version, tt.plan, tt.state, tt.forceAll)
+			input := BuildUpdateInput(tt.serviceID, tt.version, tt.plan)
 			tt.validate(t, input)
 		})
 	}

--- a/internal/resources/backend/expand.go
+++ b/internal/resources/backend/expand.go
@@ -2,7 +2,6 @@ package backend
 
 import (
 	fastly "github.com/fastly/go-fastly/v15/fastly"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/fastly/terraform-provider-fastly/internal/service"
 )
@@ -38,63 +37,43 @@ func BuildCreateInput(serviceID string, version int, m NestedModel) *fastly.Crea
 	return input
 }
 
-func BuildUpdateInput(serviceID string, version int, plan NestedModel, state *NestedModel, forceAll bool) *fastly.UpdateBackendInput {
+func BuildUpdateInput(serviceID string, version int, plan NestedModel) *fastly.UpdateBackendInput {
 	input := &fastly.UpdateBackendInput{
 		ServiceID:      serviceID,
 		ServiceVersion: version,
 		Name:           service.StringValue(plan.Name),
 	}
 
-	setString := func(attr types.String, old types.String, setter func(string)) {
-		if forceAll || state == nil || service.StringValue(attr) != service.StringValue(old) {
-			setter(service.StringValue(attr))
-		}
-	}
-	setInt := func(attr types.Int64, old types.Int64, setter func(int)) {
-		if forceAll || state == nil || service.Int64Value(attr) != service.Int64Value(old) {
-			setter(int(service.Int64Value(attr)))
-		}
-	}
-	setBool := func(attr types.Bool, old types.Bool, setter func(bool)) {
-		if forceAll || state == nil || service.BoolValue(attr) != service.BoolValue(old) {
-			setter(service.BoolValue(attr))
-		}
-	}
+	input.Address = new(service.StringValue(plan.Address))
+	input.Port = new(int(service.Int64Value(plan.Port)))
+	input.BetweenBytesTimeout = new(int(service.Int64Value(plan.BetweenBytesTimeout)))
+	input.ConnectTimeout = new(int(service.Int64Value(plan.ConnectTimeout)))
+	input.ErrorThreshold = new(int(service.Int64Value(plan.ErrorThreshold)))
+	input.FirstByteTimeout = new(int(service.Int64Value(plan.FirstByteTimeout)))
+	input.HealthCheck = new(service.StringValue(plan.HealthCheck))
+	input.MaxConn = new(int(service.Int64Value(plan.MaxConn)))
+	input.Weight = new(int(service.Int64Value(plan.Weight)))
+	input.PreferIPv6 = new(fastly.Compatibool(service.BoolValue(plan.PreferIPv6)))
+	input.SSLCheckCert = new(fastly.Compatibool(service.BoolValue(plan.SSLCheckCert)))
+	input.Shield = new(service.StringValue(plan.Shield))
+	input.UseSSL = new(fastly.Compatibool(service.BoolValue(plan.UseSSL)))
+	input.AutoLoadbalance = new(fastly.Compatibool(service.BoolValue(plan.AutoLoadbalance)))
+	input.RequestCondition = new(service.StringValue(plan.RequestCondition))
 
-	var old NestedModel
-	if state != nil {
-		old = *state
-	}
-
-	setString(plan.Address, old.Address, func(v string) { input.Address = new(v) })
-	setInt(plan.Port, old.Port, func(v int) { input.Port = new(v) })
-	setInt(plan.BetweenBytesTimeout, old.BetweenBytesTimeout, func(v int) { input.BetweenBytesTimeout = new(v) })
-	setInt(plan.ConnectTimeout, old.ConnectTimeout, func(v int) { input.ConnectTimeout = new(v) })
-	setInt(plan.ErrorThreshold, old.ErrorThreshold, func(v int) { input.ErrorThreshold = new(v) })
-	setInt(plan.FirstByteTimeout, old.FirstByteTimeout, func(v int) { input.FirstByteTimeout = new(v) })
-	setString(plan.HealthCheck, old.HealthCheck, func(v string) { input.HealthCheck = new(v) })
-	setInt(plan.KeepaliveTime, old.KeepaliveTime, func(v int) { input.KeepAliveTime = new(v) })
-	setInt(plan.MaxConn, old.MaxConn, func(v int) { input.MaxConn = new(v) })
-	setInt(plan.MaxLifetime, old.MaxLifetime, func(v int) { input.MaxLifetime = new(v) })
-	setString(plan.MaxTLSVersion, old.MaxTLSVersion, func(v string) { input.MaxTLSVersion = new(v) })
-	setInt(plan.MaxUse, old.MaxUse, func(v int) { input.MaxUse = new(v) })
-	setString(plan.MinTLSVersion, old.MinTLSVersion, func(v string) { input.MinTLSVersion = new(v) })
-	setString(plan.OverrideHost, old.OverrideHost, func(v string) { input.OverrideHost = new(v) })
-	setBool(plan.PreferIPv6, old.PreferIPv6, func(v bool) { input.PreferIPv6 = new(fastly.Compatibool(v)) })
-	setString(plan.RequestCondition, old.RequestCondition, func(v string) { input.RequestCondition = new(v) })
-	setString(plan.ShareKey, old.ShareKey, func(v string) { input.ShareKey = new(v) })
-	setString(plan.Shield, old.Shield, func(v string) { input.Shield = new(v) })
-	setString(plan.SSLCACert, old.SSLCACert, func(v string) { input.SSLCACert = new(v) })
-	setString(plan.SSLCertHostname, old.SSLCertHostname, func(v string) { input.SSLCertHostname = new(v) })
-	setBool(plan.SSLCheckCert, old.SSLCheckCert, func(v bool) { input.SSLCheckCert = new(fastly.Compatibool(v)) })
-	setString(plan.SSLCiphers, old.SSLCiphers, func(v string) { input.SSLCiphers = new(v) })
-	setString(plan.SSLClientCert, old.SSLClientCert, func(v string) { input.SSLClientCert = new(v) })
-	setString(plan.SSLClientKey, old.SSLClientKey, func(v string) { input.SSLClientKey = new(v) })
-	setString(plan.SSLSNIHostname, old.SSLSNIHostname, func(v string) { input.SSLSNIHostname = new(v) })
-	setBool(plan.UseSSL, old.UseSSL, func(v bool) { input.UseSSL = new(fastly.Compatibool(v)) })
-	setInt(plan.Weight, old.Weight, func(v int) { input.Weight = new(v) })
-	setBool(plan.AutoLoadbalance, old.AutoLoadbalance, func(v bool) { input.AutoLoadbalance = new(fastly.Compatibool(v)) })
-	setString(plan.Comment, old.Comment, func(v string) { input.Comment = new(v) })
+	input.KeepAliveTime = fastly.NullInt(int(service.Int64Value(plan.KeepaliveTime)))
+	input.MaxLifetime = fastly.NullInt(int(service.Int64Value(plan.MaxLifetime)))
+	input.MaxUse = fastly.NullInt(int(service.Int64Value(plan.MaxUse)))
+	input.Comment = fastly.NullString(service.StringValue(plan.Comment))
+	input.MinTLSVersion = fastly.NullString(service.StringValue(plan.MinTLSVersion))
+	input.MaxTLSVersion = fastly.NullString(service.StringValue(plan.MaxTLSVersion))
+	input.OverrideHost = fastly.NullString(service.StringValue(plan.OverrideHost))
+	input.ShareKey = fastly.NullString(service.StringValue(plan.ShareKey))
+	input.SSLCACert = fastly.NullString(service.StringValue(plan.SSLCACert))
+	input.SSLCertHostname = fastly.NullString(service.StringValue(plan.SSLCertHostname))
+	input.SSLCiphers = fastly.NullString(service.StringValue(plan.SSLCiphers))
+	input.SSLClientCert = fastly.NullString(service.StringValue(plan.SSLClientCert))
+	input.SSLClientKey = fastly.NullString(service.StringValue(plan.SSLClientKey))
+	input.SSLSNIHostname = fastly.NullString(service.StringValue(plan.SSLSNIHostname))
 
 	return input
 }

--- a/internal/resources/backend/resource.go
+++ b/internal/resources/backend/resource.go
@@ -173,20 +173,16 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 		return
 	}
 
-	forceAll := plan.Version.ValueInt64() != state.Version.ValueInt64()
 	opts := BuildUpdateInput(
 		plan.Service.ValueString(),
 		int(plan.Version.ValueInt64()),
 		plan.NestedModel,
-		&state.NestedModel,
-		forceAll,
 	)
 
 	tflog.Debug(ctx, "Updating Fastly service backend", map[string]any{
 		"service_id": opts.ServiceID,
 		"version":    opts.ServiceVersion,
 		"name":       opts.Name,
-		"force_all":  forceAll,
 	})
 
 	b, err := r.providerData.Client.UpdateBackend(ctx, opts)

--- a/internal/resources/backend/schema.go
+++ b/internal/resources/backend/schema.go
@@ -401,7 +401,7 @@ func Reconcile(ctx context.Context, client *fastly.Client, serviceID string, ver
 
 		remoteModel := FlattenToNestedModel(remoteBackend)
 		if !desiredBackend.ModelsEqual(remoteModel) {
-			input := BuildUpdateInput(serviceID, version, desiredBackend, &remoteModel, false)
+			input := BuildUpdateInput(serviceID, version, desiredBackend)
 			if _, err := client.UpdateBackend(ctx, input); err != nil {
 				return err
 			}

--- a/internal/resources/domain/expand.go
+++ b/internal/resources/domain/expand.go
@@ -10,9 +10,7 @@ func expandCreate(m Model) *fastly.CreateDomainInput {
 		ServiceVersion: int(m.Version.ValueInt64()),
 		Name:           new(m.Name.ValueString()),
 	}
-	if !m.Comment.IsNull() && m.Comment.ValueString() != "" {
-		opts.Comment = new(m.Comment.ValueString())
-	}
+	opts.Comment = fastly.NullString(m.Comment.ValueString())
 	return opts
 }
 
@@ -22,8 +20,6 @@ func expandUpdate(m Model) *fastly.UpdateDomainInput {
 		ServiceVersion: int(m.Version.ValueInt64()),
 		Name:           m.Name.ValueString(),
 	}
-	if !m.Comment.IsNull() && m.Comment.ValueString() != "" {
-		opts.Comment = new(m.Comment.ValueString())
-	}
+	opts.Comment = fastly.NullString(m.Comment.ValueString())
 	return opts
 }


### PR DESCRIPTION
### Change summary

Remove unnecessary per-field diffing logic in backend and domain expand
  functions. The Fastly API UpdateBackendInput and UpdateDomainInput use
  `omitempty` tags on all fields, meaning the API accepts full objects and
  only processes non-nil pointer fields.

  Changes:
  - backend/expand.go: Drop state/forceAll params and closure-based setters BuildUpdateInput() now always sends all fields using new() for required fields and fastly.NullString/NullInt for optional ones
  - backend/resource.go: Remove forceAll calculation and simplify call site
  - backend/schema.go: Update Reconcile() call site
  - domain/expand.go: Replace conditional comment handling with fastly.NullString() in expandCreate() and expandUpdate()
  - backend/backend_test.go: Remove state/forceAll test params, update cases

 All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/terraform-provider-fastly/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

* [x] Does your submission pass tests?
* [x] Post the output of your test runs
<img width="513" height="55" alt="Screenshot 2026-06-22 at 11 35 08 AM" src="https://github.com/user-attachments/assets/61b79f8b-c04a-4beb-9d24-8386916a45c5" />
<img width="566" height="875" alt="Screenshot 2026-06-22 at 11 35 55 AM" src="https://github.com/user-attachments/assets/2f2c5494-8b7d-4b1e-929e-5b1045fa8e67" />
