### PR TITLE
[CDTOOL-1679] - Allow `configuration_id` attribute changes to be updated without requiring a resource replacement for TLS Subscriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 - fix(logging): Validate logging `format` length (max 12288 characters) at plan/validate time instead of failing at apply time ([#1342](https://github.com/fastly/terraform-provider-fastly/pull/1342))
 
+- fix(tls_subscription): allow `configuration_id` attribute changes to be updated without requiring a resource replacement [#1353](https://github.com/fastly/terraform-provider-fastly/pull/1353)
+
 ### Dependencies
 
 ## 9.3.1 (July 09, 2026)

--- a/fastly/resource_fastly_tls_subscription.go
+++ b/fastly/resource_fastly_tls_subscription.go
@@ -353,18 +353,19 @@ func resourceFastlyTLSSubscriptionRead(ctx context.Context, d *schema.ResourceDa
 func resourceFastlyTLSSubscriptionUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// NOTE: Terraform might trigger an update even when it doesn't make sense.
 	//
-	// This is because along with the "domains" and "common_name" attributes,
-	// there are other attributes a customer might modify, such as
-	// "force_update" (which has no effect on the upstream data model).
+	// This is because along with the "domains", "common_name", and
+	// "configuration_id" attributes, there are other attributes a customer
+	// might modify, such as "force_update" (which has no effect on the
+	// upstream data model).
 	//
 	// So we don't want to call the API if the customer neither passes a change to
-	// domains or to the common_name attributes as that would be a waste of
+	// domains, common_name, or configuration_id as that would be a waste of
 	// network resources.
 	//
 	// This is why we wrap the API request in the following conditional check.
-	// We then send BOTH "domains" and "common_name" in the API request.
-	// This is because they both will have a pre-existing value.
-	if d.HasChanges("domains", "common_name") {
+	// We then send "domains", "common_name" AND "configuration_id" in the API
+	// request. This is because they will all have a pre-existing value.
+	if d.HasChanges("domains", "common_name", "configuration_id") {
 		// NOTE: The API doesn't care if the domains are in a different order.
 		// I mention this because if it did, then we'd only want to set the Domains
 		// field on the input struct if there was a change because we otherwise

--- a/fastly/resource_fastly_tls_subscription_test.go
+++ b/fastly/resource_fastly_tls_subscription_test.go
@@ -64,6 +64,18 @@ func TestAccResourceFastlyTLSSubscription_Config(t *testing.T) {
 				),
 			},
 			{
+				// Regression test: changing ONLY configuration_id (no change
+				// to domains/common_name) must actually reach the API. If it
+				// doesn't, this step's automatic post-apply plan check fails
+				// because the diff reappears on the next refresh.
+				Config: testAccResourceFastlyTLSSubscriptionConfigWithConfigurationID(name, domain1, domain2, commonName2),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "configuration_id"),
+					// subscription is "updated" so the subscription ID should remain the same
+					resource.TestCheckResourceAttrPtr(resourceName, "id", &subscriptionID),
+				),
+			},
+			{
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
@@ -105,6 +117,43 @@ resource "fastly_tls_subscription" "subject" {
   domains = [for domain in fastly_service_vcl.test.domain : domain.name]
   common_name = "%s"
   certificate_authority = "lets-encrypt"
+}
+`, name, domain1, domain2, commonName)
+}
+
+// testAccResourceFastlyTLSSubscriptionConfigWithConfigurationID pins
+// configuration_id to a specific, non-default TLS configuration, so that a
+// subsequent step can change configuration_id alone and verify the change is
+// actually applied (see TestAccResourceFastlyTLSSubscription_Config).
+func testAccResourceFastlyTLSSubscriptionConfigWithConfigurationID(name, domain1, domain2, commonName string) string {
+	return fmt.Sprintf(`
+data "fastly_tls_configuration" "secondary" {
+  name = "HTTP/3 & TLS v1.3 (s.sni)"
+}
+
+resource "fastly_service_vcl" "test" {
+  name = "%s"
+
+  domain {
+    name = "%s"
+  }
+
+  domain {
+    name = "%s"
+  }
+
+  backend {
+    address = "127.0.0.1"
+    name    = "localhost"
+  }
+
+  force_destroy = true
+}
+resource "fastly_tls_subscription" "subject" {
+  domains = [for domain in fastly_service_vcl.test.domain : domain.name]
+  common_name = "%s"
+  certificate_authority = "lets-encrypt"
+  configuration_id = data.fastly_tls_configuration.secondary.id
 }
 `, name, domain1, domain2, commonName)
 }


### PR DESCRIPTION
### Change summary

This PR corrects the unexpected behavior where `configuration_id` updates would silently fail when no other attribute changes were made to a `fastly_tls_subscription` resource. 

 All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/terraform-provider-fastly/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

* [x] Does your submission pass tests?
* [x] Post the output of your test runs

```
=== RUN   TestAccResourceFastlyTLSSubscription_Config
=== PAUSE TestAccResourceFastlyTLSSubscription_Config
=== CONT  TestAccResourceFastlyTLSSubscription_Config
--- PASS: TestAccResourceFastlyTLSSubscription_Config (29.34s)
PASS
```

### Changes to Core Features:

* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### User Impact

Users will now be able to update subscriptions with non-active domains to point to a different `configuration_id`. 
