### PR TITLE
Update CHANGELOG.md to point to PRs instead of Issue #s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,11 @@
 
 ### ENHANCEMENTS:
 
-- feat(tls/subscription): include subscription ID and domains in `fastly_tls_subscription` API error messages so failing resources can be identified when managing many subscriptions ([#888](https://github.com/fastly/terraform-provider-fastly/issues/888))
+- feat(tls/subscription): include subscription ID and domains in `fastly_tls_subscription` API error messages so failing resources can be identified when managing many subscriptions ([#1344](https://github.com/fastly/terraform-provider-fastly/pull/1344))
 
 ### BUG FIXES:
 
-- fix(logging): Validate logging `format` length (max 12288 characters) at plan/validate time instead of failing at apply time ([#1340](https://github.com/fastly/terraform-provider-fastly/issues/1340))
+- fix(logging): Validate logging `format` length (max 12288 characters) at plan/validate time instead of failing at apply time ([#1342](https://github.com/fastly/terraform-provider-fastly/pull/1342))
 
 ### Dependencies
 


### PR DESCRIPTION
### Change summary

Updated changelog entries to point to the PRs where the work was done instead of the issues where they were reported.

 All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/terraform-provider-fastly/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->