### PR TITLE
[CDTOOL-1665] Preserve _auto backend and domain list ordering

### DIFF
--- a/internal/acceptance_tests/blocks/backend_multiple.tf
+++ b/internal/acceptance_tests/blocks/backend_multiple.tf
@@ -1,19 +1,19 @@
-  backend {
-    name              = "backend-primary"
-    address           = "api-primary.example.com"
-    port              = 443
-    use_ssl           = true
-    ssl_cert_hostname = "api-primary.example.com"
-    ssl_sni_hostname  = "api-primary.example.com"
-    weight            = 100
-  }
+backend {
+  name              = "backend-primary"
+  address           = "api-primary.example.com"
+  port              = 443
+  use_ssl           = true
+  ssl_cert_hostname = "api-primary.example.com"
+  ssl_sni_hostname  = "api-primary.example.com"
+  weight            = 100
+}
 
-  backend {
-    name              = "backend-secondary"
-    address           = "api-secondary.example.com"
-    port              = 443
-    use_ssl           = true
-    ssl_cert_hostname = "api-secondary.example.com"
-    ssl_sni_hostname  = "api-secondary.example.com"
-    weight            = 50
-  }
+backend {
+  name              = "backend-secondary"
+  address           = "api-secondary.example.com"
+  port              = 443
+  use_ssl           = true
+  ssl_cert_hostname = "api-secondary.example.com"
+  ssl_sni_hostname  = "api-secondary.example.com"
+  weight            = 50
+}

--- a/internal/acceptance_tests/blocks/backend_multiple_reversed.tf
+++ b/internal/acceptance_tests/blocks/backend_multiple_reversed.tf
@@ -1,0 +1,19 @@
+backend {
+  name              = "a"
+  address           = "a.example.com"
+  port              = 443
+  use_ssl           = true
+  ssl_cert_hostname = "a.example.com"
+  ssl_sni_hostname  = "a.example.com"
+  weight            = 100
+}
+
+backend {
+  name              = "b"
+  address           = "b.example.com"
+  port              = 443
+  use_ssl           = true
+  ssl_cert_hostname = "b.example.com"
+  ssl_sni_hostname  = "b.example.com"
+  weight            = 100
+}

--- a/internal/acceptance_tests/blocks/backend_multiple_unsorted.tf
+++ b/internal/acceptance_tests/blocks/backend_multiple_unsorted.tf
@@ -1,0 +1,19 @@
+backend {
+  name              = "b"
+  address           = "b.example.com"
+  port              = 443
+  use_ssl           = true
+  ssl_cert_hostname = "b.example.com"
+  ssl_sni_hostname  = "b.example.com"
+  weight            = 100
+}
+
+backend {
+  name              = "a"
+  address           = "a.example.com"
+  port              = 443
+  use_ssl           = true
+  ssl_cert_hostname = "a.example.com"
+  ssl_sni_hostname  = "a.example.com"
+  weight            = 100
+}

--- a/internal/acceptance_tests/blocks/backend_single.tf
+++ b/internal/acceptance_tests/blocks/backend_single.tf
@@ -1,8 +1,8 @@
-  backend {
-    name              = "{{.BACKEND_NAME}}"
-    address           = "api.example.com"
-    port              = 443
-    use_ssl           = true
-    ssl_cert_hostname = "api.example.com"
-    ssl_sni_hostname  = "api.example.com"
-  }
+backend {
+  name              = "{{.BACKEND_NAME}}"
+  address           = "api.example.com"
+  port              = 443
+  use_ssl           = true
+  ssl_cert_hostname = "api.example.com"
+  ssl_sni_hostname  = "api.example.com"
+}

--- a/internal/acceptance_tests/blocks/domain_multiple_reversed.tf
+++ b/internal/acceptance_tests/blocks/domain_multiple_reversed.tf
@@ -1,0 +1,7 @@
+domain {
+  name = "{{.DOMAIN_A_NAME}}"
+}
+
+domain {
+  name = "{{.DOMAIN_B_NAME}}"
+}

--- a/internal/acceptance_tests/blocks/domain_multiple_unsorted.tf
+++ b/internal/acceptance_tests/blocks/domain_multiple_unsorted.tf
@@ -1,0 +1,7 @@
+domain {
+  name = "{{.DOMAIN_B_NAME}}"
+}
+
+domain {
+  name = "{{.DOMAIN_A_NAME}}"
+}

