### PR TITLE
fix(logging_s3): Update `placement` attribute to allow `null` reset

### DIFF
--- a/internal/acceptance_tests/blocks/logging_s3_placement_none.tf
+++ b/internal/acceptance_tests/blocks/logging_s3_placement_none.tf
@@ -1,0 +1,11 @@
+resource "fastly_service_logging_s3" "test" {
+  service_id  = fastly_service_cdn.test.id
+  version     = {{.SERVICE_VERSION}}
+  name        = "{{.LOGGING_S3_NAME}}"
+  bucket_name = "{{.BUCKET_NAME}}"
+  authentication = {
+    access_key = "AKIAIOSFODNN7EXAMPLE"
+    secret_key = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+  }
+  placement = "none"
+}

--- a/internal/acceptance_tests/logging_s3_test.go
+++ b/internal/acceptance_tests/logging_s3_test.go
@@ -115,6 +115,53 @@ func TestAccFastlyServiceLoggingS3_iamRole(t *testing.T) {
 	})
 }
 
+// TestAccFastlyServiceLoggingS3_credentialSwitchClearsKeys verifies that
+// switching auth from access_key/secret_key to iam_role on update actually
+// clears the previously-set keys against the API. BuildUpdateInput must send
+// the cleared credentials as "" (via new()) rather than fastly.NullString,
+// which maps "" to nil, omits the field, and leaves the old keys in place —
+// producing an inconsistent-result error when the read-back still shows them.
+func TestAccFastlyServiceLoggingS3_credentialSwitchClearsKeys(t *testing.T) {
+	t.Parallel()
+	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	domainName := fmt.Sprintf("%s.example.com", acctest.RandString(10))
+	loggerName := fmt.Sprintf("s3-logger-%s", acctest.RandString(10))
+	bucketName := fmt.Sprintf("tf-test-bucket-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
+		CheckDestroy:             CheckServiceDestroy("fastly_service_cdn"),
+		Steps: []resource.TestStep{
+			{
+				// Start with access_key + secret_key set.
+				Config: ConfigLoggingS3Basic(serviceName, domainName, loggerName, bucketName),
+				Check: resource.ComposeTestCheckFunc(
+					CheckServiceExists("fastly_service_cdn.test"),
+					resource.TestCheckResourceAttr("fastly_service_logging_s3.test", "authentication.access_key", "AKIAIOSFODNN7EXAMPLE"),
+					resource.TestCheckResourceAttr("fastly_service_logging_s3.test", "authentication.secret_key", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"),
+					resource.TestCheckResourceAttr("fastly_service_logging_s3.test", "authentication.iam_role", ""),
+				),
+			},
+			{
+				// Switch to iam_role: the keys must clear back to "".
+				Config: ConfigLoggingS3IAM(serviceName, domainName, loggerName, bucketName),
+				Check: resource.ComposeTestCheckFunc(
+					CheckServiceExists("fastly_service_cdn.test"),
+					resource.TestCheckResourceAttr("fastly_service_logging_s3.test", "authentication.iam_role", "arn:aws:iam::123456789012:role/FastlyS3Access"),
+					resource.TestCheckResourceAttr("fastly_service_logging_s3.test", "authentication.access_key", ""),
+					resource.TestCheckResourceAttr("fastly_service_logging_s3.test", "authentication.secret_key", ""),
+				),
+			},
+			{
+				// The clear must leave no residual diff against the same config.
+				Config:   ConfigLoggingS3IAM(serviceName, domainName, loggerName, bucketName),
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
 // TestAccFastlyServiceLoggingS3_authEnvDefaults verifies that access_key and
 // secret_key still pick up FASTLY_S3_ACCESS_KEY / FASTLY_S3_SECRET_KEY when
 // the entire authentication object is omitted from config. This exercises the
@@ -228,7 +275,67 @@ func TestAccFastlyServiceLoggingS3_clearToDefaults(t *testing.T) {
 					resource.TestCheckResourceAttr("fastly_service_logging_s3.test", "acl", ""),
 					resource.TestCheckResourceAttr("fastly_service_logging_s3.test", "redundancy", ""),
 					resource.TestCheckResourceAttr("fastly_service_logging_s3.test", "file_max_bytes", "0"),
+					// placement has no default: unconfigured means unset, distinct
+					// from "none" — see TestAccFastlyServiceLoggingS3_placementUnsetVsNone.
+					resource.TestCheckNoResourceAttr("fastly_service_logging_s3.test", "placement"),
 				),
+			},
+			{
+				// The clear must leave no residual diff against the same config.
+				Config:   ConfigLoggingS3Defaults(serviceName, domainName, loggerName, bucketName),
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+// TestAccFastlyServiceLoggingS3_placementUnsetVsNone verifies that leaving
+// placement unconfigured and explicitly setting it to "none" are distinct,
+// round-trippable states — not just on create but across updates in both
+// directions — rather than being collapsed together, since the API treats an
+// unset placement (auto-place in vcl_log/vcl_deliver) differently from an
+// explicit "none" (suppress the log statement entirely).
+func TestAccFastlyServiceLoggingS3_placementUnsetVsNone(t *testing.T) {
+	t.Parallel()
+	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	domainName := fmt.Sprintf("%s.example.com", acctest.RandString(10))
+	loggerName := fmt.Sprintf("s3-logger-%s", acctest.RandString(10))
+	bucketName := fmt.Sprintf("tf-test-bucket-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
+		CheckDestroy:             CheckServiceDestroy("fastly_service_cdn"),
+		Steps: []resource.TestStep{
+			{
+				// Start unset.
+				Config: ConfigLoggingS3Basic(serviceName, domainName, loggerName, bucketName),
+				Check: resource.ComposeTestCheckFunc(
+					CheckServiceExists("fastly_service_cdn.test"),
+					resource.TestCheckNoResourceAttr("fastly_service_logging_s3.test", "placement"),
+				),
+			},
+			{
+				// Update to explicit "none".
+				Config: ConfigLoggingS3PlacementNone(serviceName, domainName, loggerName, bucketName),
+				Check: resource.ComposeTestCheckFunc(
+					CheckServiceExists("fastly_service_cdn.test"),
+					resource.TestCheckResourceAttr("fastly_service_logging_s3.test", "placement", "none"),
+				),
+			},
+			{
+				// Update back to unset.
+				Config: ConfigLoggingS3Basic(serviceName, domainName, loggerName, bucketName),
+				Check: resource.ComposeTestCheckFunc(
+					CheckServiceExists("fastly_service_cdn.test"),
+					resource.TestCheckNoResourceAttr("fastly_service_logging_s3.test", "placement"),
+				),
+			},
+			{
+				// The API's null response must leave no residual diff against the
+				// same, still-unset config.
+				Config:   ConfigLoggingS3Basic(serviceName, domainName, loggerName, bucketName),
+				PlanOnly: true,
 			},
 		},
 	})
@@ -280,6 +387,12 @@ func TestAccFastlyServiceLoggingS3_importBasic(t *testing.T) {
 // TestAccFastlyServiceLoggingS3_compressionCodec verifies that setting compression_codec
 // without gzip_level does not result in an API error (the two fields are mutually exclusive).
 // With gzip_level unset it stays at the -1 sentinel and is never sent to the API.
+// TestAccFastlyServiceLoggingS3_compressionCodec also verifies compression_codec
+// clears back to its "" default on update. compression_codec is Optional+Computed
+// with a static "" default; BuildUpdateInput must always send it via new() rather
+// than fastly.NullString, or clearing a previously-set value never reaches the API
+// (it gets omitted instead of sent as "") and the second step's check fails with
+// the old value still applied.
 func TestAccFastlyServiceLoggingS3_compressionCodec(t *testing.T) {
 	t.Parallel()
 	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
@@ -299,6 +412,18 @@ func TestAccFastlyServiceLoggingS3_compressionCodec(t *testing.T) {
 					resource.TestCheckResourceAttr("fastly_service_logging_s3.test", "compression_codec", "zstd"),
 					resource.TestCheckResourceAttr("fastly_service_logging_s3.test", "gzip_level", "-1"),
 				),
+			},
+			{
+				Config: ConfigLoggingS3Defaults(serviceName, domainName, loggerName, bucketName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("fastly_service_logging_s3.test", "compression_codec", ""),
+					resource.TestCheckResourceAttr("fastly_service_logging_s3.test", "gzip_level", "-1"),
+				),
+			},
+			{
+				// The clear must leave no residual diff against the same config.
+				Config:   ConfigLoggingS3Defaults(serviceName, domainName, loggerName, bucketName),
+				PlanOnly: true,
 			},
 		},
 	})

--- a/internal/acceptance_tests/test_helpers.go
+++ b/internal/acceptance_tests/test_helpers.go
@@ -1533,6 +1533,22 @@ func ConfigLoggingS3Defaults(serviceName, domainName, loggerName, bucketName str
 	)
 }
 
+func ConfigLoggingS3PlacementNone(serviceName, domainName, loggerName, bucketName string) string {
+	return BuildConfig(
+		ServiceCDN,
+		map[string]string{
+			"SERVICE_NAME":    serviceName,
+			"SERVICE_COMMENT": "",
+			"DOMAIN_NAME":     domainName,
+			"SERVICE_VERSION": "1",
+			"LOGGING_S3_NAME": loggerName,
+			"BUCKET_NAME":     bucketName,
+		},
+		"internal/acceptance_tests/blocks/service_cdn_domain.tf",
+		"internal/acceptance_tests/blocks/logging_s3_placement_none.tf",
+	)
+}
+
 func ConfigLoggingS3CompressionCodec(serviceName, domainName, loggerName, bucketName string) string {
 	return BuildConfig(
 		ServiceCDN,

--- a/internal/resources/loggings3/expand.go
+++ b/internal/resources/loggings3/expand.go
@@ -145,13 +145,17 @@ func BuildComputeUpdateInput(serviceID string, version int, m ComputeNestedModel
 		BucketName:     new(service.StringValue(m.BucketName)),
 	}
 
-	input.AccessKey = fastly.NullString(service.StringValue(m.AccessKey()))
-	input.SecretKey = fastly.NullString(service.StringValue(m.SecretKey()))
-	input.IAMRole = fastly.NullString(service.StringValue(m.IAMRole()))
+	// Credentials default to "" and can be cleared — e.g. switching from
+	// access_key/secret_key to iam_role auth. Always send a concrete value via
+	// new() rather than fastly.NullString, which maps "" to nil, omits the field
+	// (access_key,omitempty), and leaves the previously-set credential in place.
+	input.AccessKey = new(service.StringValue(m.AccessKey()))
+	input.SecretKey = new(service.StringValue(m.SecretKey()))
+	input.IAMRole = new(service.StringValue(m.IAMRole()))
 	input.Domain = fastly.NullString(service.StringValue(m.Domain))
 	input.Path = new(service.StringValue(m.Path))
 	input.Period = fastly.NullInt(int(service.Int64Value(m.Period)))
-	input.CompressionCodec = fastly.NullString(service.StringValue(m.CompressionCodec))
+	input.CompressionCodec = new(service.StringValue(m.CompressionCodec))
 	// Only send an explicitly configured gzip_level. DefaultGzipLevel (-1) means
 	// unset: the API rejects requests that set both compression_codec and
 	// gzip_level, and it auto-manages the level when omitted.
@@ -160,7 +164,7 @@ func BuildComputeUpdateInput(serviceID string, version int, m ComputeNestedModel
 	}
 	input.MessageType = fastly.NullString(service.StringValue(m.MessageType))
 	input.TimestampFormat = fastly.NullString(service.StringValue(m.TimestampFormat))
-	input.PublicKey = fastly.NullString(service.StringValue(m.PublicKey))
+	input.PublicKey = new(service.StringValue(m.PublicKey))
 	input.ProcessingRegion = fastly.NullString(service.StringValue(m.ProcessingRegion))
 
 	aclVal := fastly.S3AccessControlList(service.StringValue(m.ACL))
@@ -173,7 +177,7 @@ func BuildComputeUpdateInput(serviceID string, version int, m ComputeNestedModel
 		v := fastly.S3ServerSideEncryption(enc)
 		input.ServerSideEncryption = &v
 	}
-	input.ServerSideEncryptionKMSKeyID = fastly.NullString(service.StringValue(m.ServerSideEncryptionKMSKeyID))
+	input.ServerSideEncryptionKMSKeyID = new(service.StringValue(m.ServerSideEncryptionKMSKeyID))
 
 	fmb := int(service.Int64Value(m.FileMaxBytes))
 	input.FileMaxBytes = &fmb
@@ -190,13 +194,17 @@ func BuildUpdateInput(serviceID string, version int, m NestedModel) *fastly.Upda
 		BucketName:     new(service.StringValue(m.BucketName)),
 	}
 
-	input.AccessKey = fastly.NullString(service.StringValue(m.AccessKey()))
-	input.SecretKey = fastly.NullString(service.StringValue(m.SecretKey()))
-	input.IAMRole = fastly.NullString(service.StringValue(m.IAMRole()))
+	// Credentials default to "" and can be cleared — e.g. switching from
+	// access_key/secret_key to iam_role auth. Always send a concrete value via
+	// new() rather than fastly.NullString, which maps "" to nil, omits the field
+	// (access_key,omitempty), and leaves the previously-set credential in place.
+	input.AccessKey = new(service.StringValue(m.AccessKey()))
+	input.SecretKey = new(service.StringValue(m.SecretKey()))
+	input.IAMRole = new(service.StringValue(m.IAMRole()))
 	input.Domain = fastly.NullString(service.StringValue(m.Domain))
 	input.Path = new(service.StringValue(m.Path))
 	input.Period = fastly.NullInt(int(service.Int64Value(m.Period)))
-	input.CompressionCodec = fastly.NullString(service.StringValue(m.CompressionCodec))
+	input.CompressionCodec = new(service.StringValue(m.CompressionCodec))
 	// Only send an explicitly configured gzip_level. DefaultGzipLevel (-1) means
 	// unset: the API rejects requests that set both compression_codec and
 	// gzip_level, and it auto-manages the level when omitted.
@@ -207,14 +215,19 @@ func BuildUpdateInput(serviceID string, version int, m NestedModel) *fastly.Upda
 	input.FormatVersion = fastly.NullInt(int(service.Int64Value(m.FormatVersion)))
 	input.MessageType = fastly.NullString(service.StringValue(m.MessageType))
 	input.TimestampFormat = fastly.NullString(service.StringValue(m.TimestampFormat))
-	// placement is Optional+Computed with a static "none" default (schema.go),
-	// so it is never actually empty here — unlike endpoints where placement is
-	// truly optional, there is no unset state to preserve as a JSON null.
-	// UpdateS3Input.Placement is still a *Nullable[string] because go-fastly
-	// models placement uniformly across logging endpoints.
-	input.Placement = fastly.NewNullable(service.StringValue(m.Placement))
-	input.ResponseCondition = fastly.NullString(service.StringValue(m.ResponseCondition))
-	input.PublicKey = fastly.NullString(service.StringValue(m.PublicKey))
+	// placement can be cleared back to unset / nil (distinct from "none" —
+	// see schema.go). UpdateS3Input.Placement is a *Nullable[string]
+	// specifically so this can be sent as a real JSON null: omitting the field
+	// leaves the previous value in place, and sending a literal empty string
+	// gets stored as "" rather than reverting to null/auto-placement — neither
+	// actually clears it.
+	if v := service.StringValue(m.Placement); v != "" {
+		input.Placement = fastly.NewNullable(v)
+	} else {
+		input.Placement = fastly.NullValue[string]()
+	}
+	input.ResponseCondition = new(service.StringValue(m.ResponseCondition))
+	input.PublicKey = new(service.StringValue(m.PublicKey))
 	input.ProcessingRegion = fastly.NullString(service.StringValue(m.ProcessingRegion))
 
 	aclVal := fastly.S3AccessControlList(service.StringValue(m.ACL))
@@ -227,7 +240,7 @@ func BuildUpdateInput(serviceID string, version int, m NestedModel) *fastly.Upda
 		v := fastly.S3ServerSideEncryption(enc)
 		input.ServerSideEncryption = &v
 	}
-	input.ServerSideEncryptionKMSKeyID = fastly.NullString(service.StringValue(m.ServerSideEncryptionKMSKeyID))
+	input.ServerSideEncryptionKMSKeyID = new(service.StringValue(m.ServerSideEncryptionKMSKeyID))
 
 	fmb := int(service.Int64Value(m.FileMaxBytes))
 	input.FileMaxBytes = &fmb

--- a/internal/resources/loggings3/flatten.go
+++ b/internal/resources/loggings3/flatten.go
@@ -35,7 +35,7 @@ func FlattenToNestedModel(s *fastly.S3) NestedModel {
 	m.FormatVersion = service.Int64PointerOrDefault(s.FormatVersion, DefaultFormatVersion)
 	m.MessageType = service.StringPointerOrDefault(s.MessageType, DefaultMessageType)
 	m.TimestampFormat = service.StringPointerOrDefault(s.TimestampFormat, DefaultTimestampFormat)
-	m.Placement = service.StringPointerOrDefault(s.Placement, DefaultPlacement)
+	m.Placement = service.StringPointerOrNull(s.Placement)
 	m.ResponseCondition = service.StringPointerOrDefault(s.ResponseCondition, DefaultResponseCondition)
 	m.PublicKey = service.StringPointerOrDefault(s.PublicKey, DefaultPublicKey)
 	m.ProcessingRegion = service.StringPointerOrDefault(s.ProcessingRegion, DefaultProcessingRegion)

--- a/internal/resources/loggings3/loggings3_test.go
+++ b/internal/resources/loggings3/loggings3_test.go
@@ -19,7 +19,7 @@ func defaultNestedModel() NestedModel {
 		commonModel:       defaultCommonModel(),
 		Format:            types.StringValue(constants.LoggingS3DefaultFormat),
 		FormatVersion:     types.Int64Value(DefaultFormatVersion),
-		Placement:         types.StringValue(DefaultPlacement),
+		Placement:         types.StringNull(),
 		ResponseCondition: types.StringValue(DefaultResponseCondition),
 	}
 }
@@ -519,10 +519,18 @@ func TestBuildUpdateInput(t *testing.T) {
 				assert.Equal(t, fastly.S3AccessControlList(""), *input.ACL)
 				assert.NotNil(t, input.Redundancy)
 				assert.Equal(t, fastly.S3Redundancy(""), *input.Redundancy)
-				assert.Nil(t, input.ServerSideEncryption)
+				assert.Nil(t, input.ServerSideEncryption, "server_side_encryption is a strict enum; the API rejects an explicit \"\", so it must stay omitted when unset")
 				assert.NotNil(t, input.FileMaxBytes)
 				assert.Equal(t, 0, *input.FileMaxBytes)
-				assert.Equal(t, fastly.NewNullable(DefaultPlacement), input.Placement, "placement defaults to \"none\" via the schema, never an unset null")
+				assert.Equal(t, fastly.NullValue[string](), input.Placement, "unset placement clears to a JSON null, distinct from an explicit \"none\"")
+				assert.NotNil(t, input.CompressionCodec)
+				assert.Equal(t, "", *input.CompressionCodec)
+				assert.NotNil(t, input.ResponseCondition)
+				assert.Equal(t, "", *input.ResponseCondition)
+				assert.NotNil(t, input.PublicKey)
+				assert.Equal(t, "", *input.PublicKey)
+				assert.NotNil(t, input.ServerSideEncryptionKMSKeyID)
+				assert.Equal(t, "", *input.ServerSideEncryptionKMSKeyID)
 			},
 		},
 		{
@@ -541,6 +549,48 @@ func TestBuildUpdateInput(t *testing.T) {
 				assert.Equal(t, 1, *input.FormatVersion)
 				assert.Equal(t, fastly.NewNullable("none"), input.Placement)
 				assert.Equal(t, "response-condition-1", *input.ResponseCondition)
+				assert.Equal(t, "pgp-public-key", *input.PublicKey)
+				assert.Equal(t, "kms-key-1", *input.ServerSideEncryptionKMSKeyID)
+			},
+		},
+		{
+			name:      "clearing previously-set optional fields back to defaults",
+			serviceID: "service-789",
+			version:   3,
+			model: func() NestedModel {
+				m := fullNestedModel()
+				m.CompressionCodec = types.StringValue(DefaultCompressionCodec)
+				m.ResponseCondition = types.StringValue(DefaultResponseCondition)
+				m.PublicKey = types.StringValue(DefaultPublicKey)
+				m.ServerSideEncryption = types.StringValue(DefaultServerSideEncryption)
+				m.ServerSideEncryptionKMSKeyID = types.StringValue(DefaultServerSideEncryptionKMSKeyID)
+				m.Placement = types.StringNull()
+				// Switch from access_key/secret_key auth to iam_role: the two
+				// key credentials clear to "".
+				m.Authentication = NewAuthenticationObject(
+					types.StringValue(""),
+					types.StringValue(""),
+					types.StringValue("arn:aws:iam::123456789012:role/test"),
+				)
+				return m
+			}(),
+			validate: func(t *testing.T, input *fastly.UpdateS3Input) {
+				assert.NotNil(t, input.CompressionCodec)
+				assert.Equal(t, "", *input.CompressionCodec)
+				assert.NotNil(t, input.ResponseCondition)
+				assert.Equal(t, "", *input.ResponseCondition)
+				assert.NotNil(t, input.PublicKey)
+				assert.Equal(t, "", *input.PublicKey)
+				assert.Nil(t, input.ServerSideEncryption, "server_side_encryption is a strict enum; the API rejects an explicit \"\", so clearing it must omit the field")
+				assert.NotNil(t, input.ServerSideEncryptionKMSKeyID)
+				assert.Equal(t, "", *input.ServerSideEncryptionKMSKeyID)
+				assert.Equal(t, fastly.NullValue[string](), input.Placement, "clearing placement must send a JSON null, not omit the field")
+				assert.NotNil(t, input.AccessKey, "clearing access_key must send \"\", not omit the field, or the old credential survives")
+				assert.Equal(t, "", *input.AccessKey)
+				assert.NotNil(t, input.SecretKey)
+				assert.Equal(t, "", *input.SecretKey)
+				assert.NotNil(t, input.IAMRole)
+				assert.Equal(t, "arn:aws:iam::123456789012:role/test", *input.IAMRole)
 			},
 		},
 	}
