### PR TITLE
[CDTOOL-1507] Port Image Optimizer default settings for the automatic-lifecycle service family

### DIFF
--- a/docs/resources/service_cdn_auto.md
+++ b/docs/resources/service_cdn_auto.md
@@ -26,6 +26,7 @@ Automatic-lifecycle Fastly CDN service resource with nested versioned configurat
 - `domain` (Block List) Domains attached to this service. (see [below for nested schema](#nestedblock--domain))
 - `force_destroy` (Boolean) Deactivate the active version before deleting the service. Default `false`.
 - `gzip` (Block List) Gzip configurations attached to this service. (see [below for nested schema](#nestedblock--gzip))
+- `image_optimizer_default_settings` (Block List) Image Optimizer default settings for this service. At most one block is supported. The Image Optimizer product must already be enabled on the service (e.g. via `fastly_service_product_image_optimizer`) before these settings can be persisted; enabling the product and configuring this block cannot be done in the same initial `apply`, since this block is reconciled as part of this resource's own create step, before a separate product-enablement resource (which depends on this resource's `id`) can run. Enable the product in a prior `apply` first. (see [below for nested schema](#nestedblock--image_optimizer_default_settings))
 - `logging_s3` (Block List) S3 logging endpoints attached to this service. (see [below for nested schema](#nestedblock--logging_s3))
 - `reuse` (Boolean) Deactivate the active version but do not delete the service, allowing it to be reused/imported elsewhere. Default `false`.
 
@@ -123,6 +124,20 @@ Optional:
 - `cache_condition` (String) Name of already defined `condition` controlling when this gzip configuration applies. This `condition` must be of type `CACHE`.
 - `content_types` (List of String) The content-type for each type of content you wish to have dynamically gzip'ed. Example: `["text/html", "text/css"]`.
 - `extensions` (List of String) File extensions for each file type to dynamically gzip. Example: `["css", "js"]`.
+
+
+<a id="nestedblock--image_optimizer_default_settings"></a>
+### Nested Schema for `image_optimizer_default_settings`
+
+Optional:
+
+- `allow_video` (Boolean) Enables GIF to MP4 transformations on this service. Default `false`.
+- `jpeg_quality` (Number) The default quality to use with JPEG output. This can be overridden with the `quality` parameter on specific image optimizer requests. Default `85`.
+- `jpeg_type` (String) The default type of JPEG output to use. This can be overridden with `format=bjpeg` and `format=pjpeg` on specific image optimizer requests. Valid values are `auto`, `baseline` and `progressive`. Default `auto`.
+- `resize_filter` (String) The type of filter to use while resizing an image. Valid values are `lanczos3`, `lanczos2`, `bicubic`, `bilinear` and `nearest`. Default `lanczos3`.
+- `upscale` (Boolean) Whether or not we should allow output images to render at sizes larger than input. Default `false`.
+- `webp` (Boolean) Controls whether or not to default to WebP output when the client supports it. This is equivalent to adding `auto=webp` to all image optimizer requests. Default `false`.
+- `webp_quality` (Number) The default quality to use with WebP output. This can be overridden with the second option in the `quality` URL parameter on specific image optimizer requests. Default `85`.
 
 
 <a id="nestedblock--logging_s3"></a>

--- a/examples/orchestration-cdn-auto/README.md
+++ b/examples/orchestration-cdn-auto/README.md
@@ -12,6 +12,7 @@ The example provisions and manages:
 - one domain per service
 - one ACL per service (service 1 has an IP allowlist, service 2 has a temporary blocklist)
 - one gzip configuration on service 1
+- Image Optimizer default settings on service 1
 
 ## What this example is for
 
@@ -48,8 +49,15 @@ Expected bootstrap behavior:
 
 1. Terraform creates both `fastly_service_cdn_auto` services.
 2. Fastly creates editable version `1` for each new service.
-3. The provider reconciles the nested `domain`, `backend`, `acl`, and `gzip` blocks to version `1`.
+3. The provider reconciles the nested `domain`, `backend`, `acl`, `gzip`, and
+   `image_optimizer_default_settings` blocks to version `1`.
 4. The provider validates and activates version `1`.
+
+Note: `image_optimizer_default_settings` on `service_1` requires the Image
+Optimizer product to already be enabled on that service (via the Fastly UI,
+API, or product enablement tooling) - the provider does not enable it for you.
+If it isn't enabled, remove that block or enable the product out-of-band
+before applying.
 
 ## Day-to-day workflow
 
@@ -169,6 +177,37 @@ You should see:
 - the updated `content_types` reflected in the service configuration
 - `service_2_*` outputs remain unchanged
 
+### Change Image Optimizer default settings
+
+For example, change `resize_filter` from `lanczos3` to `bicubic` on `service_1`,
+then run:
+
+```bash
+terraform apply
+```
+
+You should see:
+
+- `service_1_managed_version` increase
+- `service_1_active_version` move to the new version
+- `service_1_image_optimizer_default_settings` reflect the new value
+
+### Remove Image Optimizer default settings
+
+Delete the `image_optimizer_default_settings` block from `service_1` entirely
+and run:
+
+```bash
+terraform apply
+```
+
+You should see:
+
+- `service_1_managed_version` increase
+- `service_1_image_optimizer_default_settings` become an empty list
+- Image Optimizer default settings on the service reset back to Fastly's API
+  defaults (rather than staying at their last-configured values)
+
 ## Notes
 
 - This example is for the automatic compatibility resource family only.
@@ -176,3 +215,6 @@ You should see:
   resources for the same Fastly service.
 - This first cut is intended to mirror the current provider’s
   convenience-oriented lifecycle behavior for service, domain, and backend.
+- At most one `image_optimizer_default_settings` block is supported per
+  service, and it requires the Image Optimizer product to already be enabled
+  on that service.

--- a/examples/orchestration-cdn-auto/README.md
+++ b/examples/orchestration-cdn-auto/README.md
@@ -12,7 +12,7 @@ The example provisions and manages:
 - one domain per service
 - one ACL per service (service 1 has an IP allowlist, service 2 has a temporary blocklist)
 - one gzip configuration on service 1
-- Image Optimizer default settings on service 1
+- Image Optimizer enabled on service 1 (default settings added in a follow-up apply - see below)
 
 ## What this example is for
 
@@ -49,15 +49,18 @@ Expected bootstrap behavior:
 
 1. Terraform creates both `fastly_service_cdn_auto` services.
 2. Fastly creates editable version `1` for each new service.
-3. The provider reconciles the nested `domain`, `backend`, `acl`, `gzip`, and
-   `image_optimizer_default_settings` blocks to version `1`.
+3. The provider reconciles the nested `domain`, `backend`, `acl`, and `gzip`
+   blocks to version `1`.
 4. The provider validates and activates version `1`.
+5. `fastly_service_product_image_optimizer.service_1` enables the Image
+   Optimizer product on `service_1`.
 
-Note: `image_optimizer_default_settings` on `service_1` requires the Image
-Optimizer product to already be enabled on that service (via the Fastly UI,
-API, or product enablement tooling) - the provider does not enable it for you.
-If it isn't enabled, remove that block or enable the product out-of-band
-before applying.
+Note: `image_optimizer_default_settings` can't be added to `service_1` in
+this same bootstrap apply. That block is reconciled as part of
+`fastly_service_cdn_auto.service_1`'s own create step, which runs before
+`fastly_service_product_image_optimizer.service_1` - so Image Optimizer isn't
+enabled yet at the point the settings block would need it. See "Configure
+Image Optimizer default settings" below for the required follow-up apply.
 
 ## Day-to-day workflow
 
@@ -176,6 +179,37 @@ You should see:
 - `service_1_active_version` move to the new version
 - the updated `content_types` reflected in the service configuration
 - `service_2_*` outputs remain unchanged
+
+### Configure Image Optimizer default settings
+
+Once the bootstrap apply has enabled Image Optimizer on `service_1` via
+`fastly_service_product_image_optimizer.service_1`, add the
+`image_optimizer_default_settings` block to `fastly_service_cdn_auto.service_1`
+in `main.tf`:
+
+```hcl
+  image_optimizer_default_settings {
+    resize_filter = "lanczos3"
+    webp          = false
+    webp_quality  = 85
+    jpeg_type     = "auto"
+    jpeg_quality  = 85
+    upscale       = false
+    allow_video   = false
+  }
+```
+
+Then run:
+
+```bash
+terraform apply
+```
+
+You should see:
+
+- `service_1_managed_version` increase
+- `service_1_active_version` move to the new version
+- `service_1_image_optimizer_default_settings` reflect the configured values
 
 ### Change Image Optimizer default settings
 

--- a/examples/orchestration-cdn-auto/main.tf
+++ b/examples/orchestration-cdn-auto/main.tf
@@ -25,8 +25,8 @@ locals {
 }
 
 resource "fastly_service_cdn_auto" "service_1" {
-  name     = var.service_1_name
-  comment  = "Managed by Terraform"
+  name    = var.service_1_name
+  comment = "Managed by Terraform"
   domain {
     name = "www.service1.example.com"
   }
@@ -50,11 +50,24 @@ resource "fastly_service_cdn_auto" "service_1" {
     content_types = ["text/html", "text/css", "application/javascript"]
     extensions    = ["css", "js", "html"]
   }
+
+  # Requires the Image Optimizer product to already be enabled on this service
+  # (via the Fastly UI, API, or product enablement tooling). Remove this block
+  # to reset Image Optimizer default settings back to their API defaults.
+  image_optimizer_default_settings {
+    resize_filter = "lanczos3"
+    webp          = false
+    webp_quality  = 85
+    jpeg_type     = "auto"
+    jpeg_quality  = 85
+    upscale       = false
+    allow_video   = false
+  }
 }
 
 resource "fastly_service_cdn_auto" "service_2" {
-  name     = var.service_2_name
-  comment  = "Managed by Terraform"
+  name    = var.service_2_name
+  comment = "Managed by Terraform"
   domain {
     name = "www.service2.example.com"
   }

--- a/examples/orchestration-cdn-auto/main.tf
+++ b/examples/orchestration-cdn-auto/main.tf
@@ -50,19 +50,17 @@ resource "fastly_service_cdn_auto" "service_1" {
     content_types = ["text/html", "text/css", "application/javascript"]
     extensions    = ["css", "js", "html"]
   }
+}
 
-  # Requires the Image Optimizer product to already be enabled on this service
-  # (via the Fastly UI, API, or product enablement tooling). Remove this block
-  # to reset Image Optimizer default settings back to their API defaults.
-  image_optimizer_default_settings {
-    resize_filter = "lanczos3"
-    webp          = false
-    webp_quality  = 85
-    jpeg_type     = "auto"
-    jpeg_quality  = 85
-    upscale       = false
-    allow_video   = false
-  }
+# Image Optimizer must be enabled on service_1 before an
+# image_optimizer_default_settings block can be added to fastly_service_cdn_auto.service_1.
+# This resource can be applied together with the service's own creation, since it only
+# depends on the service's id. But image_optimizer_default_settings is reconciled inside
+# the service resource's own create step, which runs before this resource - so the settings
+# block itself must be added in a later apply, once this resource has enabled the product.
+# See README.md's "Configure Image Optimizer default settings" section.
+resource "fastly_service_product_image_optimizer" "service_1" {
+  service_id = fastly_service_cdn_auto.service_1.id
 }
 
 resource "fastly_service_cdn_auto" "service_2" {

--- a/examples/orchestration-cdn-auto/outputs.tf
+++ b/examples/orchestration-cdn-auto/outputs.tf
@@ -33,6 +33,11 @@ output "service_1_acl_id" {
   value       = fastly_service_cdn_auto.service_1.acl[0].acl_id
 }
 
+output "service_1_image_optimizer_default_settings" {
+  description = "Image Optimizer default settings configured on service 1."
+  value       = fastly_service_cdn_auto.service_1.image_optimizer_default_settings
+}
+
 output "service_2_acl_id" {
   description = "ACL ID for service 2 temporary blocklist."
   value       = fastly_service_cdn_auto.service_2.acl[0].acl_id

--- a/internal/acceptance_tests/blocks/image_optimizer_default_settings_single.tf
+++ b/internal/acceptance_tests/blocks/image_optimizer_default_settings_single.tf
@@ -1,0 +1,9 @@
+image_optimizer_default_settings {
+  resize_filter = "lanczos3"
+  webp          = false
+  webp_quality  = 85
+  jpeg_type     = "auto"
+  jpeg_quality  = 85
+  upscale       = false
+  allow_video   = false
+}

--- a/internal/acceptance_tests/blocks/image_optimizer_default_settings_updated.tf
+++ b/internal/acceptance_tests/blocks/image_optimizer_default_settings_updated.tf
@@ -1,0 +1,9 @@
+image_optimizer_default_settings {
+  resize_filter = "bicubic"
+  webp          = true
+  webp_quality  = 70
+  jpeg_type     = "progressive"
+  jpeg_quality  = 90
+  upscale       = true
+  allow_video   = true
+}

--- a/internal/acceptance_tests/image_optimizer_default_settings_test.go
+++ b/internal/acceptance_tests/image_optimizer_default_settings_test.go
@@ -79,6 +79,7 @@ func TestAccFastlyServiceCDNAuto_imageOptimizerDefaultSettings(t *testing.T) {
 					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "image_optimizer_default_settings.#", "0"),
 					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "active_version", "4"),
 					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "managed_version", "4"),
+					CheckImageOptimizerDefaultSettingsMatchAPIDefaults("fastly_service_cdn_auto.test"),
 				),
 			},
 		},

--- a/internal/acceptance_tests/image_optimizer_default_settings_test.go
+++ b/internal/acceptance_tests/image_optimizer_default_settings_test.go
@@ -1,0 +1,86 @@
+package acceptancetests
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+// TestAccFastlyServiceCDNAuto_imageOptimizerDefaultSettings exercises the full lifecycle of the
+// image_optimizer_default_settings nested block on fastly_service_cdn_auto: create, update,
+// removal (reset to API defaults), and import. Image Optimizer must be enabled on the service
+// before its default settings can be persisted, which in turn requires the test account to be
+// allowed to enable Image Optimizer.
+func TestAccFastlyServiceCDNAuto_imageOptimizerDefaultSettings(t *testing.T) {
+	t.Parallel()
+	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	domainName := fmt.Sprintf("%s.example.com", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
+		CheckDestroy:             CheckServiceDestroy("fastly_service_cdn_auto"),
+		Steps: []resource.TestStep{
+			{
+				// Bootstrap the service with Image Optimizer enabled via
+				// fastly_service_product_image_optimizer before any image_optimizer_default_settings
+				// block is configured.
+				Config: ConfigCDNAutoImageOptimizerEnabled(serviceName, domainName),
+				Check: resource.ComposeTestCheckFunc(
+					CheckServiceExists("fastly_service_cdn_auto.test"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "image_optimizer_default_settings.#", "0"),
+				),
+			},
+			{
+				Config: ConfigCDNAutoWithImageOptimizerDefaultSettings(serviceName, domainName),
+				Check: resource.ComposeTestCheckFunc(
+					CheckServiceExists("fastly_service_cdn_auto.test"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "image_optimizer_default_settings.#", "1"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "image_optimizer_default_settings.0.resize_filter", "lanczos3"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "image_optimizer_default_settings.0.webp", "false"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "image_optimizer_default_settings.0.webp_quality", "85"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "image_optimizer_default_settings.0.jpeg_type", "auto"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "image_optimizer_default_settings.0.jpeg_quality", "85"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "image_optimizer_default_settings.0.upscale", "false"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "image_optimizer_default_settings.0.allow_video", "false"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "active_version", "2"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "managed_version", "2"),
+				),
+			},
+			{
+				ResourceName:            "fastly_service_cdn_auto.test",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"force_destroy", "reuse"},
+			},
+			{
+				Config: ConfigCDNAutoWithImageOptimizerDefaultSettingsUpdated(serviceName, domainName),
+				Check: resource.ComposeTestCheckFunc(
+					CheckServiceExists("fastly_service_cdn_auto.test"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "image_optimizer_default_settings.#", "1"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "image_optimizer_default_settings.0.resize_filter", "bicubic"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "image_optimizer_default_settings.0.webp", "true"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "image_optimizer_default_settings.0.webp_quality", "70"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "image_optimizer_default_settings.0.jpeg_type", "progressive"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "image_optimizer_default_settings.0.jpeg_quality", "90"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "image_optimizer_default_settings.0.upscale", "true"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "image_optimizer_default_settings.0.allow_video", "true"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "active_version", "3"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "managed_version", "3"),
+				),
+			},
+			{
+				// Removing the block resets Image Optimizer default settings back to API defaults.
+				Config: ConfigCDNAutoImageOptimizerEnabled(serviceName, domainName),
+				Check: resource.ComposeTestCheckFunc(
+					CheckServiceExists("fastly_service_cdn_auto.test"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "image_optimizer_default_settings.#", "0"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "active_version", "4"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "managed_version", "4"),
+				),
+			},
+		},
+	})
+}

--- a/internal/acceptance_tests/test_helpers.go
+++ b/internal/acceptance_tests/test_helpers.go
@@ -214,7 +214,7 @@ func CheckImageOptimizerDefaultSettingsMatchAPIDefaults(resourceName string) res
 			return fmt.Errorf("error fetching Image Optimizer default settings: %w", err)
 		}
 		if settings == nil {
-			return nil
+			return fmt.Errorf("expected Image Optimizer default settings to be populated since Image Optimizer remains enabled, got nil")
 		}
 
 		var mismatches []string

--- a/internal/acceptance_tests/test_helpers.go
+++ b/internal/acceptance_tests/test_helpers.go
@@ -14,6 +14,7 @@ import (
 	"github.com/fastly/go-fastly/v16/fastly"
 	"github.com/fastly/terraform-provider-fastly/internal/errors"
 	"github.com/fastly/terraform-provider-fastly/internal/provider"
+	"github.com/fastly/terraform-provider-fastly/internal/resources/imageoptimizerdefaultsettings"
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -41,34 +42,6 @@ func NewFastlyClient() (*fastly.Client, error) {
 		return nil, fmt.Errorf("FASTLY_API_TOKEN environment variable must be set")
 	}
 	return fastly.NewClient(apiToken)
-}
-
-// CreateTestKVStore creates a KV Store fixture directly against the Fastly API for use as a
-// resource_link target, and registers its cleanup via t.Cleanup. Returns the store's ID.
-//
-// This provider doesn't yet have a dedicated resource for KV Stores, so resource_link
-// acceptance tests need a real linkable resource created out-of-band from Terraform.
-//
-// TODO: once a fastly_kvstore resource exists, replace this raw go-fastly client call with a
-// Terraform-managed fixture (e.g. via config_builder.go) so the fixture participates in the
-// same state/plan lifecycle as the rest of the test config.
-func CreateTestKVStore(t *testing.T, name string) string {
-	client, err := NewFastlyClient()
-	if err != nil {
-		t.Fatalf("error creating Fastly client: %s", err)
-	}
-
-	store, err := client.CreateKVStore(context.Background(), &fastly.CreateKVStoreInput{Name: name})
-	if err != nil {
-		t.Fatalf("error creating KV Store fixture: %s", err)
-	}
-	t.Cleanup(func() {
-		if err := client.DeleteKVStore(context.Background(), &fastly.DeleteKVStoreInput{StoreID: store.StoreID}); err != nil {
-			t.Logf("error deleting KV Store fixture %q: %s", store.StoreID, err)
-		}
-	})
-
-	return store.StoreID
 }
 
 // serviceDestroyCheckAttempts and serviceDestroyCheckInterval bound the retry loop in
@@ -204,6 +177,71 @@ func CheckGzipFieldClearedRemotely(resourceName, gzipName, field, staleValue str
 
 		if raw == staleValue {
 			return fmt.Errorf("gzip %q %s still equals the stale value %q in Fastly - the remote value was not actually cleared", gzipName, field, staleValue)
+		}
+
+		return nil
+	}
+}
+
+// CheckImageOptimizerDefaultSettingsMatchAPIDefaults returns a TestCheckFunc that fetches Image
+// Optimizer default settings directly from the Fastly API (bypassing Terraform state) and fails
+// if any field still holds a previously-configured, non-default value. This exists because the
+// read path only surfaces image_optimizer_default_settings when the block is present in config,
+// so a state-only check of the block being absent can pass even if the remote settings were
+// never actually reset.
+func CheckImageOptimizerDefaultSettingsMatchAPIDefaults(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceName)
+		}
+
+		version, err := strconv.Atoi(rs.Primary.Attributes["active_version"])
+		if err != nil {
+			return fmt.Errorf("error parsing active_version: %w", err)
+		}
+
+		client, err := NewFastlyClient()
+		if err != nil {
+			return fmt.Errorf("error creating Fastly client: %w", err)
+		}
+
+		settings, err := client.GetImageOptimizerDefaultSettings(context.Background(), &fastly.GetImageOptimizerDefaultSettingsInput{
+			ServiceID:      rs.Primary.ID,
+			ServiceVersion: version,
+		})
+		if err != nil {
+			return fmt.Errorf("error fetching Image Optimizer default settings: %w", err)
+		}
+		if settings == nil {
+			return nil
+		}
+
+		var mismatches []string
+		if settings.ResizeFilter != imageoptimizerdefaultsettings.DefaultResizeFilter {
+			mismatches = append(mismatches, fmt.Sprintf("resize_filter=%q, want %q", settings.ResizeFilter, imageoptimizerdefaultsettings.DefaultResizeFilter))
+		}
+		if settings.Webp != imageoptimizerdefaultsettings.DefaultWebp {
+			mismatches = append(mismatches, fmt.Sprintf("webp=%v, want %v", settings.Webp, imageoptimizerdefaultsettings.DefaultWebp))
+		}
+		if settings.WebpQuality != imageoptimizerdefaultsettings.DefaultWebpQuality {
+			mismatches = append(mismatches, fmt.Sprintf("webp_quality=%d, want %d", settings.WebpQuality, imageoptimizerdefaultsettings.DefaultWebpQuality))
+		}
+		if settings.JpegType != imageoptimizerdefaultsettings.DefaultJpegType {
+			mismatches = append(mismatches, fmt.Sprintf("jpeg_type=%q, want %q", settings.JpegType, imageoptimizerdefaultsettings.DefaultJpegType))
+		}
+		if settings.JpegQuality != imageoptimizerdefaultsettings.DefaultJpegQuality {
+			mismatches = append(mismatches, fmt.Sprintf("jpeg_quality=%d, want %d", settings.JpegQuality, imageoptimizerdefaultsettings.DefaultJpegQuality))
+		}
+		if settings.Upscale != imageoptimizerdefaultsettings.DefaultUpscale {
+			mismatches = append(mismatches, fmt.Sprintf("upscale=%v, want %v", settings.Upscale, imageoptimizerdefaultsettings.DefaultUpscale))
+		}
+		if settings.AllowVideo != imageoptimizerdefaultsettings.DefaultAllowVideo {
+			mismatches = append(mismatches, fmt.Sprintf("allow_video=%v, want %v", settings.AllowVideo, imageoptimizerdefaultsettings.DefaultAllowVideo))
+		}
+
+		if len(mismatches) > 0 {
+			return fmt.Errorf("Image Optimizer default settings were not reset to API defaults in Fastly: %s", strings.Join(mismatches, ", "))
 		}
 
 		return nil

