### PR TITLE
Move acls and kvstores into configs

### DIFF
--- a/internal/acceptance_tests/blocks/acl_entries_resource.tf
+++ b/internal/acceptance_tests/blocks/acl_entries_resource.tf
@@ -1,0 +1,9 @@
+resource "fastly_acl" "acl" {
+  name = "{{.ACL_NAME}}"
+}
+
+resource "fastly_acl_entries" "acl_entries" {
+  acl_id         = fastly_acl.acl.id
+  entries        = {{.ENTRIES}}
+  manage_entries = true
+}

--- a/internal/acceptance_tests/blocks/acl_entries_resource_unmanaged.tf
+++ b/internal/acceptance_tests/blocks/acl_entries_resource_unmanaged.tf
@@ -1,0 +1,8 @@
+resource "fastly_acl" "acl" {
+  name = "{{.ACL_NAME}}"
+}
+
+resource "fastly_acl_entries" "acl_entries" {
+  acl_id  = fastly_acl.acl.id
+  entries = {{.ENTRIES}}
+}

--- a/internal/acceptance_tests/blocks/acl_resource_single.tf
+++ b/internal/acceptance_tests/blocks/acl_resource_single.tf
@@ -1,0 +1,3 @@
+resource "fastly_acl" "acl" {
+  name = "{{.ACL_NAME}}"
+}

--- a/internal/acceptance_tests/blocks/acl_resource_two.tf
+++ b/internal/acceptance_tests/blocks/acl_resource_two.tf
@@ -1,0 +1,7 @@
+resource "fastly_acl" "acl1" {
+  name = "{{.ACL_NAME_1}}"
+}
+
+resource "fastly_acl" "acl2" {
+  name = "{{.ACL_NAME_2}}"
+}

--- a/internal/acceptance_tests/blocks/kvstore_force_destroy.tf
+++ b/internal/acceptance_tests/blocks/kvstore_force_destroy.tf
@@ -1,0 +1,4 @@
+resource "fastly_kvstore" "store" {
+  name          = "{{.KVSTORE_NAME}}"
+  force_destroy = true
+}

--- a/internal/acceptance_tests/blocks/kvstore_single.tf
+++ b/internal/acceptance_tests/blocks/kvstore_single.tf
@@ -1,0 +1,3 @@
+resource "fastly_kvstore" "store" {
+  name = "{{.KVSTORE_NAME}}"
+}

--- a/internal/acceptance_tests/blocks/kvstore_three_with_datasource.tf
+++ b/internal/acceptance_tests/blocks/kvstore_three_with_datasource.tf
@@ -1,0 +1,19 @@
+resource "fastly_kvstore" "store_1" {
+  name = "{{.KVSTORE_NAME_1}}"
+}
+
+resource "fastly_kvstore" "store_2" {
+  name = "{{.KVSTORE_NAME_2}}"
+}
+
+resource "fastly_kvstore" "store_3" {
+  name = "{{.KVSTORE_NAME_3}}"
+}
+
+data "fastly_kvstores" "example" {
+  depends_on = [
+    fastly_kvstore.store_1,
+    fastly_kvstore.store_2,
+    fastly_kvstore.store_3,
+  ]
+}

--- a/internal/acceptance_tests/blocks/kvstore_two.tf
+++ b/internal/acceptance_tests/blocks/kvstore_two.tf
@@ -1,0 +1,7 @@
+resource "fastly_kvstore" "kv1" {
+  name = "{{.KVSTORE_NAME_1}}"
+}
+
+resource "fastly_kvstore" "kv2" {
+  name = "{{.KVSTORE_NAME_2}}"
+}

--- a/internal/acceptance_tests/blocks/kvstore_with_location.tf
+++ b/internal/acceptance_tests/blocks/kvstore_with_location.tf
@@ -1,0 +1,4 @@
+resource "fastly_kvstore" "store" {
+  name     = "{{.KVSTORE_NAME}}"
+  location = "{{.KVSTORE_LOCATION}}"
+}