@@ -565,6 +615,40 @@ func TestBuildComputeUpdateInput(t *testing.T) {
 	assert.Nil(t, input.FormatVersion)
 	assert.Nil(t, input.Placement)
 	assert.Nil(t, input.ResponseCondition)
+	assert.Equal(t, "pgp-public-key", *input.PublicKey)
+	assert.Equal(t, fastly.S3ServerSideEncryption("aws:kms"), *input.ServerSideEncryption)
+	assert.Equal(t, "kms-key-1", *input.ServerSideEncryptionKMSKeyID)
+}
+
+func TestBuildComputeUpdateInput_clearingOptionalFieldsBackToDefaults(t *testing.T) {
+	m := ComputeNestedModel{commonModel: fullNestedModel().commonModel}
+	m.CompressionCodec = types.StringValue(DefaultCompressionCodec)
+	m.PublicKey = types.StringValue(DefaultPublicKey)
+	m.ServerSideEncryption = types.StringValue(DefaultServerSideEncryption)
+	m.ServerSideEncryptionKMSKeyID = types.StringValue(DefaultServerSideEncryptionKMSKeyID)
+	// Switch from access_key/secret_key auth to iam_role: the two key
+	// credentials clear to "".
+	m.Authentication = NewAuthenticationObject(
+		types.StringValue(""),
+		types.StringValue(""),
+		types.StringValue("arn:aws:iam::123456789012:role/test"),
+	)
+
+	input := BuildComputeUpdateInput("service-789", 3, m)
+
+	assert.NotNil(t, input.CompressionCodec)
+	assert.Equal(t, "", *input.CompressionCodec)
+	assert.NotNil(t, input.PublicKey)
+	assert.Equal(t, "", *input.PublicKey)
+	assert.Nil(t, input.ServerSideEncryption, "server_side_encryption is a strict enum; the API rejects an explicit \"\", so clearing it must omit the field")
+	assert.NotNil(t, input.ServerSideEncryptionKMSKeyID)
+	assert.Equal(t, "", *input.ServerSideEncryptionKMSKeyID)
+	assert.NotNil(t, input.AccessKey, "clearing access_key must send \"\", not omit the field, or the old credential survives")
+	assert.Equal(t, "", *input.AccessKey)
+	assert.NotNil(t, input.SecretKey)
+	assert.Equal(t, "", *input.SecretKey)
+	assert.NotNil(t, input.IAMRole)
+	assert.Equal(t, "arn:aws:iam::123456789012:role/test", *input.IAMRole)
 }
 
 func TestClearVCLOnlyCreateFields(t *testing.T) {

--- a/internal/resources/loggings3/schema.go
+++ b/internal/resources/loggings3/schema.go
@@ -36,7 +36,6 @@ const (
 	DefaultPeriod                       = 3600
 	DefaultTimestampFormat              = "%Y-%m-%dT%H:%M:%S.000"
 	DefaultCompressionCodec             = ""
-	DefaultPlacement                    = "none"
 	DefaultResponseCondition            = ""
 	DefaultDomain                       = "s3.amazonaws.com"
 	DefaultACL                          = ""
@@ -425,9 +424,14 @@ func vclOnlyAttributes() map[string]schema.Attribute {
 			Description: "The version of the custom logging format used for the configured endpoint. The logging call gets placed by default in vcl_log if format_version is set to `2` and in `vcl_deliver` if `format_version` is set to `1`.",
 		},
 		"placement": schema.StringAttribute{
+			// Not Computed: unset and explicitly "none" are distinct states on the
+			// API (unset lets the API auto-place the logging call; "none" suppresses
+			// it entirely), and the API always resolves to exactly what was
+			// configured — never some other server-computed value — so there is
+			// nothing for Computed to add. Keeping it plain Optional means removing
+			// placement from config is a real, visible diff from Terraform core's own
+			// plan proposal, with no plan modifier required to force it.
 			Optional: true,
-			Computed: true,
-			Default:  stringdefault.StaticString(DefaultPlacement),
 			Validators: []validator.String{
 				stringvalidator.OneOf("none"),
 			},


### PR DESCRIPTION
### Change summary

This PR updates the S3 Logging resource to reflect the improvements made to the New Relic OLTP in [ffd4aa0](https://github.com/fastly/terraform-provider-fastly/pull/1356/commits/ffd4aa04d9187a584dcb329b8649c745b7952c41). 

Primarily, we are ensuring that the `placement` attribute can be reset back to `null` when it was previously set to `none`. Tests are also updated to ensure optional attributes can be updated to `""`. 

 All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/terraform-provider-fastly/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

* [x] Does your submission pass tests?
* [x] Post the output of your test runs

```
 make test-acc KEYWORD='S3'
==> Running acceptance tests...
    Note: This requires FASTLY_API_TOKEN to be set
=== RUN   TestAccFastlyServiceCDNAuto_withLoggingS3
=== PAUSE TestAccFastlyServiceCDNAuto_withLoggingS3
=== RUN   TestAccFastlyServiceCDNAuto_withLoggingS3Update
=== PAUSE TestAccFastlyServiceCDNAuto_withLoggingS3Update
=== RUN   TestAccFastlyServiceCDNAuto_withLoggingS3GzipCodec
=== PAUSE TestAccFastlyServiceCDNAuto_withLoggingS3GzipCodec
=== RUN   TestAccFastlyServiceCDNAuto_withMultipleLoggingS3
=== PAUSE TestAccFastlyServiceCDNAuto_withMultipleLoggingS3
=== RUN   TestAccFastlyServiceCDNAuto_withBackendAndLoggingS3
=== PAUSE TestAccFastlyServiceCDNAuto_withBackendAndLoggingS3
=== RUN   TestAccFastlyServiceComputeAuto_withLoggingS3
=== PAUSE TestAccFastlyServiceComputeAuto_withLoggingS3
=== RUN   TestAccFastlyServiceComputeAuto_loggingS3RejectsVCLOnlyFields
=== PAUSE TestAccFastlyServiceComputeAuto_loggingS3RejectsVCLOnlyFields
=== RUN   TestAccFastlyServiceLoggingS3_basic
=== PAUSE TestAccFastlyServiceLoggingS3_basic
=== RUN   TestAccFastlyServiceLoggingS3_update
=== PAUSE TestAccFastlyServiceLoggingS3_update
=== RUN   TestAccFastlyServiceLoggingS3_iamRole
=== PAUSE TestAccFastlyServiceLoggingS3_iamRole
=== RUN   TestAccFastlyServiceLoggingS3_authEnvDefaults
--- PASS: TestAccFastlyServiceLoggingS3_authEnvDefaults (14.94s)
=== RUN   TestAccFastlyServiceLoggingS3_allAttr
=== PAUSE TestAccFastlyServiceLoggingS3_allAttr
=== RUN   TestAccFastlyServiceLoggingS3_clearToDefaults
=== PAUSE TestAccFastlyServiceLoggingS3_clearToDefaults
=== RUN   TestAccFastlyServiceLoggingS3_placementUnsetVsNone
=== PAUSE TestAccFastlyServiceLoggingS3_placementUnsetVsNone
=== RUN   TestAccFastlyServiceLoggingS3_importBasic
=== PAUSE TestAccFastlyServiceLoggingS3_importBasic
=== RUN   TestAccFastlyServiceLoggingS3_compressionCodec
=== PAUSE TestAccFastlyServiceLoggingS3_compressionCodec
=== RUN   TestAccFastlyServiceLoggingS3_gzipCodec
=== PAUSE TestAccFastlyServiceLoggingS3_gzipCodec
=== RUN   TestAccFastlyServiceLoggingS3_codecConflict
=== PAUSE TestAccFastlyServiceLoggingS3_codecConflict
=== RUN   TestAccFastlyServiceLoggingS3_computeRejectsVCLOnlyFields
=== PAUSE TestAccFastlyServiceLoggingS3_computeRejectsVCLOnlyFields
=== RUN   TestAccFastlyServiceLoggingS3_versionUpdateInPlace
=== PAUSE TestAccFastlyServiceLoggingS3_versionUpdateInPlace
=== CONT  TestAccFastlyServiceCDNAuto_withLoggingS3
=== CONT  TestAccFastlyServiceLoggingS3_versionUpdateInPlace
=== CONT  TestAccFastlyServiceLoggingS3_compressionCodec
=== CONT  TestAccFastlyServiceLoggingS3_codecConflict
=== CONT  TestAccFastlyServiceLoggingS3_placementUnsetVsNone
=== CONT  TestAccFastlyServiceLoggingS3_gzipCodec
=== CONT  TestAccFastlyServiceLoggingS3_computeRejectsVCLOnlyFields
=== CONT  TestAccFastlyServiceLoggingS3_importBasic
=== CONT  TestAccFastlyServiceComputeAuto_withLoggingS3
=== CONT  TestAccFastlyServiceLoggingS3_basic
=== CONT  TestAccFastlyServiceLoggingS3_clearToDefaults
=== CONT  TestAccFastlyServiceLoggingS3_allAttr
=== CONT  TestAccFastlyServiceCDNAuto_withMultipleLoggingS3
=== CONT  TestAccFastlyServiceCDNAuto_withBackendAndLoggingS3
=== CONT  TestAccFastlyServiceLoggingS3_update
=== CONT  TestAccFastlyServiceLoggingS3_iamRole
--- PASS: TestAccFastlyServiceLoggingS3_codecConflict (0.30s)
=== CONT  TestAccFastlyServiceCDNAuto_withLoggingS3GzipCodec
--- PASS: TestAccFastlyServiceLoggingS3_computeRejectsVCLOnlyFields (57.24s)
=== CONT  TestAccFastlyServiceCDNAuto_withLoggingS3Update
--- PASS: TestAccFastlyServiceLoggingS3_gzipCodec (77.83s)
=== CONT  TestAccFastlyServiceComputeAuto_loggingS3RejectsVCLOnlyFields
--- PASS: TestAccFastlyServiceComputeAuto_loggingS3RejectsVCLOnlyFields (0.14s)
--- PASS: TestAccFastlyServiceLoggingS3_importBasic (78.48s)
--- PASS: TestAccFastlyServiceLoggingS3_basic (79.62s)
--- PASS: TestAccFastlyServiceLoggingS3_allAttr (81.90s)
--- PASS: TestAccFastlyServiceLoggingS3_iamRole (83.47s)
--- PASS: TestAccFastlyServiceLoggingS3_compressionCodec (93.66s)
--- PASS: TestAccFastlyServiceLoggingS3_update (95.19s)
--- PASS: TestAccFastlyServiceLoggingS3_clearToDefaults (103.73s)
--- PASS: TestAccFastlyServiceLoggingS3_placementUnsetVsNone (106.25s)
--- PASS: TestAccFastlyServiceLoggingS3_versionUpdateInPlace (109.86s)
--- PASS: TestAccFastlyServiceCDNAuto_withLoggingS3GzipCodec (111.48s)
--- PASS: TestAccFastlyServiceCDNAuto_withBackendAndLoggingS3 (112.37s)
--- PASS: TestAccFastlyServiceCDNAuto_withMultipleLoggingS3 (112.83s)
--- PASS: TestAccFastlyServiceComputeAuto_withLoggingS3 (113.34s)
--- PASS: TestAccFastlyServiceCDNAuto_withLoggingS3 (122.70s)
--- PASS: TestAccFastlyServiceCDNAuto_withLoggingS3Update (78.02s)
=== RUN   TestAccFastlyServiceLoggingS3_credentialSwitchClearsKeys
=== PAUSE TestAccFastlyServiceLoggingS3_credentialSwitchClearsKeys
=== CONT  TestAccFastlyServiceLoggingS3_credentialSwitchClearsKeys
--- PASS: TestAccFastlyServiceLoggingS3_credentialSwitchClearsKeys (18.77s)
PASS
```

### Changes to Core Features:

* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?