--- a/internal/acceptance_tests/test_helpers.go
+++ b/internal/acceptance_tests/test_helpers.go
@@ -43,6 +43,34 @@ func NewFastlyClient() (*fastly.Client, error) {
 	return fastly.NewClient(apiToken)
 }
 
+// CreateTestKVStore creates a KV Store fixture directly against the Fastly API for use as a
+// resource_link target, and registers its cleanup via t.Cleanup. Returns the store's ID.
+//
+// This provider doesn't yet have a dedicated resource for KV Stores, so resource_link
+// acceptance tests need a real linkable resource created out-of-band from Terraform.
+//
+// TODO: once a fastly_kvstore resource exists, replace this raw go-fastly client call with a
+// Terraform-managed fixture (e.g. via config_builder.go) so the fixture participates in the
+// same state/plan lifecycle as the rest of the test config.
+func CreateTestKVStore(t *testing.T, name string) string {
+	client, err := NewFastlyClient()
+	if err != nil {
+		t.Fatalf("error creating Fastly client: %s", err)
+	}
+
+	store, err := client.CreateKVStore(context.Background(), &fastly.CreateKVStoreInput{Name: name})
+	if err != nil {
+		t.Fatalf("error creating KV Store fixture: %s", err)
+	}
+	t.Cleanup(func() {
+		if err := client.DeleteKVStore(context.Background(), &fastly.DeleteKVStoreInput{StoreID: store.StoreID}); err != nil {
+			t.Logf("error deleting KV Store fixture %q: %s", store.StoreID, err)
+		}
+	})
+
+	return store.StoreID
+}
+
 // serviceDestroyCheckAttempts and serviceDestroyCheckInterval bound the retry loop in
 // CheckServiceDestroy, which tolerates the Fastly API's soft-delete taking a moment to become
 // visible on a subsequent read - most noticeable when many acceptance tests run in parallel.
