### PR TITLE
Expose certificate_id on tls_subscription_validation to fix empty cert ID in same-apply activations (#1197)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,13 @@
 
 ### ENHANCEMENTS:
 
+- feat(tls_subscription_validation): expose computed `certificate_id`, allowing issuance-dependent resources to be chained in a single apply ([#1197](https://github.com/fastly/terraform-provider-fastly/issues/1197))
+
 ### BUG FIXES:
+
+- fix(tls_subscription_validation): key resource validity on certificate presence instead of `issued` state, so subscriptions in `renewing` state no longer destroy/recreate the validation resource on refresh ([#1197](https://github.com/fastly/terraform-provider-fastly/issues/1197))
+
+- fix(tls_activation): fail fast with an actionable error when `certificate_id` is empty (certificate not yet issued) instead of an opaque API 400; document that managed subscription domains are auto-activated by Fastly and must not be paired with `fastly_tls_activation` ([#1197](https://github.com/fastly/terraform-provider-fastly/issues/1197))
 
 - fix(logging): Validate logging `format` length (max 12288 characters) at plan/validate time instead of failing at apply time ([#1340](https://github.com/fastly/terraform-provider-fastly/issues/1340))
 

--- a/docs/resources/tls_activation.md
+++ b/docs/resources/tls_activation.md
@@ -12,6 +12,8 @@ Enables TLS on a domain using a specified custom TLS certificate.
 
 ~> **Note:** The Fastly service must be provisioned _prior_ to enabling TLS on it. This can be achieved in Terraform using [`depends_on`](https://www.terraform.io/docs/configuration/meta-arguments/depends_on.html).
 
+~> **Warning:** This resource is for custom (uploaded) certificates. Do not pair it with a `fastly_tls_subscription` — Fastly automatically activates TLS on a subscription's domains once the managed certificate is issued, so creating an activation for those domains fails with `400 domain_id has already been taken` (and referencing `fastly_tls_subscription.<name>.certificate_id` in the same apply fails earlier with an empty certificate ID). For managed certificates, set `configuration_id` on the subscription and use the `fastly_tls_activation` data source to read the automatically-created activation — see the `fastly_tls_subscription_validation` documentation for a complete example.
+
 ## Example Usage
 
 Basic usage:

--- a/docs/resources/tls_subscription.md
+++ b/docs/resources/tls_subscription.md
@@ -28,6 +28,8 @@ The workflow configures a `fastly_tls_subscription` resource, then a `aws_route5
 
 We configure the `fastly_tls_subscription_validation` resource, which blocks other resources until the challenge DNS records have been validated by Fastly.
 
+~> **Warning:** Do not create a `fastly_tls_activation` for this subscription's domains. Fastly activates TLS on them automatically once the certificate is issued (a manual activation fails with `400 domain_id has already been taken`, or with an empty-certificate 400 if created in the same apply). Set `configuration_id` on this resource to control the TLS configuration, and reference `fastly_tls_subscription_validation.<name>.certificate_id` when another resource needs the issued certificate — see the `fastly_tls_subscription_validation` documentation for a complete example.
+
 Once the validation has been successful, the configured `fastly_tls_configuration` data source will filter the available results looking for an appropriate TLS configuration object. If that filtering process is successful, then the subsequent `aws_route53_record` resources (for configuring the subdomains) will be executed using the returned TLS configuration data.
 
 ```terraform

--- a/docs/resources/tls_subscription_validation.md
+++ b/docs/resources/tls_subscription_validation.md
@@ -135,6 +135,82 @@ resource "aws_route53_record" "subdomain" {
 }
 ```
 
+Managed certificates for multiple domains, in a single apply:
+
+The `certificate_id` attribute is only populated once the certificate has been issued, so resources referencing it are guaranteed to run after issuance — unlike `fastly_tls_subscription.<name>.certificate_id`, which is empty on first apply (certificates are issued asynchronously after domain validation) and causes API 400 errors when consumed in the same apply.
+
+~> **Note:** Fastly automatically activates TLS on a subscription's domains once the certificate is issued — set `configuration_id` on the `fastly_tls_subscription` itself and do **not** create a `fastly_tls_activation` for those domains (it fails with `400 domain_id has already been taken`). Use the `fastly_tls_activation` data source to read the automatically-created activation.
+
+```terraform
+# Certificates map: key = domain (common_name), value = subscription config
+variable "certificates" {
+  type = map(object({
+    authority     = optional(string, "lets-encrypt")
+    common_name   = optional(string, "")
+    domains       = set(string)
+    force_destroy = optional(bool, true)
+  }))
+}
+
+data "fastly_tls_configuration" "default_tls" {
+  default = true
+}
+
+resource "fastly_tls_subscription" "example" {
+  for_each = var.certificates
+
+  certificate_authority = each.value.authority
+  common_name           = each.value.common_name
+  domains               = each.value.domains
+  force_destroy         = each.value.force_destroy
+
+  # IMPORTANT: with a managed subscription, set the TLS configuration HERE.
+  # Fastly automatically activates TLS on the subscription's domains once the
+  # certificate is issued. Do NOT create a fastly_tls_activation for these
+  # domains — it will fail with `400 domain_id has already been taken`.
+  configuration_id = data.fastly_tls_configuration.default_tls.id
+}
+
+# The domain validation challenge records MUST be created before validation
+# can succeed. This example uses DNS-based validation: replace with your DNS
+# provider's record resource, fed from
+# fastly_tls_subscription.example[each.key].managed_dns_challenges
+# (see the fastly_tls_subscription documentation for a Route53 example).
+resource "aws_route53_record" "domain_validation" {
+  for_each = fastly_tls_subscription.example
+
+  name            = each.value.managed_dns_challenges[0].record_name
+  type            = each.value.managed_dns_challenges[0].record_type
+  records         = [each.value.managed_dns_challenges[0].record_value]
+  zone_id         = "REPLACE_WITH_YOUR_ZONE_ID"
+  allow_overwrite = true
+  ttl             = 60
+}
+
+# Blocks until the certificate has been issued. Its certificate_id attribute
+# is only known after issuance, so downstream resources referencing it are
+# guaranteed to run with a valid certificate — all in a single apply.
+resource "fastly_tls_subscription_validation" "example" {
+  for_each = var.certificates
+
+  subscription_id = fastly_tls_subscription.example[each.key].id
+  depends_on      = [aws_route53_record.domain_validation]
+}
+
+# The activation was created automatically by Fastly when the certificate was
+# issued; this data source reads it (e.g. to consume dns_records/IDs).
+data "fastly_tls_activation" "example" {
+  for_each = var.certificates
+
+  domain     = each.value.common_name
+  depends_on = [fastly_tls_subscription_validation.example]
+}
+
+output "certificate_ids" {
+  value = { for k, v in fastly_tls_subscription_validation.example : k => v.certificate_id }
+}
+```
+
 ## Timeouts
 
 `fastly_tls_subscription_validation` supports the following [Timeouts](https://www.terraform.io/docs/configuration/blocks/resources/syntax.html#operation-timeouts) configuration options:
@@ -154,6 +230,7 @@ resource "aws_route53_record" "subdomain" {
 
 ### Read-Only
 
+- `certificate_id` (String) The ID of the certificate issued for the validated subscription. Only populated once the subscription reaches the `issued` state. Reference this from `fastly_tls_activation.certificate_id` to guarantee the activation is created after the certificate exists, within a single apply.
 - `id` (String) The ID of this resource.
 
 <a id="nestedblock--timeouts"></a>

--- a/fastly/resource_fastly_tls_activation.go
+++ b/fastly/resource_fastly_tls_activation.go
@@ -59,13 +59,23 @@ func resourceFastlyTLSActivationCreate(ctx context.Context, d *schema.ResourceDa
 	conn := meta.(*APIClient).conn
 	var diags diag.Diagnostics
 
+	certificateID := d.Get("certificate_id").(string)
+	if certificateID == "" {
+		return diag.Errorf(
+			"certificate_id is empty: the certificate for the referenced TLS subscription has not been issued yet " +
+				"(certificates are issued asynchronously after domain validation). " +
+				"Reference `fastly_tls_subscription_validation.<name>.certificate_id` instead of " +
+				"`fastly_tls_subscription.<name>.certificate_id` so the activation waits for issuance within a single apply.",
+		)
+	}
+
 	var configuration *fastly.TLSConfiguration
 	if v, ok := d.GetOk("configuration_id"); ok {
 		configuration = &fastly.TLSConfiguration{ID: v.(string)}
 	}
 
 	activation, err := conn.CreateTLSActivation(ctx, &fastly.CreateTLSActivationInput{
-		Certificate:   &fastly.CustomTLSCertificate{ID: d.Get("certificate_id").(string)},
+		Certificate:   &fastly.CustomTLSCertificate{ID: certificateID},
 		Configuration: configuration,
 		Domain:        &fastly.TLSDomain{ID: d.Get("domain").(string)},
 	})

--- a/fastly/resource_fastly_tls_subscription_validation.go
+++ b/fastly/resource_fastly_tls_subscription_validation.go
@@ -20,6 +20,11 @@ func resourceFastlyTLSSubscriptionValidation() *schema.Resource {
 		ReadContext:   resourceFastlyTLSSubscriptionValidationRead,
 		DeleteContext: resourceFastlyTLSSubscriptionValidationDelete,
 		Schema: map[string]*schema.Schema{
+			"certificate_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The ID of the certificate issued for the validated subscription. Only populated once the subscription reaches the `issued` state. Reference this from `fastly_tls_activation.certificate_id` to guarantee the activation is created after the certificate exists, within a single apply.",
+			},
 			"subscription_id": {
 				Type:        schema.TypeString,
 				Description: "The ID of the TLS Subscription that should be validated.",
@@ -89,10 +94,23 @@ func resourceFastlyTLSSubscriptionValidationRead(ctx context.Context, d *schema.
 		return diag.FromErr(err)
 	}
 
-	if subscription.State != subscriptionStateIssued {
+	// NOTE: there must be only one certificate id included per subscription.
+	// A subscription with a certificate may be in the "issued" or "renewing"
+	// state; both are valid, so validity is keyed off the certificate's
+	// presence rather than the state (avoids destroy/recreate churn during
+	// renewals).
+	certificateID := ""
+	if len(subscription.Certificates) > 0 {
+		certificateID = subscription.Certificates[0].ID
+	}
+
+	if certificateID == "" {
 		d.SetId("")
 	} else {
 		d.SetId(subscriptionID)
+		if err := d.Set("certificate_id", certificateID); err != nil {
+			return diag.FromErr(err)
+		}
 	}
 
 	return nil

--- a/fastly/resource_fastly_tls_subscription_validation_test.go
+++ b/fastly/resource_fastly_tls_subscription_validation_test.go
@@ -1,0 +1,24 @@
+package fastly
+
+import (
+	"testing"
+)
+
+// The validation resource cannot be exercised via acceptance tests because
+// completing domain validation requires a real, publicly resolvable
+// domain. This at least pins the schema contract for certificate_id, which
+// downstream fastly_tls_activation configurations depend on.
+func TestResourceFastlyTLSSubscriptionValidation_CertificateIDSchema(t *testing.T) {
+	s := resourceFastlyTLSSubscriptionValidation().Schema
+
+	certificateID, ok := s["certificate_id"]
+	if !ok {
+		t.Fatal("expected schema to contain certificate_id")
+	}
+	if !certificateID.Computed {
+		t.Error("expected certificate_id to be computed")
+	}
+	if certificateID.Required || certificateID.Optional {
+		t.Error("expected certificate_id to be read-only")
+	}
+}

--- a/templates/resources/tls_activation.md.tmpl
+++ b/templates/resources/tls_activation.md.tmpl
@@ -12,6 +12,8 @@ Enables TLS on a domain using a specified custom TLS certificate.
 
 ~> **Note:** The Fastly service must be provisioned _prior_ to enabling TLS on it. This can be achieved in Terraform using [`depends_on`](https://www.terraform.io/docs/configuration/meta-arguments/depends_on.html).
 
+~> **Warning:** This resource is for custom (uploaded) certificates. Do not pair it with a `fastly_tls_subscription` — Fastly automatically activates TLS on a subscription's domains once the managed certificate is issued, so creating an activation for those domains fails with `400 domain_id has already been taken` (and referencing `fastly_tls_subscription.<name>.certificate_id` in the same apply fails earlier with an empty certificate ID). For managed certificates, set `configuration_id` on the subscription and use the `fastly_tls_activation` data source to read the automatically-created activation — see the `fastly_tls_subscription_validation` documentation for a complete example.
+
 ## Example Usage
 
 Basic usage:

--- a/templates/resources/tls_subscription.md.tmpl
+++ b/templates/resources/tls_subscription.md.tmpl
@@ -28,6 +28,8 @@ The workflow configures a `fastly_tls_subscription` resource, then a `aws_route5
 
 We configure the `fastly_tls_subscription_validation` resource, which blocks other resources until the challenge DNS records have been validated by Fastly.
 
+~> **Warning:** Do not create a `fastly_tls_activation` for this subscription's domains. Fastly activates TLS on them automatically once the certificate is issued (a manual activation fails with `400 domain_id has already been taken`, or with an empty-certificate 400 if created in the same apply). Set `configuration_id` on this resource to control the TLS configuration, and reference `fastly_tls_subscription_validation.<name>.certificate_id` when another resource needs the issued certificate — see the `fastly_tls_subscription_validation` documentation for a complete example.
+
 Once the validation has been successful, the configured `fastly_tls_configuration` data source will filter the available results looking for an appropriate TLS configuration object. If that filtering process is successful, then the subsequent `aws_route53_record` resources (for configuring the subdomains) will be executed using the returned TLS configuration data.
 
 {{ tffile "examples/resources/tls_subscription_basic_usage.tf" }}

--- a/templates/resources/tls_subscription_validation.md.tmpl
+++ b/templates/resources/tls_subscription_validation.md.tmpl
@@ -20,6 +20,82 @@ DNS Validation with AWS Route53:
 
 {{ tffile "examples/resources/tls_subscription_basic_usage.tf" }}
 
+Managed certificates for multiple domains, in a single apply:
+
+The `certificate_id` attribute is only populated once the certificate has been issued, so resources referencing it are guaranteed to run after issuance — unlike `fastly_tls_subscription.<name>.certificate_id`, which is empty on first apply (certificates are issued asynchronously after domain validation) and causes API 400 errors when consumed in the same apply.
+
+~> **Note:** Fastly automatically activates TLS on a subscription's domains once the certificate is issued — set `configuration_id` on the `fastly_tls_subscription` itself and do **not** create a `fastly_tls_activation` for those domains (it fails with `400 domain_id has already been taken`). Use the `fastly_tls_activation` data source to read the automatically-created activation.
+
+```terraform
+# Certificates map: key = domain (common_name), value = subscription config
+variable "certificates" {
+  type = map(object({
+    authority     = optional(string, "lets-encrypt")
+    common_name   = optional(string, "")
+    domains       = set(string)
+    force_destroy = optional(bool, true)
+  }))
+}
+
+data "fastly_tls_configuration" "default_tls" {
+  default = true
+}
+
+resource "fastly_tls_subscription" "example" {
+  for_each = var.certificates
+
+  certificate_authority = each.value.authority
+  common_name           = each.value.common_name
+  domains               = each.value.domains
+  force_destroy         = each.value.force_destroy
+
+  # IMPORTANT: with a managed subscription, set the TLS configuration HERE.
+  # Fastly automatically activates TLS on the subscription's domains once the
+  # certificate is issued. Do NOT create a fastly_tls_activation for these
+  # domains — it will fail with `400 domain_id has already been taken`.
+  configuration_id = data.fastly_tls_configuration.default_tls.id
+}
+
+# The domain validation challenge records MUST be created before validation
+# can succeed. This example uses DNS-based validation: replace with your DNS
+# provider's record resource, fed from
+# fastly_tls_subscription.example[each.key].managed_dns_challenges
+# (see the fastly_tls_subscription documentation for a Route53 example).
+resource "aws_route53_record" "domain_validation" {
+  for_each = fastly_tls_subscription.example
+
+  name            = each.value.managed_dns_challenges[0].record_name
+  type            = each.value.managed_dns_challenges[0].record_type
+  records         = [each.value.managed_dns_challenges[0].record_value]
+  zone_id         = "REPLACE_WITH_YOUR_ZONE_ID"
+  allow_overwrite = true
+  ttl             = 60
+}
+
+# Blocks until the certificate has been issued. Its certificate_id attribute
+# is only known after issuance, so downstream resources referencing it are
+# guaranteed to run with a valid certificate — all in a single apply.
+resource "fastly_tls_subscription_validation" "example" {
+  for_each = var.certificates
+
+  subscription_id = fastly_tls_subscription.example[each.key].id
+  depends_on      = [aws_route53_record.domain_validation]
+}
+
+# The activation was created automatically by Fastly when the certificate was
+# issued; this data source reads it (e.g. to consume dns_records/IDs).
+data "fastly_tls_activation" "example" {
+  for_each = var.certificates
+
+  domain     = each.value.common_name
+  depends_on = [fastly_tls_subscription_validation.example]
+}
+
+output "certificate_ids" {
+  value = { for k, v in fastly_tls_subscription_validation.example : k => v.certificate_id }
+}
+```
+
 ## Timeouts
 
 `fastly_tls_subscription_validation` supports the following [Timeouts](https://www.terraform.io/docs/configuration/blocks/resources/syntax.html#operation-timeouts) configuration options:


### PR DESCRIPTION
### Change summary

Fixes #1197 `fastly_tls_activation` (or anything else) consuming
`fastly_tls_subscription.certificate_id` in the same apply receives an empty
value, because certificates are issued asynchronously after DNS/ACME
validation, and fails with `400 … tls_certificate_id is missing or empty`.

Changes:

1. **`fastly_tls_subscription_validation` now exports `certificate_id`**
   (computed). The resource already blocks until the subscription is issued;
   exposing the certificate ID lets users chain issuance-dependent resources
   in a single apply — same pattern as `aws_acm_certificate_validation.certificate_arn`.
2. **Renewal churn guard:** the validation resource's Read now keys validity
   on the certificate's presence rather than `state == "issued"`, so a
   subscription in `renewing` state no longer destroys/recreates the
   validation resource (and cascades to consumers) on every renewal refresh.
3. **Fail fast:** `fastly_tls_activation` Create returns an actionable error
   when `certificate_id` is empty instead of the opaque API 400.
4. **Docs corrected:** managed subscriptions are auto-activated by Fastly on
   issuance — pairing `fastly_tls_activation` with `fastly_tls_subscription`
   fails with `400 domain_id has already been taken`. Docs now direct users to
   set `configuration_id` on the subscription and read the auto-created
   activation via the `fastly_tls_activation` data source; a complete
   multi-domain example was added.

All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?

### New Feature Submissions:

* [x] Does your submission pass tests?
* [x] Post the output of your test runs

`go build ./...`, `go vet ./fastly/` clean; new schema unit test passes
(`TestResourceFastlyTLSSubscriptionValidation_CertificateIDSchema`).

Acceptance-testing the full flow is not possible in CI (completing an ACME
DNS challenge requires a real, publicly resolvable domain), so it was
verified manually end-to-end against real domains:

* **Before** (released provider, issue's config): apply fails with
  `400 … param is missing or the value is empty: tls_certificate_id`.
* **After** (this branch, `certificate_id` chained through the validation
  resource): one single apply — subscription → validation blocks (~38s after
  challenge records existed) → certificate IDs populated → downstream
  data sources read the auto-created activations. Second `terraform plan`
  shows no changes.

### User Impact

* New computed attribute `fastly_tls_subscription_validation.certificate_id`; no breaking changes.
* Users previously stuck on the 400 need no state surgery: point the consumer
  at the validation resource's `certificate_id` and re-apply.
* Subscriptions in `renewing` state no longer recreate the validation resource.

### Are there any considerations that need to be addressed for release?

None; additive change, existing configurations are unaffected.