--- a/internal/acceptance_tests/blocks/domain_single.tf
+++ b/internal/acceptance_tests/blocks/domain_single.tf
@@ -1,3 +1,3 @@
-  domain {
-    name = "{{.DOMAIN_NAME}}"
-  }
+domain {
+  name = "{{.DOMAIN_NAME}}"
+}

--- a/internal/acceptance_tests/blocks/package.tf
+++ b/internal/acceptance_tests/blocks/package.tf
@@ -1,3 +1,3 @@
-  package {
-    filename = "{{.PACKAGE_PATH}}"
-  }
+package {
+  filename = "{{.PACKAGE_PATH}}"
+}

--- a/internal/acceptance_tests/config_builder.go
+++ b/internal/acceptance_tests/config_builder.go
@@ -90,12 +90,15 @@ func BuildConfig(serviceType ServiceType, replacements map[string]string, blockP
 			panic(fmt.Sprintf("failed to execute block template %s: %v", blockPath, err))
 		}
 
-		resourcesBuilder.WriteString(blockBuf.String())
+		block := normalizeNestedBlockIndent(blockBuf.String())
+		if resourcesBuilder.Len() > 0 {
+			resourcesBuilder.WriteString("\n")
+		}
+		resourcesBuilder.WriteString(block)
 	}
 
 	// Add the rendered resources to template data
-	resources := strings.TrimSuffix(resourcesBuilder.String(), "\n")
-	templateData["RESOURCES"] = resources
+	templateData["RESOURCES"] = resourcesBuilder.String()
 
 	// Load service template
 	templatePath := filepath.Join(repoRoot, "internal/acceptance_tests/blocks", string(serviceType)+".tf")
@@ -116,4 +119,36 @@ func BuildConfig(serviceType ServiceType, replacements map[string]string, blockP
 	}
 
 	return buf.String()
+}
+
+func normalizeNestedBlockIndent(block string) string {
+	block = strings.Trim(block, "\n")
+	if block == "" {
+		return ""
+	}
+
+	lines := strings.Split(block, "\n")
+	minIndent := -1
+	for _, line := range lines {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+
+		indent := len(line) - len(strings.TrimLeft(line, " \t"))
+		if minIndent == -1 || indent < minIndent {
+			minIndent = indent
+		}
+	}
+
+	for i, line := range lines {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		if minIndent > 0 && len(line) >= minIndent {
+			line = line[minIndent:]
+		}
+		lines[i] = "  " + line
+	}
+
+	return strings.Join(lines, "\n")
 }

--- a/internal/acceptance_tests/service_cdn_auto_test.go
+++ b/internal/acceptance_tests/service_cdn_auto_test.go
@@ -176,6 +176,7 @@ func TestAccFastlyServiceCDNAuto_preservesBackendAndDomainOrder(t *testing.T) {
 	domainBName := fmt.Sprintf("b-%s.example.com", acctest.RandString(10))
 	domainAName := fmt.Sprintf("a-%s.example.com", acctest.RandString(10))
 	config := ConfigCDNAutoUnsortedBackendAndDomainBlocks(serviceName, domainBName, domainAName)
+	reversedConfig := ConfigCDNAutoReversedBackendAndDomainBlocks(serviceName, domainBName, domainAName)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { PreCheck(t) },
@@ -194,10 +195,32 @@ func TestAccFastlyServiceCDNAuto_preservesBackendAndDomainOrder(t *testing.T) {
 					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "domain.#", "2"),
 					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "domain.0.name", domainBName),
 					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "domain.1.name", domainAName),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "active_version", "1"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "managed_version", "1"),
 				),
 			},
 			{
 				Config:   config,
+				PlanOnly: true,
+			},
+			{
+				Config: reversedConfig,
+				Check: resource.ComposeTestCheckFunc(
+					CheckServiceExists("fastly_service_cdn_auto.test"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "backend.#", "2"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "backend.0.name", "a"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "backend.0.address", "a.example.com"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "backend.1.name", "b"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "backend.1.address", "b.example.com"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "domain.#", "2"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "domain.0.name", domainAName),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "domain.1.name", domainBName),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "active_version", "1"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "managed_version", "1"),
+				),
+			},
+			{
+				Config:   reversedConfig,
 				PlanOnly: true,
 			},
 		},