@@ -314,6 +342,61 @@ func ConfigCDNAutoReversedBackendAndDomainBlocks(serviceName, domainBName, domai
 		"internal/acceptance_tests/blocks/domain_multiple_reversed.tf",
 		"internal/acceptance_tests/blocks/backend_multiple_reversed.tf",
 	)
+}
+
+// imageOptimizerProductEnablement returns a fastly_service_product_image_optimizer resource
+// block that enables Image Optimizer on the given service resource reference (e.g.
+// "fastly_service_cdn_auto.test"). Image Optimizer default settings can only be persisted once
+// the product has been enabled on the service.
+func imageOptimizerProductEnablement(serviceRef string) string {
+	return fmt.Sprintf(`
+resource "fastly_service_product_image_optimizer" "image_optimizer" {
+  service_id = %s.id
+}
+`, serviceRef)
+}
+
+// ConfigCDNAutoImageOptimizerEnabled returns a CDN auto service config with a domain and Image
+// Optimizer enabled via fastly_service_product_image_optimizer, but no
+// image_optimizer_default_settings block.
+func ConfigCDNAutoImageOptimizerEnabled(serviceName, domainName string) string {
+	return BuildConfig(
+		ServiceCDNAuto,
+		map[string]string{
+			"SERVICE_NAME": serviceName,
+			"DOMAIN_NAME":  domainName,
+		},
+		"internal/acceptance_tests/blocks/domain_single.tf",
+	) + imageOptimizerProductEnablement("fastly_service_cdn_auto.test")
+}
+
+// ConfigCDNAutoWithImageOptimizerDefaultSettings returns a CDN auto service config with a
+// domain, Image Optimizer enabled, and default (all-default-value) Image Optimizer default
+// settings.
+func ConfigCDNAutoWithImageOptimizerDefaultSettings(serviceName, domainName string) string {
+	return BuildConfig(
+		ServiceCDNAuto,
+		map[string]string{
+			"SERVICE_NAME": serviceName,
+			"DOMAIN_NAME":  domainName,
+		},
+		"internal/acceptance_tests/blocks/domain_single.tf",
+		"internal/acceptance_tests/blocks/image_optimizer_default_settings_single.tf",
+	) + imageOptimizerProductEnablement("fastly_service_cdn_auto.test")
+}
+
+// ConfigCDNAutoWithImageOptimizerDefaultSettingsUpdated returns a CDN auto service config with
+// a domain, Image Optimizer enabled, and non-default Image Optimizer default settings.
+func ConfigCDNAutoWithImageOptimizerDefaultSettingsUpdated(serviceName, domainName string) string {
+	return BuildConfig(
+		ServiceCDNAuto,
+		map[string]string{
+			"SERVICE_NAME": serviceName,
+			"DOMAIN_NAME":  domainName,
+		},
+		"internal/acceptance_tests/blocks/domain_single.tf",
+		"internal/acceptance_tests/blocks/image_optimizer_default_settings_updated.tf",
+	) + imageOptimizerProductEnablement("fastly_service_cdn_auto.test")
 }
 
 // ConfigCDNAutoWithACL returns a CDN auto service config with a domain and ACL

