### PR TITLE
[CDTOOL-1547] Add support for ACLs in Compute

### DIFF
--- a/docs/data-sources/acls.md
+++ b/docs/data-sources/acls.md
@@ -1,0 +1,43 @@
+---
+page_title: "fastly_acls Data Source - fastly"
+subcategory: ""
+description: |-
+  Use this data source to retrieve a list of Fastly ACLs.
+---
+
+# fastly_acls (Data Source)
+
+Use this data source to retrieve a list of [Fastly ACLs](https://www.fastly.com/documentation/reference/api/compute-acls/).
+
+## Example Usage
+
+```terraform
+data "fastly_acls" "example" {}
+
+output "fastly_acls_all" {
+  value = data.fastly_acls.example.acls
+}
+
+output "fastly_acls_filtered" {
+  # Example: get the ID of the ACL named "my_acl"
+  value = one([
+    for acl in data.fastly_acls.example.acls :
+    acl.id if acl.name == "my_acl"
+  ])
+}
+```
+
+## Schema
+
+### Read-Only
+
+- `acls` (Attributes Set) List of all ACLs. (see [below for nested schema](#nestedatt--acls))
+- `id` (String) Terraform data source identifier.
+
+<a id="nestedatt--acls"></a>
+### Nested Schema for `acls`
+
+Read-Only:
+
+- `id` (String) Identifier of the ACL.
+- `name` (String) Name of the ACL.

--- a/docs/resources/acl.md
+++ b/docs/resources/acl.md
@@ -1,0 +1,38 @@
+---
+page_title: "fastly_acl Resource - fastly"
+subcategory: ""
+description: |-
+  Provides an Access Control List (ACL) that defines CIDR-based access rules and is accessible to Compute services during request processing.
+---
+
+# fastly_acl (Resource)
+
+Provides an Access Control List (ACL) that defines CIDR-based access rules (e.g., allow/block IP ranges) and is accessible to Compute services during request processing.
+
+This resource is versionless: it is not tied to a service version and is managed independently of any `fastly_service_compute` resource.
+
+## Example Usage
+
+```terraform
+resource "fastly_acl" "example" {
+  name = "my_acl"
+}
+```
+
+## Schema
+
+### Required
+
+- `name` (String) A unique name to identify the ACL. Changing this attribute will delete and recreate the ACL, discarding its current entries. Any `resource_link` referencing this ACL must be removed first.
+
+### Read-Only
+
+- `id` (String) The ID of this ACL.
+
+## Import
+
+Fastly ACLs can be imported using their ACL ID, e.g.
+
+```shell
+terraform import fastly_acl.example <acl_id>
+```

--- a/internal/acceptance_tests/acl_test.go
+++ b/internal/acceptance_tests/acl_test.go
@@ -1,0 +1,166 @@
+package acceptancetests
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/fastly/go-fastly/v16/fastly/computeacls"
+	"github.com/fastly/terraform-provider-fastly/internal/errors"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+func TestAccFastlyACL_basic(t *testing.T) {
+	t.Parallel()
+	aclName := fmt.Sprintf("tf_test_acl_%s", acctest.RandString(10))
+	aclNameUpdated := fmt.Sprintf("tf_test_acl_updated_%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
+		CheckDestroy:             CheckACLDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: ConfigACL(aclName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("fastly_acl.acl", "name", aclName),
+					resource.TestCheckResourceAttrSet("fastly_acl.acl", "id"),
+				),
+			},
+			{
+				// Changing the name forces replacement.
+				Config: ConfigACL(aclNameUpdated),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("fastly_acl.acl", "name", aclNameUpdated),
+					resource.TestCheckResourceAttrSet("fastly_acl.acl", "id"),
+				),
+			},
+			{
+				ResourceName:      "fastly_acl.acl",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+// CheckServiceAndACLDestroy composes CheckServiceDestroy for the given service resource
+// type with CheckACLDestroy, for tests that manage both a service and one or more
+// fastly_acl resources.
+func CheckServiceAndACLDestroy(resourceType string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if err := CheckServiceDestroy(resourceType)(s); err != nil {
+			return err
+		}
+		return CheckACLDestroy(s)
+	}
+}
+
+func CheckACLDestroy(s *terraform.State) error {
+	client, err := NewFastlyClient()
+	if err != nil {
+		return fmt.Errorf("error creating Fastly client: %w", err)
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "fastly_acl" {
+			continue
+		}
+
+		id := rs.Primary.ID
+		_, err := computeacls.Describe(context.Background(), client, &computeacls.DescribeInput{ComputeACLID: &id})
+		if errors.IsNotFound(err) {
+			continue
+		}
+		if err != nil {
+			return fmt.Errorf("error checking if ACL was destroyed: %w", err)
+		}
+
+		return fmt.Errorf("ACL %s still exists", id)
+	}
+
+	return nil
+}
+
+func ConfigACL(name string) string {
+	return fmt.Sprintf(`
+resource "fastly_acl" "acl" {
+  name = %q
+}
+`, name)
+}
+
+func TestAccFastlyDataSourceACLs(t *testing.T) {
+	t.Parallel()
+	h := acctest.RandString(10)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
+		CheckDestroy:             CheckACLDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: ConfigACLsDataSource(h),
+				Check: resource.ComposeTestCheckFunc(
+					func(s *terraform.State) error {
+						rs, ok := s.RootModule().Resources["data.fastly_acls.example"]
+						if !ok {
+							return fmt.Errorf("not found: data.fastly_acls.example")
+						}
+
+						want := []string{
+							fmt.Sprintf("tf_%s_1", h),
+							fmt.Sprintf("tf_%s_2", h),
+							fmt.Sprintf("tf_%s_3", h),
+						}
+
+						var found int
+						var got []string
+						for k, v := range rs.Primary.Attributes {
+							if strings.HasSuffix(k, ".name") {
+								got = append(got, v)
+								if slices.Contains(want, v) {
+									found++
+								}
+							}
+						}
+
+						if found != len(want) {
+							return fmt.Errorf("want: %v, got: %v", want, got)
+						}
+
+						return nil
+					},
+				),
+			},
+		},
+	})
+}
+
+func ConfigACLsDataSource(h string) string {
+	return fmt.Sprintf(`
+resource "fastly_acl" "acl_1" {
+  name = "tf_%s_1"
+}
+
+resource "fastly_acl" "acl_2" {
+  name = "tf_%s_2"
+}
+
+resource "fastly_acl" "acl_3" {
+  name = "tf_%s_3"
+}
+
+data "fastly_acls" "example" {
+  depends_on = [
+    fastly_acl.acl_1,
+    fastly_acl.acl_2,
+    fastly_acl.acl_3,
+  ]
+}
+`, h, h, h)
+}

--- a/internal/acceptance_tests/blocks/resource_link_acl.tf
+++ b/internal/acceptance_tests/blocks/resource_link_acl.tf
@@ -1,0 +1,10 @@
+resource "fastly_acl" "acl" {
+  name = "{{.ACL_NAME}}"
+}
+
+resource "fastly_service_resource_link" "test" {
+  service_id  = fastly_service_compute.test.id
+  version     = {{.SERVICE_VERSION}}
+  name        = "{{.RESOURCE_LINK_NAME}}"
+  resource_id = fastly_acl.acl.id
+}

--- a/internal/acceptance_tests/blocks/resource_link_ref.tf
+++ b/internal/acceptance_tests/blocks/resource_link_ref.tf
@@ -1,0 +1,4 @@
+resource_link {
+  name        = "{{.RESOURCE_LINK_NAME}}"
+  resource_id = {{.RESOURCE_LINK_TARGET_ID}}
+}

