### PR TITLE
Render in-place plan diffs for snippet blocks (#802)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 ### BREAKING:
 
+- breaking(service_vcl): the `snippet` block is now a list instead of a set. Existing state upgrades automatically (schema v1 -> v2); the first plan after upgrading may show a one-time, order-only diff for `snippet` blocks — applying it makes no changes to the service. Expressions that relied on the attribute being a set (e.g. passing `fastly_service_vcl.x.snippet` to set functions) may need a `tolist()`/`toset()` adjustment ([#802](https://github.com/fastly/terraform-provider-fastly/issues/802))
+
 ### ENHANCEMENTS:
+
+- enhancement(service_vcl): render in-place attribute diffs for `snippet` blocks — a one-line `content` edit now plans as a `~ content` line diff instead of a whole-block remove/add pair ([#802](https://github.com/fastly/terraform-provider-fastly/issues/802))
 
 ### BUG FIXES:
 

--- a/docs/resources/service_vcl.md
+++ b/docs/resources/service_vcl.md
@@ -272,7 +272,7 @@ $ terraform import fastly_service_vcl.demo xxxxxxxxxxxxxxxxxxxx@2
 - `request_setting` (Block Set) (see [below for nested schema](#nestedblock--request_setting))
 - `response_object` (Block Set) (see [below for nested schema](#nestedblock--response_object))
 - `reuse` (Boolean) Services that are active cannot be destroyed. If set to `true` a service Terraform intends to destroy will instead be deactivated (allowing it to be reused by importing it into another Terraform project). If `false`, attempting to destroy an active service will cause an error. Default `false`
-- `snippet` (Block Set) (see [below for nested schema](#nestedblock--snippet))
+- `snippet` (Block List) (see [below for nested schema](#nestedblock--snippet))
 - `stage` (Boolean) Conditionally enables new service versions to be staged. If set to `true`, all changes made by an `apply` step will be staged, even if `apply` did not create a new draft version. Default `false`
 - `stale_if_error` (Boolean) Enables serving a stale object if there is an error
 - `stale_if_error_ttl` (Number) The default time-to-live (TTL) for serving the stale object for the version

--- a/fastly/block_fastly_service_snippet.go
+++ b/fastly/block_fastly_service_snippet.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -35,7 +36,9 @@ func (h *SnippetServiceAttributeHandler) Key() string {
 // GetSchema returns the resource schema.
 func (h *SnippetServiceAttributeHandler) GetSchema() *schema.Schema {
 	return &schema.Schema{
-		Type:     schema.TypeSet,
+		// TypeList (not TypeSet) so plans render in-place attribute diffs.
+		// Order carries no meaning for the API; Read keeps it stable by name.
+		Type:     schema.TypeList,
 		Optional: true,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
@@ -82,7 +85,7 @@ func (h *SnippetServiceAttributeHandler) Create(ctx context.Context, d *schema.R
 
 // Read refreshes the resource.
 func (h *SnippetServiceAttributeHandler) Read(ctx context.Context, d *schema.ResourceData, _ map[string]any, serviceVersion int, conn *gofastly.Client) error {
-	localState := d.Get(h.Key()).(*schema.Set).List()
+	localState := d.Get(h.Key()).([]any)
 
 	if len(localState) > 0 || d.Get("imported").(bool) || d.Get("force_refresh").(bool) {
 		log.Printf("[DEBUG] Refreshing VCL Snippets for (%s)", d.Id())
@@ -94,7 +97,7 @@ func (h *SnippetServiceAttributeHandler) Read(ctx context.Context, d *schema.Res
 			return fmt.Errorf("error looking up VCL Snippets for (%s), version (%v): %s", d.Id(), serviceVersion, err)
 		}
 
-		vsl := flattenSnippets(remoteState)
+		vsl := reorderSnippetsByPriorState(flattenSnippets(remoteState), localState)
 
 		if err := d.Set(h.GetKey(), vsl); err != nil {
 			log.Printf("[WARN] Error setting VCL Snippets for (%s): %s", d.Id(), err)
@@ -176,6 +179,40 @@ func buildSnippet(snippetMap any) *gofastly.CreateSnippetInput {
 	opts.Type = gofastly.ToPointer(gofastly.SnippetType(snippetType))
 
 	return &opts
+}
+
+// reorderSnippetsByPriorState orders flattened snippets by prior state order
+// (keyed by name) since the API listing order is not stable and would
+// otherwise surface as phantom list diffs. Unknown names are appended sorted.
+func reorderSnippetsByPriorState(flattened []map[string]any, priorState []any) []map[string]any {
+	position := map[string]int{}
+	for i, prior := range priorState {
+		if m, ok := prior.(map[string]any); ok {
+			if name, ok := m["name"].(string); ok {
+				position[name] = i
+			}
+		}
+	}
+
+	name := func(m map[string]any) string {
+		n, _ := m["name"].(string)
+		return n
+	}
+
+	sort.SliceStable(flattened, func(i, j int) bool {
+		pi, iKnown := position[name(flattened[i])]
+		pj, jKnown := position[name(flattened[j])]
+		switch {
+		case iKnown && jKnown:
+			return pi < pj
+		case iKnown != jKnown:
+			return iKnown
+		default:
+			return name(flattened[i]) < name(flattened[j])
+		}
+	})
+
+	return flattened
 }
 
 // flattenSnippets models data into format suitable for saving to Terraform state.

--- a/fastly/block_fastly_service_snippet_test.go
+++ b/fastly/block_fastly_service_snippet_test.go
@@ -14,6 +14,61 @@ import (
 	gofastly "github.com/fastly/go-fastly/v16/fastly"
 )
 
+func TestReorderSnippetsByPriorState(t *testing.T) {
+	cases := []struct {
+		desc      string
+		flattened []map[string]any
+		prior     []any
+		want      []string
+	}{
+		{
+			desc: "remote order flips but prior state order wins",
+			flattened: []map[string]any{
+				{"name": "b"},
+				{"name": "a"},
+			},
+			prior: []any{
+				map[string]any{"name": "a"},
+				map[string]any{"name": "b"},
+			},
+			want: []string{"a", "b"},
+		},
+		{
+			desc: "snippets unknown to prior state are appended sorted by name",
+			flattened: []map[string]any{
+				{"name": "z-new"},
+				{"name": "known"},
+				{"name": "a-new"},
+			},
+			prior: []any{
+				map[string]any{"name": "known"},
+			},
+			want: []string{"known", "a-new", "z-new"},
+		},
+		{
+			desc: "empty prior state sorts by name",
+			flattened: []map[string]any{
+				{"name": "c"},
+				{"name": "a"},
+				{"name": "b"},
+			},
+			prior: nil,
+			want:  []string{"a", "b", "c"},
+		},
+	}
+
+	for _, c := range cases {
+		got := reorderSnippetsByPriorState(c.flattened, c.prior)
+		var names []string
+		for _, m := range got {
+			names = append(names, m["name"].(string))
+		}
+		if !reflect.DeepEqual(names, c.want) {
+			t.Errorf("%s: got %v, want %v", c.desc, names, c.want)
+		}
+	}
+}
+
 func TestResourceFastlyFlattenSnippets(t *testing.T) {
 	cases := []struct {
 		remote []*gofastly.Snippet

--- a/fastly/diff.go
+++ b/fastly/diff.go
@@ -50,52 +50,58 @@ func NewSetDiff(keyFunc KeyFunc) *SetDiff {
 // 'comment' attribute, but in order to compare changes using SetDiff we only
 // really have the option to use 'name' as the lookup key.
 func (h *SetDiff) Diff(oldSet, newSet *schema.Set) (*DiffResult, error) {
-	// Convert the set into a map to facilitate lookup
-	oldSetMap := map[any]any{}
-	newSetMap := map[any]any{}
+	return h.DiffLists(oldSet.List(), newSet.List())
+}
 
-	for _, elem := range oldSet.List() {
+// DiffLists is the schema.TypeList equivalent of Diff: elements are matched
+// by KeyFunc and compared by deep equality, so element order is irrelevant.
+func (h *SetDiff) DiffLists(oldList, newList []any) (*DiffResult, error) {
+	// Convert the lists into maps to facilitate lookup
+	oldMap := map[any]any{}
+	newMap := map[any]any{}
+
+	for _, elem := range oldList {
 		key, err := h.computeKey(elem)
 		if err != nil {
 			return nil, newElementKeyError(elem, err)
 		}
-		oldSetMap[key] = elem
+		oldMap[key] = elem
 	}
 
-	for _, elem := range newSet.List() {
+	for _, elem := range newList {
 		key, err := h.computeKey(elem)
 		if err != nil {
 			return nil, newElementKeyError(elem, err)
 		}
-		newSetMap[key] = elem
+		newMap[key] = elem
 	}
 
-	// Compute all added and modified elements using Terraform set comparison method.
-	var added, modified []any
-	for _, newElem := range newSet.Difference(oldSet).List() {
+	var added, modified, unmodified []any
+	for _, newElem := range newList {
 		key, err := h.computeKey(newElem)
 		if err != nil {
 			return nil, newElementKeyError(newElem, err)
 		}
-		if oldSetMap[key] != nil {
-			modified = append(modified, newElem)
-		} else {
+		switch oldElem, exists := oldMap[key]; {
+		case !exists:
 			added = append(added, newElem)
+		case reflect.DeepEqual(oldElem, newElem):
+			unmodified = append(unmodified, newElem)
+		default:
+			modified = append(modified, newElem)
 		}
 	}
 
 	var deleted []any
-	for _, oldElem := range oldSet.Difference(newSet).List() {
+	for _, oldElem := range oldList {
 		key, err := h.computeKey(oldElem)
 		if err != nil {
 			return nil, newElementKeyError(oldElem, err)
 		}
-		if newSetMap[key] == nil {
+		if _, exists := newMap[key]; !exists {
 			deleted = append(deleted, oldElem)
 		}
 	}
-
-	unmodified := oldSet.Intersection(newSet).List()
 
 	return &DiffResult{
 		Added:      added,
@@ -124,7 +130,11 @@ func (h *SetDiff) computeKey(elem any) (any, error) {
 // attribute) it might have unexpected consequences (e.g. a nested resource
 // gets replaced/recreated). Safer to only update attributes that need to be.
 func (h *SetDiff) Filter(modified map[string]any, oldSet *schema.Set) map[string]any {
-	elements := oldSet.List()
+	return h.FilterList(modified, oldSet.List())
+}
+
+// FilterList is the schema.TypeList equivalent of Filter.
+func (h *SetDiff) FilterList(modified map[string]any, elements []any) map[string]any {
 	filtered := make(map[string]any)
 
 	for _, e := range elements {

--- a/fastly/diff_test.go
+++ b/fastly/diff_test.go
@@ -119,6 +119,42 @@ func TestSetDiff_Diff(t *testing.T) {
 	}
 }
 
+func TestSetDiff_DiffLists(t *testing.T) {
+	differ := NewSetDiff(testKeyFuncByName)
+
+	oldList := []any{
+		map[string]any{"name": "a", "value": "value-a"},
+		map[string]any{"name": "b", "value": "value-b"},
+		map[string]any{"name": "d", "value": "value-d"},
+	}
+	newList := []any{
+		map[string]any{"name": "a", "value": "value-a-new"},
+		map[string]any{"name": "c", "value": "value-c"},
+		map[string]any{"name": "d", "value": "value-d"},
+	}
+
+	diff, err := differ.DiffLists(oldList, newList)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	assert.Equal(t, []any{map[string]any{"name": "c", "value": "value-c"}}, diff.Added)
+	assert.Equal(t, []any{map[string]any{"name": "a", "value": "value-a-new"}}, diff.Modified)
+	assert.Equal(t, []any{map[string]any{"name": "b", "value": "value-b"}}, diff.Deleted)
+	assert.Equal(t, []any{map[string]any{"name": "d", "value": "value-d"}}, diff.Unmodified)
+
+	// A pure reorder must produce no changes.
+	reordered := []any{oldList[2], oldList[0], oldList[1]}
+	diff, err = differ.DiffLists(oldList, reordered)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assert.Empty(t, diff.Added)
+	assert.Empty(t, diff.Modified)
+	assert.Empty(t, diff.Deleted)
+	assert.Len(t, diff.Unmodified, 3)
+}
+
 func testKeyFuncByName(element any) (any, error) {
 	elemMap := element.(map[string]any)
 	return elemMap["name"], nil

--- a/fastly/resource_fastly_service_vcl.go
+++ b/fastly/resource_fastly_service_vcl.go
@@ -67,13 +67,19 @@ var vclService = &BaseServiceDefinition{
 func resourceServiceVCL() *schema.Resource {
 	resource := resourceService(vclService)
 
-	// Add schema version and state upgraders for bot_management breaking change (v9.0.0)
-	resource.SchemaVersion = 1
+	// v0 -> v1: bot_management breaking change (v9.0.0)
+	// v1 -> v2: snippet block container changed from TypeSet to TypeList
+	resource.SchemaVersion = 2
 	resource.StateUpgraders = []schema.StateUpgrader{
 		{
 			Version: 0,
 			Type:    serviceVCLStateUpgraderV0().CoreConfigSchema().ImpliedType(),
 			Upgrade: upgradeServiceVCLStateV0toV1,
+		},
+		{
+			Version: 1,
+			Type:    serviceVCLStateUpgraderV1().CoreConfigSchema().ImpliedType(),
+			Upgrade: upgradeServiceVCLStateV1toV2,
 		},
 	}
 

--- a/fastly/resource_fastly_service_vcl_state_upgrade.go
+++ b/fastly/resource_fastly_service_vcl_state_upgrade.go
@@ -78,6 +78,41 @@ func upgradeServiceVCLStateV0toV1(_ context.Context, rawState map[string]any, _ 
 	return rawState, nil
 }
 
+// upgradeServiceVCLStateV1toV2 upgrades the state schema from version 1 to version 2,
+// where the snippet block moved from TypeSet to TypeList. Both serialize as a JSON
+// array, so the raw state passes through unchanged.
+func upgradeServiceVCLStateV1toV2(_ context.Context, rawState map[string]any, _ any) (map[string]any, error) {
+	if rawState == nil {
+		return rawState, nil
+	}
+
+	log.Println("[DEBUG] Upgrading fastly_service_vcl state from v1 to v2 (snippet TypeSet -> TypeList)")
+
+	return rawState, nil
+}
+
+// serviceVCLStateUpgraderV1 returns the parts of the version 1 schema of the service
+// VCL resource that are relevant to the v1 -> v2 upgrade, where snippet was a TypeSet.
+func serviceVCLStateUpgraderV1() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"snippet": {
+				Type:        schema.TypeSet,
+				Description: "VCL snippets (v1 schema, set container)",
+				Optional:    true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"content":  {Type: schema.TypeString, Description: "Snippet content", Required: true},
+						"name":     {Type: schema.TypeString, Description: "Snippet name", Required: true},
+						"priority": {Type: schema.TypeInt, Description: "Snippet priority", Optional: true},
+						"type":     {Type: schema.TypeString, Description: "Snippet type", Required: true},
+					},
+				},
+			},
+		},
+	}
+}
+
 // serviceVCLStateUpgraderV0 returns the schema for version 0 of the service VCL resource.
 // This represents the schema before the bot_management change in v9.0.0.
 func serviceVCLStateUpgraderV0() *schema.Resource {

--- a/fastly/resource_fastly_service_vcl_state_upgrade_test.go
+++ b/fastly/resource_fastly_service_vcl_state_upgrade_test.go
@@ -5,6 +5,46 @@ import (
 	"testing"
 )
 
+func TestUpgradeServiceVCLStateV1toV2_SnippetsPassThrough(t *testing.T) {
+	rawState := map[string]any{
+		"snippet": []any{
+			map[string]any{
+				"name":     "my_snippet",
+				"type":     "init",
+				"priority": 100,
+				"content":  "table my_table {}",
+			},
+		},
+	}
+
+	upgraded, err := upgradeServiceVCLStateV1toV2(context.Background(), rawState, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	snippets, ok := upgraded["snippet"].([]any)
+	if !ok {
+		t.Fatalf("expected snippet to be []any, got %T", upgraded["snippet"])
+	}
+	if len(snippets) != 1 {
+		t.Fatalf("expected 1 snippet, got %d", len(snippets))
+	}
+	snippet := snippets[0].(map[string]any)
+	if snippet["name"] != "my_snippet" || snippet["content"] != "table my_table {}" {
+		t.Errorf("snippet data was not preserved: %v", snippet)
+	}
+}
+
+func TestUpgradeServiceVCLStateV1toV2_NilState(t *testing.T) {
+	upgraded, err := upgradeServiceVCLStateV1toV2(context.Background(), nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if upgraded != nil {
+		t.Errorf("expected nil state to pass through, got %v", upgraded)
+	}
+}
+
 func TestUpgradeServiceVCLStateV0toV1_BotManagementTrue(t *testing.T) {
 	// Test upgrading when bot_management was true
 	// In rawState, Sets are represented as []any slices

--- a/fastly/service_crud_attribute_definition.go
+++ b/fastly/service_crud_attribute_definition.go
@@ -80,15 +80,15 @@ func (h *blockSetAttributeHandler) Read(ctx context.Context, d *schema.ResourceD
 
 func (h *blockSetAttributeHandler) Process(ctx context.Context, d *schema.ResourceData, serviceVersion int, conn *gofastly.Client) error {
 	oldVal, newVal := d.GetChange(h.handler.Key())
-	if oldVal == nil {
-		oldVal = new(schema.Set)
-	}
-	if newVal == nil {
-		newVal = new(schema.Set)
-	}
 
-	oldSet := oldVal.(*schema.Set)
-	newSet := newVal.(*schema.Set)
+	oldList, err := toResourceList(oldVal)
+	if err != nil {
+		return err
+	}
+	newList, err := toResourceList(newVal)
+	if err != nil {
+		return err
+	}
 
 	setDiff := NewSetDiff(func(resource any) (any, error) {
 		t, ok := resource.(map[string]any)
@@ -98,7 +98,7 @@ func (h *blockSetAttributeHandler) Process(ctx context.Context, d *schema.Resour
 		return t["name"], nil
 	})
 
-	diffResult, err := setDiff.Diff(oldSet, newSet)
+	diffResult, err := setDiff.DiffLists(oldList, newList)
 	if err != nil {
 		return err
 	}
@@ -121,7 +121,7 @@ func (h *blockSetAttributeHandler) Process(ctx context.Context, d *schema.Resour
 
 	for _, resource := range diffResult.Modified {
 		resource := resource.(map[string]any)
-		modified := setDiff.Filter(resource, oldSet)
+		modified := setDiff.FilterList(resource, oldList)
 		err := h.handler.Update(ctx, d, resource, modified, serviceVersion, conn)
 		if err != nil {
 			return err
@@ -129,6 +129,21 @@ func (h *blockSetAttributeHandler) Process(ctx context.Context, d *schema.Resour
 	}
 
 	return nil
+}
+
+// toResourceList normalizes a nested block value (TypeSet or TypeList
+// container) into a list of resources.
+func toResourceList(val any) ([]any, error) {
+	switch t := val.(type) {
+	case nil:
+		return nil, nil
+	case *schema.Set:
+		return t.List(), nil
+	case []any:
+		return t, nil
+	default:
+		return nil, fmt.Errorf("unexpected nested block container type: %T", val)
+	}
 }
 
 func (h *blockSetAttributeHandler) HasChange(d *schema.ResourceData) bool {


### PR DESCRIPTION
### Change summary

Fixes #802.

Editing one line of a `snippet` block's `content` used to render as a remove+add of the whole block (or worse ... with multiple snippets, Terraform cross-matches set elements and shows one snippet "becoming" another). 

"Root cause" is `snippet` is a `schema.TypeSet`, and since Terraform 0.12 set element identity is pure value equality computed by core: no provider-side hook (custom `Set:` hash, `DiffSuppressFunc`, `CustomizeDiff`) can change that rendering. Notably, apply behavior was already correct: the provider matches snippets by `name` and issues in-place `UpdateSnippet` calls. The noise was purely a display artifact.

This PR converts the container to `schema.TypeList`, with two guards so that ordering (meaningless to the Fastly API: execution order is driven by `priority`) never produces spurious diffs:

1. `Read` reorders remote results to match prior state order, keyed by `name` (the list API does not guarantee stable ordering); snippets created out-of-band are appended sorted by name.
2. Apply still matches by `name`: `SetDiff` gained list-based `DiffLists`/`FilterList` (the set methods delegate to them ... all other blocks are behavior-identical), and the shared CRUD `Process` handler accepts both containers via `toResourceList`. A pure config reorder applies with **zero** snippet API calls.

State migration: set and list serialize identically (JSON array), so data is compatible as-is; `SchemaVersion` is bumped 1 → 2 with a pass-through upgrader to make the change explicit.

**Before** (v9.x: one line of `my_snippet` edited; Terraform cross-matches the two set elements, so each snippet's entire content is shown replaced by the other's):

```hcl
  # fastly_service_vcl.this will be updated in-place
  ~ resource "fastly_service_vcl" "this" {
      ~ active_version     = 2 -> (known after apply)
      ~ cloned_version     = 2 -> (known after apply)
        id                 = "<REDACTED>"
        name               = "<REDACTED>"
        # (12 unchanged attributes hidden)

      ~ snippet {
          ~ content  = <<-EOT
              - table my_table {
              -   "foo": "bar",
              -   "bar": "foo",
              - }
              - # line 1
              - # line 2
              - # line 3 -- REMOVE ME
              - # line 4
              - # line 5
            EOT
            # (1 unchanged attribute hidden)
        }

    ~ snippet {
          ~ content  = <<-EOT
              + table my_table {
              +   "foo": "bar",
              +   "bar": "foo",
              + }
              + # line 1
              + # line 2
              + # line 4
              + # line 5
            EOT
            # (1 unchanged attribute hidden)
        }

        # (1 unchanged block hidden)
    }
```

**After** (this PR, same edit: only the changed line shows):

```hcl
  # fastly_service_vcl.this will be updated in-place
  ~ resource "fastly_service_vcl" "this" {
      ~ active_version     = 2 -> (known after apply)
      ~ cloned_version     = 2 -> (known after apply)
        id                 = "<REDACTED>"
        name               = "<REDACTED>"
        # (12 unchanged attributes hidden)

      ~ snippet {
          ~ content  = <<-EOT
                table my_table {
                  "foo": "bar",
                  "bar": "foo",
                }
                # line 1
                # line 2
              - # line 3 -- REMOVE ME
                # line 4
                # line 5
            EOT
            name     = "my_snippet"
            # (2 unchanged attributes hidden)
        }

        # (3 unchanged blocks hidden)
    }
```

Scope is deliberately snippet-only; `vcl` and `dynamicsnippet` share the identical pattern and can follow in separate PRs if this approach is accepted (`toResourceList` already supports them).

All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?

### Changes to Core Features:

* [x] Have you written new tests for your core changes, as applicable? (`TestSetDiff_DiffLists`, `TestReorderSnippetsByPriorState`, `TestUpgradeServiceVCLStateV1toV2_*`)
* [x] Have you successfully run tests with your changes locally? `go build ./...`, `go vet ./fastly/`, `go test ./fastly/`: 222 pass. Verified end-to-end against a real service: one-line edit renders an in-place diff (outputs above); no-op refresh plans "No changes."; config reorder applies with zero snippet API calls.

### User Impact

- Plans for content-heavy snippets become reviewable: a 1-line change shows as a 1-line diff.
- The exported `snippet` attribute changes type from set-of-objects to list-of-objects; expressions feeding it to set functions may need `tolist()`/`toset()` adjustments.

### Are there any considerations that need to be addressed for release?

- Semver: should ship in a **major** release (attribute type change + schema version bump; state is not downgradeable afterwards).
- Release notes should call out the one-time, order-only `snippet` diff on the first plan after upgrading (state carries the old set's hash ordering); applying it makes no API changes and subsequent plans are clean.