--- a/internal/resources/imageoptimizerdefaultsettings/expand.go
+++ b/internal/resources/imageoptimizerdefaultsettings/expand.go
@@ -1,0 +1,70 @@
+package imageoptimizerdefaultsettings
+
+import (
+	"fmt"
+
+	"github.com/fastly/terraform-provider-fastly/internal/service"
+
+	fastly "github.com/fastly/go-fastly/v16/fastly"
+)
+
+func parseResizeFilter(v string) (*fastly.ImageOptimizerResizeFilter, error) {
+	var rf fastly.ImageOptimizerResizeFilter
+	switch v {
+	case "lanczos3":
+		rf = fastly.ImageOptimizerLanczos3
+	case "lanczos2":
+		rf = fastly.ImageOptimizerLanczos2
+	case "bicubic":
+		rf = fastly.ImageOptimizerBicubic
+	case "bilinear":
+		rf = fastly.ImageOptimizerBilinear
+	case "nearest":
+		rf = fastly.ImageOptimizerNearest
+	default:
+		return nil, fmt.Errorf("invalid resize_filter: %q", v)
+	}
+	return &rf, nil
+}
+
+func parseJpegType(v string) (*fastly.ImageOptimizerJpegType, error) {
+	var jt fastly.ImageOptimizerJpegType
+	switch v {
+	case "auto":
+		jt = fastly.ImageOptimizerAuto
+	case "baseline":
+		jt = fastly.ImageOptimizerBaseline
+	case "progressive":
+		jt = fastly.ImageOptimizerProgressive
+	default:
+		return nil, fmt.Errorf("invalid jpeg_type: %q", v)
+	}
+	return &jt, nil
+}
+
+// BuildUpdateInput builds the API input to fully replace Image Optimizer default settings
+// for a service version. All fields are always populated so that boolean fields (which
+// cannot be represented as "unset" in Go) are never accidentally dropped from an update.
+func BuildUpdateInput(serviceID string, version int, m NestedModel) (*fastly.UpdateImageOptimizerDefaultSettingsInput, error) {
+	resizeFilter, err := parseResizeFilter(service.StringValue(m.ResizeFilter))
+	if err != nil {
+		return nil, err
+	}
+
+	jpegType, err := parseJpegType(service.StringValue(m.JpegType))
+	if err != nil {
+		return nil, err
+	}
+
+	return &fastly.UpdateImageOptimizerDefaultSettingsInput{
+		ServiceID:      serviceID,
+		ServiceVersion: version,
+		AllowVideo:     new(service.BoolValue(m.AllowVideo)),
+		JpegQuality:    new(int(service.Int64Value(m.JpegQuality))),
+		JpegType:       jpegType,
+		ResizeFilter:   resizeFilter,
+		Upscale:        new(service.BoolValue(m.Upscale)),
+		Webp:           new(service.BoolValue(m.Webp)),
+		WebpQuality:    new(int(service.Int64Value(m.WebpQuality))),
+	}, nil
+}

