### PR TITLE
[CDTOOL-1675] Increase Signal `name` attribute character limit to `128`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### BUG FIXES:
 
+- fix(ngwaf/signals): increase character limit of the `name` attribute to `128` characters ([#1338](https://github.com/fastly/go-fastly/pull/1338))
+
 - fix(ngwaf/rules): allow `templated_signal` rules to be created without conditions ([#1330](https://github.com/fastly/go-fastly/pull/1330))
 
 ### Dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### BUG FIXES:
 
-- fix(ngwaf/signals): increase character limit of the `name` attribute to `128` characters ([#1338](https://github.com/fastly/go-fastly/pull/1338))
+- fix(ngwaf/signals): increase character limit of the `name` attribute to `128` ([#1338](https://github.com/fastly/go-fastly/pull/1338))
 
 - fix(ngwaf/rules): allow `templated_signal` rules to be created without conditions ([#1330](https://github.com/fastly/go-fastly/pull/1330))
 

--- a/fastly/ngwaf_signal_helpers.go
+++ b/fastly/ngwaf_signal_helpers.go
@@ -32,7 +32,7 @@ func resourceFastlyNGWAFSignalBase() *schema.Resource {
 				ForceNew:     true,
 				Required:     true,
 				Description:  "The name of the signal. Special characters and periods are not accepted.",
-				ValidateFunc: validation.StringLenBetween(3, 25),
+				ValidateFunc: validation.StringLenBetween(3, 128),
 			},
 			"reference_id": {
 				Type:        schema.TypeString,


### PR DESCRIPTION
### Change summary

This PR increases the `name` attribute for Signals from the previous API limit of `25` to the now current limit of `128`. 

 All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/terraform-provider-fastly/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

* [x] Does your submission pass tests?
* [x] Post the output of your test runs

```
=== RUN   TestAccFastlyNGWAFAccountSignal_basic
=== PAUSE TestAccFastlyNGWAFAccountSignal_basic
=== CONT  TestAccFastlyNGWAFAccountSignal_basic
--- PASS: TestAccFastlyNGWAFAccountSignal_basic (11.85s)
PASS

=== RUN   TestAccFastlyNGWAFWorkspaceSignal_basic
=== PAUSE TestAccFastlyNGWAFWorkspaceSignal_basic
=== CONT  TestAccFastlyNGWAFWorkspaceSignal_basic
--- PASS: TestAccFastlyNGWAFWorkspaceSignal_basic (17.41s)
PASS
```

### Changes to Core Features:

* [ ] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### User Impact

Users will no longer be capped at a lower expected limit for Signal names. 


Solves issue #1337 