--- a/internal/acceptance_tests/service_cdn_auto_test.go
+++ b/internal/acceptance_tests/service_cdn_auto_test.go
@@ -170,6 +170,40 @@ func TestAccFastlyServiceCDNAuto_multipleBackends(t *testing.T) {
 	})
 }
 
+func TestAccFastlyServiceCDNAuto_preservesBackendAndDomainOrder(t *testing.T) {
+	t.Parallel()
+	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	domainBName := fmt.Sprintf("b-%s.example.com", acctest.RandString(10))
+	domainAName := fmt.Sprintf("a-%s.example.com", acctest.RandString(10))
+	config := ConfigCDNAutoUnsortedBackendAndDomainBlocks(serviceName, domainBName, domainAName)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
+		CheckDestroy:             CheckServiceDestroy("fastly_service_cdn_auto"),
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					CheckServiceExists("fastly_service_cdn_auto.test"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "backend.#", "2"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "backend.0.name", "b"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "backend.0.address", "b.example.com"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "backend.1.name", "a"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "backend.1.address", "a.example.com"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "domain.#", "2"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "domain.0.name", domainBName),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "domain.1.name", domainAName),
+				),
+			},
+			{
+				Config:   config,
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
 func TestAccFastlyServiceCDNAuto_import(t *testing.T) {
 	t.Parallel()
 	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))

--- a/internal/acceptance_tests/service_compute_auto_test.go
+++ b/internal/acceptance_tests/service_compute_auto_test.go
@@ -130,6 +130,63 @@ func TestAccFastlyServiceComputeAuto_multipleBackends(t *testing.T) {
 	})
 }
 
+func TestAccFastlyServiceComputeAuto_preservesBackendAndDomainOrder(t *testing.T) {
+	t.Parallel()
+	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	domainBName := fmt.Sprintf("b-%s.example.com", acctest.RandString(10))
+	domainAName := fmt.Sprintf("a-%s.example.com", acctest.RandString(10))
+	config := ConfigComputeAutoUnsortedBackendAndDomainBlocks(serviceName, domainBName, domainAName)
+	reversedConfig := ConfigComputeAutoReversedBackendAndDomainBlocks(serviceName, domainBName, domainAName)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
+		CheckDestroy:             CheckServiceDestroy("fastly_service_compute_auto"),
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					CheckServiceExists("fastly_service_compute_auto.test"),
+					resource.TestCheckResourceAttr("fastly_service_compute_auto.test", "backend.#", "2"),
+					resource.TestCheckResourceAttr("fastly_service_compute_auto.test", "backend.0.name", "b"),
+					resource.TestCheckResourceAttr("fastly_service_compute_auto.test", "backend.0.address", "b.example.com"),
+					resource.TestCheckResourceAttr("fastly_service_compute_auto.test", "backend.1.name", "a"),
+					resource.TestCheckResourceAttr("fastly_service_compute_auto.test", "backend.1.address", "a.example.com"),
+					resource.TestCheckResourceAttr("fastly_service_compute_auto.test", "domain.#", "2"),
+					resource.TestCheckResourceAttr("fastly_service_compute_auto.test", "domain.0.name", domainBName),
+					resource.TestCheckResourceAttr("fastly_service_compute_auto.test", "domain.1.name", domainAName),
+					resource.TestCheckResourceAttr("fastly_service_compute_auto.test", "active_version", "1"),
+					resource.TestCheckResourceAttr("fastly_service_compute_auto.test", "managed_version", "1"),
+				),
+			},
+			{
+				Config:   config,
+				PlanOnly: true,
+			},
+			{
+				Config: reversedConfig,
+				Check: resource.ComposeTestCheckFunc(
+					CheckServiceExists("fastly_service_compute_auto.test"),
+					resource.TestCheckResourceAttr("fastly_service_compute_auto.test", "backend.#", "2"),
+					resource.TestCheckResourceAttr("fastly_service_compute_auto.test", "backend.0.name", "a"),
+					resource.TestCheckResourceAttr("fastly_service_compute_auto.test", "backend.0.address", "a.example.com"),
+					resource.TestCheckResourceAttr("fastly_service_compute_auto.test", "backend.1.name", "b"),
+					resource.TestCheckResourceAttr("fastly_service_compute_auto.test", "backend.1.address", "b.example.com"),
+					resource.TestCheckResourceAttr("fastly_service_compute_auto.test", "domain.#", "2"),
+					resource.TestCheckResourceAttr("fastly_service_compute_auto.test", "domain.0.name", domainAName),
+					resource.TestCheckResourceAttr("fastly_service_compute_auto.test", "domain.1.name", domainBName),
+					resource.TestCheckResourceAttr("fastly_service_compute_auto.test", "active_version", "1"),
+					resource.TestCheckResourceAttr("fastly_service_compute_auto.test", "managed_version", "1"),
+				),
+			},
+			{
+				Config:   reversedConfig,
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
 func TestAccFastlyServiceComputeAuto_import(t *testing.T) {
 	t.Parallel()
 	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))