--- a/internal/resources/imageoptimizerdefaultsettings/flatten.go
+++ b/internal/resources/imageoptimizerdefaultsettings/flatten.go
@@ -1,0 +1,112 @@
+package imageoptimizerdefaultsettings
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	fastly "github.com/fastly/go-fastly/v16/fastly"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func FlattenToNestedModel(s *fastly.ImageOptimizerDefaultSettings) NestedModel {
+	if s == nil {
+		return NestedModel{}
+	}
+
+	return NestedModel{
+		AllowVideo:   types.BoolValue(s.AllowVideo),
+		JpegQuality:  types.Int64Value(int64(s.JpegQuality)),
+		JpegType:     types.StringValue(s.JpegType),
+		ResizeFilter: types.StringValue(s.ResizeFilter),
+		Upscale:      types.BoolValue(s.Upscale),
+		Webp:         types.BoolValue(s.Webp),
+		WebpQuality:  types.Int64Value(int64(s.WebpQuality)),
+	}
+}
+
+// ReadForVersion reads Image Optimizer default settings for a service version.
+//
+// Because a service always has *some* default settings once Image Optimizer has ever been
+// enabled (regardless of whether this block is configured in Terraform), the remote API is
+// only queried when current is non-empty. This avoids surfacing settings as configuration
+// drift for users who never declared this block. forceRefresh bypasses that check - callers
+// must set it on the first Read following an import, since the incoming state has no prior
+// current value to gate on even when the block is actually configured remotely.
+func ReadForVersion(ctx context.Context, client *fastly.Client, serviceID string, version int, current []NestedModel, forceRefresh bool) ([]NestedModel, error) {
+	if len(current) == 0 && !forceRefresh {
+		return nil, nil
+	}
+
+	remote, err := client.GetImageOptimizerDefaultSettings(ctx, &fastly.GetImageOptimizerDefaultSettingsInput{
+		ServiceID:      serviceID,
+		ServiceVersion: version,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if remote == nil {
+		return nil, nil
+	}
+
+	return []NestedModel{FlattenToNestedModel(remote)}, nil
+}
+
+// Reconcile ensures the Image Optimizer default settings for a service version match desired.
+//
+// Image Optimizer default settings always exist server-side once Image Optimizer has been
+// enabled, so create and update are the same operation: a full replace of all fields.
+// Removing the block from configuration resets the settings back to their API defaults,
+// but only when previous shows the block was actually configured before - otherwise there
+// is nothing to reset, since the block was never under this resource's management.
+func Reconcile(ctx context.Context, client *fastly.Client, serviceID string, version int, previous, desired []NestedModel) error {
+	if len(desired) == 0 {
+		if len(previous) == 0 {
+			return nil
+		}
+		return resetToDefaults(ctx, client, serviceID, version)
+	}
+
+	remote, err := client.GetImageOptimizerDefaultSettings(ctx, &fastly.GetImageOptimizerDefaultSettingsInput{
+		ServiceID:      serviceID,
+		ServiceVersion: version,
+	})
+	if err != nil {
+		return err
+	}
+	if remote != nil && desired[0].ModelsEqual(FlattenToNestedModel(remote)) {
+		return nil
+	}
+
+	return update(ctx, client, serviceID, version, desired[0])
+}
+
+func update(ctx context.Context, client *fastly.Client, serviceID string, version int, m NestedModel) error {
+	input, err := BuildUpdateInput(serviceID, version, m)
+	if err != nil {
+		return err
+	}
+
+	_, err = client.UpdateImageOptimizerDefaultSettings(ctx, input)
+	return err
+}
+
+// resetToDefaults resets Image Optimizer default settings back to their API defaults. If the
+// service no longer has Image Optimizer enabled, the API rejects the update; that error is
+// swallowed since a service without Image Optimizer enabled already has no default settings.
+func resetToDefaults(ctx context.Context, client *fastly.Client, serviceID string, version int) error {
+	err := update(ctx, client, serviceID, version, defaultNestedModel())
+	if err == nil {
+		return nil
+	}
+
+	if he, ok := err.(*fastly.HTTPError); ok && he.StatusCode == http.StatusBadRequest {
+		for _, e := range he.Errors {
+			if strings.Contains(e.Detail, "Image Optimizer is not enabled on this service") {
+				return nil
+			}
+		}
+	}
+
+	return err
+}

--- a/internal/resources/imageoptimizerdefaultsettings/imageoptimizerdefaultsettings_test.go
+++ b/internal/resources/imageoptimizerdefaultsettings/imageoptimizerdefaultsettings_test.go
@@ -1,0 +1,147 @@
+package imageoptimizerdefaultsettings
+
+import (
+	"testing"
+
+	fastly "github.com/fastly/go-fastly/v16/fastly"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func fullNestedModel() NestedModel {
+	return NestedModel{
+		AllowVideo:   types.BoolValue(true),
+		JpegQuality:  types.Int64Value(90),
+		JpegType:     types.StringValue("progressive"),
+		ResizeFilter: types.StringValue("bicubic"),
+		Upscale:      types.BoolValue(true),
+		Webp:         types.BoolValue(true),
+		WebpQuality:  types.Int64Value(80),
+	}
+}
+
+func TestFlattenToNestedModel(t *testing.T) {
+	t.Run("nil settings", func(t *testing.T) {
+		m := FlattenToNestedModel(nil)
+		assert.Equal(t, NestedModel{}, m)
+	})
+
+	t.Run("full settings", func(t *testing.T) {
+		s := &fastly.ImageOptimizerDefaultSettings{
+			AllowVideo:   true,
+			JpegQuality:  90,
+			JpegType:     "progressive",
+			ResizeFilter: "bicubic",
+			Upscale:      true,
+			Webp:         true,
+			WebpQuality:  80,
+		}
+		m := FlattenToNestedModel(s)
+		assert.Equal(t, fullNestedModel(), m)
+	})
+}
+
+func TestDefaultNestedModel(t *testing.T) {
+	d := defaultNestedModel()
+	assert.Equal(t, types.BoolValue(false), d.AllowVideo)
+	assert.Equal(t, types.Int64Value(85), d.JpegQuality)
+	assert.Equal(t, types.StringValue("auto"), d.JpegType)
+	assert.Equal(t, types.StringValue("lanczos3"), d.ResizeFilter)
+	assert.Equal(t, types.BoolValue(false), d.Upscale)
+	assert.Equal(t, types.BoolValue(false), d.Webp)
+	assert.Equal(t, types.Int64Value(85), d.WebpQuality)
+}
+
+func TestModelsEqual(t *testing.T) {
+	a := fullNestedModel()
+	b := fullNestedModel()
+	assert.True(t, a.ModelsEqual(b))
+
+	b.Webp = types.BoolValue(false)
+	assert.False(t, a.ModelsEqual(b))
+}
+
+func TestEqual(t *testing.T) {
+	tests := []struct {
+		name     string
+		a        []NestedModel
+		b        []NestedModel
+		expected bool
+	}{
+		{name: "both empty", a: nil, b: nil, expected: true},
+		{name: "different lengths", a: []NestedModel{fullNestedModel()}, b: nil, expected: false},
+		{name: "equal single", a: []NestedModel{fullNestedModel()}, b: []NestedModel{fullNestedModel()}, expected: true},
+		{
+			name:     "different single",
+			a:        []NestedModel{fullNestedModel()},
+			b:        []NestedModel{defaultNestedModel()},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, Equal(tt.a, tt.b))
+		})
+	}
+}
+
+func TestParseResizeFilter(t *testing.T) {
+	for _, v := range ResizeFilters {
+		t.Run(v, func(t *testing.T) {
+			rf, err := parseResizeFilter(v)
+			assert.NoError(t, err)
+			assert.Equal(t, v, rf.String())
+		})
+	}
+
+	t.Run("invalid", func(t *testing.T) {
+		_, err := parseResizeFilter("invalid")
+		assert.Error(t, err)
+	})
+}
+
+func TestParseJpegType(t *testing.T) {
+	for _, v := range JpegTypes {
+		t.Run(v, func(t *testing.T) {
+			jt, err := parseJpegType(v)
+			assert.NoError(t, err)
+			assert.Equal(t, v, jt.String())
+		})
+	}
+
+	t.Run("invalid", func(t *testing.T) {
+		_, err := parseJpegType("invalid")
+		assert.Error(t, err)
+	})
+}
+
+func TestBuildUpdateInput(t *testing.T) {
+	t.Run("valid model", func(t *testing.T) {
+		input, err := BuildUpdateInput("svc-123", 5, fullNestedModel())
+		assert.NoError(t, err)
+		assert.Equal(t, "svc-123", input.ServiceID)
+		assert.Equal(t, 5, input.ServiceVersion)
+		assert.Equal(t, true, *input.AllowVideo)
+		assert.Equal(t, 90, *input.JpegQuality)
+		assert.Equal(t, "progressive", input.JpegType.String())
+		assert.Equal(t, "bicubic", input.ResizeFilter.String())
+		assert.Equal(t, true, *input.Upscale)
+		assert.Equal(t, true, *input.Webp)
+		assert.Equal(t, 80, *input.WebpQuality)
+	})
+
+	t.Run("invalid jpeg_type", func(t *testing.T) {
+		m := fullNestedModel()
+		m.JpegType = types.StringValue("invalid")
+		_, err := BuildUpdateInput("svc-123", 5, m)
+		assert.Error(t, err)
+	})
+
+	t.Run("invalid resize_filter", func(t *testing.T) {
+		m := fullNestedModel()
+		m.ResizeFilter = types.StringValue("invalid")
+		_, err := BuildUpdateInput("svc-123", 5, m)
+		assert.Error(t, err)
+	})
+}

--- a/internal/resources/imageoptimizerdefaultsettings/schema.go
+++ b/internal/resources/imageoptimizerdefaultsettings/schema.go
@@ -1,0 +1,150 @@
+package imageoptimizerdefaultsettings
+
+import (
+	"github.com/fastly/terraform-provider-fastly/internal/service"
+
+	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+const (
+	DefaultAllowVideo   = false
+	DefaultJpegQuality  = 85
+	DefaultJpegType     = "auto"
+	DefaultResizeFilter = "lanczos3"
+	DefaultUpscale      = false
+	DefaultWebp         = false
+	DefaultWebpQuality  = 85
+)
+
+var (
+	JpegTypes     = []string{"auto", "baseline", "progressive"}
+	ResizeFilters = []string{"lanczos3", "lanczos2", "bicubic", "bilinear", "nearest"}
+)
+
+type NestedModel struct {
+	AllowVideo   types.Bool   `tfsdk:"allow_video"`
+	JpegQuality  types.Int64  `tfsdk:"jpeg_quality"`
+	JpegType     types.String `tfsdk:"jpeg_type"`
+	ResizeFilter types.String `tfsdk:"resize_filter"`
+	Upscale      types.Bool   `tfsdk:"upscale"`
+	Webp         types.Bool   `tfsdk:"webp"`
+	WebpQuality  types.Int64  `tfsdk:"webp_quality"`
+}
+
+func (n NestedModel) ModelsEqual(other NestedModel) bool {
+	return service.BoolValue(n.AllowVideo) == service.BoolValue(other.AllowVideo) &&
+		service.Int64Value(n.JpegQuality) == service.Int64Value(other.JpegQuality) &&
+		service.StringValue(n.JpegType) == service.StringValue(other.JpegType) &&
+		service.StringValue(n.ResizeFilter) == service.StringValue(other.ResizeFilter) &&
+		service.BoolValue(n.Upscale) == service.BoolValue(other.Upscale) &&
+		service.BoolValue(n.Webp) == service.BoolValue(other.Webp) &&
+		service.Int64Value(n.WebpQuality) == service.Int64Value(other.WebpQuality)
+}
+
+func defaultNestedModel() NestedModel {
+	return NestedModel{
+		AllowVideo:   types.BoolValue(DefaultAllowVideo),
+		JpegQuality:  types.Int64Value(DefaultJpegQuality),
+		JpegType:     types.StringValue(DefaultJpegType),
+		ResizeFilter: types.StringValue(DefaultResizeFilter),
+		Upscale:      types.BoolValue(DefaultUpscale),
+		Webp:         types.BoolValue(DefaultWebp),
+		WebpQuality:  types.Int64Value(DefaultWebpQuality),
+	}
+}
+
+func CommonAttributes() map[string]schema.Attribute {
+	return map[string]schema.Attribute{
+		"allow_video": schema.BoolAttribute{
+			Optional:    true,
+			Computed:    true,
+			Default:     booldefault.StaticBool(DefaultAllowVideo),
+			Description: "Enables GIF to MP4 transformations on this service. Default `false`.",
+		},
+		"jpeg_quality": schema.Int64Attribute{
+			Optional:    true,
+			Computed:    true,
+			Default:     int64default.StaticInt64(DefaultJpegQuality),
+			Description: "The default quality to use with JPEG output. This can be overridden with the `quality` parameter on specific image optimizer requests. Default `85`.",
+			Validators: []validator.Int64{
+				int64validator.Between(1, 100),
+			},
+		},
+		"jpeg_type": schema.StringAttribute{
+			Optional:    true,
+			Computed:    true,
+			Default:     stringdefault.StaticString(DefaultJpegType),
+			Description: "The default type of JPEG output to use. This can be overridden with `format=bjpeg` and `format=pjpeg` on specific image optimizer requests. Valid values are `auto`, `baseline` and `progressive`. Default `auto`.",
+			Validators: []validator.String{
+				stringvalidator.OneOf(JpegTypes...),
+			},
+		},
+		"resize_filter": schema.StringAttribute{
+			Optional:    true,
+			Computed:    true,
+			Default:     stringdefault.StaticString(DefaultResizeFilter),
+			Description: "The type of filter to use while resizing an image. Valid values are `lanczos3`, `lanczos2`, `bicubic`, `bilinear` and `nearest`. Default `lanczos3`.",
+			Validators: []validator.String{
+				stringvalidator.OneOf(ResizeFilters...),
+			},
+		},
+		"upscale": schema.BoolAttribute{
+			Optional:    true,
+			Computed:    true,
+			Default:     booldefault.StaticBool(DefaultUpscale),
+			Description: "Whether or not we should allow output images to render at sizes larger than input. Default `false`.",
+		},
+		"webp": schema.BoolAttribute{
+			Optional:    true,
+			Computed:    true,
+			Default:     booldefault.StaticBool(DefaultWebp),
+			Description: "Controls whether or not to default to WebP output when the client supports it. This is equivalent to adding `auto=webp` to all image optimizer requests. Default `false`.",
+		},
+		"webp_quality": schema.Int64Attribute{
+			Optional:    true,
+			Computed:    true,
+			Default:     int64default.StaticInt64(DefaultWebpQuality),
+			Description: "The default quality to use with WebP output. This can be overridden with the second option in the `quality` URL parameter on specific image optimizer requests. Default `85`.",
+			Validators: []validator.Int64{
+				int64validator.Between(1, 100),
+			},
+		},
+	}
+}
+
+// NestedBlockSchema returns the image_optimizer_default_settings block for use inside
+// _auto aggregate resources. At most one block is supported per service, since Image
+// Optimizer default settings are a singleton per service version.
+func NestedBlockSchema() schema.ListNestedBlock {
+	return schema.ListNestedBlock{
+		Description: "Image Optimizer default settings for this service. At most one block is supported. " +
+			"The Image Optimizer product must already be enabled on the service (e.g. via `fastly_service_product_image_optimizer`) " +
+			"before these settings can be persisted; enabling the product and configuring this block cannot be done in the same " +
+			"initial `apply`, since this block is reconciled as part of this resource's own create step, before a separate " +
+			"product-enablement resource (which depends on this resource's `id`) can run. Enable the product in a prior `apply` first.",
+		NestedObject: schema.NestedBlockObject{
+			Attributes: CommonAttributes(),
+		},
+		Validators: []validator.List{
+			listvalidator.SizeAtMost(1),
+		},
+	}
+}
+
+func Equal(a, b []NestedModel) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	if len(a) == 0 {
+		return true
+	}
+	return a[0].ModelsEqual(b[0])
+}

--- a/internal/resources/servicecdnauto/resource.go
+++ b/internal/resources/servicecdnauto/resource.go
@@ -10,6 +10,7 @@ import (
 	"github.com/fastly/terraform-provider-fastly/internal/resources/cdnacl"
 	"github.com/fastly/terraform-provider-fastly/internal/resources/domain"
 	"github.com/fastly/terraform-provider-fastly/internal/resources/gzip"
+	"github.com/fastly/terraform-provider-fastly/internal/resources/imageoptimizerdefaultsettings"
 	"github.com/fastly/terraform-provider-fastly/internal/resources/loggings3"
 	"github.com/fastly/terraform-provider-fastly/internal/service"
 
@@ -29,6 +30,12 @@ type Resource struct {
 	providerData *fastlyclient.Data
 }
 
+// imageOptimizerImportedPrivateKey marks, via private state, that the current Read follows an
+// import. ImportStatePassthroughID leaves ImageOptimizerDefaultSettings empty in state (only "id"
+// is set), so without this marker a just-imported service with the block configured remotely
+// would incorrectly read back as absent - see ReadForVersion's forceRefresh parameter.
+const imageOptimizerImportedPrivateKey = "image_optimizer_default_settings_imported"
+
 var _ resource.Resource = &Resource{}
 var _ resource.ResourceWithConfigure = &Resource{}
 var _ resource.ResourceWithImportState = &Resource{}
@@ -38,18 +45,19 @@ func NewResource() resource.Resource {
 }
 
 type Model struct {
-	ID             types.String            `tfsdk:"id"`
-	Name           types.String            `tfsdk:"name"`
-	Comment        types.String            `tfsdk:"comment"`
-	ForceDestroy   types.Bool              `tfsdk:"force_destroy"`
-	Reuse          types.Bool              `tfsdk:"reuse"`
-	ActiveVersion  types.Int64             `tfsdk:"active_version"`
-	ManagedVersion types.Int64             `tfsdk:"managed_version"`
-	Domain         []domain.NestedModel    `tfsdk:"domain"`
-	Backend        []backend.NestedModel   `tfsdk:"backend"`
-	ACL            []cdnacl.NestedModel    `tfsdk:"acl"`
-	Gzip           []gzip.NestedModel      `tfsdk:"gzip"`
-	LoggingS3      []loggings3.NestedModel `tfsdk:"logging_s3"`
+	ID                            types.String                                `tfsdk:"id"`
+	Name                          types.String                                `tfsdk:"name"`
+	Comment                       types.String                                `tfsdk:"comment"`
+	ForceDestroy                  types.Bool                                  `tfsdk:"force_destroy"`
+	Reuse                         types.Bool                                  `tfsdk:"reuse"`
+	ActiveVersion                 types.Int64                                 `tfsdk:"active_version"`
+	ManagedVersion                types.Int64                                 `tfsdk:"managed_version"`
+	Domain                        []domain.NestedModel                        `tfsdk:"domain"`
+	Backend                       []backend.NestedModel                       `tfsdk:"backend"`
+	ACL                           []cdnacl.NestedModel                        `tfsdk:"acl"`
+	Gzip                          []gzip.NestedModel                          `tfsdk:"gzip"`
+	LoggingS3                     []loggings3.NestedModel                     `tfsdk:"logging_s3"`
+	ImageOptimizerDefaultSettings []imageoptimizerdefaultsettings.NestedModel `tfsdk:"image_optimizer_default_settings"`
 }
 
 func (r *Resource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -99,11 +107,12 @@ func (r *Resource) Schema(_ context.Context, _ resource.SchemaRequest, resp *res
 			},
 		},
 		Blocks: map[string]schema.Block{
-			"domain":     domain.NestedBlockSchema(),
-			"backend":    backend.NestedBlockSchema(),
-			"acl":        cdnacl.NestedBlockSchema(),
-			"gzip":       gzip.NestedBlockSchema(),
-			"logging_s3": loggings3.NestedBlockSchema(),
+			"domain":                           domain.NestedBlockSchema(),
+			"backend":                          backend.NestedBlockSchema(),
+			"acl":                              cdnacl.NestedBlockSchema(),
+			"gzip":                             gzip.NestedBlockSchema(),
+			"logging_s3":                       loggings3.NestedBlockSchema(),
+			"image_optimizer_default_settings": imageoptimizerdefaultsettings.NestedBlockSchema(),
 		},
 	}
 }
