### PR TITLE
[CDTOOL-1546] Add support for compute ACL entries

### DIFF
--- a/docs/resources/acl_entries.md
+++ b/docs/resources/acl_entries.md
@@ -1,0 +1,76 @@
+---
+page_title: "fastly_acl_entries Resource - fastly"
+subcategory: ""
+description: |-
+  Manages CIDR-based allow/block entries within a Fastly ACL.
+---
+
+# fastly_acl_entries (Resource)
+
+Manages CIDR-based allow/block entries within a Fastly ACL.
+
+By default, Terraform does not continue to manage the entries after the initial `terraform apply`. This allows you to make changes to ACL entries outside of Terraform using the [Fastly API](https://developer.fastly.com/reference/api/) or [Fastly CLI](https://developer.fastly.com/learning/tools/cli/) without Terraform resetting them.
+
+To have Terraform continue managing the entries after creation (e.g., deleting any entries not defined in the config), set `manage_entries = true`.
+
+~> **Note:** Use `manage_entries = true` cautiously. Terraform will overwrite external changes and delete any unmanaged entries.
+
+## Example Usage
+
+Basic usage (with seeded values, unmanaged after initial apply):
+
+```terraform
+resource "fastly_acl" "example" {
+  name = "my_acl"
+}
+
+resource "fastly_acl_entries" "example" {
+  acl_id = fastly_acl.example.id
+  entries = {
+    "192.0.2.0/24"    = "ALLOW"
+    "198.51.100.0/24" = "BLOCK"
+  }
+}
+```
+
+Terraform-managed usage (where Terraform controls entries long-term):
+
+```terraform
+resource "fastly_acl" "example" {
+  name = "my_acl"
+}
+
+resource "fastly_acl_entries" "example" {
+  acl_id = fastly_acl.example.id
+  entries = {
+    "203.0.113.0/24"  = "BLOCK"
+    "198.51.100.0/24" = "ALLOW"
+  }
+  manage_entries = true
+}
+```
+
+## Schema
+
+### Required
+
+- `acl_id` (String) The ID of the ACL that the entries belong to.
+- `entries` (Map of String) A map representing the entries in the ACL, where the keys are CIDR prefixes and the values are actions (`ALLOW` or `BLOCK`).
+
+### Optional
+
+- `manage_entries` (Boolean) Manage the ACL entries in Terraform (default: `false`). If `true`, Terraform will ensure that the ACL's entries match the entries in the Terraform configuration.
+
+### Read-Only
+
+- `id` (String) Terraform resource identifier. Format: `acl_id/entries`.
+
+## Import
+
+Fastly ACL entries can be imported using the format `<acl_id>/entries`, e.g.
+
+```shell
+terraform import fastly_acl_entries.example <acl_id>/entries
+```
+
+When imported, `manage_entries` is automatically set to `true`.

--- a/docs/resources/acl_entries.md
+++ b/docs/resources/acl_entries.md
@@ -59,7 +59,7 @@ resource "fastly_acl_entries" "example" {
 
 ### Optional
 
-- `manage_entries` (Boolean) Manage the ACL entries in Terraform (default: `false`). If `true`, Terraform will ensure that the ACL's entries match the entries in the Terraform configuration.
+- `manage_entries` (Boolean) Manage the ACL entries in Terraform (default: `false`). If `true`, Terraform will ensure that the ACL's entries match the entries in the Terraform configuration. When importing this resource, `manage_entries` is always set to `true`, so any ACL entries not present in the Terraform configuration will be deleted on the next apply.
 
 ### Read-Only
 
@@ -73,4 +73,6 @@ Fastly ACL entries can be imported using the format `<acl_id>/entries`, e.g.
 terraform import fastly_acl_entries.example <acl_id>/entries
 ```
 
-When imported, `manage_entries` is automatically set to `true`.
+Import reads the ACL's current entries from the Fastly API into state as-is; it does not modify the ACL or delete anything by itself.
+
+However, `manage_entries` is always set to `true` on import, regardless of the value in your configuration. Because of this, your `entries` map must match what was imported before you run `terraform apply` — any entry present in state (from the import) but missing from your configuration will be deleted on the next apply. Run `terraform show` after importing to see the entries that were read in, and copy them into your configuration before applying.

--- a/docs/resources/service_cdn_acl_entries.md
+++ b/docs/resources/service_cdn_acl_entries.md
@@ -76,7 +76,16 @@ drift in ACL entries:
   managed by external systems (e.g., via API, scripts, or other automation).
 
 When importing an existing ACL entries resource, `manage_entries` is automatically
-set to `true` to enable drift detection.
+set to `true`, regardless of the value in your configuration, to enable drift
+detection.
+
+Import reads the ACL's current entries from the Fastly API into state as-is; it
+does not modify the ACL or delete anything by itself. But because `manage_entries`
+is forced to `true`, your `entry` blocks must match what was imported before you
+run `terraform apply` — any entry present in state (from the import) but missing
+from your configuration will be deleted on the next apply. Run `terraform show`
+after importing to see the entries that were read in, and copy them into your
+configuration before applying.
 
 ## Schema
 
@@ -88,7 +97,7 @@ set to `true` to enable drift detection.
 ### Optional
 
 - `entry` (Block Set) ACL Entries. (see [below for nested schema](#nestedblock--entry))
-- `manage_entries` (Boolean) Whether to reapply changes if the state of the entries drifts, i.e. if entries are managed externally.
+- `manage_entries` (Boolean) Whether to reapply changes if the state of the entries drifts, i.e. if entries are managed externally. When importing this resource, `manage_entries` is always set to `true`, so any ACL entries not present in the Terraform configuration will be deleted on the next apply.
 
 ### Read-Only
 
@@ -125,4 +134,4 @@ Example:
 terraform import fastly_service_cdn_acl_entries.example SU1Z0isxPaozGVKXdv0eY/7Lsb7Y8w6St2eqwFgqzc
 ```
 
-When imported, `manage_entries` is automatically set to `true`.
+Import reads the current entries from the API into state and sets `manage_entries = true`; it does not delete anything by itself. See [Behavior and Drift Management](#behavior-and-drift-management) above — make sure your `entry` blocks match the imported entries before running `terraform apply`, since `manage_entries = true` will delete any entry missing from your configuration.

--- a/examples/acl-entries/README.md
+++ b/examples/acl-entries/README.md
@@ -1,0 +1,32 @@
+# ACL Entries Example
+
+This example demonstrates managing a Fastly ACL and its entries using the `fastly_acl` and `fastly_acl_entries` resources.
+
+## Usage
+
+1. Set your Fastly API token:
+   ```bash
+   export FASTLY_API_TOKEN=your_token_here
+   ```
+
+2. Initialize Terraform:
+   ```bash
+   terraform init
+   ```
+
+3. Apply the configuration:
+   ```bash
+   terraform apply
+   ```
+
+## Features
+
+- Creates an ACL, independent of any service or service version
+- Manages CIDR-based allow/block entries in the ACL
+
+## Important Notes
+
+- `fastly_acl` is versionless: it is not tied to a service version
+- The `manage_entries` attribute controls whether Terraform should detect and reconcile drift in ACL entries
+- Set `manage_entries = false` (the default) if entries are managed externally (e.g., via API or other tools)
+- Entries are keyed by CIDR prefix; each value must be `ALLOW` or `BLOCK`

--- a/examples/acl-entries/main.tf
+++ b/examples/acl-entries/main.tf
@@ -1,0 +1,27 @@
+terraform {
+  required_providers {
+    fastly = {
+      source = "fastly/fastly"
+    }
+  }
+}
+
+provider "fastly" {
+  # API token set via FASTLY_API_TOKEN environment variable
+}
+
+resource "fastly_acl" "example" {
+  name = "example-acl"
+}
+
+# Manage ACL entries with explicit resource
+resource "fastly_acl_entries" "example" {
+  acl_id         = fastly_acl.example.id
+  manage_entries = true
+
+  entries = {
+    "192.0.2.0/24"    = "ALLOW"
+    "198.51.100.0/24" = "BLOCK"
+    "203.0.113.10/32" = "BLOCK"
+  }
+}

--- a/internal/acceptance_tests/acl_entries_test.go
+++ b/internal/acceptance_tests/acl_entries_test.go
@@ -39,10 +39,9 @@ func TestAccFastlyACLEntries_create(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:            "fastly_acl_entries.acl_entries",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"manage_entries"},
+				ResourceName:      "fastly_acl_entries.acl_entries",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})

--- a/internal/acceptance_tests/acl_entries_test.go
+++ b/internal/acceptance_tests/acl_entries_test.go
@@ -15,18 +15,16 @@ import (
 
 func TestAccFastlyACLEntries_create(t *testing.T) {
 	t.Parallel()
-	PreCheckAcc(t)
 
 	aclName := fmt.Sprintf("tf_test_acl_%s", acctest.RandString(10))
-	aclID := CreateTestACL(t, aclName)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { PreCheck(t) },
 		ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
-		CheckDestroy:             CheckACLEntriesDestroy(aclID),
+		CheckDestroy:             CheckACLDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: ConfigACLEntries(aclID, map[string]string{
+				Config: ConfigACLEntries(aclName, map[string]string{
 					"192.0.2.0/24":    "ALLOW",
 					"198.51.100.0/24": "BLOCK",
 				}),
@@ -52,18 +50,16 @@ func TestAccFastlyACLEntries_create(t *testing.T) {
 
 func TestAccFastlyACLEntries_update(t *testing.T) {
 	t.Parallel()
-	PreCheckAcc(t)
 
 	aclName := fmt.Sprintf("tf_test_acl_%s", acctest.RandString(10))
-	aclID := CreateTestACL(t, aclName)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { PreCheck(t) },
 		ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
-		CheckDestroy:             CheckACLEntriesDestroy(aclID),
+		CheckDestroy:             CheckACLDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: ConfigACLEntries(aclID, map[string]string{
+				Config: ConfigACLEntries(aclName, map[string]string{
 					"192.0.2.0/24":    "ALLOW",
 					"198.51.100.0/24": "BLOCK",
 				}),
@@ -75,7 +71,7 @@ func TestAccFastlyACLEntries_update(t *testing.T) {
 				),
 			},
 			{
-				Config: ConfigACLEntries(aclID, map[string]string{
+				Config: ConfigACLEntries(aclName, map[string]string{
 					"203.0.113.0/24":  "BLOCK",
 					"198.51.100.0/24": "ALLOW",
 				}),
@@ -93,18 +89,16 @@ func TestAccFastlyACLEntries_update(t *testing.T) {
 
 func TestAccFastlyACLEntries_delete(t *testing.T) {
 	t.Parallel()
-	PreCheckAcc(t)
 
 	aclName := fmt.Sprintf("tf_test_acl_%s", acctest.RandString(10))
-	aclID := CreateTestACL(t, aclName)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { PreCheck(t) },
 		ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
-		CheckDestroy:             CheckACLEntriesDestroy(aclID),
+		CheckDestroy:             CheckACLDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: ConfigACLEntries(aclID, map[string]string{
+				Config: ConfigACLEntries(aclName, map[string]string{
 					"192.0.2.0/24": "ALLOW",
 				}),
 				Check: resource.ComposeTestCheckFunc(
@@ -114,7 +108,7 @@ func TestAccFastlyACLEntries_delete(t *testing.T) {
 				),
 			},
 			{
-				Config: ConfigACLEntries(aclID, map[string]string{}),
+				Config: ConfigACLEntries(aclName, map[string]string{}),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("fastly_acl_entries.acl_entries", "entries.%", "0"),
 					CheckStandaloneACLEntriesRemoteState("fastly_acl_entries.acl_entries", map[string]string{}),
@@ -129,18 +123,16 @@ func TestAccFastlyACLEntries_delete(t *testing.T) {
 // produces no plan diff -- the provider must not apply or show the change.
 func TestAccFastlyACLEntries_manageEntriesFalseSuppressDrift(t *testing.T) {
 	t.Parallel()
-	PreCheckAcc(t)
 
 	aclName := fmt.Sprintf("tf_test_acl_%s", acctest.RandString(10))
-	aclID := CreateTestACL(t, aclName)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { PreCheck(t) },
 		ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
-		CheckDestroy:             CheckACLEntriesDestroy(aclID),
+		CheckDestroy:             CheckACLDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: ConfigACLEntriesUnmanaged(aclID, map[string]string{
+				Config: ConfigACLEntriesUnmanaged(aclName, map[string]string{
 					"192.0.2.0/24": "ALLOW",
 				}),
 				Check: resource.ComposeTestCheckFunc(
@@ -148,7 +140,7 @@ func TestAccFastlyACLEntries_manageEntriesFalseSuppressDrift(t *testing.T) {
 				),
 			},
 			{
-				Config: ConfigACLEntriesUnmanaged(aclID, map[string]string{
+				Config: ConfigACLEntriesUnmanaged(aclName, map[string]string{
 					"203.0.113.0/24": "BLOCK",
 				}),
 				PlanOnly:           true,
@@ -166,7 +158,7 @@ func TestAccFastlyACLEntries_invalidPrefix(t *testing.T) {
 		ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
 		Steps: []resource.TestStep{
 			{
-				Config: ConfigACLEntries("fake-acl-id", map[string]string{
+				Config: ConfigACLEntries("tf_test_acl_invalid_config", map[string]string{
 					"not_a_cidr": "ALLOW",
 				}),
 				ExpectError: regexp.MustCompile("not a valid CIDR prefix"),
@@ -183,38 +175,13 @@ func TestAccFastlyACLEntries_invalidAction(t *testing.T) {
 		ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
 		Steps: []resource.TestStep{
 			{
-				Config: ConfigACLEntries("fake-acl-id", map[string]string{
+				Config: ConfigACLEntries("tf_test_acl_invalid_config", map[string]string{
 					"192.0.2.0/24": "PERMIT",
 				}),
 				ExpectError: regexp.MustCompile("must be either ALLOW or BLOCK"),
 			},
 		},
 	})
-}
-
-// CheckACLEntriesDestroy returns a TestCheckFunc verifying that Terraform destroy
-// cleared every entry from the given ACL. The ACL itself is a fixture created
-// out-of-band via CreateTestACL, so its own lifecycle isn't asserted here.
-func CheckACLEntriesDestroy(aclID string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		client, err := NewFastlyClient()
-		if err != nil {
-			return fmt.Errorf("error creating Fastly client: %w", err)
-		}
-
-		resp, err := computeacls.ListEntries(context.Background(), client, &computeacls.ListEntriesInput{
-			ComputeACLID: &aclID,
-		})
-		if err != nil {
-			return fmt.Errorf("error listing ACL entries: %w", err)
-		}
-
-		if len(resp.Entries) != 0 {
-			return fmt.Errorf("expected ACL %s to have no entries after destroy, found %d", aclID, len(resp.Entries))
-		}
-
-		return nil
-	}
 }
 
 func CheckStandaloneACLEntriesRemoteState(resourceName string, want map[string]string) resource.TestCheckFunc {
@@ -248,32 +215,4 @@ func CheckStandaloneACLEntriesRemoteState(resourceName string, want map[string]s
 
 		return nil
 	}
-}
-
-func ConfigACLEntries(aclID string, entries map[string]string) string {
-	return fmt.Sprintf(`
-resource "fastly_acl_entries" "acl_entries" {
-  acl_id = %q
-  entries        = %s
-  manage_entries = true
-}
-`, aclID, entriesHCL(entries))
-}
-
-func ConfigACLEntriesUnmanaged(aclID string, entries map[string]string) string {
-	return fmt.Sprintf(`
-resource "fastly_acl_entries" "acl_entries" {
-  acl_id = %q
-  entries        = %s
-}
-`, aclID, entriesHCL(entries))
-}
-
-func entriesHCL(entries map[string]string) string {
-	hcl := "{\n"
-	for prefix, action := range entries {
-		hcl += fmt.Sprintf("    %q = %q\n", prefix, action)
-	}
-	hcl += "  }"
-	return hcl
 }

--- a/internal/acceptance_tests/acl_entries_test.go
+++ b/internal/acceptance_tests/acl_entries_test.go
@@ -1,0 +1,279 @@
+package acceptancetests
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"regexp"
+	"testing"
+
+	"github.com/fastly/go-fastly/v16/fastly/computeacls"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+func TestAccFastlyACLEntries_create(t *testing.T) {
+	t.Parallel()
+	PreCheckAcc(t)
+
+	aclName := fmt.Sprintf("tf_test_acl_%s", acctest.RandString(10))
+	aclID := CreateTestACL(t, aclName)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
+		CheckDestroy:             CheckACLEntriesDestroy(aclID),
+		Steps: []resource.TestStep{
+			{
+				Config: ConfigACLEntries(aclID, map[string]string{
+					"192.0.2.0/24":    "ALLOW",
+					"198.51.100.0/24": "BLOCK",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("fastly_acl_entries.acl_entries", "entries.%", "2"),
+					resource.TestCheckResourceAttr("fastly_acl_entries.acl_entries", "entries.192.0.2.0/24", "ALLOW"),
+					resource.TestCheckResourceAttr("fastly_acl_entries.acl_entries", "entries.198.51.100.0/24", "BLOCK"),
+					CheckStandaloneACLEntriesRemoteState("fastly_acl_entries.acl_entries", map[string]string{
+						"192.0.2.0/24":    "ALLOW",
+						"198.51.100.0/24": "BLOCK",
+					}),
+				),
+			},
+			{
+				ResourceName:            "fastly_acl_entries.acl_entries",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"manage_entries"},
+			},
+		},
+	})
+}
+
+func TestAccFastlyACLEntries_update(t *testing.T) {
+	t.Parallel()
+	PreCheckAcc(t)
+
+	aclName := fmt.Sprintf("tf_test_acl_%s", acctest.RandString(10))
+	aclID := CreateTestACL(t, aclName)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
+		CheckDestroy:             CheckACLEntriesDestroy(aclID),
+		Steps: []resource.TestStep{
+			{
+				Config: ConfigACLEntries(aclID, map[string]string{
+					"192.0.2.0/24":    "ALLOW",
+					"198.51.100.0/24": "BLOCK",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					CheckStandaloneACLEntriesRemoteState("fastly_acl_entries.acl_entries", map[string]string{
+						"192.0.2.0/24":    "ALLOW",
+						"198.51.100.0/24": "BLOCK",
+					}),
+				),
+			},
+			{
+				Config: ConfigACLEntries(aclID, map[string]string{
+					"203.0.113.0/24":  "BLOCK",
+					"198.51.100.0/24": "ALLOW",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("fastly_acl_entries.acl_entries", "entries.%", "2"),
+					CheckStandaloneACLEntriesRemoteState("fastly_acl_entries.acl_entries", map[string]string{
+						"203.0.113.0/24":  "BLOCK",
+						"198.51.100.0/24": "ALLOW",
+					}),
+				),
+			},
+		},
+	})
+}
+
+func TestAccFastlyACLEntries_delete(t *testing.T) {
+	t.Parallel()
+	PreCheckAcc(t)
+
+	aclName := fmt.Sprintf("tf_test_acl_%s", acctest.RandString(10))
+	aclID := CreateTestACL(t, aclName)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
+		CheckDestroy:             CheckACLEntriesDestroy(aclID),
+		Steps: []resource.TestStep{
+			{
+				Config: ConfigACLEntries(aclID, map[string]string{
+					"192.0.2.0/24": "ALLOW",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					CheckStandaloneACLEntriesRemoteState("fastly_acl_entries.acl_entries", map[string]string{
+						"192.0.2.0/24": "ALLOW",
+					}),
+				),
+			},
+			{
+				Config: ConfigACLEntries(aclID, map[string]string{}),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("fastly_acl_entries.acl_entries", "entries.%", "0"),
+					CheckStandaloneACLEntriesRemoteState("fastly_acl_entries.acl_entries", map[string]string{}),
+				),
+			},
+		},
+	})
+}
+
+// TestAccFastlyACLEntries_manageEntriesFalseSuppressDrift verifies
+// that when manage_entries = false, changing the entries map in config
+// produces no plan diff -- the provider must not apply or show the change.
+func TestAccFastlyACLEntries_manageEntriesFalseSuppressDrift(t *testing.T) {
+	t.Parallel()
+	PreCheckAcc(t)
+
+	aclName := fmt.Sprintf("tf_test_acl_%s", acctest.RandString(10))
+	aclID := CreateTestACL(t, aclName)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
+		CheckDestroy:             CheckACLEntriesDestroy(aclID),
+		Steps: []resource.TestStep{
+			{
+				Config: ConfigACLEntriesUnmanaged(aclID, map[string]string{
+					"192.0.2.0/24": "ALLOW",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("fastly_acl_entries.acl_entries", "manage_entries", "false"),
+				),
+			},
+			{
+				Config: ConfigACLEntriesUnmanaged(aclID, map[string]string{
+					"203.0.113.0/24": "BLOCK",
+				}),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
+func TestAccFastlyACLEntries_invalidPrefix(t *testing.T) {
+	t.Parallel()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: ConfigACLEntries("fake-acl-id", map[string]string{
+					"not_a_cidr": "ALLOW",
+				}),
+				ExpectError: regexp.MustCompile("not a valid CIDR prefix"),
+			},
+		},
+	})
+}
+
+func TestAccFastlyACLEntries_invalidAction(t *testing.T) {
+	t.Parallel()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: ConfigACLEntries("fake-acl-id", map[string]string{
+					"192.0.2.0/24": "PERMIT",
+				}),
+				ExpectError: regexp.MustCompile("must be either ALLOW or BLOCK"),
+			},
+		},
+	})
+}
+
+// CheckACLEntriesDestroy returns a TestCheckFunc verifying that Terraform destroy
+// cleared every entry from the given ACL. The ACL itself is a fixture created
+// out-of-band via CreateTestACL, so its own lifecycle isn't asserted here.
+func CheckACLEntriesDestroy(aclID string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client, err := NewFastlyClient()
+		if err != nil {
+			return fmt.Errorf("error creating Fastly client: %w", err)
+		}
+
+		resp, err := computeacls.ListEntries(context.Background(), client, &computeacls.ListEntriesInput{
+			ComputeACLID: &aclID,
+		})
+		if err != nil {
+			return fmt.Errorf("error listing ACL entries: %w", err)
+		}
+
+		if len(resp.Entries) != 0 {
+			return fmt.Errorf("expected ACL %s to have no entries after destroy, found %d", aclID, len(resp.Entries))
+		}
+
+		return nil
+	}
+}
+
+func CheckStandaloneACLEntriesRemoteState(resourceName string, want map[string]string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceName)
+		}
+
+		id := rs.Primary.Attributes["acl_id"]
+		client, err := NewFastlyClient()
+		if err != nil {
+			return fmt.Errorf("error creating Fastly client: %w", err)
+		}
+
+		resp, err := computeacls.ListEntries(context.Background(), client, &computeacls.ListEntriesInput{
+			ComputeACLID: &id,
+		})
+		if err != nil {
+			return fmt.Errorf("error listing ACL entries: %w", err)
+		}
+
+		got := make(map[string]string)
+		for _, entry := range resp.Entries {
+			got[entry.Prefix] = entry.Action
+		}
+
+		if !reflect.DeepEqual(got, want) {
+			return fmt.Errorf("error matching remote state:\nexpected: %#v\ngot: %#v", want, got)
+		}
+
+		return nil
+	}
+}
+
+func ConfigACLEntries(aclID string, entries map[string]string) string {
+	return fmt.Sprintf(`
+resource "fastly_acl_entries" "acl_entries" {
+  acl_id = %q
+  entries        = %s
+  manage_entries = true
+}
+`, aclID, entriesHCL(entries))
+}
+
+func ConfigACLEntriesUnmanaged(aclID string, entries map[string]string) string {
+	return fmt.Sprintf(`
+resource "fastly_acl_entries" "acl_entries" {
+  acl_id = %q
+  entries        = %s
+}
+`, aclID, entriesHCL(entries))
+}
+
+func entriesHCL(entries map[string]string) string {
+	hcl := "{\n"
+	for prefix, action := range entries {
+		hcl += fmt.Sprintf("    %q = %q\n", prefix, action)
+	}
+	hcl += "  }"
+	return hcl
+}

--- a/internal/acceptance_tests/test_helpers.go
+++ b/internal/acceptance_tests/test_helpers.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/fastly/go-fastly/v16/fastly"
-	"github.com/fastly/go-fastly/v16/fastly/computeacls"
 	"github.com/fastly/terraform-provider-fastly/internal/errors"
 	"github.com/fastly/terraform-provider-fastly/internal/provider"
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
@@ -93,34 +92,6 @@ const (
 	serviceDestroyCheckAttempts = 5
 	serviceDestroyCheckInterval = 2 * time.Second
 )
-
-// CreateTestACL creates an ACL fixture directly against the Fastly API for use as
-// a fastly_acl_entries target, and registers its cleanup via t.Cleanup. Returns the ACL's ID.
-//
-// This provider doesn't yet have a dedicated fastly_acl resource, so fastly_acl_entries
-// acceptance tests need a real ACL created out-of-band from Terraform.
-//
-// TODO: once a fastly_acl resource exists, replace this raw go-fastly client call with a
-// Terraform-managed fixture (e.g. via config_builder.go) so the fixture participates in the
-// same state/plan lifecycle as the rest of the test config.
-func CreateTestACL(t *testing.T, name string) string {
-	client, err := NewFastlyClient()
-	if err != nil {
-		t.Fatalf("error creating Fastly client: %s", err)
-	}
-
-	acl, err := computeacls.Create(context.Background(), client, &computeacls.CreateInput{Name: &name})
-	if err != nil {
-		t.Fatalf("error creating ACL fixture: %s", err)
-	}
-	t.Cleanup(func() {
-		if err := computeacls.Delete(context.Background(), client, &computeacls.DeleteInput{ComputeACLID: &acl.ComputeACLID}); err != nil {
-			t.Logf("error deleting ACL fixture %q: %s", acl.ComputeACLID, err)
-		}
-	})
-
-	return acl.ComputeACLID
-}
 
 // CheckServiceDestroy returns a TestCheckFunc that verifies a service resource was destroyed
 func CheckServiceDestroy(resourceType string) resource.TestCheckFunc {
@@ -900,7 +871,7 @@ func ConfigDomainForImport(serviceName, domainName, additionalDomainName string)
 	)
 }
 
-// Configuration helpers for ACL entries resources
+// Configuration helpers for CDN service ACL entries resources
 
 func aclEntriesBase(serviceName, domainName, aclName string) (ServiceType, map[string]string) {
 	return ServiceCDN, map[string]string{
@@ -1011,4 +982,47 @@ func ConfigACLEntriesManyEntries(serviceName, domainName, aclName string, count 
 		"internal/acceptance_tests/blocks/acl_explicit.tf",
 		"internal/acceptance_tests/blocks/acl_entries_many.tf",
 	)
+}
+
+// Configuration helpers for the standalone Compute ACL entries resource (fastly_acl_entries)
+
+// ConfigACLEntries returns a config declaring a fastly_acl resource alongside a
+// fastly_acl_entries resource (with manage_entries = true) that targets it.
+func ConfigACLEntries(aclName string, entries map[string]string) string {
+	return fmt.Sprintf(`
+resource "fastly_acl" "acl" {
+  name = %q
+}
+
+resource "fastly_acl_entries" "acl_entries" {
+  acl_id         = fastly_acl.acl.id
+  entries        = %s
+  manage_entries = true
+}
+`, aclName, entriesHCL(entries))
+}
+
+// ConfigACLEntriesUnmanaged mirrors ConfigACLEntries but omits manage_entries,
+// leaving it at its default (false).
+func ConfigACLEntriesUnmanaged(aclName string, entries map[string]string) string {
+	return fmt.Sprintf(`
+resource "fastly_acl" "acl" {
+  name = %q
+}
+
+resource "fastly_acl_entries" "acl_entries" {
+  acl_id  = fastly_acl.acl.id
+  entries = %s
+}
+`, aclName, entriesHCL(entries))
+}
+
+func entriesHCL(entries map[string]string) string {
+	var hcl strings.Builder
+	hcl.WriteString("{\n")
+	for prefix, action := range entries {
+		fmt.Fprintf(&hcl, "    %q = %q\n", prefix, action)
+	}
+	hcl.WriteString("  }")
+	return hcl.String()
 }

--- a/internal/acceptance_tests/test_helpers.go
+++ b/internal/acceptance_tests/test_helpers.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/fastly/go-fastly/v16/fastly"
+	"github.com/fastly/go-fastly/v16/fastly/computeacls"
 	"github.com/fastly/terraform-provider-fastly/internal/errors"
 	"github.com/fastly/terraform-provider-fastly/internal/provider"
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
@@ -92,6 +93,34 @@ const (
 	serviceDestroyCheckAttempts = 5
 	serviceDestroyCheckInterval = 2 * time.Second
 )
+
+// CreateTestACL creates an ACL fixture directly against the Fastly API for use as
+// a fastly_acl_entries target, and registers its cleanup via t.Cleanup. Returns the ACL's ID.
+//
+// This provider doesn't yet have a dedicated fastly_acl resource, so fastly_acl_entries
+// acceptance tests need a real ACL created out-of-band from Terraform.
+//
+// TODO: once a fastly_acl resource exists, replace this raw go-fastly client call with a
+// Terraform-managed fixture (e.g. via config_builder.go) so the fixture participates in the
+// same state/plan lifecycle as the rest of the test config.
+func CreateTestACL(t *testing.T, name string) string {
+	client, err := NewFastlyClient()
+	if err != nil {
+		t.Fatalf("error creating Fastly client: %s", err)
+	}
+
+	acl, err := computeacls.Create(context.Background(), client, &computeacls.CreateInput{Name: &name})
+	if err != nil {
+		t.Fatalf("error creating ACL fixture: %s", err)
+	}
+	t.Cleanup(func() {
+		if err := computeacls.Delete(context.Background(), client, &computeacls.DeleteInput{ComputeACLID: &acl.ComputeACLID}); err != nil {
+			t.Logf("error deleting ACL fixture %q: %s", acl.ComputeACLID, err)
+		}
+	})
+
+	return acl.ComputeACLID
+}
 
 // CheckServiceDestroy returns a TestCheckFunc that verifies a service resource was destroyed
 func CheckServiceDestroy(resourceType string) resource.TestCheckFunc {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -22,6 +22,7 @@ import (
 	"github.com/fastly/terraform-provider-fastly/internal/datasources/acls"
 	"github.com/fastly/terraform-provider-fastly/internal/datasources/serviceversion"
 	"github.com/fastly/terraform-provider-fastly/internal/resources/acl"
+	"github.com/fastly/terraform-provider-fastly/internal/resources/aclentries"
 	"github.com/fastly/terraform-provider-fastly/internal/resources/backend"
 	"github.com/fastly/terraform-provider-fastly/internal/resources/cdnacl"
 	"github.com/fastly/terraform-provider-fastly/internal/resources/cdnaclentries"
@@ -98,6 +99,7 @@ func (p *fastlyProvider) Configure(ctx context.Context, req provider.ConfigureRe
 func (p *fastlyProvider) Resources(_ context.Context) []func() resource.Resource {
 	return []func() resource.Resource{
 		acl.NewResource,
+		aclentries.NewResource,
 		backend.NewResource,
 		cdnacl.NewResource,
 		cdnaclentries.NewResource,

--- a/internal/resources/aclentries/aclentries_test.go
+++ b/internal/resources/aclentries/aclentries_test.go
@@ -1,0 +1,115 @@
+package aclentries
+
+import (
+	"context"
+	"testing"
+
+	"github.com/fastly/go-fastly/v16/fastly/computeacls"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExpandEntries(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("null map returns nil", func(t *testing.T) {
+		var diags diag.Diagnostics
+		result := expandEntries(ctx, types.MapNull(types.StringType), &diags)
+		assert.Nil(t, result)
+		assert.False(t, diags.HasError())
+	})
+
+	t.Run("populated map", func(t *testing.T) {
+		m, d := types.MapValue(types.StringType, map[string]attr.Value{
+			"192.0.2.0/24": types.StringValue("ALLOW"),
+		})
+		assert.False(t, d.HasError())
+
+		var diags diag.Diagnostics
+		result := expandEntries(ctx, m, &diags)
+		assert.False(t, diags.HasError())
+		assert.Equal(t, map[string]string{"192.0.2.0/24": "ALLOW"}, result)
+	})
+}
+
+func TestFlattenEntries(t *testing.T) {
+	var diags diag.Diagnostics
+	remote := []computeacls.ComputeACLEntry{
+		{Prefix: "192.0.2.0/24", Action: "ALLOW"},
+		{Prefix: "198.51.100.0/24", Action: "BLOCK"},
+	}
+
+	result := flattenEntries(remote, &diags)
+	assert.False(t, diags.HasError())
+
+	var got map[string]string
+	assert.False(t, result.ElementsAs(context.Background(), &got, false).HasError())
+	assert.Equal(t, map[string]string{
+		"192.0.2.0/24":    "ALLOW",
+		"198.51.100.0/24": "BLOCK",
+	}, got)
+}
+
+func TestBuildBatchEntries(t *testing.T) {
+	tests := []struct {
+		name     string
+		old      map[string]string
+		new      map[string]string
+		manage   bool
+		expected []*computeacls.BatchComputeACLEntry
+	}{
+		{
+			name: "create only",
+			old:  nil,
+			new: map[string]string{
+				"192.0.2.0/24": "ALLOW",
+			},
+			manage: true,
+			expected: []*computeacls.BatchComputeACLEntry{
+				{Prefix: new("192.0.2.0/24"), Action: new("ALLOW"), Operation: new(createOperation)},
+			},
+		},
+		{
+			name: "update when prefix already exists",
+			old: map[string]string{
+				"192.0.2.0/24": "ALLOW",
+			},
+			new: map[string]string{
+				"192.0.2.0/24": "BLOCK",
+			},
+			manage: true,
+			expected: []*computeacls.BatchComputeACLEntry{
+				{Prefix: new("192.0.2.0/24"), Action: new("BLOCK"), Operation: new(updateOperation)},
+			},
+		},
+		{
+			name: "delete when managed and prefix removed",
+			old: map[string]string{
+				"192.0.2.0/24": "ALLOW",
+			},
+			new:    map[string]string{},
+			manage: true,
+			expected: []*computeacls.BatchComputeACLEntry{
+				{Prefix: new("192.0.2.0/24"), Operation: new(deleteOperation)},
+			},
+		},
+		{
+			name: "no delete when unmanaged",
+			old: map[string]string{
+				"192.0.2.0/24": "ALLOW",
+			},
+			new:      map[string]string{},
+			manage:   false,
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := buildBatchEntries(tt.old, tt.new, tt.manage)
+			assert.ElementsMatch(t, tt.expected, result)
+		})
+	}
+}

--- a/internal/resources/aclentries/expand.go
+++ b/internal/resources/aclentries/expand.go
@@ -1,0 +1,58 @@
+package aclentries
+
+import (
+	"context"
+
+	"github.com/fastly/go-fastly/v16/fastly/computeacls"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+const (
+	createOperation = "create"
+	updateOperation = "update"
+	deleteOperation = "delete"
+)
+
+func expandEntries(ctx context.Context, entries types.Map, diags *diag.Diagnostics) map[string]string {
+	if entries.IsNull() || entries.IsUnknown() {
+		return nil
+	}
+
+	var result map[string]string
+	diags.Append(entries.ElementsAs(ctx, &result, false)...)
+	return result
+}
+
+// buildBatchEntries diffs oldEntries against newEntries and returns the batch
+// operations needed to reconcile them. Deletions are only included when
+// manage is true, since unmanaged entries left out of newEntries are assumed
+// to be intentionally omitted from Terraform's view of the ACL, not removed.
+func buildBatchEntries(oldEntries, newEntries map[string]string, manage bool) []*computeacls.BatchComputeACLEntry {
+	var batch []*computeacls.BatchComputeACLEntry
+
+	if manage {
+		for prefix := range oldEntries {
+			if _, ok := newEntries[prefix]; !ok {
+				batch = append(batch, &computeacls.BatchComputeACLEntry{
+					Prefix:    new(prefix),
+					Operation: new(deleteOperation),
+				})
+			}
+		}
+	}
+
+	for prefix, action := range newEntries {
+		op := createOperation
+		if _, ok := oldEntries[prefix]; ok {
+			op = updateOperation
+		}
+		batch = append(batch, &computeacls.BatchComputeACLEntry{
+			Prefix:    new(prefix),
+			Action:    new(action),
+			Operation: new(op),
+		})
+	}
+
+	return batch
+}

--- a/internal/resources/aclentries/flatten.go
+++ b/internal/resources/aclentries/flatten.go
@@ -1,0 +1,19 @@
+package aclentries
+
+import (
+	"github.com/fastly/go-fastly/v16/fastly/computeacls"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func flattenEntries(remote []computeacls.ComputeACLEntry, diags *diag.Diagnostics) types.Map {
+	elements := make(map[string]attr.Value, len(remote))
+	for _, e := range remote {
+		elements[e.Prefix] = types.StringValue(e.Action)
+	}
+
+	m, d := types.MapValue(types.StringType, elements)
+	diags.Append(d...)
+	return m
+}

--- a/internal/resources/aclentries/resource.go
+++ b/internal/resources/aclentries/resource.go
@@ -1,0 +1,287 @@
+package aclentries
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	fastlyclient "github.com/fastly/terraform-provider-fastly/internal/client"
+	"github.com/fastly/terraform-provider-fastly/internal/errors"
+
+	"github.com/fastly/go-fastly/v16/fastly"
+	"github.com/fastly/go-fastly/v16/fastly/computeacls"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+var _ resource.Resource = &Resource{}
+var _ resource.ResourceWithImportState = &Resource{}
+var _ resource.ResourceWithModifyPlan = &Resource{}
+
+type Resource struct {
+	client *fastly.Client
+}
+
+func NewResource() resource.Resource {
+	return &Resource{}
+}
+
+func (r *Resource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_acl_entries"
+}
+
+func (r *Resource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Manages CIDR-based allow/block entries within a Fastly ACL.",
+		Attributes:  ResourceAttributes(),
+	}
+}
+
+func (r *Resource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	data, diags := fastlyclient.FromProviderData(req.ProviderData)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() || data == nil {
+		return
+	}
+
+	r.client = data.Client
+}
+
+func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan Model
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	aclID := plan.ACLID.ValueString()
+
+	tflog.Debug(ctx, "Creating Fastly ACL entries", map[string]any{
+		"acl_id": aclID,
+	})
+
+	newEntries := expandEntries(ctx, plan.Entries, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	batch := buildBatchEntries(nil, newEntries, plan.ManageEntries.ValueBool())
+	if err := r.updateEntries(ctx, aclID, batch); err != nil {
+		resp.Diagnostics.AddError("Error creating ACL entries", fmt.Sprintf("ACL %s: %s", aclID, err))
+		return
+	}
+
+	plan.ID = types.StringValue(fmt.Sprintf("%s/entries", aclID))
+
+	if len(newEntries) == 0 && !plan.ManageEntries.ValueBool() {
+		tflog.Debug(ctx, "Skipping ACL entries refresh after create: manage_entries is false and no entries were configured")
+		resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+		return
+	}
+
+	remote, err := r.listEntries(ctx, aclID)
+	if err != nil {
+		resp.Diagnostics.AddError("Error refreshing ACL entries", err.Error())
+		return
+	}
+
+	plan.Entries = flattenEntries(remote, &resp.Diagnostics)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+func (r *Resource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var state Model
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if !state.ManageEntries.ValueBool() {
+		tflog.Debug(ctx, "Skipping ACL entries refresh: manage_entries is false")
+		return
+	}
+
+	aclID := state.ACLID.ValueString()
+
+	tflog.Debug(ctx, "Reading Fastly ACL entries", map[string]any{
+		"acl_id": aclID,
+	})
+
+	remote, err := r.listEntries(ctx, aclID)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			tflog.Warn(ctx, "ACL not found, removing entries from state", map[string]any{
+				"acl_id": aclID,
+			})
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.AddError("Error reading ACL entries", err.Error())
+		return
+	}
+
+	state.Entries = flattenEntries(remote, &resp.Diagnostics)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var plan Model
+	var state Model
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	aclID := plan.ACLID.ValueString()
+
+	tflog.Debug(ctx, "Updating Fastly ACL entries", map[string]any{
+		"acl_id": aclID,
+	})
+
+	oldEntries := expandEntries(ctx, state.Entries, &resp.Diagnostics)
+	newEntries := expandEntries(ctx, plan.Entries, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	batch := buildBatchEntries(oldEntries, newEntries, plan.ManageEntries.ValueBool())
+	if err := r.updateEntries(ctx, aclID, batch); err != nil {
+		resp.Diagnostics.AddError("Error updating ACL entries", fmt.Sprintf("ACL %s: %s", aclID, err))
+		return
+	}
+
+	remote, err := r.listEntries(ctx, aclID)
+	if err != nil {
+		resp.Diagnostics.AddError("Error refreshing ACL entries", err.Error())
+		return
+	}
+
+	plan.Entries = flattenEntries(remote, &resp.Diagnostics)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+func (r *Resource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var state Model
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	aclID := state.ACLID.ValueString()
+
+	tflog.Debug(ctx, "Deleting Fastly ACL entries", map[string]any{
+		"acl_id": aclID,
+	})
+
+	entries := expandEntries(ctx, state.Entries, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	batch := buildBatchEntries(entries, nil, true)
+	if err := r.updateEntries(ctx, aclID, batch); err != nil {
+		if errors.IsNotFound(err) {
+			return
+		}
+		resp.Diagnostics.AddError("Error deleting ACL entries", fmt.Sprintf("ACL %s: %s", aclID, err))
+	}
+}
+
+func (r *Resource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	aclID, suffix, ok := strings.Cut(req.ID, "/")
+	if !ok || suffix != "entries" {
+		resp.Diagnostics.AddError(
+			"Invalid Import ID",
+			fmt.Sprintf("Invalid id: %s. The ID should be in the format <acl_id>/entries", req.ID),
+		)
+		return
+	}
+
+	tflog.Debug(ctx, "Importing ACL entries", map[string]any{
+		"acl_id": aclID,
+	})
+
+	remote, err := r.listEntries(ctx, aclID)
+	if err != nil {
+		resp.Diagnostics.AddError("Error reading ACL entries", err.Error())
+		return
+	}
+	entries := flattenEntries(remote, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), fmt.Sprintf("%s/entries", aclID))...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("acl_id"), aclID)...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("entries"), entries)...)
+}
+
+// ModifyPlan preserves the prior state's entries when manage_entries is
+// false, so unmanaged drift in the config doesn't surface as a plan diff.
+func (r *Resource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	if req.Plan.Raw.IsNull() || req.State.Raw.IsNull() {
+		return
+	}
+
+	var plan Model
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if plan.ManageEntries.ValueBool() {
+		return
+	}
+
+	var state Model
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if !plan.ACLID.Equal(state.ACLID) {
+		return
+	}
+
+	plan.Entries = state.Entries
+	resp.Diagnostics.Append(resp.Plan.Set(ctx, &plan)...)
+}
+
+func (r *Resource) listEntries(ctx context.Context, aclID string) ([]computeacls.ComputeACLEntry, error) {
+	var entries []computeacls.ComputeACLEntry
+	var cursor *string
+
+	for {
+		page, err := computeacls.ListEntries(ctx, r.client, &computeacls.ListEntriesInput{
+			ComputeACLID: &aclID,
+			Cursor:       cursor,
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		entries = append(entries, page.Entries...)
+
+		if page.Meta.NextCursor == "" {
+			break
+		}
+		cursor = new(page.Meta.NextCursor)
+	}
+
+	return entries, nil
+}
+
+func (r *Resource) updateEntries(ctx context.Context, aclID string, batch []*computeacls.BatchComputeACLEntry) error {
+	if len(batch) == 0 {
+		return nil
+	}
+
+	return computeacls.Update(ctx, r.client, &computeacls.UpdateInput{
+		ComputeACLID: &aclID,
+		Entries:      batch,
+	})
+}

--- a/internal/resources/aclentries/resource.go
+++ b/internal/resources/aclentries/resource.go
@@ -205,19 +205,9 @@ func (r *Resource) ImportState(ctx context.Context, req resource.ImportStateRequ
 		"acl_id": aclID,
 	})
 
-	remote, err := r.listEntries(ctx, aclID)
-	if err != nil {
-		resp.Diagnostics.AddError("Error reading ACL entries", err.Error())
-		return
-	}
-	entries := flattenEntries(remote, &resp.Diagnostics)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), fmt.Sprintf("%s/entries", aclID))...)
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("acl_id"), aclID)...)
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("entries"), entries)...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("manage_entries"), true)...)
 }
 
 // ModifyPlan preserves the prior state's entries when manage_entries is

--- a/internal/resources/aclentries/schema.go
+++ b/internal/resources/aclentries/schema.go
@@ -1,0 +1,50 @@
+package aclentries
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+type Model struct {
+	ID            types.String `tfsdk:"id"`
+	ACLID         types.String `tfsdk:"acl_id"`
+	Entries       types.Map    `tfsdk:"entries"`
+	ManageEntries types.Bool   `tfsdk:"manage_entries"`
+}
+
+func ResourceAttributes() map[string]schema.Attribute {
+	return map[string]schema.Attribute{
+		"id": schema.StringAttribute{
+			Computed:    true,
+			Description: "Terraform resource identifier. Format: `acl_id/entries`.",
+			PlanModifiers: []planmodifier.String{
+				stringplanmodifier.UseStateForUnknown(),
+			},
+		},
+		"acl_id": schema.StringAttribute{
+			Required:    true,
+			Description: "The ID of the ACL that the entries belong to.",
+			PlanModifiers: []planmodifier.String{
+				stringplanmodifier.RequiresReplace(),
+			},
+		},
+		"entries": schema.MapAttribute{
+			Required:    true,
+			ElementType: types.StringType,
+			Description: "A map representing the entries in the ACL, where the keys are CIDR prefixes and the values are actions (`ALLOW` or `BLOCK`).",
+			Validators: []validator.Map{
+				ValidEntries(),
+			},
+		},
+		"manage_entries": schema.BoolAttribute{
+			Optional:    true,
+			Computed:    true,
+			Default:     booldefault.StaticBool(false),
+			Description: "Manage the ACL entries in Terraform (default: `false`). If `true`, Terraform will ensure that the ACL's entries match the entries in the Terraform configuration.",
+		},
+	}
+}

--- a/internal/resources/aclentries/schema.go
+++ b/internal/resources/aclentries/schema.go
@@ -44,7 +44,7 @@ func ResourceAttributes() map[string]schema.Attribute {
 			Optional:    true,
 			Computed:    true,
 			Default:     booldefault.StaticBool(false),
-			Description: "Manage the ACL entries in Terraform (default: `false`). If `true`, Terraform will ensure that the ACL's entries match the entries in the Terraform configuration.",
+			Description: "Manage the ACL entries in Terraform (default: `false`). If `true`, Terraform will ensure that the ACL's entries match the entries in the Terraform configuration. When importing this resource, `manage_entries` is always set to `true`, so any ACL entries not present in the Terraform configuration will be deleted on the next apply.",
 		},
 	}
 }

--- a/internal/resources/aclentries/validator.go
+++ b/internal/resources/aclentries/validator.go
@@ -1,0 +1,56 @@
+package aclentries
+
+import (
+	"context"
+	"fmt"
+	"net"
+
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// validEntriesValidator checks that every key in the entries map is a valid
+// CIDR prefix and every value is one of the actions the ACL API
+// accepts.
+type validEntriesValidator struct{}
+
+func ValidEntries() validator.Map {
+	return validEntriesValidator{}
+}
+
+func (v validEntriesValidator) Description(_ context.Context) string {
+	return "Keys must be valid CIDR prefixes and values must be either ALLOW or BLOCK."
+}
+
+func (v validEntriesValidator) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+
+func (v validEntriesValidator) ValidateMap(_ context.Context, req validator.MapRequest, resp *validator.MapResponse) {
+	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
+		return
+	}
+
+	for prefix, value := range req.ConfigValue.Elements() {
+		if _, _, err := net.ParseCIDR(prefix); err != nil {
+			resp.Diagnostics.AddAttributeError(
+				req.Path,
+				"Invalid ACL Entry Prefix",
+				fmt.Sprintf("%q is not a valid CIDR prefix: %s", prefix, err),
+			)
+		}
+
+		strVal, ok := value.(types.String)
+		if !ok || strVal.IsUnknown() || strVal.IsNull() {
+			continue
+		}
+
+		if action := strVal.ValueString(); action != "ALLOW" && action != "BLOCK" {
+			resp.Diagnostics.AddAttributeError(
+				req.Path,
+				"Invalid ACL Entry Action",
+				fmt.Sprintf("action %q for prefix %q must be either ALLOW or BLOCK", action, prefix),
+			)
+		}
+	}
+}

--- a/internal/resources/aclentries/validator_test.go
+++ b/internal/resources/aclentries/validator_test.go
@@ -1,0 +1,66 @@
+package aclentries
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidEntriesValidator(t *testing.T) {
+	tests := []struct {
+		name      string
+		entries   map[string]attr.Value
+		wantError bool
+	}{
+		{
+			name: "valid entries",
+			entries: map[string]attr.Value{
+				"192.0.2.0/24": types.StringValue("ALLOW"),
+			},
+		},
+		{
+			name: "invalid CIDR prefix",
+			entries: map[string]attr.Value{
+				"not_a_cidr": types.StringValue("ALLOW"),
+			},
+			wantError: true,
+		},
+		{
+			name: "invalid action",
+			entries: map[string]attr.Value{
+				"192.0.2.0/24": types.StringValue("PERMIT"),
+			},
+			wantError: true,
+		},
+		{
+			name: "unknown value is skipped for action check",
+			entries: map[string]attr.Value{
+				"192.0.2.0/24": types.StringUnknown(),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m, diags := types.MapValue(types.StringType, tt.entries)
+			if diags.HasError() {
+				t.Fatalf("unexpected error building map: %v", diags)
+			}
+
+			req := validator.MapRequest{
+				Path:        path.Root("entries"),
+				ConfigValue: m,
+			}
+			resp := &validator.MapResponse{}
+
+			ValidEntries().ValidateMap(context.Background(), req, resp)
+
+			assert.Equal(t, tt.wantError, resp.Diagnostics.HasError())
+		})
+	}
+}

--- a/internal/resources/cdnaclentries/resource.go
+++ b/internal/resources/cdnaclentries/resource.go
@@ -312,9 +312,19 @@ func (r *Resource) ImportState(ctx context.Context, req resource.ImportStateRequ
 	serviceID := split[0]
 	aclID := split[1]
 
+	remote, err := r.refreshEntries(ctx, serviceID, aclID)
+	if err != nil {
+		resp.Diagnostics.AddError("Error reading ACL entries", err.Error())
+		return
+	}
+	entries := flattenEntries(ctx, remote, types.SetNull(types.ObjectType{AttrTypes: entryAttrTypes}), &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("service_id"), serviceID)...)
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("acl_id"), aclID)...)
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("manage_entries"), true)...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("entry"), entries)...)
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), req.ID)...)
 }
 

--- a/internal/resources/cdnaclentries/resource.go
+++ b/internal/resources/cdnaclentries/resource.go
@@ -312,19 +312,9 @@ func (r *Resource) ImportState(ctx context.Context, req resource.ImportStateRequ
 	serviceID := split[0]
 	aclID := split[1]
 
-	remote, err := r.refreshEntries(ctx, serviceID, aclID)
-	if err != nil {
-		resp.Diagnostics.AddError("Error reading ACL entries", err.Error())
-		return
-	}
-	entries := flattenEntries(ctx, remote, types.SetNull(types.ObjectType{AttrTypes: entryAttrTypes}), &resp.Diagnostics)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("service_id"), serviceID)...)
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("acl_id"), aclID)...)
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("entry"), entries)...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("manage_entries"), true)...)
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), req.ID)...)
 }
 