--- a/internal/acceptance_tests/test_helpers.go
+++ b/internal/acceptance_tests/test_helpers.go
@@ -170,6 +170,22 @@ func ConfigCDNAutoUnsortedBackendAndDomainBlocks(serviceName, domainBName, domai
 	)
 }
 
+// ConfigCDNAutoReversedBackendAndDomainBlocks returns a CDN auto service config
+// with the same backend and domain blocks as ConfigCDNAutoUnsortedBackendAndDomainBlocks,
+// but declared in the reverse order.
+func ConfigCDNAutoReversedBackendAndDomainBlocks(serviceName, domainBName, domainAName string) string {
+	return BuildConfig(
+		ServiceCDNAuto,
+		map[string]string{
+			"SERVICE_NAME":  serviceName,
+			"DOMAIN_B_NAME": domainBName,
+			"DOMAIN_A_NAME": domainAName,
+		},
+		"internal/acceptance_tests/blocks/domain_multiple_reversed.tf",
+		"internal/acceptance_tests/blocks/backend_multiple_reversed.tf",
+	)
+}
+
 // Configuration helpers for Compute Auto service
 
 // ConfigComputeAutoBasic returns a basic Compute auto service config with a domain and package

--- a/internal/acceptance_tests/test_helpers.go
+++ b/internal/acceptance_tests/test_helpers.go
@@ -155,6 +155,21 @@ func ConfigCDNAutoMultipleBackends(serviceName, domainName string) string {
 	)
 }
 
+// ConfigCDNAutoUnsortedBackendAndDomainBlocks returns a CDN auto service config
+// with backend and domain blocks declared in non-sorted order.
+func ConfigCDNAutoUnsortedBackendAndDomainBlocks(serviceName, domainBName, domainAName string) string {
+	return BuildConfig(
+		ServiceCDNAuto,
+		map[string]string{
+			"SERVICE_NAME":  serviceName,
+			"DOMAIN_B_NAME": domainBName,
+			"DOMAIN_A_NAME": domainAName,
+		},
+		"internal/acceptance_tests/blocks/domain_multiple_unsorted.tf",
+		"internal/acceptance_tests/blocks/backend_multiple_unsorted.tf",
+	)
+}
+
 // Configuration helpers for Compute Auto service
 
 // ConfigComputeAutoBasic returns a basic Compute auto service config with a domain and package

--- a/internal/acceptance_tests/test_helpers.go
+++ b/internal/acceptance_tests/test_helpers.go
@@ -233,6 +233,41 @@ func ConfigComputeAutoMultipleBackends(serviceName, domainName string) string {
 	)
 }
 
+// ConfigComputeAutoUnsortedBackendAndDomainBlocks returns a Compute auto service config
+// with backend and domain blocks declared in non-sorted order.
+func ConfigComputeAutoUnsortedBackendAndDomainBlocks(serviceName, domainBName, domainAName string) string {
+	return BuildConfig(
+		ServiceComputeAuto,
+		map[string]string{
+			"SERVICE_NAME":  serviceName,
+			"DOMAIN_B_NAME": domainBName,
+			"DOMAIN_A_NAME": domainAName,
+			"PACKAGE_PATH":  GetPackagePath(),
+		},
+		"internal/acceptance_tests/blocks/domain_multiple_unsorted.tf",
+		"internal/acceptance_tests/blocks/backend_multiple_unsorted.tf",
+		"internal/acceptance_tests/blocks/package.tf",
+	)
+}
+
+// ConfigComputeAutoReversedBackendAndDomainBlocks returns a Compute auto service config
+// with the same backend and domain blocks as ConfigComputeAutoUnsortedBackendAndDomainBlocks,
+// but declared in the reverse order.
+func ConfigComputeAutoReversedBackendAndDomainBlocks(serviceName, domainBName, domainAName string) string {
+	return BuildConfig(
+		ServiceComputeAuto,
+		map[string]string{
+			"SERVICE_NAME":  serviceName,
+			"DOMAIN_B_NAME": domainBName,
+			"DOMAIN_A_NAME": domainAName,
+			"PACKAGE_PATH":  GetPackagePath(),
+		},
+		"internal/acceptance_tests/blocks/domain_multiple_reversed.tf",
+		"internal/acceptance_tests/blocks/backend_multiple_reversed.tf",
+		"internal/acceptance_tests/blocks/package.tf",
+	)
+}
+
 // Configuration helpers for CDN service (explicit version management)
 
 // ConfigServiceCDNBasic returns a basic CDN service config without any nested resources

