### PR TITLE
Validate logging format length at plan time (#1340)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### BUG FIXES:
 
+- Validate logging `format` length (max 12288 characters) at plan/validate time instead of failing at apply time ([#1340](https://github.com/fastly/terraform-provider-fastly/issues/1340))
+
 ### Dependencies
 
 ## 9.3.1 (July 09, 2026)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### BUG FIXES:
 
-- Validate logging `format` length (max 12288 characters) at plan/validate time instead of failing at apply time ([#1340](https://github.com/fastly/terraform-provider-fastly/issues/1340))
+- fix(logging): Validate logging `format` length (max 12288 characters) at plan/validate time instead of failing at apply time ([#1340](https://github.com/fastly/terraform-provider-fastly/issues/1340))
 
 ### Dependencies
 

--- a/fastly/block_fastly_service_logging_bigquery.go
+++ b/fastly/block_fastly_service_logging_bigquery.go
@@ -92,10 +92,11 @@ func (h *BigQueryLoggingServiceAttributeHandler) GetSchema() *schema.Schema {
 
 	if h.GetServiceMetadata().serviceType == ServiceTypeVCL {
 		blockAttributes["format"] = &schema.Schema{
-			Type:        schema.TypeString,
-			Optional:    true,
-			Description: "The logging format desired.",
-			Default:     LoggingBigQueryDefaultFormat,
+			Type:             schema.TypeString,
+			Optional:         true,
+			Description:      "The logging format desired.",
+			Default:          LoggingBigQueryDefaultFormat,
+			ValidateDiagFunc: validateLoggingFormat(),
 		}
 		blockAttributes["response_condition"] = &schema.Schema{
 			Type:        schema.TypeString,

--- a/fastly/block_fastly_service_logging_blobstorage.go
+++ b/fastly/block_fastly_service_logging_blobstorage.go
@@ -118,10 +118,11 @@ func (h *BlobStorageLoggingServiceAttributeHandler) GetSchema() *schema.Schema {
 
 	if h.GetServiceMetadata().serviceType == ServiceTypeVCL {
 		blockAttributes["format"] = &schema.Schema{
-			Type:        schema.TypeString,
-			Optional:    true,
-			Default:     LoggingBlobStorageDefaultFormat,
-			Description: "Apache-style string or VCL variables to use for log formatting.",
+			Type:             schema.TypeString,
+			Optional:         true,
+			Default:          LoggingBlobStorageDefaultFormat,
+			Description:      "Apache-style string or VCL variables to use for log formatting.",
+			ValidateDiagFunc: validateLoggingFormat(),
 		}
 		blockAttributes["format_version"] = &schema.Schema{
 			Type:             schema.TypeInt,

--- a/fastly/block_fastly_service_logging_cloudfiles.go
+++ b/fastly/block_fastly_service_logging_cloudfiles.go
@@ -117,10 +117,11 @@ func (h *CloudfilesServiceAttributeHandler) GetSchema() *schema.Schema {
 
 	if h.GetServiceMetadata().serviceType == ServiceTypeVCL {
 		blockAttributes["format"] = &schema.Schema{
-			Type:        schema.TypeString,
-			Optional:    true,
-			Default:     LoggingCloudFilesDefaultFormat,
-			Description: "Apache style log formatting.",
+			Type:             schema.TypeString,
+			Optional:         true,
+			Default:          LoggingCloudFilesDefaultFormat,
+			Description:      "Apache style log formatting.",
+			ValidateDiagFunc: validateLoggingFormat(),
 		}
 		blockAttributes["format_version"] = &schema.Schema{
 			Type:             schema.TypeInt,

--- a/fastly/block_fastly_service_logging_datadog.go
+++ b/fastly/block_fastly_service_logging_datadog.go
@@ -62,10 +62,11 @@ func (h *DatadogServiceAttributeHandler) GetSchema() *schema.Schema {
 
 	if h.GetServiceMetadata().serviceType == ServiceTypeVCL {
 		blockAttributes["format"] = &schema.Schema{
-			Type:        schema.TypeString,
-			Optional:    true,
-			Default:     LoggingDatadogDefaultFormat,
-			Description: "Apache-style string or VCL variables to use for log formatting.",
+			Type:             schema.TypeString,
+			Optional:         true,
+			Default:          LoggingDatadogDefaultFormat,
+			Description:      "Apache-style string or VCL variables to use for log formatting.",
+			ValidateDiagFunc: validateLoggingFormat(),
 		}
 		blockAttributes["format_version"] = &schema.Schema{
 			Type:             schema.TypeInt,

--- a/fastly/block_fastly_service_logging_digitalocean.go
+++ b/fastly/block_fastly_service_logging_digitalocean.go
@@ -117,10 +117,11 @@ func (h *DigitalOceanServiceAttributeHandler) GetSchema() *schema.Schema {
 
 	if h.GetServiceMetadata().serviceType == ServiceTypeVCL {
 		blockAttributes["format"] = &schema.Schema{
-			Type:        schema.TypeString,
-			Optional:    true,
-			Default:     LoggingDigitalOceanDefaultFormat,
-			Description: "Apache style log formatting.",
+			Type:             schema.TypeString,
+			Optional:         true,
+			Default:          LoggingDigitalOceanDefaultFormat,
+			Description:      "Apache style log formatting.",
+			ValidateDiagFunc: validateLoggingFormat(),
 		}
 		blockAttributes["format_version"] = &schema.Schema{
 			Type:             schema.TypeInt,

--- a/fastly/block_fastly_service_logging_elasticsearch.go
+++ b/fastly/block_fastly_service_logging_elasticsearch.go
@@ -112,10 +112,11 @@ func (h *ElasticSearchServiceAttributeHandler) GetSchema() *schema.Schema {
 
 	if h.GetServiceMetadata().serviceType == ServiceTypeVCL {
 		blockAttributes["format"] = &schema.Schema{
-			Type:        schema.TypeString,
-			Optional:    true,
-			Default:     LoggingElasticsearchDefaultFormat,
-			Description: "Apache-style string or VCL variables to use for log formatting.",
+			Type:             schema.TypeString,
+			Optional:         true,
+			Default:          LoggingElasticsearchDefaultFormat,
+			Description:      "Apache-style string or VCL variables to use for log formatting.",
+			ValidateDiagFunc: validateLoggingFormat(),
 		}
 		blockAttributes["format_version"] = &schema.Schema{
 			Type:             schema.TypeInt,

--- a/fastly/block_fastly_service_logging_ftp.go
+++ b/fastly/block_fastly_service_logging_ftp.go
@@ -118,10 +118,11 @@ func (h *FTPServiceAttributeHandler) GetSchema() *schema.Schema {
 
 	if h.GetServiceMetadata().serviceType == ServiceTypeVCL {
 		blockAttributes["format"] = &schema.Schema{
-			Type:        schema.TypeString,
-			Optional:    true,
-			Description: "Apache-style string or VCL variables to use for log formatting.",
-			Default:     LoggingFTPDefaultFormat,
+			Type:             schema.TypeString,
+			Optional:         true,
+			Description:      "Apache-style string or VCL variables to use for log formatting.",
+			Default:          LoggingFTPDefaultFormat,
+			ValidateDiagFunc: validateLoggingFormat(),
 		}
 		blockAttributes["format_version"] = &schema.Schema{
 			Type:             schema.TypeInt,

--- a/fastly/block_fastly_service_logging_gcs.go
+++ b/fastly/block_fastly_service_logging_gcs.go
@@ -119,10 +119,11 @@ func (h *GCSLoggingServiceAttributeHandler) GetSchema() *schema.Schema {
 
 	if h.GetServiceMetadata().serviceType == ServiceTypeVCL {
 		blockAttributes["format"] = &schema.Schema{
-			Type:        schema.TypeString,
-			Optional:    true,
-			Default:     LoggingGCSDefaultFormat,
-			Description: "Apache-style string or VCL variables to use for log formatting",
+			Type:             schema.TypeString,
+			Optional:         true,
+			Default:          LoggingGCSDefaultFormat,
+			Description:      "Apache-style string or VCL variables to use for log formatting",
+			ValidateDiagFunc: validateLoggingFormat(),
 		}
 		blockAttributes["format_version"] = &schema.Schema{
 			Type:             schema.TypeInt,

--- a/fastly/block_fastly_service_logging_googlepubsub.go
+++ b/fastly/block_fastly_service_logging_googlepubsub.go
@@ -79,10 +79,11 @@ func (h *GooglePubSubServiceAttributeHandler) GetSchema() *schema.Schema {
 
 	if h.GetServiceMetadata().serviceType == ServiceTypeVCL {
 		blockAttributes["format"] = &schema.Schema{
-			Type:        schema.TypeString,
-			Optional:    true,
-			Default:     LoggingGooglePubSubDefaultFormat,
-			Description: "Apache style log formatting.",
+			Type:             schema.TypeString,
+			Optional:         true,
+			Default:          LoggingGooglePubSubDefaultFormat,
+			Description:      "Apache style log formatting.",
+			ValidateDiagFunc: validateLoggingFormat(),
 		}
 		blockAttributes["format_version"] = &schema.Schema{
 			Type:             schema.TypeInt,

--- a/fastly/block_fastly_service_logging_grafanacloudlogs.go
+++ b/fastly/block_fastly_service_logging_grafanacloudlogs.go
@@ -71,10 +71,11 @@ func (h *GrafanaCloudLogsServiceAttributeHandler) GetSchema() *schema.Schema {
 
 	if h.GetServiceMetadata().serviceType == ServiceTypeVCL {
 		blockAttributes["format"] = &schema.Schema{
-			Type:        schema.TypeString,
-			Optional:    true,
-			Default:     LoggingGrafanaCloudLogsDefaultFormat,
-			Description: "Apache-style string or VCL variables to use for log formatting.",
+			Type:             schema.TypeString,
+			Optional:         true,
+			Default:          LoggingGrafanaCloudLogsDefaultFormat,
+			Description:      "Apache-style string or VCL variables to use for log formatting.",
+			ValidateDiagFunc: validateLoggingFormat(),
 		}
 		blockAttributes["format_version"] = &schema.Schema{
 			Type:             schema.TypeInt,

--- a/fastly/block_fastly_service_logging_heroku.go
+++ b/fastly/block_fastly_service_logging_heroku.go
@@ -63,10 +63,11 @@ func (h *HerokuServiceAttributeHandler) GetSchema() *schema.Schema {
 
 	if h.GetServiceMetadata().serviceType == ServiceTypeVCL {
 		blockAttributes["format"] = &schema.Schema{
-			Type:        schema.TypeString,
-			Optional:    true,
-			Default:     LoggingHerokuDefaultFormat,
-			Description: "Apache-style string or VCL variables to use for log formatting.",
+			Type:             schema.TypeString,
+			Optional:         true,
+			Default:          LoggingHerokuDefaultFormat,
+			Description:      "Apache-style string or VCL variables to use for log formatting.",
+			ValidateDiagFunc: validateLoggingFormat(),
 		}
 		blockAttributes["format_version"] = &schema.Schema{
 			Type:             schema.TypeInt,

--- a/fastly/block_fastly_service_logging_honeycomb.go
+++ b/fastly/block_fastly_service_logging_honeycomb.go
@@ -61,10 +61,11 @@ func (h *HoneycombServiceAttributeHandler) GetSchema() *schema.Schema {
 
 	if h.GetServiceMetadata().serviceType == ServiceTypeVCL {
 		blockAttributes["format"] = &schema.Schema{
-			Type:        schema.TypeString,
-			Optional:    true,
-			Default:     LoggingHoneycombDefaultFormat,
-			Description: "Apache style log formatting. Your log must produce valid JSON that Honeycomb can ingest.",
+			Type:             schema.TypeString,
+			Optional:         true,
+			Default:          LoggingHoneycombDefaultFormat,
+			Description:      "Apache style log formatting. Your log must produce valid JSON that Honeycomb can ingest.",
+			ValidateDiagFunc: validateLoggingFormat(),
 		}
 		blockAttributes["format_version"] = &schema.Schema{
 			Type:             schema.TypeInt,

--- a/fastly/block_fastly_service_logging_https.go
+++ b/fastly/block_fastly_service_logging_https.go
@@ -150,10 +150,11 @@ func (h *HTTPSLoggingServiceAttributeHandler) GetSchema() *schema.Schema {
 
 	if h.GetServiceMetadata().serviceType == ServiceTypeVCL {
 		blockAttributes["format"] = &schema.Schema{
-			Type:        schema.TypeString,
-			Optional:    true,
-			Default:     LoggingHTTPSDefaultFormat,
-			Description: "Apache-style string or VCL variables to use for log formatting.",
+			Type:             schema.TypeString,
+			Optional:         true,
+			Default:          LoggingHTTPSDefaultFormat,
+			Description:      "Apache-style string or VCL variables to use for log formatting.",
+			ValidateDiagFunc: validateLoggingFormat(),
 		}
 		blockAttributes["format_version"] = &schema.Schema{
 			Type:             schema.TypeInt,

--- a/fastly/block_fastly_service_logging_kafka.go
+++ b/fastly/block_fastly_service_logging_kafka.go
@@ -127,10 +127,11 @@ func (h *KafkaServiceAttributeHandler) GetSchema() *schema.Schema {
 
 	if h.GetServiceMetadata().serviceType == ServiceTypeVCL {
 		blockAttributes["format"] = &schema.Schema{
-			Type:        schema.TypeString,
-			Optional:    true,
-			Default:     LoggingKafkaDefaultFormat,
-			Description: "Apache style log formatting.",
+			Type:             schema.TypeString,
+			Optional:         true,
+			Default:          LoggingKafkaDefaultFormat,
+			Description:      "Apache style log formatting.",
+			ValidateDiagFunc: validateLoggingFormat(),
 		}
 		blockAttributes["format_version"] = &schema.Schema{
 			Type:             schema.TypeInt,

--- a/fastly/block_fastly_service_logging_kinesis.go
+++ b/fastly/block_fastly_service_logging_kinesis.go
@@ -79,10 +79,11 @@ func (h *KinesisServiceAttributeHandler) GetSchema() *schema.Schema {
 
 	if h.GetServiceMetadata().serviceType == ServiceTypeVCL {
 		blockAttributes["format"] = &schema.Schema{
-			Type:        schema.TypeString,
-			Optional:    true,
-			Default:     LoggingKinesisDefaultFormat,
-			Description: "Apache style log formatting.",
+			Type:             schema.TypeString,
+			Optional:         true,
+			Default:          LoggingKinesisDefaultFormat,
+			Description:      "Apache style log formatting.",
+			ValidateDiagFunc: validateLoggingFormat(),
 		}
 		blockAttributes["format_version"] = &schema.Schema{
 			Type:             schema.TypeInt,

--- a/fastly/block_fastly_service_logging_logentries.go
+++ b/fastly/block_fastly_service_logging_logentries.go
@@ -67,10 +67,11 @@ func (h *LogentriesServiceAttributeHandler) GetSchema() *schema.Schema {
 
 	if h.GetServiceMetadata().serviceType == ServiceTypeVCL {
 		blockAttributes["format"] = &schema.Schema{
-			Type:        schema.TypeString,
-			Optional:    true,
-			Default:     `%h %l %u %t "%r" %>s %b`,
-			Description: "Apache-style string or VCL variables to use for log formatting",
+			Type:             schema.TypeString,
+			Optional:         true,
+			Default:          `%h %l %u %t "%r" %>s %b`,
+			Description:      "Apache-style string or VCL variables to use for log formatting",
+			ValidateDiagFunc: validateLoggingFormat(),
 		}
 		blockAttributes["format_version"] = &schema.Schema{
 			Type:             schema.TypeInt,

--- a/fastly/block_fastly_service_logging_loggly.go
+++ b/fastly/block_fastly_service_logging_loggly.go
@@ -57,10 +57,11 @@ func (h *LogglyServiceAttributeHandler) GetSchema() *schema.Schema {
 
 	if h.GetServiceMetadata().serviceType == ServiceTypeVCL {
 		blockAttributes["format"] = &schema.Schema{
-			Type:        schema.TypeString,
-			Optional:    true,
-			Default:     LoggingLogglyDefaultFormat,
-			Description: "Apache-style string or VCL variables to use for log formatting.",
+			Type:             schema.TypeString,
+			Optional:         true,
+			Default:          LoggingLogglyDefaultFormat,
+			Description:      "Apache-style string or VCL variables to use for log formatting.",
+			ValidateDiagFunc: validateLoggingFormat(),
 		}
 		blockAttributes["format_version"] = &schema.Schema{
 			Type:             schema.TypeInt,

--- a/fastly/block_fastly_service_logging_logshuttle.go
+++ b/fastly/block_fastly_service_logging_logshuttle.go
@@ -62,10 +62,11 @@ func (h *LogshuttleServiceAttributeHandler) GetSchema() *schema.Schema {
 
 	if h.GetServiceMetadata().serviceType == ServiceTypeVCL {
 		blockAttributes["format"] = &schema.Schema{
-			Type:        schema.TypeString,
-			Optional:    true,
-			Default:     LoggingLogshuttleDefaultFormat,
-			Description: "Apache style log formatting.",
+			Type:             schema.TypeString,
+			Optional:         true,
+			Default:          LoggingLogshuttleDefaultFormat,
+			Description:      "Apache style log formatting.",
+			ValidateDiagFunc: validateLoggingFormat(),
 		}
 		blockAttributes["format_version"] = &schema.Schema{
 			Type:             schema.TypeInt,

--- a/fastly/block_fastly_service_logging_newrelic.go
+++ b/fastly/block_fastly_service_logging_newrelic.go
@@ -62,10 +62,11 @@ func (h *NewRelicServiceAttributeHandler) GetSchema() *schema.Schema {
 
 	if h.GetServiceMetadata().serviceType == ServiceTypeVCL {
 		blockAttributes["format"] = &schema.Schema{
-			Type:        schema.TypeString,
-			Optional:    true,
-			Default:     LoggingNewRelicDefaultFormat,
-			Description: "Apache style log formatting. Your log must produce valid JSON that New Relic Logs can ingest.",
+			Type:             schema.TypeString,
+			Optional:         true,
+			Default:          LoggingNewRelicDefaultFormat,
+			Description:      "Apache style log formatting. Your log must produce valid JSON that New Relic Logs can ingest.",
+			ValidateDiagFunc: validateLoggingFormat(),
 		}
 		blockAttributes["format_version"] = &schema.Schema{
 			Type:             schema.TypeInt,

--- a/fastly/block_fastly_service_logging_newrelicotlp.go
+++ b/fastly/block_fastly_service_logging_newrelicotlp.go
@@ -35,9 +35,10 @@ func (h *NewRelicOTLPServiceAttributeHandler) Key() string {
 func (h *NewRelicOTLPServiceAttributeHandler) GetSchema() *schema.Schema {
 	blockAttributes := map[string]*schema.Schema{
 		"format": {
-			Type:        schema.TypeString,
-			Optional:    true,
-			Description: "Apache style log formatting. Your log must produce valid JSON that New Relic OTLP can ingest.",
+			Type:             schema.TypeString,
+			Optional:         true,
+			Description:      "Apache style log formatting. Your log must produce valid JSON that New Relic OTLP can ingest.",
+			ValidateDiagFunc: validateLoggingFormat(),
 		},
 		"format_version": {
 			Type:             schema.TypeInt,

--- a/fastly/block_fastly_service_logging_openstack.go
+++ b/fastly/block_fastly_service_logging_openstack.go
@@ -117,10 +117,11 @@ func (h *OpenstackServiceAttributeHandler) GetSchema() *schema.Schema {
 
 	if h.GetServiceMetadata().serviceType == ServiceTypeVCL {
 		blockAttributes["format"] = &schema.Schema{
-			Type:        schema.TypeString,
-			Optional:    true,
-			Default:     LoggingOpenStackDefaultFormat,
-			Description: "Apache style log formatting.",
+			Type:             schema.TypeString,
+			Optional:         true,
+			Default:          LoggingOpenStackDefaultFormat,
+			Description:      "Apache style log formatting.",
+			ValidateDiagFunc: validateLoggingFormat(),
 		}
 		blockAttributes["format_version"] = &schema.Schema{
 			Type:             schema.TypeInt,

--- a/fastly/block_fastly_service_logging_papertrail.go
+++ b/fastly/block_fastly_service_logging_papertrail.go
@@ -60,10 +60,11 @@ func (h *PaperTrailServiceAttributeHandler) GetSchema() *schema.Schema {
 
 	if h.GetServiceMetadata().serviceType == ServiceTypeVCL {
 		blockAttributes["format"] = &schema.Schema{
-			Type:        schema.TypeString,
-			Optional:    true,
-			Default:     LoggingPapertrailDefaultFormat,
-			Description: "A Fastly [log format string](https://docs.fastly.com/en/guides/custom-log-formats)",
+			Type:             schema.TypeString,
+			Optional:         true,
+			Default:          LoggingPapertrailDefaultFormat,
+			Description:      "A Fastly [log format string](https://docs.fastly.com/en/guides/custom-log-formats)",
+			ValidateDiagFunc: validateLoggingFormat(),
 		}
 		blockAttributes["format_version"] = &schema.Schema{
 			Type:             schema.TypeInt,

--- a/fastly/block_fastly_service_logging_s3.go
+++ b/fastly/block_fastly_service_logging_s3.go
@@ -195,10 +195,11 @@ func (h *S3LoggingServiceAttributeHandler) GetSchema() *schema.Schema {
 
 	if h.GetServiceMetadata().serviceType == ServiceTypeVCL {
 		blockAttributes["format"] = &schema.Schema{
-			Type:        schema.TypeString,
-			Optional:    true,
-			Default:     LoggingS3DefaultFormat,
-			Description: "Apache-style string or VCL variables to use for log formatting.",
+			Type:             schema.TypeString,
+			Optional:         true,
+			Default:          LoggingS3DefaultFormat,
+			Description:      "Apache-style string or VCL variables to use for log formatting.",
+			ValidateDiagFunc: validateLoggingFormat(),
 		}
 		blockAttributes["format_version"] = &schema.Schema{
 			Type:             schema.TypeInt,

--- a/fastly/block_fastly_service_logging_scalyr.go
+++ b/fastly/block_fastly_service_logging_scalyr.go
@@ -67,10 +67,11 @@ func (h *ScalyrServiceAttributeHandler) GetSchema() *schema.Schema {
 
 	if h.GetServiceMetadata().serviceType == ServiceTypeVCL {
 		blockAttributes["format"] = &schema.Schema{
-			Type:        schema.TypeString,
-			Optional:    true,
-			Default:     LoggingScalyrDefaultFormat,
-			Description: "Apache style log formatting.",
+			Type:             schema.TypeString,
+			Optional:         true,
+			Default:          LoggingScalyrDefaultFormat,
+			Description:      "Apache style log formatting.",
+			ValidateDiagFunc: validateLoggingFormat(),
 		}
 		blockAttributes["format_version"] = &schema.Schema{
 			Type:             schema.TypeInt,

--- a/fastly/block_fastly_service_logging_sftp.go
+++ b/fastly/block_fastly_service_logging_sftp.go
@@ -130,10 +130,11 @@ func (h *SFTPServiceAttributeHandler) GetSchema() *schema.Schema {
 
 	if h.GetServiceMetadata().serviceType == ServiceTypeVCL {
 		blockAttributes["format"] = &schema.Schema{
-			Type:        schema.TypeString,
-			Optional:    true,
-			Default:     LoggingSFTPDefaultFormat,
-			Description: "Apache-style string or VCL variables to use for log formatting.",
+			Type:             schema.TypeString,
+			Optional:         true,
+			Default:          LoggingSFTPDefaultFormat,
+			Description:      "Apache-style string or VCL variables to use for log formatting.",
+			ValidateDiagFunc: validateLoggingFormat(),
 		}
 		blockAttributes["format_version"] = &schema.Schema{
 			Type:             schema.TypeInt,

--- a/fastly/block_fastly_service_logging_splunk.go
+++ b/fastly/block_fastly_service_logging_splunk.go
@@ -92,10 +92,11 @@ func (h *SplunkServiceAttributeHandler) GetSchema() *schema.Schema {
 
 	if h.GetServiceMetadata().serviceType == ServiceTypeVCL {
 		blockAttributes["format"] = &schema.Schema{
-			Type:        schema.TypeString,
-			Optional:    true,
-			Default:     LoggingSplunkDefaultFormat,
-			Description: "Apache-style string or VCL variables to use for log formatting (default: `%h %l %u %t \"%r\" %>s %b`)",
+			Type:             schema.TypeString,
+			Optional:         true,
+			Default:          LoggingSplunkDefaultFormat,
+			Description:      "Apache-style string or VCL variables to use for log formatting (default: `%h %l %u %t \"%r\" %>s %b`)",
+			ValidateDiagFunc: validateLoggingFormat(),
 		}
 		blockAttributes["format_version"] = &schema.Schema{
 			Type:             schema.TypeInt,

--- a/fastly/block_fastly_service_logging_sumologic.go
+++ b/fastly/block_fastly_service_logging_sumologic.go
@@ -62,10 +62,11 @@ func (h *SumologicServiceAttributeHandler) GetSchema() *schema.Schema {
 
 	if h.GetServiceMetadata().serviceType == ServiceTypeVCL {
 		blockAttributes["format"] = &schema.Schema{
-			Type:        schema.TypeString,
-			Optional:    true,
-			Default:     LoggingSumologicDefaultFormat,
-			Description: "Apache-style string or VCL variables to use for log formatting",
+			Type:             schema.TypeString,
+			Optional:         true,
+			Default:          LoggingSumologicDefaultFormat,
+			Description:      "Apache-style string or VCL variables to use for log formatting",
+			ValidateDiagFunc: validateLoggingFormat(),
 		}
 		blockAttributes["format_version"] = &schema.Schema{
 			Type:             schema.TypeInt,

--- a/fastly/block_fastly_service_logging_syslog.go
+++ b/fastly/block_fastly_service_logging_syslog.go
@@ -105,10 +105,11 @@ func (h *SyslogServiceAttributeHandler) GetSchema() *schema.Schema {
 
 	if h.GetServiceMetadata().serviceType == ServiceTypeVCL {
 		blockAttributes["format"] = &schema.Schema{
-			Type:        schema.TypeString,
-			Optional:    true,
-			Default:     LoggingSyslogDefaultFormat,
-			Description: "Apache-style string or VCL variables to use for log formatting",
+			Type:             schema.TypeString,
+			Optional:         true,
+			Default:          LoggingSyslogDefaultFormat,
+			Description:      "Apache-style string or VCL variables to use for log formatting",
+			ValidateDiagFunc: validateLoggingFormat(),
 		}
 		blockAttributes["format_version"] = &schema.Schema{
 			Type:             schema.TypeInt,

--- a/fastly/validators.go
+++ b/fastly/validators.go
@@ -17,6 +17,43 @@ func validateLoggingFormatVersion() schema.SchemaValidateDiagFunc {
 	return validation.ToDiagFunc(validation.IntBetween(1, 2))
 }
 
+// maximumLoggingFormatLength is the maximum length the Fastly API accepts
+// for a logging endpoint `format` string. Exceeding it is only rejected by
+// the API at apply time, so we enforce it at plan/validate time instead.
+const maximumLoggingFormatLength = 12288
+
+func validateLoggingFormat() schema.SchemaValidateDiagFunc {
+	return func(i any, p cty.Path) diag.Diagnostics {
+		v, ok := i.(string)
+		if !ok {
+			return diag.Errorf("expected type of %q to be string", renderAttributePath(p))
+		}
+		if len(v) > maximumLoggingFormatLength {
+			return diag.Errorf("expected length of %q to be at most %d, got %d", renderAttributePath(p), maximumLoggingFormatLength, len(v))
+		}
+		return nil
+	}
+}
+
+// renderAttributePath renders a cty.Path as a dotted attribute address
+// (e.g. `logging_datadog.0.format`) for use in validation error messages.
+func renderAttributePath(p cty.Path) string {
+	parts := make([]string, 0, len(p))
+	for _, step := range p {
+		switch s := step.(type) {
+		case cty.GetAttrStep:
+			parts = append(parts, s.Name)
+		case cty.IndexStep:
+			if s.Key.Type() == cty.String {
+				parts = append(parts, s.Key.AsString())
+			} else {
+				parts = append(parts, s.Key.AsBigFloat().String())
+			}
+		}
+	}
+	return strings.Join(parts, ".")
+}
+
 func validateLoggingMessageType() schema.SchemaValidateDiagFunc {
 	return validation.ToDiagFunc(validation.StringInSlice([]string{
 		"classic",

--- a/fastly/validators_test.go
+++ b/fastly/validators_test.go
@@ -2,6 +2,7 @@ package fastly
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/go-cty/cty"
@@ -24,6 +25,30 @@ func TestValidateLoggingFormatVersion(t *testing.T) {
 	} {
 		t.Run(name, func(t *testing.T) {
 			actualWarns, actualErrors := diagToWarnsAndErrs(validateLoggingFormatVersion()(testcase.value, cty.GetAttrPath("format_version")))
+			if len(actualWarns) != testcase.expectedWarns {
+				t.Errorf("expected %d warnings, actual %d ", testcase.expectedWarns, len(actualWarns))
+			}
+			if len(actualErrors) != testcase.expectedErrors {
+				t.Errorf("expected %d errors, actual %d ", testcase.expectedErrors, len(actualErrors))
+			}
+		})
+	}
+}
+
+func TestValidateLoggingFormat(t *testing.T) {
+	for name, testcase := range map[string]struct {
+		value          string
+		expectedWarns  int
+		expectedErrors int
+	}{
+		"empty":    {"", 0, 0},
+		"short":    {"%h %l %u %t \"%r\" %>s %b", 0, 0},
+		"max":      {strings.Repeat("a", maximumLoggingFormatLength), 0, 0},
+		"over-max": {strings.Repeat("a", maximumLoggingFormatLength+1), 0, 1},
+		"way-over": {strings.Repeat("a", maximumLoggingFormatLength*2), 0, 1},
+	} {
+		t.Run(name, func(t *testing.T) {
+			actualWarns, actualErrors := diagToWarnsAndErrs(validateLoggingFormat()(testcase.value, cty.GetAttrPath("format")))
 			if len(actualWarns) != testcase.expectedWarns {
 				t.Errorf("expected %d warnings, actual %d ", testcase.expectedWarns, len(actualWarns))
 			}


### PR DESCRIPTION
### Change summary

Fixes #1340.

The Fastly API rejects logging endpoint `format` strings longer than 12,288 characters (12 KiB), but the provider performed no client-side validation. An oversized `format` passed both `terraform validate` and `terraform plan` and only failed at `terraform apply` when the API rejected the service version — breaking plan-gated CI/CD pipelines, which approve changes that are then guaranteed to fail on apply.

This PR adds plan/validate-time enforcement of the limit:

* New shared validator `validateLoggingFormat()` in `fastly/validators.go`, following the existing `validateLoggingFormatVersion()` pattern, with a `maximumLoggingFormatLength = 12288` constant.
* Wired via `ValidateDiagFunc` into the `format` attribute of all 28 `logging_*` blocks (`block_fastly_service_logging_*.go`).
* The error message reports the full attribute path and the offending length instead of echoing the (potentially multi-KB) format string, so users can immediately identify which logging block is over the limit.
* Unit test `TestValidateLoggingFormat` covering empty, short, exactly-at-limit, and over-limit values.
* CHANGELOG entry under UNRELEASED → BUG FIXES.

Example output with an oversized format (13,000 chars) — both commands now fail before apply:

```
​$ terraform validate

Error: expected length of "logging_datadog.0.format" to be at most 12288, got 13000

  with fastly_service_vcl.demo,
  on log-error.tf line 13, in resource "fastly_service_vcl" "demo":
  13: resource "fastly_service_vcl" "demo" {
```

All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/terraform-provider-fastly/pulls) for the same update/change?

### New Feature Submissions:

* [x] Does your submission pass tests?
* [x] Post the output of your test runs

```sh
$ make test
go  test
ok  	github.com/fastly/terraform-provider-fastly/fastly	2.198s
echo $(go list ./...) | xargs -t -n4 go test -timeout=30s -parallel=4
ok  	github.com/fastly/terraform-provider-fastly/fastly	2.198s

$ go vet ./fastly/
(no issues)

$ go test ./fastly/ -run TestValidateLogging
ok — 32 passed (includes new TestValidateLoggingFormat)
```

### Changes to Core Features:

* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### User Impact

Configurations with a logging `format` over 12,288 characters now fail at `terraform validate`/`plan` with a clear, addressable error instead of failing mid-`apply` with an API error. No impact on any configuration that is currently applyable — such configs are already rejected by the API today; this only moves the failure earlier.

### Are there any considerations that need to be addressed for release?

No breaking changes. The only behavioral change is that previously "plannable-but-unapplyable" configurations now fail at plan time, which is the intended fix. If Fastly ever raises the API limit, the single `maximumLoggingFormatLength` constant needs updating.