--- a/internal/resources/cdnaclentries/schema.go
+++ b/internal/resources/cdnaclentries/schema.go
@@ -54,7 +54,7 @@ func ResourceAttributes() map[string]schema.Attribute {
 			Optional:    true,
 			Computed:    true,
 			Default:     booldefault.StaticBool(false),
-			Description: "Whether to reapply changes if the state of the entries drifts, i.e. if entries are managed externally.",
+			Description: "Whether to reapply changes if the state of the entries drifts, i.e. if entries are managed externally. When importing this resource, `manage_entries` is always set to `true`, so any ACL entries not present in the Terraform configuration will be deleted on the next apply.",
 		},
 	}
 }

--- a/scripts/test-lifecycle-compute/README.md
+++ b/scripts/test-lifecycle-compute/README.md
@@ -14,6 +14,7 @@ The test suite validates the complete lifecycle of Fastly Compute services manag
 - Version cloning action (`fastly_service_version_clone`)
 - Version activation action (`fastly_service_version_activate`)
 - ACL creation (`fastly_acl`) -- versionless, created alongside the services
+- ACL entries management (`fastly_acl_entries`)
 - Attaching an ACL to a service (`fastly_service_resource_link`), including moving the link forward across cloned/activated versions
 - Resource updates
 - Resource destruction