--- a/internal/reconcile/reconcile.go
+++ b/internal/reconcile/reconcile.go
@@ -103,6 +103,43 @@ func (r *Resource[T, API]) ReadForVersion(ctx context.Context, client *fastly.Cl
 	return result, nil
 }
 
+// MatchOrder returns items ordered to match the names in order.
+// Items with names not present in order are appended in stable name order.
+func MatchOrder[T any](items []T, order []T, getName func(T) string) []T {
+	itemsByName := make(map[string]T, len(items))
+	for _, item := range items {
+		itemsByName[getName(item)] = item
+	}
+
+	result := make([]T, 0, len(items))
+	seen := make(map[string]struct{}, len(items))
+
+	for _, orderedItem := range order {
+		name := getName(orderedItem)
+		item, ok := itemsByName[name]
+		if !ok {
+			continue
+		}
+		result = append(result, item)
+		seen[name] = struct{}{}
+	}
+
+	unmatched := make([]T, 0, len(items))
+	for _, item := range items {
+		if _, ok := seen[getName(item)]; ok {
+			continue
+		}
+		unmatched = append(unmatched, item)
+	}
+
+	sort.Slice(unmatched, func(i, j int) bool {
+		return getName(unmatched[i]) < getName(unmatched[j])
+	})
+
+	result = append(result, unmatched...)
+	return result
+}
+
 func ModelsEqual[T any](a, b []T, getName func(T) string, equals func(T, T) bool, sortable bool) bool {
 	if sortable {
 		sortedA := make([]T, len(a))

--- a/internal/reconcile/reconcile_test.go
+++ b/internal/reconcile/reconcile_test.go
@@ -282,6 +282,61 @@ func TestResource_ReadForVersion(t *testing.T) {
 	})
 }
 