@@ -202,6 +211,18 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 		return
 	}
 	plan.LoggingS3 = loggings3.MatchOrder(loggingS3s, plan.LoggingS3)
+
+	if err := imageoptimizerdefaultsettings.Reconcile(ctx, r.providerData.AutoClient(), serviceID, version, nil, plan.ImageOptimizerDefaultSettings); err != nil {
+		resp.Diagnostics.AddError("Error reconciling Image Optimizer default settings", err.Error())
+		return
+	}
+
+	imageOptimizerDefaultSettings, err := imageoptimizerdefaultsettings.ReadForVersion(ctx, r.providerData.AutoClient(), serviceID, version, plan.ImageOptimizerDefaultSettings, false)
+	if err != nil {
+		resp.Diagnostics.AddError("Error reading service Image Optimizer default settings", err.Error())
+		return
+	}
+	plan.ImageOptimizerDefaultSettings = imageOptimizerDefaultSettings
 
 	if err := service.ValidateVersion(ctx, r.providerData.AutoClient(), serviceID, version); err != nil {
 		resp.Diagnostics.AddError("Error validating service version", err.Error())
@@ -302,6 +323,23 @@ func (r *Resource) Read(ctx context.Context, req resource.ReadRequest, resp *res
 	state.Gzip = gzip.MatchOrder(gzips, state.Gzip)
 	state.LoggingS3 = loggings3.MatchOrder(loggingS3s, state.LoggingS3)
 
+	importedBytes, diags := req.Private.GetKey(ctx, imageOptimizerImportedPrivateKey)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	imported := len(importedBytes) > 0
+	if imported {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, imageOptimizerImportedPrivateKey, nil)...)
+	}
+
+	imageOptimizerDefaultSettings, err := imageoptimizerdefaultsettings.ReadForVersion(ctx, r.providerData.AutoClient(), state.ID.ValueString(), readVersion, state.ImageOptimizerDefaultSettings, imported)
+	if err != nil {
+		resp.Diagnostics.AddError("Error reading service Image Optimizer default settings", err.Error())
+		return
+	}
+	state.ImageOptimizerDefaultSettings = imageOptimizerDefaultSettings
+
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
@@ -328,7 +366,7 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 		return
 	}
 
