### PR TITLE
add polling to ACL entries to prevent reads after from showing a diff

### DIFF
--- a/internal/resources/aclentries/aclentries_test.go
+++ b/internal/resources/aclentries/aclentries_test.go
@@ -113,3 +113,113 @@ func TestBuildBatchEntries(t *testing.T) {
 		})
 	}
 }
+
+func TestEntriesConverged(t *testing.T) {
+	tests := []struct {
+		name      string
+		remote    []computeacls.ComputeACLEntry
+		batch     []*computeacls.BatchComputeACLEntry
+		converged bool
+	}{
+		{
+			name:   "create not yet visible",
+			remote: nil,
+			batch: []*computeacls.BatchComputeACLEntry{
+				{Prefix: new("192.0.2.0/24"), Action: new("ALLOW"), Operation: new(createOperation)},
+			},
+			converged: false,
+		},
+		{
+			name: "create visible",
+			remote: []computeacls.ComputeACLEntry{
+				{Prefix: "192.0.2.0/24", Action: "ALLOW"},
+			},
+			batch: []*computeacls.BatchComputeACLEntry{
+				{Prefix: new("192.0.2.0/24"), Action: new("ALLOW"), Operation: new(createOperation)},
+			},
+			converged: true,
+		},
+		{
+			name: "update not yet visible",
+			remote: []computeacls.ComputeACLEntry{
+				{Prefix: "192.0.2.0/24", Action: "ALLOW"},
+			},
+			batch: []*computeacls.BatchComputeACLEntry{
+				{Prefix: new("192.0.2.0/24"), Action: new("BLOCK"), Operation: new(updateOperation)},
+			},
+			converged: false,
+		},
+		{
+			name: "update visible",
+			remote: []computeacls.ComputeACLEntry{
+				{Prefix: "192.0.2.0/24", Action: "BLOCK"},
+			},
+			batch: []*computeacls.BatchComputeACLEntry{
+				{Prefix: new("192.0.2.0/24"), Action: new("BLOCK"), Operation: new(updateOperation)},
+			},
+			converged: true,
+		},
+		{
+			name: "delete not yet visible",
+			remote: []computeacls.ComputeACLEntry{
+				{Prefix: "192.0.2.0/24", Action: "ALLOW"},
+			},
+			batch: []*computeacls.BatchComputeACLEntry{
+				{Prefix: new("192.0.2.0/24"), Operation: new(deleteOperation)},
+			},
+			converged: false,
+		},
+		{
+			name:   "delete visible",
+			remote: nil,
+			batch: []*computeacls.BatchComputeACLEntry{
+				{Prefix: new("192.0.2.0/24"), Operation: new(deleteOperation)},
+			},
+			converged: true,
+		},
+		{
+			name: "mixed operations all converged",
+			remote: []computeacls.ComputeACLEntry{
+				{Prefix: "198.51.100.0/24", Action: "ALLOW"},
+				{Prefix: "203.0.113.0/24", Action: "BLOCK"},
+			},
+			batch: []*computeacls.BatchComputeACLEntry{
+				{Prefix: new("192.0.2.0/24"), Operation: new(deleteOperation)},
+				{Prefix: new("198.51.100.0/24"), Action: new("ALLOW"), Operation: new(updateOperation)},
+				{Prefix: new("203.0.113.0/24"), Action: new("BLOCK"), Operation: new(createOperation)},
+			},
+			converged: true,
+		},
+		{
+			name: "mixed operations one still pending",
+			remote: []computeacls.ComputeACLEntry{
+				{Prefix: "192.0.2.0/24", Action: "ALLOW"},
+				{Prefix: "198.51.100.0/24", Action: "ALLOW"},
+				{Prefix: "203.0.113.0/24", Action: "BLOCK"},
+			},
+			batch: []*computeacls.BatchComputeACLEntry{
+				{Prefix: new("192.0.2.0/24"), Operation: new(deleteOperation)},
+				{Prefix: new("198.51.100.0/24"), Action: new("ALLOW"), Operation: new(updateOperation)},
+				{Prefix: new("203.0.113.0/24"), Action: new("BLOCK"), Operation: new(createOperation)},
+			},
+			converged: false,
+		},
+		{
+			name: "unrelated remote entries are ignored",
+			remote: []computeacls.ComputeACLEntry{
+				{Prefix: "192.0.2.0/24", Action: "ALLOW"},
+				{Prefix: "203.0.113.0/24", Action: "BLOCK"},
+			},
+			batch: []*computeacls.BatchComputeACLEntry{
+				{Prefix: new("192.0.2.0/24"), Action: new("ALLOW"), Operation: new(createOperation)},
+			},
+			converged: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.converged, entriesConverged(tt.remote, tt.batch))
+		})
+	}
+}