--- a/internal/acceptance_tests/test_helpers.go
+++ b/internal/acceptance_tests/test_helpers.go
@@ -518,14 +518,11 @@ func ConfigComputeAutoWithBackend(serviceName, domainName, backendName string) s
 // domain, package, and a resource_link block pointing at a Terraform-managed fastly_kvstore
 // (declared as a sibling resource, referenced by ID rather than a literal string).
 func ConfigComputeAutoWithKVStoreResourceLink(serviceName, domainName, storeName, linkName string) string {
-	kvStoreConfig := fmt.Sprintf(`
-resource "fastly_kvstore" "store" {
-  name = %q
-}
+	kvStoreConfig := RenderBlock("internal/acceptance_tests/blocks/kvstore_single.tf", map[string]string{
+		"KVSTORE_NAME": storeName,
+	})
 
-`, storeName)
-
-	return kvStoreConfig + BuildConfig(
+	return kvStoreConfig + "\n" + BuildConfig(
 		ServiceComputeAuto,
 		map[string]string{
 			"SERVICE_NAME":            serviceName,
@@ -547,14 +544,11 @@ resource "fastly_kvstore" "store" {
 // service, so tests that remove a resource_link and then delete its target KV Store need this as
 // an intermediate step: unlink first and let that settle, then delete the KV Store in a later step.
 func ConfigComputeAutoWithStandaloneKVStore(serviceName, domainName, storeName string) string {
-	kvStoreConfig := fmt.Sprintf(`
-resource "fastly_kvstore" "store" {
-  name = %q
-}
+	kvStoreConfig := RenderBlock("internal/acceptance_tests/blocks/kvstore_single.tf", map[string]string{
+		"KVSTORE_NAME": storeName,
+	})
 
-`, storeName)
-
-	return kvStoreConfig + ConfigComputeAutoBasic(serviceName, domainName)
+	return kvStoreConfig + "\n" + ConfigComputeAutoBasic(serviceName, domainName)
 }
 
 // ConfigComputeAutoWithKVStoreResourceLinkTarget returns a Compute auto service config
@@ -563,18 +557,12 @@ resource "fastly_kvstore" "store" {
 // targeted, so retargeting exercises the reconcile delete-old/create-new pass without deleting
 // either KV Store.
 func ConfigComputeAutoWithKVStoreResourceLinkTarget(serviceName, domainName, storeName1, storeName2, linkName, targetLabel string) string {
-	kvStoreConfig := fmt.Sprintf(`
-resource "fastly_kvstore" "kv1" {
-  name = %q
-}
+	kvStoreConfig := RenderBlock("internal/acceptance_tests/blocks/kvstore_two.tf", map[string]string{
+		"KVSTORE_NAME_1": storeName1,
+		"KVSTORE_NAME_2": storeName2,
+	})
 
-resource "fastly_kvstore" "kv2" {
-  name = %q
-}
-
-`, storeName1, storeName2)
-
-	return kvStoreConfig + BuildConfig(
+	return kvStoreConfig + "\n" + BuildConfig(
 		ServiceComputeAuto,
 		map[string]string{
 			"SERVICE_NAME":            serviceName,
@@ -591,74 +579,48 @@ resource "fastly_kvstore" "kv2" {
 
 // ConfigKVStore returns a minimal standalone fastly_kvstore config.
 func ConfigKVStore(name string) string {
-	return fmt.Sprintf(`
-resource "fastly_kvstore" "store" {
-  name = %q
-}
-`, name)
+	return RenderBlock("internal/acceptance_tests/blocks/kvstore_single.tf", map[string]string{
+		"KVSTORE_NAME": name,
+	})
 }
 
 // ConfigKVStoreWithLocation returns a standalone fastly_kvstore config with an explicit
 // location, for exercising the location attribute's plan-time validation and its
 // replace-on-change behavior.
 func ConfigKVStoreWithLocation(name, location string) string {
-	return fmt.Sprintf(`
-resource "fastly_kvstore" "store" {
-  name     = %q
-  location = %q
-}
-`, name, location)
+	return RenderBlock("internal/acceptance_tests/blocks/kvstore_with_location.tf", map[string]string{
+		"KVSTORE_NAME":     name,
+		"KVSTORE_LOCATION": location,
+	})
 }
 
 // ConfigKVStoreForceDestroy returns a standalone fastly_kvstore config with force_destroy set,
 // for exercising deletion of a KV Store that still contains entries.
 func ConfigKVStoreForceDestroy(name string) string {
-	return fmt.Sprintf(`
-resource "fastly_kvstore" "store" {
-  name          = %q
-  force_destroy = true
-}
-`, name)
+	return RenderBlock("internal/acceptance_tests/blocks/kvstore_force_destroy.tf", map[string]string{
+		"KVSTORE_NAME": name,
+	})
 }
 
 // ConfigKVStoresDataSource returns a config declaring three fastly_kvstore resources alongside
 // a fastly_kvstores data source that depends on all three.
 func ConfigKVStoresDataSource(h string) string {
-	return fmt.Sprintf(`
-resource "fastly_kvstore" "store_1" {
-  name = "tf_%s_1"
-}
-
-resource "fastly_kvstore" "store_2" {
-  name = "tf_%s_2"
-}
-
-resource "fastly_kvstore" "store_3" {
-  name = "tf_%s_3"
-}
-
-data "fastly_kvstores" "example" {
-  depends_on = [
-    fastly_kvstore.store_1,
-    fastly_kvstore.store_2,
-    fastly_kvstore.store_3,
-  ]
-}
-`, h, h, h)
+	return RenderBlock("internal/acceptance_tests/blocks/kvstore_three_with_datasource.tf", map[string]string{
+		"KVSTORE_NAME_1": fmt.Sprintf("tf_%s_1", h),
+		"KVSTORE_NAME_2": fmt.Sprintf("tf_%s_2", h),
+		"KVSTORE_NAME_3": fmt.Sprintf("tf_%s_3", h),
+	})
 }
 
 // ConfigComputeAutoWithACLResourceLink returns a Compute auto service config with a
 // domain, package, and a resource_link block pointing at a Terraform-managed fastly_acl
 // (declared as a sibling resource, referenced by ID rather than a literal string).
 func ConfigComputeAutoWithACLResourceLink(serviceName, domainName, aclName, linkName string) string {
-	aclConfig := fmt.Sprintf(`
-resource "fastly_acl" "acl" {
-  name = %q
-}
+	aclConfig := RenderBlock("internal/acceptance_tests/blocks/acl_resource_single.tf", map[string]string{
+		"ACL_NAME": aclName,
+	})
 
-`, aclName)
-
-	return aclConfig + BuildConfig(
+	return aclConfig + "\n" + BuildConfig(
 		ServiceComputeAuto,
 		map[string]string{
 			"SERVICE_NAME":            serviceName,
@@ -680,14 +642,11 @@ resource "fastly_acl" "acl" {
 // service, so tests that remove a resource_link and then delete its target ACL need this as an
 // intermediate step: unlink first and let that settle, then delete the ACL in a later step.
 func ConfigComputeAutoWithStandaloneACL(serviceName, domainName, aclName string) string {
-	aclConfig := fmt.Sprintf(`
-resource "fastly_acl" "acl" {
-  name = %q
-}
+	aclConfig := RenderBlock("internal/acceptance_tests/blocks/acl_resource_single.tf", map[string]string{
+		"ACL_NAME": aclName,
+	})
 
-`, aclName)
-
-	return aclConfig + ConfigComputeAutoBasic(serviceName, domainName)
+	return aclConfig + "\n" + ConfigComputeAutoBasic(serviceName, domainName)
 }
 
 // ConfigComputeAutoWithACLResourceLinkTarget returns a Compute auto service config
@@ -695,18 +654,12 @@ resource "fastly_acl" "acl" {
 // whichever is named by targetLabel. Both ACLs stay declared regardless of which is targeted, so
 // retargeting exercises the reconcile delete-old/create-new pass without deleting either ACL.
 func ConfigComputeAutoWithACLResourceLinkTarget(serviceName, domainName, aclName1, aclName2, linkName, targetLabel string) string {
-	aclConfig := fmt.Sprintf(`
-resource "fastly_acl" "acl1" {
-  name = %q
-}
+	aclConfig := RenderBlock("internal/acceptance_tests/blocks/acl_resource_two.tf", map[string]string{
+		"ACL_NAME_1": aclName1,
+		"ACL_NAME_2": aclName2,
+	})
 
-resource "fastly_acl" "acl2" {
-  name = %q
-}
-
-`, aclName1, aclName2)
-
-	return aclConfig + BuildConfig(
+	return aclConfig + "\n" + BuildConfig(
 		ServiceComputeAuto,
 		map[string]string{
 			"SERVICE_NAME":            serviceName,

--- a/internal/acceptance_tests/test_helpers.go
+++ b/internal/acceptance_tests/test_helpers.go
@@ -1138,32 +1138,19 @@ func ConfigACLEntriesManyEntries(serviceName, domainName, aclName string, count 
 // ConfigACLEntries returns a config declaring a fastly_acl resource alongside a
 // fastly_acl_entries resource (with manage_entries = true) that targets it.
 func ConfigACLEntries(aclName string, entries map[string]string) string {
-	return fmt.Sprintf(`
-resource "fastly_acl" "acl" {
-  name = %q
-}
-
-resource "fastly_acl_entries" "acl_entries" {
-  acl_id         = fastly_acl.acl.id
-  entries        = %s
-  manage_entries = true
-}
-`, aclName, entriesHCL(entries))
+	return RenderBlock("internal/acceptance_tests/blocks/acl_entries_resource.tf", map[string]string{
+		"ACL_NAME": aclName,
+		"ENTRIES":  entriesHCL(entries),
+	})
 }
 
 // ConfigACLEntriesUnmanaged mirrors ConfigACLEntries but omits manage_entries,
 // leaving it at its default (false).
 func ConfigACLEntriesUnmanaged(aclName string, entries map[string]string) string {
-	return fmt.Sprintf(`
-resource "fastly_acl" "acl" {
-  name = %q
-}
-
-resource "fastly_acl_entries" "acl_entries" {
-  acl_id  = fastly_acl.acl.id
-  entries = %s
-}
-`, aclName, entriesHCL(entries))
+	return RenderBlock("internal/acceptance_tests/blocks/acl_entries_resource_unmanaged.tf", map[string]string{
+		"ACL_NAME": aclName,
+		"ENTRIES":  entriesHCL(entries),
+	})
 }
 
 func entriesHCL(entries map[string]string) string {


### PR DESCRIPTION
### Change summary

Noticed these got put into raw HCL instead of configs

 All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/terraform-provider-fastly/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

* [x] Does your submission pass tests?
* [x] Post the output of your test runs
<img width="628" height="789" alt="Screenshot 2026-07-27 at 4 43 18 PM" src="https://github.com/user-attachments/assets/63c82453-8541-4d21-8867-019ab291ccb9" />