-	nestedChanged := !domain.Equal(plan.Domain, state.Domain) || !backend.Equal(plan.Backend, state.Backend) || !cdnacl.Equal(plan.ACL, state.ACL) || !gzip.Equal(plan.Gzip, state.Gzip) || !loggings3.Equal(plan.LoggingS3, state.LoggingS3)
+	nestedChanged := !domain.Equal(plan.Domain, state.Domain) || !backend.Equal(plan.Backend, state.Backend) || !cdnacl.Equal(plan.ACL, state.ACL) || !gzip.Equal(plan.Gzip, state.Gzip) || !loggings3.Equal(plan.LoggingS3, state.LoggingS3) || !imageoptimizerdefaultsettings.Equal(plan.ImageOptimizerDefaultSettings, state.ImageOptimizerDefaultSettings)
 	needsVersionChange := nestedChanged
 
 	targetVersion := 0
@@ -422,6 +460,18 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 		}
 		plan.LoggingS3 = loggings3.MatchOrder(loggingS3s, plan.LoggingS3)
 
+		if err := imageoptimizerdefaultsettings.Reconcile(ctx, r.providerData.AutoClient(), serviceID, targetVersion, state.ImageOptimizerDefaultSettings, plan.ImageOptimizerDefaultSettings); err != nil {
+			resp.Diagnostics.AddError("Error reconciling Image Optimizer default settings", err.Error())
+			return
+		}
+
+		imageOptimizerDefaultSettings, err := imageoptimizerdefaultsettings.ReadForVersion(ctx, r.providerData.AutoClient(), serviceID, targetVersion, plan.ImageOptimizerDefaultSettings, false)
+		if err != nil {
+			resp.Diagnostics.AddError("Error reading service Image Optimizer default settings", err.Error())
+			return
+		}
+		plan.ImageOptimizerDefaultSettings = imageOptimizerDefaultSettings
+
 		if err := service.ValidateVersion(ctx, r.providerData.AutoClient(), serviceID, targetVersion); err != nil {
 			resp.Diagnostics.AddError("Error validating service version", err.Error())
 			return
@@ -447,6 +497,7 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 		plan.ACL = cdnacl.MatchOrder(state.ACL, plan.ACL)
 		plan.Gzip = gzip.MatchOrder(state.Gzip, plan.Gzip)
 		plan.LoggingS3 = loggings3.MatchOrder(state.LoggingS3, plan.LoggingS3)
+		plan.ImageOptimizerDefaultSettings = state.ImageOptimizerDefaultSettings
 	}
 
 	plan.ID = state.ID