--- a/internal/resources/aclentries/resource.go
+++ b/internal/resources/aclentries/resource.go
@@ -288,7 +288,8 @@ func (r *Resource) updateEntries(ctx context.Context, aclID string, batch []*com
 // waitForEntries polls listEntries until the remote state reflects every
 // operation in batch, since the batch update endpoint applies asynchronously.
 func (r *Resource) waitForEntries(ctx context.Context, aclID string, batch []*computeacls.BatchComputeACLEntry) ([]computeacls.ComputeACLEntry, error) {
-	deadline := time.Now().Add(entriesPollTimeout)
+	ctx, cancel := context.WithTimeout(ctx, entriesPollTimeout)
+	defer cancel()
 
 	for {
 		remote, err := r.listEntries(ctx, aclID)
@@ -300,13 +301,9 @@ func (r *Resource) waitForEntries(ctx context.Context, aclID string, batch []*co
 			return remote, nil
 		}
 
-		if time.Now().After(deadline) {
-			return nil, fmt.Errorf("timed out after %s waiting for ACL entries to reflect the update", entriesPollTimeout)
-		}
-
 		select {
 		case <-ctx.Done():
-			return nil, ctx.Err()
+			return nil, fmt.Errorf("timed out after %s waiting for ACL entries to reflect the update: %w", entriesPollTimeout, ctx.Err())
 		case <-time.After(entriesPollInterval):
 		}
 	}

--- a/internal/resources/aclentries/resource.go
+++ b/internal/resources/aclentries/resource.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	fastlyclient "github.com/fastly/terraform-provider-fastly/internal/client"
 	"github.com/fastly/terraform-provider-fastly/internal/errors"
@@ -15,6 +16,14 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+// The compute ACL batch update endpoint responds 202 Accepted and applies the
+// batch asynchronously, so a list call immediately afterward can race the
+// propagation. Poll until the listed entries reflect the batch we sent.
+const (
+	entriesPollInterval = 500 * time.Millisecond
+	entriesPollTimeout  = 30 * time.Second
 )
 
 var _ resource.Resource = &Resource{}
@@ -82,7 +91,7 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 		return
 	}
 
-	remote, err := r.listEntries(ctx, aclID)
+	remote, err := r.waitForEntries(ctx, aclID, batch)
 	if err != nil {
 		resp.Diagnostics.AddError("Error refreshing ACL entries", err.Error())
 		return
@@ -154,7 +163,7 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 		return
 	}
 
-	remote, err := r.listEntries(ctx, aclID)
+	remote, err := r.waitForEntries(ctx, aclID, batch)
 	if err != nil {
 		resp.Diagnostics.AddError("Error refreshing ACL entries", err.Error())
 		return
@@ -274,4 +283,56 @@ func (r *Resource) updateEntries(ctx context.Context, aclID string, batch []*com
 		ComputeACLID: &aclID,
 		Entries:      batch,
 	})
+}
+
+// waitForEntries polls listEntries until the remote state reflects every
+// operation in batch, since the batch update endpoint applies asynchronously.
+func (r *Resource) waitForEntries(ctx context.Context, aclID string, batch []*computeacls.BatchComputeACLEntry) ([]computeacls.ComputeACLEntry, error) {
+	deadline := time.Now().Add(entriesPollTimeout)
+
+	for {
+		remote, err := r.listEntries(ctx, aclID)
+		if err != nil {
+			return nil, err
+		}
+
+		if entriesConverged(remote, batch) {
+			return remote, nil
+		}
+
+		if time.Now().After(deadline) {
+			return nil, fmt.Errorf("timed out after %s waiting for ACL entries to reflect the update", entriesPollTimeout)
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(entriesPollInterval):
+		}
+	}
+}
+
+// entriesConverged reports whether remote already reflects every operation
+// in batch: deleted prefixes absent, created/updated prefixes present with
+// the expected action.
+func entriesConverged(remote []computeacls.ComputeACLEntry, batch []*computeacls.BatchComputeACLEntry) bool {
+	remoteActions := make(map[string]string, len(remote))
+	for _, e := range remote {
+		remoteActions[e.Prefix] = e.Action
+	}
+
+	for _, op := range batch {
+		action, exists := remoteActions[*op.Prefix]
+		if *op.Operation == deleteOperation {
+			if exists {
+				return false
+			}
+			continue
+		}
+		if !exists || action != *op.Action {
+			return false
+		}
+	}
+
+	return true
 }


### PR DESCRIPTION

<img width="647" height="159" alt="Screenshot 2026-07-21 at 11 37 05 AM" src="https://github.com/user-attachments/assets/b1d36008-403e-41f4-bb96-0ff815aa6d9e" />

there was a case where tests would fail because the batch update functions would return 202 from the API but the reads after wouldn't reflect the new changes because the operations weren't completed. Added a wait and timeout to handle those cases.

All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/terraform-provider-fastly/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

* [x] Does your submission pass tests?
* [x] Post the output of your test runs
<img width="736" height="204" alt="Screenshot 2026-07-21 at 11 40 13 AM" src="https://github.com/user-attachments/assets/0592e07c-74b0-491d-a166-9aebb47cc134" />