@@ -57,11 +58,12 @@ cd scripts/test-lifecycle-compute
 5. **Verify State**: Checks that resources were created correctly
 6. **Test Package Upload**: Invokes `fastly_service_compute_package_upload` actions for both services
 7. **Test Resource Updates**: Modifies a service comment while version 1 is still editable
-8. **Test Clone Action**: Invokes version clone actions for both services (creates version 2)
-9. **Test Activate Action**: Uploads package and activates version 2
-10. **Test Version-Locked Writes**: Clones to version 3, adds new resources, uploads package, and activates -- and verifies the ACL's resource_link followed service 1 onto the new version
-11. **Test Destruction**: Cleans up all resources via `terraform destroy`, including the resource_link and the ACL
-12. **Cleanup**: Removes temporary test directory
+8. **Test ACL Entries Update**: Removes one ACL entry and flips the action on the other, verifying the change against the API
+9. **Test Clone Action**: Invokes version clone actions for both services (creates version 2)
+10. **Test Activate Action**: Uploads package and activates version 2
+11. **Test Version-Locked Writes**: Clones to version 3, adds new resources, uploads package, and activates -- and verifies the ACL's resource_link followed service 1 onto the new version
+12. **Test Destruction**: Cleans up all resources via `terraform destroy`, including the resource_link, the ACL, and its entries
+13. **Cleanup**: Removes temporary test directory
 
 ## Resource Cleanup
 
