### PR TITLE
Implement `UseStateForUnknown()` Pattern for the Backend `keepalive_time` Attribute

### DIFF
--- a/internal/acceptance_tests/backend_test.go
+++ b/internal/acceptance_tests/backend_test.go
@@ -8,7 +8,10 @@ import (
 	"github.com/fastly/go-fastly/v15/fastly"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 )
 
 func TestAccFastlyServiceBackend_basic(t *testing.T) {
@@ -93,13 +96,39 @@ func TestAccFastlyServiceBackend_fullConfig(t *testing.T) {
 					resource.TestCheckResourceAttr("fastly_service_backend.origin", "ssl_sni_hostname", "sni.example.com"),
 					resource.TestCheckResourceAttr("fastly_service_backend.origin", "min_tls_version", "1.2"),
 					resource.TestCheckResourceAttr("fastly_service_backend.origin", "max_tls_version", "1.3"),
+					resource.TestCheckResourceAttr("fastly_service_backend.origin", "ssl_ciphers", "ECDHE-RSA-AES128-GCM-SHA256"),
 					resource.TestCheckResourceAttr("fastly_service_backend.origin", "weight", "75"),
 					resource.TestCheckResourceAttr("fastly_service_backend.origin", "max_conn", "100"),
 					resource.TestCheckResourceAttr("fastly_service_backend.origin", "connect_timeout", "2000"),
 					resource.TestCheckResourceAttr("fastly_service_backend.origin", "first_byte_timeout", "10000"),
 					resource.TestCheckResourceAttr("fastly_service_backend.origin", "between_bytes_timeout", "5000"),
+					resource.TestCheckResourceAttr("fastly_service_backend.origin", "error_threshold", "5"),
+					resource.TestCheckResourceAttr("fastly_service_backend.origin", "keepalive_time", "60"),
+					resource.TestCheckResourceAttr("fastly_service_backend.origin", "max_lifetime", "30000"),
+					resource.TestCheckResourceAttr("fastly_service_backend.origin", "max_use", "10"),
+					resource.TestCheckResourceAttr("fastly_service_backend.origin", "override_host", "override.example.com"),
+					resource.TestCheckResourceAttr("fastly_service_backend.origin", "shield", "iad-va-us"),
 					resource.TestCheckResourceAttr("fastly_service_backend.origin", "auto_loadbalance", "true"),
 					resource.TestCheckResourceAttr("fastly_service_backend.origin", "comment", "Full test backend"),
+				),
+			},
+			{
+				// keepalive_time is the only attribute without a Default (the API omits it when unset),
+				// so it relies on UseStateForUnknown. This step omits it from config and changes an
+				// unrelated field to verify it stays known in the plan rather than drifting to (known after apply).
+				Config: ConfigBackendFullUpdated(serviceName, domainName, backendName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectKnownValue(
+							"fastly_service_backend.origin",
+							tfjsonpath.New("keepalive_time"),
+							knownvalue.Int64Exact(60),
+						),
+					},
+				},
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("fastly_service_backend.origin", "weight", "50"),
+					resource.TestCheckResourceAttr("fastly_service_backend.origin", "keepalive_time", "60"),
 				),
 			},
 		},

--- a/internal/acceptance_tests/blocks/backend_full_updated.tf
+++ b/internal/acceptance_tests/blocks/backend_full_updated.tf
@@ -65,13 +65,12 @@ EOT
   min_tls_version       = "1.2"
   max_tls_version       = "1.3"
   ssl_ciphers           = "ECDHE-RSA-AES128-GCM-SHA256"
-  weight                = 75
+  weight                = 50
   max_conn              = 100
   connect_timeout       = 2000
   first_byte_timeout    = 10000
   between_bytes_timeout = 5000
   error_threshold       = 5
-  keepalive_time        = 60
   max_lifetime          = 30000
   max_use               = 10
   override_host         = "override.example.com"

--- a/internal/acceptance_tests/test_helpers.go
+++ b/internal/acceptance_tests/test_helpers.go
@@ -617,6 +617,21 @@ func ConfigBackendFull(serviceName, domainName, backendName string) string {
 	)
 }
 
+func ConfigBackendFullUpdated(serviceName, domainName, backendName string) string {
+	return BuildConfig(
+		ServiceCDN,
+		map[string]string{
+			"SERVICE_NAME":    serviceName,
+			"SERVICE_COMMENT": "",
+			"DOMAIN_NAME":     domainName,
+			"SERVICE_VERSION": "1",
+			"BACKEND_NAME":    backendName,
+		},
+		"internal/acceptance_tests/blocks/service_cdn_domain.tf",
+		"internal/acceptance_tests/blocks/backend_full_updated.tf",
+	)
+}
+
 // ConfigBackendMultiple returns a config with multiple backend resources
 func ConfigBackendMultiple(serviceName, domainName, backend1Name, backend2Name string) string {
 	return BuildConfig(

--- a/internal/resources/backend/schema.go
+++ b/internal/resources/backend/schema.go
@@ -12,6 +12,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
@@ -215,8 +217,15 @@ func CommonAttributes() map[string]schema.Attribute {
 			Description: "Name of a defined healthcheck to assign to this backend.",
 		},
 		"keepalive_time": schema.Int64Attribute{
-			Optional:    true,
-			Computed:    true,
+			Optional: true,
+			Computed: true,
+			// Since there is no default for keepalive_time and the API omits the field from both create
+			// and read responses when unset, a static default would diverge from what flatten writes to
+			// state. UseStateForUnknown preserves the prior state value when the field is omitted from
+			// config, preventing (known after apply) drift on unrelated updates.
+			PlanModifiers: []planmodifier.Int64{
+				int64planmodifier.UseStateForUnknown(),
+			},
 			Description: "How long in seconds to keep a persistent connection to the backend between requests.",
 		},
 		"max_conn": schema.Int64Attribute{


### PR DESCRIPTION
### Change summary

Currently, any plan that causes resources to be re-evaluated - which happens when a referenced resource such as `logging_s3` has a planned change results in a drift of the `keepalive_time` attribute. This stems from the API not setting a default for this attribute on creation or on further retrieval requests - which in turn diverges from what flatten writes to state.

IE:
```
resource "fastly_service_cdn_auto" "example" {
    name    = "new-provider-test"
    comment = "Managed by Terraform"

    domain {
      name = "www.exampled.com"
    }
    
     backend {
      name    = "origin-1"
      address = "origin1.example.com"
    }

    logging_s3 {
      name = "my s3 log"
      bucket_name = "test_bucket"
...
```
After applying a change to a attribute such as `logging_s3.bucket_name` from `test_bucket` to `test_bucket_two`, a resulting diff will indicate that there is a drift to the `keepalive_time` attribute, even though no changes were made to the `backend` block. 

IE:
```
backend {
          + keepalive_time        = (known after apply)
            name                  = "origin-1"
            # (27 unchanged attributes hidden)
 ```
 
 This PR implements [UseStateForUnknown()](https://developer.hashicorp.com/terraform/plugin/framework/resources/plan-modification#usestateforunknown) through a plan modifier, which copies the prior state value, if not null. Thus handling the potential drift scenario. 

 All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/terraform-provider-fastly/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

* [x] Does your submission pass tests?
* [x] Post the output of your test runs

### Changes to Core Features:

* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?