--- a/internal/acceptance_tests/service_compute_auto_test.go
+++ b/internal/acceptance_tests/service_compute_auto_test.go
@@ -260,6 +260,201 @@ func TestAccFastlyServiceComputeAuto_resourceLinkImport(t *testing.T) {
 	})
 }
 
+func TestAccFastlyServiceComputeAuto_withACLResourceLink(t *testing.T) {
+	t.Parallel()
+	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	domainName := fmt.Sprintf("%s.example.com", acctest.RandString(10))
+	aclName := fmt.Sprintf("tf_test_acl_%s", acctest.RandString(10))
+	linkName := fmt.Sprintf("tf_test_link_%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
+		CheckDestroy:             CheckServiceAndACLDestroy("fastly_service_compute_auto"),
+		Steps: []resource.TestStep{
+			{
+				Config: ConfigComputeAutoWithACLResourceLink(serviceName, domainName, aclName, linkName),
+				Check: resource.ComposeTestCheckFunc(
+					CheckServiceExists("fastly_service_compute_auto.test"),
+					resource.TestCheckResourceAttr("fastly_acl.acl", "name", aclName),
+					resource.TestCheckResourceAttr("fastly_service_compute_auto.test", "resource_link.#", "1"),
+					resource.TestCheckResourceAttr("fastly_service_compute_auto.test", "resource_link.0.name", linkName),
+					resource.TestCheckResourceAttrPair("fastly_service_compute_auto.test", "resource_link.0.resource_id", "fastly_acl.acl", "id"),
+					resource.TestCheckResourceAttrSet("fastly_service_compute_auto.test", "resource_link.0.link_id"),
+					// Verify version 1 is created and activated with the resource link
+					resource.TestCheckResourceAttr("fastly_service_compute_auto.test", "active_version", "1"),
+					resource.TestCheckResourceAttr("fastly_service_compute_auto.test", "managed_version", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccFastlyServiceComputeAuto_ACLResourceLinkRename(t *testing.T) {
+	t.Parallel()
+	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	domainName := fmt.Sprintf("%s.example.com", acctest.RandString(10))
+	aclName := fmt.Sprintf("tf_test_acl_%s", acctest.RandString(10))
+	linkName := fmt.Sprintf("tf_test_link_%s", acctest.RandString(10))
+	linkNameRenamed := fmt.Sprintf("tf_test_link_renamed_%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
+		CheckDestroy:             CheckServiceAndACLDestroy("fastly_service_compute_auto"),
+		Steps: []resource.TestStep{
+			{
+				Config: ConfigComputeAutoWithACLResourceLink(serviceName, domainName, aclName, linkName),
+				Check: resource.ComposeTestCheckFunc(
+					CheckServiceExists("fastly_service_compute_auto.test"),
+					resource.TestCheckResourceAttr("fastly_service_compute_auto.test", "resource_link.#", "1"),
+					resource.TestCheckResourceAttr("fastly_service_compute_auto.test", "resource_link.0.name", linkName),
+					resource.TestCheckResourceAttrPair("fastly_service_compute_auto.test", "resource_link.0.resource_id", "fastly_acl.acl", "id"),
+					resource.TestCheckResourceAttr("fastly_service_compute_auto.test", "active_version", "1"),
+					resource.TestCheckResourceAttr("fastly_service_compute_auto.test", "managed_version", "1"),
+				),
+			},
+			{
+				// Renaming the alias (same resource_id) is applied in place via UpdateResource,
+				// but still requires a new service version like any other nested config change.
+				Config: ConfigComputeAutoWithACLResourceLink(serviceName, domainName, aclName, linkNameRenamed),
+				Check: resource.ComposeTestCheckFunc(
+					CheckServiceExists("fastly_service_compute_auto.test"),
+					resource.TestCheckResourceAttr("fastly_service_compute_auto.test", "resource_link.#", "1"),
+					resource.TestCheckResourceAttr("fastly_service_compute_auto.test", "resource_link.0.name", linkNameRenamed),
+					resource.TestCheckResourceAttrPair("fastly_service_compute_auto.test", "resource_link.0.resource_id", "fastly_acl.acl", "id"),
+					resource.TestCheckResourceAttr("fastly_service_compute_auto.test", "active_version", "2"),
+					resource.TestCheckResourceAttr("fastly_service_compute_auto.test", "managed_version", "2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccFastlyServiceComputeAuto_ACLResourceLinkRetarget(t *testing.T) {
+	t.Parallel()
+	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	domainName := fmt.Sprintf("%s.example.com", acctest.RandString(10))
+	aclName1 := fmt.Sprintf("tf_test_acl_1_%s", acctest.RandString(10))
+	aclName2 := fmt.Sprintf("tf_test_acl_2_%s", acctest.RandString(10))
+	linkName := fmt.Sprintf("tf_test_link_%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
+		CheckDestroy:             CheckServiceAndACLDestroy("fastly_service_compute_auto"),
+		Steps: []resource.TestStep{
+			{
+				Config: ConfigComputeAutoWithACLResourceLinkTarget(serviceName, domainName, aclName1, aclName2, linkName, "acl1"),
+				Check: resource.ComposeTestCheckFunc(
+					CheckServiceExists("fastly_service_compute_auto.test"),
+					resource.TestCheckResourceAttr("fastly_acl.acl1", "name", aclName1),
+					resource.TestCheckResourceAttr("fastly_acl.acl2", "name", aclName2),
+					resource.TestCheckResourceAttr("fastly_service_compute_auto.test", "resource_link.#", "1"),
+					resource.TestCheckResourceAttrPair("fastly_service_compute_auto.test", "resource_link.0.resource_id", "fastly_acl.acl1", "id"),
+					resource.TestCheckResourceAttr("fastly_service_compute_auto.test", "active_version", "1"),
+				),
+			},
+			{
+				// Pointing the same alias at a different ACL can't be done via
+				// UpdateResource (it only renames), so this exercises delete-old/create-new
+				// within the same reconcile pass. Both ACLs stay declared throughout, since
+				// the Fastly API rejects deleting an ACL in the same request that
+				// unlinks it.
+				Config: ConfigComputeAutoWithACLResourceLinkTarget(serviceName, domainName, aclName1, aclName2, linkName, "acl2"),
+				Check: resource.ComposeTestCheckFunc(
+					CheckServiceExists("fastly_service_compute_auto.test"),
+					resource.TestCheckResourceAttrSet("fastly_acl.acl1", "id"),
+					resource.TestCheckResourceAttr("fastly_service_compute_auto.test", "resource_link.#", "1"),
+					resource.TestCheckResourceAttr("fastly_service_compute_auto.test", "resource_link.0.name", linkName),
+					resource.TestCheckResourceAttrPair("fastly_service_compute_auto.test", "resource_link.0.resource_id", "fastly_acl.acl2", "id"),
+					resource.TestCheckResourceAttr("fastly_service_compute_auto.test", "active_version", "2"),
+					resource.TestCheckResourceAttr("fastly_service_compute_auto.test", "managed_version", "2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccFastlyServiceComputeAuto_ACLResourceLinkRemove(t *testing.T) {
+	t.Parallel()
+	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	domainName := fmt.Sprintf("%s.example.com", acctest.RandString(10))
+	aclName := fmt.Sprintf("tf_test_acl_%s", acctest.RandString(10))
+	linkName := fmt.Sprintf("tf_test_link_%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
+		CheckDestroy:             CheckServiceAndACLDestroy("fastly_service_compute_auto"),
+		Steps: []resource.TestStep{
+			{
+				Config: ConfigComputeAutoWithACLResourceLink(serviceName, domainName, aclName, linkName),
+				Check: resource.ComposeTestCheckFunc(
+					CheckServiceExists("fastly_service_compute_auto.test"),
+					resource.TestCheckResourceAttr("fastly_service_compute_auto.test", "resource_link.#", "1"),
+					resource.TestCheckResourceAttr("fastly_service_compute_auto.test", "active_version", "1"),
+				),
+			},
+			{
+				// Removing the block entirely from an existing service deletes the link
+				// in-place on a newly cloned/activated version, without touching the service.
+				// The ACL stays declared (unlinked) here rather than disappearing in this same
+				// apply, since the Fastly API rejects deleting an ACL in the same
+				// request that unlinks it.
+				Config: ConfigComputeAutoWithStandaloneACL(serviceName, domainName, aclName),
+				Check: resource.ComposeTestCheckFunc(
+					CheckServiceExists("fastly_service_compute_auto.test"),
+					resource.TestCheckResourceAttrSet("fastly_acl.acl", "id"),
+					resource.TestCheckResourceAttr("fastly_service_compute_auto.test", "resource_link.#", "0"),
+					resource.TestCheckResourceAttr("fastly_service_compute_auto.test", "active_version", "2"),
+					resource.TestCheckResourceAttr("fastly_service_compute_auto.test", "managed_version", "2"),
+				),
+			},
+			{
+				// Now that the ACL has been unlinked and that change has settled in its own
+				// apply, it can be safely deleted.
+				Config: ConfigComputeAutoBasic(serviceName, domainName),
+				Check: resource.ComposeTestCheckFunc(
+					CheckServiceExists("fastly_service_compute_auto.test"),
+					resource.TestCheckResourceAttr("fastly_service_compute_auto.test", "resource_link.#", "0"),
+					resource.TestCheckResourceAttr("fastly_service_compute_auto.test", "active_version", "2"),
+					resource.TestCheckResourceAttr("fastly_service_compute_auto.test", "managed_version", "2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccFastlyServiceComputeAuto_ACLResourceLinkImport(t *testing.T) {
+	t.Parallel()
+	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	domainName := fmt.Sprintf("%s.example.com", acctest.RandString(10))
+	aclName := fmt.Sprintf("tf_test_acl_%s", acctest.RandString(10))
+	linkName := fmt.Sprintf("tf_test_link_%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
+		CheckDestroy:             CheckServiceAndACLDestroy("fastly_service_compute_auto"),
+		Steps: []resource.TestStep{
+			{
+				Config: ConfigComputeAutoWithACLResourceLink(serviceName, domainName, aclName, linkName),
+				Check: resource.ComposeTestCheckFunc(
+					CheckServiceExists("fastly_service_compute_auto.test"),
+					resource.TestCheckResourceAttr("fastly_service_compute_auto.test", "resource_link.#", "1"),
+				),
+			},
+			{
+				ResourceName:            "fastly_service_compute_auto.test",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"force_destroy", "package", "reuse"},
+			},
+		},
+	})
+}
+
 func TestAccFastlyServiceComputeAuto_update(t *testing.T) {
 	t.Parallel()
 	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))

--- a/internal/acceptance_tests/service_resource_link_test.go
+++ b/internal/acceptance_tests/service_resource_link_test.go
@@ -18,7 +18,7 @@ func TestAccFastlyServiceResourceLink_ACL(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { PreCheck(t) },
 		ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
-		CheckDestroy:             CheckServiceDestroy("fastly_service_compute"),
+		CheckDestroy:             CheckServiceAndACLDestroy("fastly_service_compute"),
 		Steps: []resource.TestStep{
 			{
 				Config: ConfigServiceComputeWithACLResourceLink(serviceName, aclName, linkName),
@@ -46,7 +46,7 @@ func TestAccFastlyServiceResourceLink_ACLRename(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { PreCheck(t) },
 		ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
-		CheckDestroy:             CheckServiceDestroy("fastly_service_compute"),
+		CheckDestroy:             CheckServiceAndACLDestroy("fastly_service_compute"),
 		Steps: []resource.TestStep{
 			{
 				Config: ConfigServiceComputeWithACLResourceLink(serviceName, aclName, linkName),
@@ -79,7 +79,7 @@ func TestAccFastlyServiceResourceLink_ACLRetarget(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { PreCheck(t) },
 		ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
-		CheckDestroy:             CheckServiceDestroy("fastly_service_compute"),
+		CheckDestroy:             CheckServiceAndACLDestroy("fastly_service_compute"),
 		Steps: []resource.TestStep{
 			{
 				Config: ConfigServiceComputeWithACLResourceLink(serviceName, aclName, linkName),
@@ -114,7 +114,7 @@ func TestAccFastlyServiceResourceLink_ACLImport(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { PreCheck(t) },
 		ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
-		CheckDestroy:             CheckServiceDestroy("fastly_service_compute"),
+		CheckDestroy:             CheckServiceAndACLDestroy("fastly_service_compute"),
 		Steps: []resource.TestStep{
 			{
 				Config: ConfigServiceComputeWithACLResourceLink(serviceName, aclName, linkName),

--- a/internal/acceptance_tests/service_resource_link_test.go
+++ b/internal/acceptance_tests/service_resource_link_test.go
@@ -1,0 +1,144 @@
+package acceptancetests
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+func TestAccFastlyServiceResourceLink_ACL(t *testing.T) {
+	t.Parallel()
+	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	aclName := fmt.Sprintf("tf_test_acl_%s", acctest.RandString(10))
+	linkName := fmt.Sprintf("tf_test_link_%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
+		CheckDestroy:             CheckServiceDestroy("fastly_service_compute"),
+		Steps: []resource.TestStep{
+			{
+				Config: ConfigServiceComputeWithACLResourceLink(serviceName, aclName, linkName),
+				Check: resource.ComposeTestCheckFunc(
+					CheckServiceExists("fastly_service_compute.test"),
+					resource.TestCheckResourceAttr("fastly_acl.acl", "name", aclName),
+					resource.TestCheckResourceAttrSet("fastly_acl.acl", "id"),
+					resource.TestCheckResourceAttr("fastly_service_resource_link.test", "name", linkName),
+					resource.TestCheckResourceAttr("fastly_service_resource_link.test", "version", "1"),
+					resource.TestCheckResourceAttrPair("fastly_service_resource_link.test", "resource_id", "fastly_acl.acl", "id"),
+					resource.TestCheckResourceAttrSet("fastly_service_resource_link.test", "link_id"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccFastlyServiceResourceLink_ACLRename(t *testing.T) {
+	t.Parallel()
+	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	aclName := fmt.Sprintf("tf_test_acl_%s", acctest.RandString(10))
+	linkName := fmt.Sprintf("tf_test_link_%s", acctest.RandString(10))
+	linkNameRenamed := fmt.Sprintf("tf_test_link_renamed_%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
+		CheckDestroy:             CheckServiceDestroy("fastly_service_compute"),
+		Steps: []resource.TestStep{
+			{
+				Config: ConfigServiceComputeWithACLResourceLink(serviceName, aclName, linkName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("fastly_service_resource_link.test", "name", linkName),
+					resource.TestCheckResourceAttr("fastly_service_resource_link.test", "version", "1"),
+				),
+			},
+			{
+				// Renaming the alias is applied in place via UpdateResource; the underlying
+				// ACL and the same service version are untouched.
+				Config: ConfigServiceComputeWithACLResourceLink(serviceName, aclName, linkNameRenamed),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("fastly_service_resource_link.test", "name", linkNameRenamed),
+					resource.TestCheckResourceAttr("fastly_service_resource_link.test", "version", "1"),
+					resource.TestCheckResourceAttrPair("fastly_service_resource_link.test", "resource_id", "fastly_acl.acl", "id"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccFastlyServiceResourceLink_ACLRetarget(t *testing.T) {
+	t.Parallel()
+	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	aclName := fmt.Sprintf("tf_test_acl_%s", acctest.RandString(10))
+	aclNameOther := fmt.Sprintf("tf_test_acl_other_%s", acctest.RandString(10))
+	linkName := fmt.Sprintf("tf_test_link_%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
+		CheckDestroy:             CheckServiceDestroy("fastly_service_compute"),
+		Steps: []resource.TestStep{
+			{
+				Config: ConfigServiceComputeWithACLResourceLink(serviceName, aclName, linkName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("fastly_acl.acl", "name", aclName),
+					resource.TestCheckResourceAttrPair("fastly_service_resource_link.test", "resource_id", "fastly_acl.acl", "id"),
+				),
+			},
+			{
+				// Pointing the link at a different ACL forces replacement of the link
+				// (resource_id is RequiresReplace); the original ACL is then destroyed
+				// since nothing else references it.
+				Config: ConfigServiceComputeWithACLResourceLink(serviceName, aclNameOther, linkName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("fastly_acl.acl", "name", aclNameOther),
+					resource.TestCheckResourceAttr("fastly_service_resource_link.test", "name", linkName),
+					resource.TestCheckResourceAttrPair("fastly_service_resource_link.test", "resource_id", "fastly_acl.acl", "id"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccFastlyServiceResourceLink_ACLImport(t *testing.T) {
+	t.Parallel()
+	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	aclName := fmt.Sprintf("tf_test_acl_%s", acctest.RandString(10))
+	linkName := fmt.Sprintf("tf_test_link_%s", acctest.RandString(10))
+
+	var serviceID, version string
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
+		CheckDestroy:             CheckServiceDestroy("fastly_service_compute"),
+		Steps: []resource.TestStep{
+			{
+				Config: ConfigServiceComputeWithACLResourceLink(serviceName, aclName, linkName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("fastly_service_resource_link.test", "link_id"),
+					func(s *terraform.State) error {
+						rs, ok := s.RootModule().Resources["fastly_service_resource_link.test"]
+						if !ok {
+							return fmt.Errorf("resource link resource not found")
+						}
+						serviceID = rs.Primary.Attributes["service_id"]
+						version = rs.Primary.Attributes["version"]
+						return nil
+					},
+				),
+			},
+			{
+				ResourceName: "fastly_service_resource_link.test",
+				ImportStateIdFunc: func(_ *terraform.State) (string, error) {
+					return fmt.Sprintf("%s/%s/%s", serviceID, version, linkName), nil
+				},
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/internal/acceptance_tests/test_helpers.go
+++ b/internal/acceptance_tests/test_helpers.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/fastly/go-fastly/v16/fastly"
 	"github.com/fastly/terraform-provider-fastly/internal/errors"
@@ -84,6 +85,14 @@ func CreateTestKVStore(t *testing.T, name string) string {
 	return store.StoreID
 }
 
+// serviceDestroyCheckAttempts and serviceDestroyCheckInterval bound the retry loop in
+// CheckServiceDestroy, which tolerates the Fastly API's soft-delete taking a moment to become
+// visible on a subsequent read - most noticeable when many acceptance tests run in parallel.
+const (
+	serviceDestroyCheckAttempts = 5
+	serviceDestroyCheckInterval = 2 * time.Second
+)
+
 // CheckServiceDestroy returns a TestCheckFunc that verifies a service resource was destroyed
 func CheckServiceDestroy(resourceType string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
@@ -97,28 +106,44 @@ func CheckServiceDestroy(resourceType string) resource.TestCheckFunc {
 				continue
 			}
 
-			svc, err := client.GetService(context.Background(), &fastly.GetServiceInput{
-				ServiceID: rs.Primary.ID,
-			})
-
-			if errors.IsNotFound(err) {
-				continue
+			var lastErr error
+			for attempt := 1; attempt <= serviceDestroyCheckAttempts; attempt++ {
+				lastErr = checkServiceDestroyed(client, rs.Primary.ID)
+				if lastErr == nil {
+					break
+				}
+				if attempt < serviceDestroyCheckAttempts {
+					time.Sleep(serviceDestroyCheckInterval)
+				}
 			}
-
-			if err != nil {
-				return fmt.Errorf("error checking if service was destroyed: %w", err)
+			if lastErr != nil {
+				return lastErr
 			}
-
-			// Service exists - check if it's soft-deleted
-			if svc != nil && svc.DeletedAt != nil {
-				continue
-			}
-
-			return fmt.Errorf("service %s still exists", rs.Primary.ID)
 		}
 
 		return nil
 	}
+}
+
+func checkServiceDestroyed(client *fastly.Client, serviceID string) error {
+	svc, err := client.GetService(context.Background(), &fastly.GetServiceInput{
+		ServiceID: serviceID,
+	})
+
+	if errors.IsNotFound(err) {
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error checking if service was destroyed: %w", err)
+	}
+
+	// Service exists - check if it's soft-deleted
+	if svc != nil && svc.DeletedAt != nil {
+		return nil
+	}
+
+	return fmt.Errorf("service %s still exists", serviceID)
 }
 
 // CheckServiceExists returns a TestCheckFunc that verifies a service resource exists
@@ -426,6 +451,80 @@ func ConfigComputeAutoWithResourceLink(serviceName, domainName, targetID, linkNa
 	)
 }
 
+// ConfigComputeAutoWithACLResourceLink returns a Compute auto service config with a
+// domain, package, and a resource_link block pointing at a Terraform-managed fastly_acl
+// (declared as a sibling resource, referenced by ID rather than a literal string).
+func ConfigComputeAutoWithACLResourceLink(serviceName, domainName, aclName, linkName string) string {
+	aclConfig := fmt.Sprintf(`
+resource "fastly_acl" "acl" {
+  name = %q
+}
+
+`, aclName)
+
+	return aclConfig + BuildConfig(
+		ServiceComputeAuto,
+		map[string]string{
+			"SERVICE_NAME":            serviceName,
+			"DOMAIN_NAME":             domainName,
+			"PACKAGE_PATH":            GetPackagePath(),
+			"RESOURCE_LINK_NAME":      linkName,
+			"RESOURCE_LINK_TARGET_ID": "fastly_acl.acl.id",
+		},
+		"internal/acceptance_tests/blocks/domain_single.tf",
+		"internal/acceptance_tests/blocks/resource_link_ref.tf",
+		"internal/acceptance_tests/blocks/package.tf",
+	)
+}
+
+// ConfigComputeAutoWithStandaloneACL returns a Compute auto service config (domain and
+// package, no resource_link) alongside a separately declared, unlinked fastly_acl.
+//
+// The Fastly API doesn't allow deleting an ACL in the same request that unlinks it from a
+// service, so tests that remove a resource_link and then delete its target ACL need this as an
+// intermediate step: unlink first and let that settle, then delete the ACL in a later step.
+func ConfigComputeAutoWithStandaloneACL(serviceName, domainName, aclName string) string {
+	aclConfig := fmt.Sprintf(`
+resource "fastly_acl" "acl" {
+  name = %q
+}
+
+`, aclName)
+
+	return aclConfig + ConfigComputeAutoBasic(serviceName, domainName)
+}
+
+// ConfigComputeAutoWithACLResourceLinkTarget returns a Compute auto service config
+// declaring two fastly_acl resources (acl1 and acl2), with the resource_link pointing at
+// whichever is named by targetLabel. Both ACLs stay declared regardless of which is targeted, so
+// retargeting exercises the reconcile delete-old/create-new pass without deleting either ACL.
+func ConfigComputeAutoWithACLResourceLinkTarget(serviceName, domainName, aclName1, aclName2, linkName, targetLabel string) string {
+	aclConfig := fmt.Sprintf(`
+resource "fastly_acl" "acl1" {
+  name = %q
+}
+
+resource "fastly_acl" "acl2" {
+  name = %q
+}
+
+`, aclName1, aclName2)
+
+	return aclConfig + BuildConfig(
+		ServiceComputeAuto,
+		map[string]string{
+			"SERVICE_NAME":            serviceName,
+			"DOMAIN_NAME":             domainName,
+			"PACKAGE_PATH":            GetPackagePath(),
+			"RESOURCE_LINK_NAME":      linkName,
+			"RESOURCE_LINK_TARGET_ID": fmt.Sprintf("fastly_acl.%s.id", targetLabel),
+		},
+		"internal/acceptance_tests/blocks/domain_single.tf",
+		"internal/acceptance_tests/blocks/resource_link_ref.tf",
+		"internal/acceptance_tests/blocks/package.tf",
+	)
+}
+
 // ConfigComputeAutoMultipleBackends returns a Compute auto service config with multiple backends and a package
 func ConfigComputeAutoMultipleBackends(serviceName, domainName string) string {
 	return BuildConfig(
@@ -594,6 +693,22 @@ func ConfigServiceComputeWithComment(serviceName string) string {
 			"SERVICE_NAME":    serviceName,
 			"SERVICE_COMMENT": "Managed by Terraform",
 		},
+	)
+}
+
+// ConfigServiceComputeWithACLResourceLink returns an explicit Compute service config
+// with a fastly_acl linked into it via fastly_service_resource_link.
+func ConfigServiceComputeWithACLResourceLink(serviceName, aclName, linkName string) string {
+	return BuildConfig(
+		ServiceCompute,
+		map[string]string{
+			"SERVICE_NAME":       serviceName,
+			"SERVICE_COMMENT":    "",
+			"ACL_NAME":           aclName,
+			"RESOURCE_LINK_NAME": linkName,
+			"SERVICE_VERSION":    "1",
+		},
+		"internal/acceptance_tests/blocks/resource_link_acl.tf",
 	)
 }
 

--- a/internal/datasources/acls/data_source.go
+++ b/internal/datasources/acls/data_source.go
@@ -1,0 +1,134 @@
+package acls
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"sort"
+	"strings"
+
+	fastlyclient "github.com/fastly/terraform-provider-fastly/internal/client"
+
+	"github.com/fastly/go-fastly/v16/fastly"
+	"github.com/fastly/go-fastly/v16/fastly/computeacls"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+var _ datasource.DataSource = &DataSource{}
+
+type DataSource struct {
+	client *fastly.Client
+}
+
+type DataSourceModel struct {
+	ID   types.String `tfsdk:"id"`
+	Acls types.Set    `tfsdk:"acls"`
+}
+
+var aclAttrTypes = map[string]attr.Type{
+	"id":   types.StringType,
+	"name": types.StringType,
+}
+
+func NewDataSource() datasource.DataSource {
+	return &DataSource{}
+}
+
+func (d *DataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_acls"
+}
+
+func (d *DataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Use this data source to retrieve a list of Fastly ACLs.",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed:    true,
+				Description: "Terraform data source identifier.",
+			},
+			"acls": schema.SetNestedAttribute{
+				Computed:    true,
+				Description: "List of all ACLs.",
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"id": schema.StringAttribute{
+							Computed:    true,
+							Description: "Identifier of the ACL.",
+						},
+						"name": schema.StringAttribute{
+							Computed:    true,
+							Description: "Name of the ACL.",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (d *DataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	data, diags := fastlyclient.FromProviderData(req.ProviderData)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() || data == nil {
+		return
+	}
+
+	d.client = data.Client
+}
+
+func (d *DataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var state DataSourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	tflog.Debug(ctx, "Reading Fastly ACLs")
+
+	acls, err := computeacls.ListACLs(ctx, d.client)
+	if err != nil {
+		resp.Diagnostics.AddError("Error listing ACLs", err.Error())
+		return
+	}
+
+	ids := make([]string, 0, len(acls.Data))
+	elements := make([]attr.Value, 0, len(acls.Data))
+	for _, acl := range acls.Data {
+		ids = append(ids, acl.ComputeACLID)
+
+		obj, diags := types.ObjectValue(aclAttrTypes, map[string]attr.Value{
+			"id":   types.StringValue(acl.ComputeACLID),
+			"name": types.StringValue(acl.Name),
+		})
+		resp.Diagnostics.Append(diags...)
+		elements = append(elements, obj)
+	}
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	setVal, diags := types.SetValue(types.ObjectType{AttrTypes: aclAttrTypes}, elements)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	state.Acls = setVal
+	state.ID = types.StringValue(hashIDs(ids))
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+// hashIDs derives a stable data source ID from the set of ACL IDs,
+// so the ID changes whenever the underlying set of ACLs changes.
+func hashIDs(ids []string) string {
+	sorted := append([]string(nil), ids...)
+	sort.Strings(sorted)
+
+	sum := sha256.Sum256([]byte(strings.Join(sorted, ",")))
+	return hex.EncodeToString(sum[:])
+}

--- a/internal/datasources/acls/data_source_test.go
+++ b/internal/datasources/acls/data_source_test.go
@@ -1,0 +1,12 @@
+package acls
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHashIDs(t *testing.T) {
+	assert.Equal(t, hashIDs([]string{"a", "b"}), hashIDs([]string{"b", "a"}), "order should not affect the hash")
+	assert.NotEqual(t, hashIDs([]string{"a", "b"}), hashIDs([]string{"a", "c"}), "different sets should hash differently")
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -19,7 +19,9 @@ import (
 	"github.com/fastly/terraform-provider-fastly/internal/actions/versionclone"
 	"github.com/fastly/terraform-provider-fastly/internal/actions/versionstage"
 	fastlyclient "github.com/fastly/terraform-provider-fastly/internal/client"
+	"github.com/fastly/terraform-provider-fastly/internal/datasources/acls"
 	"github.com/fastly/terraform-provider-fastly/internal/datasources/serviceversion"
+	"github.com/fastly/terraform-provider-fastly/internal/resources/acl"
 	"github.com/fastly/terraform-provider-fastly/internal/resources/backend"
 	"github.com/fastly/terraform-provider-fastly/internal/resources/cdnacl"
 	"github.com/fastly/terraform-provider-fastly/internal/resources/cdnaclentries"
@@ -95,6 +97,7 @@ func (p *fastlyProvider) Configure(ctx context.Context, req provider.ConfigureRe
 
 func (p *fastlyProvider) Resources(_ context.Context) []func() resource.Resource {
 	return []func() resource.Resource{
+		acl.NewResource,
 		backend.NewResource,
 		cdnacl.NewResource,
 		cdnaclentries.NewResource,
@@ -109,6 +112,7 @@ func (p *fastlyProvider) Resources(_ context.Context) []func() resource.Resource
 
 func (p *fastlyProvider) DataSources(_ context.Context) []func() datasource.DataSource {
 	return []func() datasource.DataSource{
+		acls.NewDataSource,
 		serviceversion.NewDataSource,
 	}
 }

--- a/internal/resources/acl/acl_test.go
+++ b/internal/resources/acl/acl_test.go
@@ -1,0 +1,45 @@
+package acl
+
+import (
+	"testing"
+
+	"github.com/fastly/go-fastly/v16/fastly/computeacls"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFlatten(t *testing.T) {
+	tests := []struct {
+		name     string
+		acl      *computeacls.ComputeACL
+		initial  Model
+		expected Model
+	}{
+		{
+			name:     "nil ACL leaves model untouched",
+			acl:      nil,
+			initial:  Model{ID: types.StringValue("unchanged"), Name: types.StringValue("unchanged")},
+			expected: Model{ID: types.StringValue("unchanged"), Name: types.StringValue("unchanged")},
+		},
+		{
+			name: "populated ACL",
+			acl: &computeacls.ComputeACL{
+				ComputeACLID: "acl_abc123",
+				Name:         "my_acl",
+			},
+			initial: Model{},
+			expected: Model{
+				ID:   types.StringValue("acl_abc123"),
+				Name: types.StringValue("my_acl"),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := tt.initial
+			flatten(&m, tt.acl)
+			assert.Equal(t, tt.expected, m)
+		})
+	}
+}

--- a/internal/resources/acl/resource.go
+++ b/internal/resources/acl/resource.go
@@ -1,0 +1,150 @@
+package acl
+
+import (
+	"context"
+
+	fastlyclient "github.com/fastly/terraform-provider-fastly/internal/client"
+	"github.com/fastly/terraform-provider-fastly/internal/errors"
+
+	"github.com/fastly/go-fastly/v16/fastly"
+	"github.com/fastly/go-fastly/v16/fastly/computeacls"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+var _ resource.Resource = &Resource{}
+var _ resource.ResourceWithImportState = &Resource{}
+
+type Resource struct {
+	client *fastly.Client
+}
+
+func NewResource() resource.Resource {
+	return &Resource{}
+}
+
+type Model struct {
+	ID   types.String `tfsdk:"id"`
+	Name types.String `tfsdk:"name"`
+}
+
+func (r *Resource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_acl"
+}
+
+func (r *Resource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Provides an Access Control List (ACL) that defines CIDR-based access rules (e.g., allow/block IP ranges) and is accessible to Compute services during request processing.",
+		Attributes:  ResourceAttributes(),
+	}
+}
+
+func (r *Resource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	data, diags := fastlyclient.FromProviderData(req.ProviderData)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() || data == nil {
+		return
+	}
+
+	r.client = data.Client
+}
+
+func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan Model
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	tflog.Debug(ctx, "Creating Fastly ACL", map[string]any{
+		"name": plan.Name.ValueString(),
+	})
+
+	acl, err := computeacls.Create(ctx, r.client, &computeacls.CreateInput{
+		Name: plan.Name.ValueStringPointer(),
+	})
+	if err != nil {
+		resp.Diagnostics.AddError("Error creating ACL", err.Error())
+		return
+	}
+
+	flatten(&plan, acl)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+func (r *Resource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var state Model
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	tflog.Debug(ctx, "Reading Fastly ACL", map[string]any{
+		"id": state.ID.ValueString(),
+	})
+
+	acl, err := computeacls.Describe(ctx, r.client, &computeacls.DescribeInput{
+		ComputeACLID: state.ID.ValueStringPointer(),
+	})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			tflog.Warn(ctx, "ACL not found, removing from state", map[string]any{
+				"id": state.ID.ValueString(),
+			})
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.AddError("Error reading ACL", err.Error())
+		return
+	}
+
+	flatten(&state, acl)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+// Update is never invoked in practice: name is the only configurable
+// attribute and it forces replacement via RequiresReplace.
+func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var plan Model
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+func (r *Resource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var state Model
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	tflog.Debug(ctx, "Deleting Fastly ACL", map[string]any{
+		"id": state.ID.ValueString(),
+	})
+
+	err := computeacls.Delete(ctx, r.client, &computeacls.DeleteInput{
+		ComputeACLID: state.ID.ValueStringPointer(),
+	})
+	if err != nil && !errors.IsNotFound(err) {
+		resp.Diagnostics.AddError("Error deleting ACL", err.Error())
+	}
+}
+
+func (r *Resource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}
+
+func flatten(m *Model, acl *computeacls.ComputeACL) {
+	if acl == nil {
+		return
+	}
+
+	m.ID = types.StringValue(acl.ComputeACLID)
+	m.Name = types.StringValue(acl.Name)
+}

--- a/internal/resources/acl/schema.go
+++ b/internal/resources/acl/schema.go
@@ -1,0 +1,26 @@
+package acl
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+)
+
+func ResourceAttributes() map[string]schema.Attribute {
+	return map[string]schema.Attribute{
+		"id": schema.StringAttribute{
+			Computed:    true,
+			Description: "The ID of this ACL.",
+			PlanModifiers: []planmodifier.String{
+				stringplanmodifier.UseStateForUnknown(),
+			},
+		},
+		"name": schema.StringAttribute{
+			Required:    true,
+			Description: "A unique name to identify the ACL. Changing this attribute will delete and recreate the ACL, discarding its current entries. Any `resource_link` referencing this ACL must be removed first.",
+			PlanModifiers: []planmodifier.String{
+				stringplanmodifier.RequiresReplace(),
+			},
+		},
+	}
+}

--- a/scripts/test-lifecycle-compute/README.md
+++ b/scripts/test-lifecycle-compute/README.md
@@ -13,6 +13,8 @@ The test suite validates the complete lifecycle of Fastly Compute services manag
 - Compute package uploads (`fastly_service_compute_package_upload` action)
 - Version cloning action (`fastly_service_version_clone`)
 - Version activation action (`fastly_service_version_activate`)
+- ACL creation (`fastly_acl`) -- versionless, created alongside the services
+- Attaching an ACL to a service (`fastly_service_resource_link`), including moving the link forward across cloned/activated versions
 - Resource updates
 - Resource destruction
 
@@ -57,8 +59,8 @@ cd scripts/test-lifecycle-compute
 7. **Test Resource Updates**: Modifies a service comment while version 1 is still editable
 8. **Test Clone Action**: Invokes version clone actions for both services (creates version 2)
 9. **Test Activate Action**: Uploads package and activates version 2
-10. **Test Version-Locked Writes**: Clones to version 3, adds new resources, uploads package, and activates
-11. **Test Destruction**: Cleans up all resources via `terraform destroy`
+10. **Test Version-Locked Writes**: Clones to version 3, adds new resources, uploads package, and activates -- and verifies the ACL's resource_link followed service 1 onto the new version
+11. **Test Destruction**: Cleans up all resources via `terraform destroy`, including the resource_link and the ACL
 12. **Cleanup**: Removes temporary test directory
 
 ## Resource Cleanup
@@ -106,6 +108,7 @@ The test creates:
 - 2 domain attachments (one per service)
 - 3 backend configurations (1 shared, 2 unique)
 - Compute package uploads to multiple versions
+- 1 ACL (versionless), attached to service 1 via a `fastly_service_resource_link`
 
 All resources are tagged with the process ID for uniqueness and are destroyed during cleanup.
 

--- a/scripts/test-lifecycle-compute/main.tf
+++ b/scripts/test-lifecycle-compute/main.tf
@@ -95,7 +95,8 @@ data "fastly_service_version" "service_1" {
   depends_on = [
     fastly_service_domain.service_1_domain,
     fastly_service_backend.service_1_backend_shared,
-    fastly_service_backend.service_1_backend_unique
+    fastly_service_backend.service_1_backend_unique,
+    fastly_service_resource_link.service_1_acl
   ]
 }
 
@@ -158,6 +159,21 @@ action "fastly_service_version_activate" "service_2_activate" {
     service_id = fastly_service_compute.service_2.id
     version    = var.service_2_version
   }
+}
+
+# ACL -- versionless resource, not tied to a service or service version.
+resource "fastly_acl" "acl" {
+  name = var.acl_name
+}
+
+# Attaches the ACL to service 1 so it's usable from Wasm code, exercising the
+# same version lifecycle (clone/activate/advance-off-locked) as the other version-scoped
+# resources below.
+resource "fastly_service_resource_link" "service_1_acl" {
+  service_id  = fastly_service_compute.service_1.id
+  version     = var.service_1_version
+  name        = var.resource_link_name
+  resource_id = fastly_acl.acl.id
 }
 
 # Actions for compute package uploads

--- a/scripts/test-lifecycle-compute/outputs.tf
+++ b/scripts/test-lifecycle-compute/outputs.tf
@@ -37,3 +37,23 @@ output "service_2_latest_version" {
   value       = data.fastly_service_version.service_2.latest_version
   description = "Service 2 latest version"
 }
+
+output "acl_id" {
+  value       = fastly_acl.acl.id
+  description = "ACL ID"
+}
+
+output "acl_name" {
+  value       = fastly_acl.acl.name
+  description = "ACL name"
+}
+
+output "resource_link_id" {
+  value       = fastly_service_resource_link.service_1_acl.link_id
+  description = "Link ID of the resource_link attaching the ACL to service 1"
+}
+
+output "resource_link_version" {
+  value       = fastly_service_resource_link.service_1_acl.version
+  description = "Service version the resource_link is currently pinned to"
+}

--- a/scripts/test-lifecycle-compute/run.sh
+++ b/scripts/test-lifecycle-compute/run.sh
@@ -31,8 +31,11 @@ PACKAGE_PATH="$REPO_ROOT/internal/acceptance_tests/fixtures/packages/valid.tar.g
 # Test configuration
 TEST_SERVICE_1_NAME="tf-test-compute-svc1-$$"
 TEST_SERVICE_2_NAME="tf-test-compute-svc2-$$"
+TEST_ACL_NAME="tf-test-acl-$$"
+TEST_RESOURCE_LINK_NAME="tf-test-compute-link-$$"
 SERVICE_1_ID=""
 SERVICE_2_ID=""
+ACL_ID=""
 
 # Log functions
 log_info() {
@@ -81,6 +84,13 @@ cleanup() {
                 "https://api.fastly.com/service/$SERVICE_2_ID" > /dev/null 2>&1 || true
 
             log_info "Emergency cleanup completed"
+        fi
+
+        if [ -n "$ACL_ID" ]; then
+            log_info "Attempting emergency cleanup of ACL..."
+            curl -s -X DELETE -H "Fastly-Key: $FASTLY_API_TOKEN" \
+                "https://api.fastly.com/resources/acls/$ACL_ID" > /dev/null 2>&1 || true
+            log_info "Emergency ACL cleanup completed"
         fi
     fi
 
@@ -163,14 +173,16 @@ setup_test_environment() {
 
     # Create terraform.tfvars
     cat > terraform.tfvars << EOF
-fastly_api_token  = "$FASTLY_API_TOKEN"
-service_1_name    = "$TEST_SERVICE_1_NAME"
-service_1_version = 1
-service_1_domain  = "test-compute-svc1-$$.example.com"
-service_2_name    = "$TEST_SERVICE_2_NAME"
-service_2_version = 1
-service_2_domain  = "test-compute-svc2-$$.example.com"
-package_path      = "$PACKAGE_PATH"
+fastly_api_token   = "$FASTLY_API_TOKEN"
+service_1_name     = "$TEST_SERVICE_1_NAME"
+service_1_version  = 1
+service_1_domain   = "test-compute-svc1-$$.example.com"
+service_2_name     = "$TEST_SERVICE_2_NAME"
+service_2_version  = 1
+service_2_domain   = "test-compute-svc2-$$.example.com"
+package_path       = "$PACKAGE_PATH"
+acl_name           = "$TEST_ACL_NAME"
+resource_link_name = "$TEST_RESOURCE_LINK_NAME"
 EOF
 
     # Create .terraformrc for local provider
@@ -216,10 +228,12 @@ apply_initial_config() {
     # Extract service IDs
     SERVICE_1_ID=$(terraform output -raw service_1_id)
     SERVICE_2_ID=$(terraform output -raw service_2_id)
+    ACL_ID=$(terraform output -raw acl_id)
 
     log_success "Initial configuration applied"
     log_info "Service 1 ID: $SERVICE_1_ID"
     log_info "Service 2 ID: $SERVICE_2_ID"
+    log_info "ACL ID: $ACL_ID"
 }
 
 # Verify initial state
@@ -247,7 +261,45 @@ verify_initial_state() {
         exit 1
     fi
 
+    local acl_id=$(terraform output -raw acl_id)
+    local acl_name=$(terraform output -raw acl_name)
+    log_info "ACL - ID: $acl_id, Name: $acl_name"
+
+    if [ -z "$acl_id" ]; then
+        log_error "ACL has no ID"
+        exit 1
+    fi
+
+    local link_version=$(terraform output -raw resource_link_version)
+    verify_resource_link "$SERVICE_1_ID" "$link_version" "$ACL_ID" "$TEST_RESOURCE_LINK_NAME"
+
     log_success "Initial state verified"
+}
+
+# Verify a resource_link exists on the given service version, pointing at the
+# given resource_id with the given name (alias).
+verify_resource_link() {
+    local service_id="$1"
+    local version="$2"
+    local expected_resource_id="$3"
+    local expected_name="$4"
+
+    local resources_response=$(curl -s -H "Fastly-Key: $FASTLY_API_TOKEN" \
+        "https://api.fastly.com/service/$service_id/version/$version/resource")
+
+    local actual_resource_id=$(echo "$resources_response" | jq -r --arg name "$expected_name" \
+        '.[] | select(.name == $name) | .resource_id')
+    local actual_name=$(echo "$resources_response" | jq -r --arg id "$expected_resource_id" \
+        '.[] | select(.resource_id == $id) | .name')
+
+    if [ "$actual_resource_id" != "$expected_resource_id" ] || [ "$actual_name" != "$expected_name" ]; then
+        log_error "Resource link on service $service_id version $version does not match expectations"
+        log_info "Expected resource_id=$expected_resource_id name=$expected_name"
+        log_info "Resources response: $resources_response"
+        return 1
+    fi
+
+    log_success "Resource link verified on service $service_id version $version (name=$expected_name, resource_id=$expected_resource_id)"
 }
 
 # Test compute package upload action
@@ -348,14 +400,16 @@ test_version_activate_action() {
     # Update service_1_version to 2 (the cloned version)
     log_info "Updating terraform.tfvars to set service versions to 2..."
     cat > terraform.tfvars << EOF
-fastly_api_token  = "$FASTLY_API_TOKEN"
-service_1_name    = "$TEST_SERVICE_1_NAME"
-service_1_version = 2
-service_1_domain  = "test-compute-svc1-$$.example.com"
-service_2_name    = "$TEST_SERVICE_2_NAME"
-service_2_version = 2
-service_2_domain  = "test-compute-svc2-$$.example.com"
-package_path      = "$PACKAGE_PATH"
+fastly_api_token   = "$FASTLY_API_TOKEN"
+service_1_name     = "$TEST_SERVICE_1_NAME"
+service_1_version  = 2
+service_1_domain   = "test-compute-svc1-$$.example.com"
+service_2_name     = "$TEST_SERVICE_2_NAME"
+service_2_version  = 2
+service_2_domain   = "test-compute-svc2-$$.example.com"
+package_path       = "$PACKAGE_PATH"
+acl_name           = "$TEST_ACL_NAME"
+resource_link_name = "$TEST_RESOURCE_LINK_NAME"
 EOF
 
     # Need to upload package to version 2 before activating
@@ -450,16 +504,18 @@ test_clone_from_latest_and_version_writes() {
     log_info "Updating terraform.tfvars to change version to $svc1_latest and add new resources..."
 
     cat > terraform.tfvars << EOF
-fastly_api_token     = "$FASTLY_API_TOKEN"
-service_1_name       = "$TEST_SERVICE_1_NAME"
-service_1_version    = $svc1_latest
-service_1_domain     = "test-compute-svc1-$$.example.com"
-service_1_new_domain = "test-compute-svc1-new-$$.example.com"
+fastly_api_token      = "$FASTLY_API_TOKEN"
+service_1_name        = "$TEST_SERVICE_1_NAME"
+service_1_version     = $svc1_latest
+service_1_domain      = "test-compute-svc1-$$.example.com"
+service_1_new_domain  = "test-compute-svc1-new-$$.example.com"
 service_1_new_backend = "new-backend.example.com"
-service_2_name       = "$TEST_SERVICE_2_NAME"
-service_2_version    = 2
-service_2_domain     = "test-compute-svc2-$$.example.com"
-package_path         = "$PACKAGE_PATH"
+service_2_name        = "$TEST_SERVICE_2_NAME"
+service_2_version     = 2
+service_2_domain      = "test-compute-svc2-$$.example.com"
+package_path          = "$PACKAGE_PATH"
+acl_name              = "$TEST_ACL_NAME"
+resource_link_name    = "$TEST_RESOURCE_LINK_NAME"
 EOF
 
     log_info "Running terraform plan to update version and add new domain and backend..."
@@ -528,6 +584,10 @@ EOF
         return 1
     fi
 
+    # Confirm the resource_link followed the service through the clone/activate
+    # cycle onto the new version, rather than being left behind on version 1.
+    verify_resource_link "$SERVICE_1_ID" "$svc1_latest" "$ACL_ID" "$TEST_RESOURCE_LINK_NAME"
+
     log_success "Clone from latest and version write tests completed"
 }
 
@@ -552,8 +612,8 @@ test_resource_updates() {
     log_success "Service update completed"
 }
 
-# The Fastly API rejects deletes of objects (domains/backends/ACLs) from a locked
-# (i.e. ever-activated) service version, and a locked version can never become
+# The Fastly API rejects deletes of objects (domains/backends/resource_links) from a
+# locked (i.e. ever-activated) service version, and a locked version can never become
 # mutable again. If Terraform state has a resource pinned to a locked version,
 # clone that version to a fresh, never-activated draft and move the resource
 # there via a normal `terraform apply`, so the eventual `terraform destroy` can
@@ -631,7 +691,21 @@ test_resource_destruction() {
 
     cd "$TEST_DIR"
 
-    log_info "Running terraform destroy..."
+    # The Fastly API rejects deleting an ACL while it's still recognized as
+    # linked, and that recognition doesn't clear the instant the resource_link (or
+    # the service it belongs to) is deleted -- destroying everything in one
+    # `terraform destroy` reliably 503s on the ACL delete. Destroy the services
+    # (which cascades to their resource_link) first, let that settle, then destroy
+    # the now-unlinked ACL separately.
+    log_info "Running terraform destroy for the services (cascades to the resource_link)..."
+    terraform destroy -auto-approve \
+        -target=fastly_service_compute.service_1 \
+        -target=fastly_service_compute.service_2
+
+    log_info "Waiting for the ACL unlink to settle..."
+    sleep 5
+
+    log_info "Running terraform destroy for the remaining ACL resources..."
     terraform destroy -auto-approve
 
     log_success "Resources destroyed"
@@ -671,9 +745,20 @@ test_resource_destruction() {
         return 1
     fi
 
-    # Clear service IDs to prevent emergency cleanup
+    local acl_response=$(curl -s -o /dev/null -w "%{http_code}" -H "Fastly-Key: $FASTLY_API_TOKEN" \
+        "https://api.fastly.com/resources/acls/$ACL_ID")
+
+    if [ "$acl_response" = "404" ]; then
+        log_success "ACL successfully deleted (not found)"
+    else
+        log_error "ACL still exists (HTTP $acl_response)"
+        return 1
+    fi
+
+    # Clear IDs to prevent emergency cleanup
     SERVICE_1_ID=""
     SERVICE_2_ID=""
+    ACL_ID=""
 
     log_success "Service destruction verified"
 }
@@ -704,6 +789,8 @@ main() {
     log_success "✓ Version data sources (data.fastly_service_version)"
     log_success "✓ Package upload action (fastly_service_compute_package_upload)"
     log_success "✓ Resource updates"
+    log_success "✓ ACL creation (fastly_acl)"
+    log_success "✓ ACL attached to a service (fastly_service_resource_link)"
     log_success "✓ Version clone action (fastly_service_version_clone)"
     log_success "✓ Version activate action (fastly_service_version_activate)"
     log_success "✓ Clone from latest version and version writes"

--- a/scripts/test-lifecycle-compute/variables.tf
+++ b/scripts/test-lifecycle-compute/variables.tf
@@ -52,3 +52,13 @@ variable "service_1_new_backend" {
   description = "Additional backend address for service 1 to be added to cloned version"
   default     = ""
 }
+
+variable "acl_name" {
+  type        = string
+  description = "Name for the test ACL"
+}
+
+variable "resource_link_name" {
+  type        = string
+  description = "Name (alias) for the resource_link that attaches the ACL to service 1"
+}

--- a/templates/data-sources/acls.md.tmpl
+++ b/templates/data-sources/acls.md.tmpl
@@ -1,0 +1,30 @@
+---
+page_title: "fastly_acls Data Source - fastly"
+subcategory: ""
+description: |-
+  Use this data source to retrieve a list of Fastly ACLs.
+---
+
+# fastly_acls (Data Source)
+
+Use this data source to retrieve a list of [Fastly ACLs](https://www.fastly.com/documentation/reference/api/compute-acls/).
+
+## Example Usage
+
+```terraform
+data "fastly_acls" "example" {}
+
+output "fastly_acls_all" {
+  value = data.fastly_acls.example.acls
+}
+
+output "fastly_acls_filtered" {
+  # Example: get the ID of the ACL named "my_acl"
+  value = one([
+    for acl in data.fastly_acls.example.acls :
+    acl.id if acl.name == "my_acl"
+  ])
+}
+```
+
+{{ .SchemaMarkdown | trimspace }}

--- a/templates/resources/acl.md.tmpl
+++ b/templates/resources/acl.md.tmpl
@@ -1,0 +1,30 @@
+---
+page_title: "fastly_acl Resource - fastly"
+subcategory: ""
+description: |-
+  Provides an Access Control List (ACL) that defines CIDR-based access rules and is accessible to Compute services during request processing.
+---
+
+# fastly_acl (Resource)
+
+Provides an Access Control List (ACL) that defines CIDR-based access rules (e.g., allow/block IP ranges) and is accessible to Compute services during request processing.
+
+This resource is versionless: it is not tied to a service version and is managed independently of any `fastly_service_compute` resource.
+
+## Example Usage
+
+```terraform
+resource "fastly_acl" "example" {
+  name = "my_acl"
+}
+```
+
+{{ .SchemaMarkdown | trimspace }}
+
+## Import
+
+Fastly ACLs can be imported using their ACL ID, e.g.
+
+```shell
+terraform import fastly_acl.example <acl_id>
+```


### PR DESCRIPTION
### Change summary

Ports the SDKv2 ACL resources to the Plugin Framework as versionless, account-level resources:
- fastly_acl — standalone ACL resource (id, name)
- fastly_acls — data source listing all account Compute ACLs
- Unit/acceptance tests, generated Registry docs, and a runnable example
- Extends the Compute lifecycle test script to cover ACL create, entries update, and destroy alongside existing service/version/action checks

 All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/terraform-provider-fastly/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

* [x] Does your submission pass tests?
* [x] Post the output of your test runs
<img width="641" height="367" alt="Screenshot 2026-07-09 at 2 55 03 PM" src="https://github.com/user-attachments/assets/e95c81d6-d661-4fd9-9898-eeac515926e7" />
<img width="547" height="247" alt="Screenshot 2026-07-09 at 2 57 20 PM" src="https://github.com/user-attachments/assets/10365fdc-c2fb-4d26-9017-1aea371bd52b" />