@@ -108,7 +110,7 @@ The test creates:
 - 2 domain attachments (one per service)
 - 3 backend configurations (1 shared, 2 unique)
 - Compute package uploads to multiple versions
-- 1 ACL (versionless), attached to service 1 via a `fastly_service_resource_link`
+- 1 ACL (versionless), with its entries managed via `fastly_acl_entries`, attached to service 1 via a `fastly_service_resource_link`
 
 All resources are tagged with the process ID for uniqueness and are destroyed during cleanup.
 

--- a/scripts/test-lifecycle-compute/main.tf
+++ b/scripts/test-lifecycle-compute/main.tf
@@ -166,6 +166,18 @@ resource "fastly_acl" "acl" {
   name = var.acl_name
 }
 
+# Manages the ACL's entries via Terraform, exercising fastly_acl_entries against
+# the ACL created above.
+resource "fastly_acl_entries" "acl_entries" {
+  acl_id         = fastly_acl.acl.id
+  manage_entries = true
+
+  entries = {
+    "192.0.2.0/24"    = "ALLOW"
+    "198.51.100.0/24" = "BLOCK"
+  }
+}
+
 # Attaches the ACL to service 1 so it's usable from Wasm code, exercising the
 # same version lifecycle (clone/activate/advance-off-locked) as the other version-scoped
 # resources below.