@@ -474,6 +525,7 @@ func (r *Resource) Delete(ctx context.Context, req resource.DeleteRequest, resp 
 
 func (r *Resource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, imageOptimizerImportedPrivateKey, []byte("true"))...)
 }
 
 func (r *Resource) selectWorkingVersion(ctx context.Context, serviceID string) (version int, shouldClone bool, err error) {


### PR DESCRIPTION
### Change summary
- Add internal/resources/imageoptimizerdefaultsettings package: a singleton nested block (schema/expand/flatten)
- Wire the image_optimizer_default_settings block into fastly_service_cdn_auto (Model, Schema, Create/Read/Update reconciliation).
- Create and update are treated as the same full-replace operation, since Image  Optimizer default settings always exist once the product is enabled; removing  the block resets settings back to API defaults, but only when it was previously configured, to avoid surfacing phantom drift for services that never declared this block.
- Add unit tests for the new package, and acceptance tests covering create, update, reset-on-removal, and import

 All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/terraform-provider-fastly/pulls) for the same update/change?

### New Feature Submissions:

* [x] Does your submission pass tests?
* [x] Post the output of your test runs
<img width="966" height="127" alt="Screenshot 2026-07-27 at 2 41 57 PM" src="https://github.com/user-attachments/assets/028ad8c6-59b5-47e4-aeed-2613bf1e8574" />

