### PR TITLE
Include subscription context in TLS subscription errors (#888)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### ENHANCEMENTS:
 
+- feat(tls/subscription): include subscription ID and domains in `fastly_tls_subscription` API error messages so failing resources can be identified when managing many subscriptions ([#888](https://github.com/fastly/terraform-provider-fastly/issues/888))
+
 ### BUG FIXES:
 
 - fix(logging): Validate logging `format` length (max 12288 characters) at plan/validate time instead of failing at apply time ([#1340](https://github.com/fastly/terraform-provider-fastly/issues/1340))

--- a/fastly/resource_fastly_tls_subscription.go
+++ b/fastly/resource_fastly_tls_subscription.go
@@ -184,7 +184,7 @@ func resourceFastlyTLSSubscriptionCreate(ctx context.Context, d *schema.Resource
 		CommonName:           commonName,
 	})
 	if err != nil {
-		return diag.FromErr(err)
+		return diag.Errorf("error creating TLS subscription for domains [%s]: %s", strings.Join(domainStrings, ", "), err)
 	}
 
 	d.SetId(subscription.ID)
@@ -213,7 +213,7 @@ func resourceFastlyTLSSubscriptionRead(ctx context.Context, d *schema.ResourceDa
 			},
 		}
 	} else if err != nil {
-		return diag.FromErr(err)
+		return diag.Errorf("error fetching TLS subscription (%s): %s", d.Id(), err)
 	}
 
 	var domains []string
@@ -395,7 +395,7 @@ func resourceFastlyTLSSubscriptionUpdate(ctx context.Context, d *schema.Resource
 		conn := meta.(*APIClient).conn
 		_, err := conn.UpdateTLSSubscription(ctx, updates)
 		if err != nil {
-			return diag.FromErr(err)
+			return diag.Errorf("error updating TLS subscription (%s) for domains [%s]: %s", d.Id(), strings.Join(domainStrings, ", "), err)
 		}
 	}
 
@@ -410,7 +410,21 @@ func resourceFastlyTLSSubscriptionDelete(ctx context.Context, d *schema.Resource
 		ID:    d.Id(),
 		Force: d.Get("force_destroy").(bool),
 	})
-	return diag.FromErr(err)
+	if err != nil {
+		return diag.Errorf("error deleting TLS subscription (%s) for domains [%s]: %s", d.Id(), strings.Join(tlsSubscriptionDomains(d), ", "), err)
+	}
+	return nil
+}
+
+// tlsSubscriptionDomains returns the subscription's domains from state, for
+// inclusion in error messages so users running many subscriptions can tell
+// which resource an API error belongs to.
+func tlsSubscriptionDomains(d *schema.ResourceData) []string {
+	var domains []string
+	for _, domain := range d.Get("domains").(*schema.Set).List() {
+		domains = append(domains, domain.(string))
+	}
+	return domains
 }
 
 func resourceFastlyTLSSubscriptionIsStateImmutable(_ context.Context, d *schema.ResourceDiff, _ any) bool {

--- a/fastly/resource_fastly_tls_subscription_test.go
+++ b/fastly/resource_fastly_tls_subscription_test.go
@@ -3,12 +3,16 @@ package fastly
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"regexp"
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
 	"github.com/fastly/go-fastly/v16/fastly"
@@ -132,6 +136,93 @@ resource "fastly_tls_subscription" "subject" {
   certificate_authority = "lets-encrypt"
 }
 `, domain, commonName)
+}
+
+func TestResourceFastlyTLSSubscriptionErrorsIncludeSubscriptionContext(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/vnd.api+json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"errors":[{"title":"Bad Request","detail":"something went wrong"}]}`))
+	}))
+	defer server.Close()
+
+	conn, err := fastly.NewClientForEndpoint("test-key", server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client := &APIClient{conn: conn}
+
+	for name, testcase := range map[string]struct {
+		invoke func(*schema.ResourceData) diag.Diagnostics
+		wants  []string
+	}{
+		"create": {
+			invoke: func(d *schema.ResourceData) diag.Diagnostics {
+				return resourceFastlyTLSSubscriptionCreate(context.Background(), d, client)
+			},
+			wants: []string{
+				"error creating TLS subscription for domains",
+				"henry.example.com",
+				"www.henry.example.com",
+				"something went wrong",
+			},
+		},
+		"read": {
+			invoke: func(d *schema.ResourceData) diag.Diagnostics {
+				return resourceFastlyTLSSubscriptionRead(context.Background(), d, client)
+			},
+			wants: []string{
+				"error fetching TLS subscription (h23m07b03)",
+				"something went wrong",
+			},
+		},
+		"update": {
+			invoke: func(d *schema.ResourceData) diag.Diagnostics {
+				// Simulate a config change so the update path calls the API.
+				if err := d.Set("common_name", "henry.example.com"); err != nil {
+					t.Fatal(err)
+				}
+				return resourceFastlyTLSSubscriptionUpdate(context.Background(), d, client)
+			},
+			wants: []string{
+				"error updating TLS subscription (h23m07b03)",
+				"henry.example.com",
+				"www.henry.example.com",
+				"something went wrong",
+			},
+		},
+		"delete": {
+			invoke: func(d *schema.ResourceData) diag.Diagnostics {
+				return resourceFastlyTLSSubscriptionDelete(context.Background(), d, client)
+			},
+			wants: []string{
+				"error deleting TLS subscription (h23m07b03)",
+				"henry.example.com",
+				"www.henry.example.com",
+				"something went wrong",
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			d := schema.TestResourceDataRaw(t, resourceFastlyTLSSubscription().Schema, map[string]any{
+				"domains":               []any{"henry.example.com", "www.henry.example.com"},
+				"certificate_authority": "lets-encrypt",
+			})
+			d.SetId("h23m07b03")
+
+			diags := testcase.invoke(d)
+			if !diags.HasError() {
+				t.Fatalf("expected %s to return an error diagnostic", name)
+			}
+
+			summary := diags[0].Summary
+			for _, want := range testcase.wants {
+				if !strings.Contains(summary, want) {
+					t.Errorf("expected %s error %q to contain %q", name, summary, want)
+				}
+			}
+		})
+	}
 }
 
 func testSweepTLSSubscription(region string) error {


### PR DESCRIPTION
### Change summary

API errors from `fastly_tls_subscription` CRUD operations were returned verbatim (e.g. "400 - Bad Request: Subscription has active domains"), with no indication of which subscription or domains they belonged to. For users managing hundreds of subscriptions, a failed destroy produced a wall of identical errors that couldn't be traced back to a resource.

Wrap create/read/update/delete errors with the subscription ID and its domains so each failure is attributable:

* **Create**: `error creating TLS subscription for domains [a.example.com, b.example.com]: <API error>` (no ID exists yet)
* **Read**: `error fetching TLS subscription (ID): <API error>`
* **Update**: `error updating TLS subscription (ID) for domains [...]: <API error>`
* **Delete** (the case reported in the issue): `error deleting TLS subscription (ID) for domains [...]: 400 - Bad Request: Subscription has active domains`

Fixes #888

All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/terraform-provider-fastly/pulls) for the same update/change?

### New Feature Submissions:

* [x] Does your submission pass tests?
* [x] Post the output of your test runs

​```sh
$ go vet ./fastly/
(no issues)

$ make test
go test
ok  	github.com/fastly/terraform-provider-fastly/fastly	2.347s
?   	github.com/fastly/terraform-provider-fastly/fastly/hashcode	[no test files]
?   	github.com/fastly/terraform-provider-fastly/version	[no test files]
​```

### Changes to Core Features:

* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### User Impact

Error messages from `fastly_tls_subscription` now identify the failing subscription by ID and domains. Users managing many subscriptions can immediately trace a failure (e.g. "Subscription has active domains" on destroy) to the specific resource, instead of seeing N identical errors. No configuration or state changes required; purely additive error context.

### Are there any considerations that need to be addressed for release?

None. No breaking changes, no schema changes, no API behavior changes — only error message text is affected. Anyone parsing provider error strings verbatim (unlikely, and not a stable interface) would see the new wrapped format.