--- a/scripts/test-lifecycle-compute/run.sh
+++ b/scripts/test-lifecycle-compute/run.sh
@@ -3,7 +3,7 @@
 # Test script for Compute service lifecycle
 # Tests: fastly_service_compute, fastly_service_domain, fastly_service_backend,
 #        fastly_service_compute_package_upload, fastly_service_version_clone,
-#        and fastly_service_version_activate actions
+#        fastly_service_version_activate actions, and fastly_acl_entries
 #
 # Coverage includes:
 #   - Clone from active version
@@ -11,6 +11,8 @@
 #   - Package uploads to specific versions
 #   - Version activation workflow
 #   - Multiple version lifecycle (versions 1, 2, 3)
+#   - ACL creation (fastly_acl) and entries management (fastly_acl_entries),
+#     attached to service 1 via fastly_service_resource_link
 
 set -euo pipefail
 
@@ -270,6 +272,8 @@ verify_initial_state() {
         exit 1
     fi
 
+    verify_acl_entries 2 "198.51.100.0/24" "BLOCK"
+
     local link_version=$(terraform output -raw resource_link_version)
     verify_resource_link "$SERVICE_1_ID" "$link_version" "$ACL_ID" "$TEST_RESOURCE_LINK_NAME"
 
@@ -300,6 +304,37 @@ verify_resource_link() {
     fi
 
     log_success "Resource link verified on service $service_id version $version (name=$expected_name, resource_id=$expected_resource_id)"
+}
+
+# Verify ACL entries against the API. Checks the total entry count
+# and, if a prefix is given, that it maps to the expected action.
+verify_acl_entries() {
+    local expected_count="$1"
+    local check_prefix="${2:-}"
+    local check_action="${3:-}"
+
+    local entries_response=$(curl -s -H "Fastly-Key: $FASTLY_API_TOKEN" \
+        "https://api.fastly.com/resources/acls/$ACL_ID/entries")
+
+    local entry_count=$(echo "$entries_response" | jq '.entries | length')
+    log_info "ACL has $entry_count entries (expected $expected_count)"
+
+    if [ "$entry_count" != "$expected_count" ]; then
+        log_error "Expected $expected_count ACL entries, found $entry_count"
+        log_info "Entries response: $entries_response"
+        return 1
+    fi
+
+    if [ -n "$check_prefix" ]; then
+        local actual_action=$(echo "$entries_response" | jq -r --arg prefix "$check_prefix" \
+            '.entries[] | select(.prefix == $prefix) | .action')
+        if [ "$actual_action" != "$check_action" ]; then
+            log_error "Expected ACL entry $check_prefix to have action $check_action, found '$actual_action'"
+            return 1
+        fi
+    fi
+
+    log_success "ACL entries verified ($entry_count entries)"
 }
 
 # Test compute package upload action
@@ -612,6 +647,33 @@ test_resource_updates() {
     log_success "Service update completed"
 }
 
+# Test ACL entries update: removes one entry and flips the
+# remaining entry's action, exercising both the delete and update batch
+# operations against the API.
+test_acl_entries_update() {
+    log_step "Testing ACL entries update"
+
+    cd "$TEST_DIR"
+
+    log_info "Updating ACL entries in config..."
+
+    sed -i.bak \
+        -e '/"192.0.2.0\/24"    = "ALLOW"/d' \
+        -e 's/"198.51.100.0\/24" = "BLOCK"/"198.51.100.0\/24" = "ALLOW"/' \
+        main.tf
+    rm -f main.tf.bak
+
+    log_info "Running terraform plan..."
+    terraform plan -out=tfplan
+
+    log_info "Running terraform apply..."
+    terraform apply tfplan
+
+    verify_acl_entries 1 "198.51.100.0/24" "ALLOW"
+
+    log_success "ACL entries update completed"
+}
+
 # The Fastly API rejects deletes of objects (domains/backends/resource_links) from a
 # locked (i.e. ever-activated) service version, and a locked version can never become
 # mutable again. If Terraform state has a resource pinned to a locked version,
@@ -696,7 +758,7 @@ test_resource_destruction() {
     # the service it belongs to) is deleted -- destroying everything in one
     # `terraform destroy` reliably 503s on the ACL delete. Destroy the services
     # (which cascades to their resource_link) first, let that settle, then destroy
-    # the now-unlinked ACL separately.
+    # the now-unlinked ACL (and its entries) separately.
     log_info "Running terraform destroy for the services (cascades to the resource_link)..."
     terraform destroy -auto-approve \
         -target=fastly_service_compute.service_1 \
@@ -775,6 +837,7 @@ main() {
     verify_initial_state
     test_package_upload_action
     test_resource_updates
+    test_acl_entries_update
     test_version_clone_action
     test_version_activate_action
     test_clone_from_latest_and_version_writes
@@ -790,6 +853,7 @@ main() {
     log_success "✓ Package upload action (fastly_service_compute_package_upload)"
     log_success "✓ Resource updates"
     log_success "✓ ACL creation (fastly_acl)"
+    log_success "✓ ACL entries management (fastly_acl_entries)"
     log_success "✓ ACL attached to a service (fastly_service_resource_link)"
     log_success "✓ Version clone action (fastly_service_version_clone)"
     log_success "✓ Version activate action (fastly_service_version_activate)"

--- a/templates/resources/acl_entries.md.tmpl
+++ b/templates/resources/acl_entries.md.tmpl
@@ -60,4 +60,6 @@ Fastly ACL entries can be imported using the format `<acl_id>/entries`, e.g.
 terraform import fastly_acl_entries.example <acl_id>/entries
 ```
 
-When imported, `manage_entries` is automatically set to `true`.
+Import reads the ACL's current entries from the Fastly API into state as-is; it does not modify the ACL or delete anything by itself.
+
+However, `manage_entries` is always set to `true` on import, regardless of the value in your configuration. Because of this, your `entries` map must match what was imported before you run `terraform apply` — any entry present in state (from the import) but missing from your configuration will be deleted on the next apply. Run `terraform show` after importing to see the entries that were read in, and copy them into your configuration before applying.

--- a/templates/resources/acl_entries.md.tmpl
+++ b/templates/resources/acl_entries.md.tmpl
@@ -1,0 +1,63 @@
+---
+page_title: "fastly_acl_entries Resource - fastly"
+subcategory: ""
+description: |-
+  Manages CIDR-based allow/block entries within a Fastly ACL.
+---
+
+# fastly_acl_entries (Resource)
+
+Manages CIDR-based allow/block entries within a Fastly ACL.
+
+By default, Terraform does not continue to manage the entries after the initial `terraform apply`. This allows you to make changes to ACL entries outside of Terraform using the [Fastly API](https://developer.fastly.com/reference/api/) or [Fastly CLI](https://developer.fastly.com/learning/tools/cli/) without Terraform resetting them.
+
+To have Terraform continue managing the entries after creation (e.g., deleting any entries not defined in the config), set `manage_entries = true`.
+
+~> **Note:** Use `manage_entries = true` cautiously. Terraform will overwrite external changes and delete any unmanaged entries.
+
+## Example Usage
+
+Basic usage (with seeded values, unmanaged after initial apply):
+
+```terraform
+resource "fastly_acl" "example" {
+  name = "my_acl"
+}
+
+resource "fastly_acl_entries" "example" {
+  acl_id = fastly_acl.example.id
+  entries = {
+    "192.0.2.0/24"    = "ALLOW"
+    "198.51.100.0/24" = "BLOCK"
+  }
+}
+```
+
+Terraform-managed usage (where Terraform controls entries long-term):
+
+```terraform
+resource "fastly_acl" "example" {
+  name = "my_acl"
+}
+
+resource "fastly_acl_entries" "example" {
+  acl_id = fastly_acl.example.id
+  entries = {
+    "203.0.113.0/24"  = "BLOCK"
+    "198.51.100.0/24" = "ALLOW"
+  }
+  manage_entries = true
+}
+```
+
+{{ .SchemaMarkdown | trimspace }}
+
+## Import
+
+Fastly ACL entries can be imported using the format `<acl_id>/entries`, e.g.
+
+```shell
+terraform import fastly_acl_entries.example <acl_id>/entries
+```
+
+When imported, `manage_entries` is automatically set to `true`.

--- a/templates/resources/service_cdn_acl_entries.md.tmpl
+++ b/templates/resources/service_cdn_acl_entries.md.tmpl
@@ -76,7 +76,16 @@ drift in ACL entries:
   managed by external systems (e.g., via API, scripts, or other automation).
 
 When importing an existing ACL entries resource, `manage_entries` is automatically
-set to `true` to enable drift detection.
+set to `true`, regardless of the value in your configuration, to enable drift
+detection.
+
+Import reads the ACL's current entries from the Fastly API into state as-is; it
+does not modify the ACL or delete anything by itself. But because `manage_entries`
+is forced to `true`, your `entry` blocks must match what was imported before you
+run `terraform apply` — any entry present in state (from the import) but missing
+from your configuration will be deleted on the next apply. Run `terraform show`
+after importing to see the entries that were read in, and copy them into your
+configuration before applying.
 
 {{ .SchemaMarkdown | trimspace }}
 
@@ -94,4 +103,4 @@ Example:
 terraform import fastly_service_cdn_acl_entries.example SU1Z0isxPaozGVKXdv0eY/7Lsb7Y8w6St2eqwFgqzc
 ```
 
-When imported, `manage_entries` is automatically set to `true`.
+Import reads the current entries from the API into state and sets `manage_entries = true`; it does not delete anything by itself. See [Behavior and Drift Management](#behavior-and-drift-management) above — make sure your `entry` blocks match the imported entries before running `terraform apply`, since `manage_entries = true` will delete any entry missing from your configuration.


### PR DESCRIPTION
### Change summary

Port the SDKv2 Compute ACL entries resource to the Plugin Framework as a versionless, account-level resource for batch-managing CIDR prefix -> ALLOW/BLOCK entries on an existing Compute ACL.

- fastly_acl_entries: manage_entries drift-suppression flag, CIDR/action validation, batch update/delete against the API
- unit and acceptance tests, generated Registry docs, and a runnable example
- extend the Compute lifecycle test script to cover ACL entries create, update, and destroy against an ACL and attached to a service via fastly_service_resource_link

 <!--
Briefly describe the changes introduced in this pull request. Include context or
reasoning behind the changes, even if they seem minor. If relevant, link to any
related discussions (e.g. Slack threads, tickets, documents).
-->

 All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/terraform-provider-fastly/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

* [x] Does your submission pass tests?
* [x] Post the output of your test runs
<img width="667" height="372" alt="Screenshot 2026-07-10 at 2 04 09 PM" src="https://github.com/user-attachments/assets/8bbf423e-3324-4ee0-8d7e-25f4029152c8" />
<img width="534" height="263" alt="Screenshot 2026-07-10 at 2 06 15 PM" src="https://github.com/user-attachments/assets/06e1925d-761f-4d8a-ba5f-410b3a8977e1" />
<img width="510" height="247" alt="Screenshot 2026-07-10 at 2 07 47 PM" src="https://github.com/user-attachments/assets/70947262-5bef-4996-bee0-ce6db26b0cb2" />