+func TestMatchOrder(t *testing.T) {
+	t.Run("orders items to match reference order", func(t *testing.T) {
+		items := []testModel{
+			{Name: "a", Value: "remote-a"},
+			{Name: "b", Value: "remote-b"},
+		}
+		order := []testModel{
+			{Name: "b"},
+			{Name: "a"},
+		}
+
+		result := MatchOrder(items, order, func(m testModel) string { return m.Name })
+
+		assert.Equal(t, []testModel{
+			{Name: "b", Value: "remote-b"},
+			{Name: "a", Value: "remote-a"},
+		}, result)
+	})
+
+	t.Run("appends unmatched items in stable name order", func(t *testing.T) {
+		items := []testModel{
+			{Name: "c", Value: "remote-c"},
+			{Name: "a", Value: "remote-a"},
+			{Name: "b", Value: "remote-b"},
+		}
+		order := []testModel{
+			{Name: "b"},
+		}
+
+		result := MatchOrder(items, order, func(m testModel) string { return m.Name })
+
+		assert.Equal(t, []testModel{
+			{Name: "b", Value: "remote-b"},
+			{Name: "a", Value: "remote-a"},
+			{Name: "c", Value: "remote-c"},
+		}, result)
+	})
+
+	t.Run("skips ordered items not present in result", func(t *testing.T) {
+		items := []testModel{
+			{Name: "b", Value: "remote-b"},
+		}
+		order := []testModel{
+			{Name: "missing"},
+			{Name: "b"},
+		}
+
+		result := MatchOrder(items, order, func(m testModel) string { return m.Name })
+
+		assert.Equal(t, []testModel{
+			{Name: "b", Value: "remote-b"},
+		}, result)
+	})
+}
+
 func TestModelsEqual(t *testing.T) {
 	t.Run("equal when same", func(t *testing.T) {
 		a := []testModel{{Name: "item1", Value: "value1"}}

--- a/internal/resources/backend/schema.go
+++ b/internal/resources/backend/schema.go
@@ -377,3 +377,7 @@ func Reconcile(ctx context.Context, client *fastly.Client, serviceID string, ver
 func Equal(a, b []NestedModel) bool {
 	return reconcile.ModelsEqual(a, b, func(m NestedModel) string { return service.StringValue(m.Name) }, NestedModel.ModelsEqual, true)
 }
+
+func MatchOrder(items, order []NestedModel) []NestedModel {
+	return reconcile.MatchOrder(items, order, func(m NestedModel) string { return service.StringValue(m.Name) })
+}

--- a/internal/resources/domain/schema.go
+++ b/internal/resources/domain/schema.go
@@ -179,3 +179,7 @@ func modelsEqual(a, b NestedModel) bool {
 
 	return ac == bc
 }
+
+func MatchOrder(items, order []NestedModel) []NestedModel {
+	return reconcile.MatchOrder(items, order, func(m NestedModel) string { return m.Name.ValueString() })
+}

--- a/internal/resources/servicecdnauto/resource.go
+++ b/internal/resources/servicecdnauto/resource.go
@@ -144,7 +144,7 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 		resp.Diagnostics.AddError("Error reading service domains", err.Error())
 		return
 	}
-	plan.Domain = domains
+	plan.Domain = domain.MatchOrder(domains, plan.Domain)
 
 	if err := backend.Reconcile(ctx, r.providerData.AutoClient(), serviceID, version, plan.Backend); err != nil {
 		resp.Diagnostics.AddError("Error reconciling backends", err.Error())
@@ -156,7 +156,7 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 		resp.Diagnostics.AddError("Error reading service backends", err.Error())
 		return
 	}
-	plan.Backend = backends
+	plan.Backend = backend.MatchOrder(backends, plan.Backend)
 
 	if err := service.ValidateVersion(ctx, r.providerData.AutoClient(), serviceID, version); err != nil {
 		resp.Diagnostics.AddError("Error validating service version", err.Error())
@@ -236,8 +236,8 @@ func (r *Resource) Read(ctx context.Context, req resource.ReadRequest, resp *res
 		resp.Diagnostics.AddError("Error reading service backends", err.Error())
 		return
 	}
-	state.Domain = domains
-	state.Backend = backends
+	state.Domain = domain.MatchOrder(domains, state.Domain)
+	state.Backend = backend.MatchOrder(backends, state.Backend)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
@@ -309,7 +309,7 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 			resp.Diagnostics.AddError("Error reading service domains", err.Error())
 			return
 		}
-		plan.Domain = domains
+		plan.Domain = domain.MatchOrder(domains, plan.Domain)
 
 		if err := backend.Reconcile(ctx, r.providerData.AutoClient(), serviceID, targetVersion, plan.Backend); err != nil {
 			resp.Diagnostics.AddError("Error reconciling backends", err.Error())
@@ -321,7 +321,7 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 			resp.Diagnostics.AddError("Error reading service backends", err.Error())
 			return
 		}
-		plan.Backend = backends
+		plan.Backend = backend.MatchOrder(backends, plan.Backend)
 
 		if err := service.ValidateVersion(ctx, r.providerData.AutoClient(), serviceID, targetVersion); err != nil {
 			resp.Diagnostics.AddError("Error validating service version", err.Error())
@@ -339,11 +339,11 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 		}
 		plan.ActiveVersion = types.Int64Value(int64(targetVersion))
 	} else {
-		// No version change needed - preserve version numbers and nested state
+		// No version change needed - preserve version numbers and order nested state to match the plan
 		plan.ManagedVersion = state.ManagedVersion
 		plan.ActiveVersion = state.ActiveVersion
-		plan.Domain = state.Domain
-		plan.Backend = state.Backend
+		plan.Domain = domain.MatchOrder(state.Domain, plan.Domain)
+		plan.Backend = backend.MatchOrder(state.Backend, plan.Backend)
 	}
 
 	plan.ID = state.ID

--- a/internal/resources/servicecomputeauto/resource.go
+++ b/internal/resources/servicecomputeauto/resource.go
@@ -160,7 +160,7 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 		resp.Diagnostics.AddError("Error reading service domains", err.Error())
 		return
 	}
-	plan.Domain = domains
+	plan.Domain = domain.MatchOrder(domains, plan.Domain)
 
 	if err := backend.Reconcile(ctx, r.providerData.AutoClient(), serviceID, version, plan.Backend); err != nil {
 		resp.Diagnostics.AddError("Error reconciling backends", err.Error())
@@ -172,7 +172,7 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 		resp.Diagnostics.AddError("Error reading service backends", err.Error())
 		return
 	}
-	plan.Backend = backends
+	plan.Backend = backend.MatchOrder(backends, plan.Backend)
 
 	if err := computepackage.Update(ctx, r.providerData.AutoClient(), serviceID, version, plan.Package); err != nil {
 		resp.Diagnostics.AddError("Error updating Compute package", err.Error())
@@ -264,8 +264,8 @@ func (r *Resource) Read(ctx context.Context, req resource.ReadRequest, resp *res
 		resp.Diagnostics.AddError("Error reading service backends", err.Error())
 		return
 	}
-	state.Domain = domains
-	state.Backend = backends
+	state.Domain = domain.MatchOrder(domains, state.Domain)
+	state.Backend = backend.MatchOrder(backends, state.Backend)
 
 	packages, err := computepackage.ReadForVersion(ctx, r.providerData.AutoClient(), state.ID.ValueString(), readVersion, state.Package)
 	if err != nil {
@@ -344,7 +344,7 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 			resp.Diagnostics.AddError("Error reading service domains", err.Error())
 			return
 		}
-		plan.Domain = domains
+		plan.Domain = domain.MatchOrder(domains, plan.Domain)
 
 		if err := backend.Reconcile(ctx, r.providerData.AutoClient(), serviceID, targetVersion, plan.Backend); err != nil {
 			resp.Diagnostics.AddError("Error reconciling backends", err.Error())
@@ -356,7 +356,7 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 			resp.Diagnostics.AddError("Error reading service backends", err.Error())
 			return
 		}
-		plan.Backend = backends
+		plan.Backend = backend.MatchOrder(backends, plan.Backend)
 
 		if len(state.Package) > 0 && len(plan.Package) == 0 {
 			resp.Diagnostics.AddError(
@@ -394,11 +394,11 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 		}
 		plan.ActiveVersion = types.Int64Value(int64(targetVersion))
 	} else {
-		// No version change needed - preserve version numbers and nested state
+		// No version change needed - preserve version numbers and order nested state to match the plan
 		plan.ManagedVersion = state.ManagedVersion
 		plan.ActiveVersion = state.ActiveVersion
-		plan.Domain = state.Domain
-		plan.Backend = state.Backend
+		plan.Domain = domain.MatchOrder(state.Domain, plan.Domain)
+		plan.Backend = backend.MatchOrder(state.Backend, plan.Backend)
 		plan.Package = state.Package
 	}
 


### PR DESCRIPTION
### Change summary

Preserves Terraform list ordering for nested `backend` and `domain` blocks on `_auto` resources.

See https://fastly.atlassian.net/browse/CDTOOL-1665 for more info.

### Reviewer Notes

- Keeps unordered comparison/reconcile behavior through the existing generic reconciler.
- Adds `reconcile.MatchOrder()` for ordering read results against plan/state.
- Orders create/update API-read results to match the planned configuration order.
- Orders read API results to match prior state order.
- Appends API-only/new elements in stable name order.
- Handles reorder-only HCL changes without requiring a Fastly version change by reordering existing nested state to match the plan.

**Also updated `BuildConfig` to indent inserted block snippets consistently. This allows block fixture files to start at column 0 while still rendering valid nested Terraform blocks inside the generated resource config.**

### Changes to Core Features:

* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

```
=== RUN   TestAccFastlyServiceCDNAuto_preservesBackendAndDomainOrder
=== PAUSE TestAccFastlyServiceCDNAuto_preservesBackendAndDomainOrder
=== RUN   TestAccFastlyServiceComputeAuto_preservesBackendAndDomainOrder
=== PAUSE TestAccFastlyServiceComputeAuto_preservesBackendAndDomainOrder
=== CONT  TestAccFastlyServiceCDNAuto_preservesBackendAndDomainOrder
=== CONT  TestAccFastlyServiceComputeAuto_preservesBackendAndDomainOrder
--- PASS: TestAccFastlyServiceCDNAuto_preservesBackendAndDomainOrder (36.15s)
--- PASS: TestAccFastlyServiceComputeAuto_preservesBackendAndDomainOrder (43.77s)
```