### PR TITLE
[CDTOOL-1542] Add custom VCL support to dual-model provider

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,7 +106,7 @@ See `internal/resources/servicecdnauto/resource.go` for the exact pattern.
 
 ## Dependencies
 
-- `github.com/fastly/go-fastly/v16` — Fastly API client  
+- `github.com/fastly/go-fastly/v17` — Fastly API client  
 - `github.com/hashicorp/terraform-plugin-framework v1.17.0` — includes `action` and `list` packages
 
 ## Related

--- a/docs/list-resources/service_vcl.md
+++ b/docs/list-resources/service_vcl.md
@@ -1,0 +1,13 @@
+---
+page_title: "fastly_service_vcl List Resource - fastly"
+subcategory: ""
+description: |-
+  List all custom VCL files across all Fastly CDN services at their active version, or latest version when no active version exists.
+---
+
+# fastly_service_vcl (List Resource)
+
+List all custom VCL files across all Fastly CDN services at their active version,
+or latest version when no active version exists.
+
+## Schema

--- a/docs/resources/service_cdn_auto.md
+++ b/docs/resources/service_cdn_auto.md
@@ -31,6 +31,7 @@ Automatic-lifecycle Fastly CDN service resource with nested versioned configurat
 - `logging_newrelicotlp` (Block List) New Relic OTLP logging endpoints attached to this service. (see [below for nested schema](#nestedblock--logging_newrelicotlp))
 - `logging_s3` (Block List) S3 logging endpoints attached to this service. (see [below for nested schema](#nestedblock--logging_s3))
 - `reuse` (Boolean) Deactivate the active version but do not delete the service, allowing it to be reused/imported elsewhere. Default `false`.
+- `vcl` (Block List) Custom VCL files attached to this service. This is modeled as a list so Terraform can render changes to `content` as an in-place string diff instead of a whole set element delete/add. (see [below for nested schema](#nestedblock--vcl))
 
 ### Read-Only
 
@@ -213,3 +214,17 @@ Optional:
 - `access_key` (String, Sensitive) The access key for your S3 account. Not required if `iam_role` is provided. Can be set via the `FASTLY_S3_ACCESS_KEY` environment variable.
 - `iam_role` (String) The Amazon Resource Name (ARN) for the IAM role granting Fastly access to S3. Not required if `access_key` and `secret_key` are provided. Can be set via the `FASTLY_S3_IAM_ROLE` environment variable.
 - `secret_key` (String, Sensitive) The secret key for your S3 account. Not required if `iam_role` is provided. Can be set via the `FASTLY_S3_SECRET_KEY` environment variable.
+
+
+
+<a id="nestedblock--vcl"></a>
+### Nested Schema for `vcl`
+
+Required:
+
+- `content` (String) The custom VCL source code to upload. Commonly configured with file("${path.module}/main.vcl") or templatefile(...).
+- `name` (String) A unique name for this custom VCL file. Included VCL files must be referenced by this exact name from the main VCL file.
+
+Optional:
+
+- `main` (Boolean) Whether this custom VCL file is the main configuration. Exactly one configured custom VCL file must be marked as main.

--- a/docs/resources/service_cdn_auto.md
+++ b/docs/resources/service_cdn_auto.md
@@ -222,7 +222,7 @@ Optional:
 
 Required:
 
-- `content` (String) The custom VCL source code to upload. Commonly configured with file("${path.module}/main.vcl") or templatefile(...).
+- `content` (String) The custom VCL source code to upload. Can configured with file("${path.module}/main.vcl") or templatefile(...).
 - `name` (String) A unique name for this custom VCL file. Included VCL files must be referenced by this exact name from the main VCL file.
 
 Optional:

--- a/docs/resources/service_cdn_auto.md
+++ b/docs/resources/service_cdn_auto.md
@@ -31,7 +31,7 @@ Automatic-lifecycle Fastly CDN service resource with nested versioned configurat
 - `logging_newrelicotlp` (Block List) New Relic OTLP logging endpoints attached to this service. (see [below for nested schema](#nestedblock--logging_newrelicotlp))
 - `logging_s3` (Block List) S3 logging endpoints attached to this service. (see [below for nested schema](#nestedblock--logging_s3))
 - `reuse` (Boolean) Deactivate the active version but do not delete the service, allowing it to be reused/imported elsewhere. Default `false`.
-- `vcl` (Block List) Custom VCL files attached to this service. This is modeled as a list so Terraform can render changes to `content` as an in-place string diff instead of a whole set element delete/add. (see [below for nested schema](#nestedblock--vcl))
+- `vcl` (Block List) Custom VCL files attached to this service. (see [below for nested schema](#nestedblock--vcl))
 
 ### Read-Only
 

--- a/docs/resources/service_vcl.md
+++ b/docs/resources/service_vcl.md
@@ -51,7 +51,7 @@ resource "fastly_service_vcl" "main" {
 
 ### Required
 
-- `content` (String) The custom VCL source code to upload. Commonly configured with file("${path.module}/main.vcl") or templatefile(...).
+- `content` (String) The custom VCL source code to upload. Can configured with file("${path.module}/main.vcl") or templatefile(...).
 - `name` (String) A unique name for this custom VCL file. Included VCL files must be referenced by this exact name from the main VCL file.
 - `service_id` (String) Fastly service ID.
 - `version` (Number) Writable Fastly service version to modify.

--- a/docs/resources/service_vcl.md
+++ b/docs/resources/service_vcl.md
@@ -1,0 +1,85 @@
+---
+page_title: "fastly_service_vcl Resource - fastly"
+subcategory: ""
+description: |-
+  Fastly custom VCL file resource. Writes directly to the specified writable CDN service version.
+---
+
+# fastly_service_vcl (Resource)
+
+Fastly custom VCL file resource. Writes directly to the specified writable CDN service version.
+
+This resource is part of the explicit/default first-class resource family. It
+manages a custom VCL file on the configured CDN service version. It does not
+clone, activate, or stage service versions.
+
+Use this resource when you want to manage custom VCL files explicitly against a
+known writable service version. For automatic service version cloning,
+validation, and activation, use the nested `vcl` block on
+`fastly_service_cdn_auto`.
+
+## Example Usage
+
+```terraform
+resource "fastly_service_cdn" "example" {
+  name = "example"
+
+  domain {
+    name = "www.example.com"
+  }
+
+  backend {
+    name    = "origin"
+    address = "origin.example.com"
+    port    = 443
+    use_ssl = true
+  }
+
+  force_destroy = true
+}
+
+resource "fastly_service_vcl" "main" {
+  service_id = fastly_service_cdn.example.id
+  version    = 1
+  name       = "main"
+  main       = true
+  content    = file("${path.module}/main.vcl")
+}
+```
+
+## Schema
+
+### Required
+
+- `content` (String) The custom VCL source code to upload. Commonly configured with file("${path.module}/main.vcl") or templatefile(...).
+- `name` (String) A unique name for this custom VCL file. Included VCL files must be referenced by this exact name from the main VCL file.
+- `service_id` (String) Fastly service ID.
+- `version` (Number) Writable Fastly service version to modify.
+
+### Optional
+
+- `main` (Boolean) Whether this custom VCL file is the main configuration. Exactly one configured custom VCL file must be marked as main.
+
+### Read-Only
+
+- `id` (String) Terraform resource identifier.
+
+## Import
+
+Import requires the service ID, service version, and custom VCL file name:
+
+```shell
+terraform import fastly_service_vcl.main SERVICE_ID/VERSION/VCL_NAME
+```
+
+Example:
+
+```shell
+terraform import fastly_service_vcl.main SU1Z0isxPaozGVKXdv0eY/3/main
+```
+
+## Version lifecycle
+
+This resource does not clone, activate, or stage service versions. Use explicit
+service-version lifecycle actions to clone, validate, stage, or activate a
+service version.

--- a/internal/acceptance_tests/blocks/vcl_explicit.tf
+++ b/internal/acceptance_tests/blocks/vcl_explicit.tf
@@ -1,0 +1,7 @@
+resource "fastly_service_vcl" "main" {
+  service_id = fastly_service_cdn.test.id
+  version    = 1
+  name       = "{{.VCL_NAME}}"
+  main       = true
+  content    = file("{{.VCL_FILE_PATH}}")
+}

--- a/internal/acceptance_tests/blocks/vcl_explicit_inline.tf
+++ b/internal/acceptance_tests/blocks/vcl_explicit_inline.tf
@@ -1,0 +1,7 @@
+resource "fastly_service_vcl" "main" {
+  service_id = fastly_service_cdn.test.id
+  version    = 1
+  name       = "{{.VCL_NAME}}"
+  main       = true
+  content    = {{.VCL_INLINE_CONTENT}}
+}

--- a/internal/acceptance_tests/blocks/vcl_nested_heredoc.tf
+++ b/internal/acceptance_tests/blocks/vcl_nested_heredoc.tf
@@ -1,0 +1,7 @@
+vcl {
+  name    = "{{.VCL_NAME}}"
+  main    = true
+  content = <<VCL
+{{.VCL_HEREDOC_CONTENT}}
+VCL
+}

--- a/internal/acceptance_tests/blocks/vcl_nested_inline.tf
+++ b/internal/acceptance_tests/blocks/vcl_nested_inline.tf
@@ -1,0 +1,5 @@
+vcl {
+  name    = "{{.VCL_NAME}}"
+  main    = true
+  content = {{.VCL_INLINE_CONTENT}}
+}

--- a/internal/acceptance_tests/blocks/vcl_nested_multiple.tf
+++ b/internal/acceptance_tests/blocks/vcl_nested_multiple.tf
@@ -1,0 +1,11 @@
+vcl {
+  name    = "{{.VCL_MAIN_NAME}}"
+  main    = true
+  content = file("{{.VCL_MAIN_FILE_PATH}}")
+}
+
+vcl {
+  name    = "{{.VCL_INCLUDE_NAME}}"
+  main    = false
+  content = file("{{.VCL_INCLUDE_FILE_PATH}}")
+}

--- a/internal/acceptance_tests/blocks/vcl_nested_no_main.tf
+++ b/internal/acceptance_tests/blocks/vcl_nested_no_main.tf
@@ -1,0 +1,5 @@
+vcl {
+  name    = "include_only"
+  main    = false
+  content = file("{{.VCL_INCLUDE_FILE_PATH}}")
+}

--- a/internal/acceptance_tests/blocks/vcl_nested_single.tf
+++ b/internal/acceptance_tests/blocks/vcl_nested_single.tf
@@ -1,0 +1,5 @@
+vcl {
+  name    = "{{.VCL_NAME}}"
+  main    = true
+  content = file("{{.VCL_FILE_PATH}}")
+}

--- a/internal/acceptance_tests/blocks/vcl_nested_two_main.tf
+++ b/internal/acceptance_tests/blocks/vcl_nested_two_main.tf
@@ -1,0 +1,11 @@
+vcl {
+  name    = "main_one"
+  main    = true
+  content = file("{{.VCL_MAIN_FILE_PATH}}")
+}
+
+vcl {
+  name    = "main_two"
+  main    = true
+  content = file("{{.VCL_SECOND_MAIN_FILE_PATH}}")
+}

--- a/internal/acceptance_tests/fixtures/vcl/main.vcl
+++ b/internal/acceptance_tests/fixtures/vcl/main.vcl
@@ -1,0 +1,46 @@
+sub vcl_recv {
+#FASTLY recv
+  return(lookup);
+}
+
+sub vcl_hash {
+  set req.hash += req.url;
+  set req.hash += req.http.host;
+#FASTLY hash
+  return(hash);
+}
+
+sub vcl_hit {
+#FASTLY hit
+  return(deliver);
+}
+
+sub vcl_miss {
+#FASTLY miss
+  return(fetch);
+}
+
+sub vcl_pass {
+#FASTLY pass
+  return(pass);
+}
+
+sub vcl_fetch {
+#FASTLY fetch
+  return(deliver);
+}
+
+sub vcl_error {
+#FASTLY error
+  return(deliver);
+}
+
+sub vcl_deliver {
+#FASTLY deliver
+  set resp.http.X-Terraform-VCL-Test = "fixture";
+  return(deliver);
+}
+
+sub vcl_log {
+#FASTLY log
+}

--- a/internal/acceptance_tests/test_helpers.go
+++ b/internal/acceptance_tests/test_helpers.go
@@ -2057,6 +2057,127 @@ func productEnablementBlock(product, serviceIDRef string, extra map[string]strin
 	return RenderBlock(fmt.Sprintf("internal/acceptance_tests/blocks/service_product_%s.tf", product), data)
 }
 
+// ConfigServiceVCLWithFile returns a CDN service with one explicit custom VCL resource
+// whose content is loaded through Terraform's file() function.
+func ConfigServiceVCLWithFile(serviceName, vclName, vclFilePath string) string {
+	return BuildConfig(
+		ServiceCDN,
+		map[string]string{
+			"SERVICE_NAME":    serviceName,
+			"SERVICE_COMMENT": "VCL acceptance test",
+			"VCL_NAME":        vclName,
+			"VCL_FILE_PATH":   filepath.ToSlash(vclFilePath),
+		},
+		"internal/acceptance_tests/blocks/vcl_explicit.tf",
+	)
+}
+
+// ConfigServiceVCLInline returns an explicit custom VCL resource whose content
+// is defined inline in HCL rather than loaded through Terraform's file() function.
+func ConfigServiceVCLInline(serviceName, vclName, content string) string {
+	return BuildConfig(
+		ServiceCDN,
+		map[string]string{
+			"SERVICE_NAME":       serviceName,
+			"SERVICE_COMMENT":    "VCL acceptance test",
+			"VCL_NAME":           vclName,
+			"VCL_INLINE_CONTENT": strconv.Quote(content),
+		},
+		"internal/acceptance_tests/blocks/vcl_explicit_inline.tf",
+	)
+}
+
+// ConfigCDNAutoWithVCLFile returns a CDN auto service with domain, backend, and one
+// nested custom VCL block whose content is loaded through Terraform's file() function.
+func ConfigCDNAutoWithVCLFile(serviceName, domainName, backendName, vclName, vclFilePath string) string {
+	return BuildConfig(
+		ServiceCDNAuto,
+		map[string]string{
+			"SERVICE_NAME":  serviceName,
+			"DOMAIN_NAME":   domainName,
+			"BACKEND_NAME":  backendName,
+			"VCL_NAME":      vclName,
+			"VCL_FILE_PATH": filepath.ToSlash(vclFilePath),
+		},
+		"internal/acceptance_tests/blocks/domain_single.tf",
+		"internal/acceptance_tests/blocks/backend_single.tf",
+		"internal/acceptance_tests/blocks/vcl_nested_single.tf",
+	)
+}
+
+// ConfigCDNAutoWithVCLInline returns a CDN auto service with domain, backend,
+// and one nested custom VCL block whose content is defined inline in HCL.
+func ConfigCDNAutoWithVCLInline(serviceName, domainName, backendName, vclName, content string) string {
+	return BuildConfig(
+		ServiceCDNAuto,
+		map[string]string{
+			"SERVICE_NAME":       serviceName,
+			"DOMAIN_NAME":        domainName,
+			"BACKEND_NAME":       backendName,
+			"VCL_NAME":           vclName,
+			"VCL_INLINE_CONTENT": strconv.Quote(content),
+		},
+		"internal/acceptance_tests/blocks/domain_single.tf",
+		"internal/acceptance_tests/blocks/backend_single.tf",
+		"internal/acceptance_tests/blocks/vcl_nested_inline.tf",
+	)
+}
+
+// ConfigCDNAutoWithMultipleVCLFiles returns a CDN auto service with a main VCL file
+// and an included library VCL file.
+func ConfigCDNAutoWithMultipleVCLFiles(serviceName, domainName, backendName, mainName, includeName, mainFilePath, includeFilePath string) string {
+	return BuildConfig(
+		ServiceCDNAuto,
+		map[string]string{
+			"SERVICE_NAME":          serviceName,
+			"DOMAIN_NAME":           domainName,
+			"BACKEND_NAME":          backendName,
+			"VCL_MAIN_NAME":         mainName,
+			"VCL_INCLUDE_NAME":      includeName,
+			"VCL_MAIN_FILE_PATH":    filepath.ToSlash(mainFilePath),
+			"VCL_INCLUDE_FILE_PATH": filepath.ToSlash(includeFilePath),
+		},
+		"internal/acceptance_tests/blocks/domain_single.tf",
+		"internal/acceptance_tests/blocks/backend_single.tf",
+		"internal/acceptance_tests/blocks/vcl_nested_multiple.tf",
+	)
+}
+
+// ConfigCDNAutoWithInvalidMultipleMainVCLFiles returns a CDN auto service with two
+// nested custom VCL files marked as main, exercising provider-side validation.
+func ConfigCDNAutoWithInvalidMultipleMainVCLFiles(serviceName, domainName, backendName, mainFilePath, secondMainFilePath string) string {
+	return BuildConfig(
+		ServiceCDNAuto,
+		map[string]string{
+			"SERVICE_NAME":              serviceName,
+			"DOMAIN_NAME":               domainName,
+			"BACKEND_NAME":              backendName,
+			"VCL_MAIN_FILE_PATH":        filepath.ToSlash(mainFilePath),
+			"VCL_SECOND_MAIN_FILE_PATH": filepath.ToSlash(secondMainFilePath),
+		},
+		"internal/acceptance_tests/blocks/domain_single.tf",
+		"internal/acceptance_tests/blocks/backend_single.tf",
+		"internal/acceptance_tests/blocks/vcl_nested_two_main.tf",
+	)
+}
+
+// ConfigCDNAutoWithInvalidNoMainVCLFile returns a CDN auto service with one
+// nested custom VCL file but no main VCL, exercising provider-side validation.
+func ConfigCDNAutoWithInvalidNoMainVCLFile(serviceName, domainName, backendName, includeFilePath string) string {
+	return BuildConfig(
+		ServiceCDNAuto,
+		map[string]string{
+			"SERVICE_NAME":          serviceName,
+			"DOMAIN_NAME":           domainName,
+			"BACKEND_NAME":          backendName,
+			"VCL_INCLUDE_FILE_PATH": filepath.ToSlash(includeFilePath),
+		},
+		"internal/acceptance_tests/blocks/domain_single.tf",
+		"internal/acceptance_tests/blocks/backend_single.tf",
+		"internal/acceptance_tests/blocks/vcl_nested_no_main.tf",
+	)
+}
+
 // joinBlocks concatenates rendered blocks, each already ending in its own
 // newline, separated by a blank line.
 func joinBlocks(blocks ...string) string {

--- a/internal/acceptance_tests/test_helpers.go
+++ b/internal/acceptance_tests/test_helpers.go
@@ -2123,6 +2123,24 @@ func ConfigCDNAutoWithVCLInline(serviceName, domainName, backendName, vclName, c
 	)
 }
 
+// ConfigCDNAutoWithVCLHeredoc returns a CDN auto service with domain, backend,
+// and one nested custom VCL block whose content is defined with a Terraform HEREDOC.
+func ConfigCDNAutoWithVCLHeredoc(serviceName, domainName, backendName, vclName, content string) string {
+	return BuildConfig(
+		ServiceCDNAuto,
+		map[string]string{
+			"SERVICE_NAME":        serviceName,
+			"DOMAIN_NAME":         domainName,
+			"BACKEND_NAME":        backendName,
+			"VCL_NAME":            vclName,
+			"VCL_HEREDOC_CONTENT": strings.TrimSuffix(content, "\n"),
+		},
+		"internal/acceptance_tests/blocks/domain_single.tf",
+		"internal/acceptance_tests/blocks/backend_single.tf",
+		"internal/acceptance_tests/blocks/vcl_nested_heredoc.tf",
+	)
+}
+
 // ConfigCDNAutoWithMultipleVCLFiles returns a CDN auto service with a main VCL file
 // and an included library VCL file.
 func ConfigCDNAutoWithMultipleVCLFiles(serviceName, domainName, backendName, mainName, includeName, mainFilePath, includeFilePath string) string {

--- a/internal/acceptance_tests/vcl_test.go
+++ b/internal/acceptance_tests/vcl_test.go
@@ -1,0 +1,298 @@
+package acceptancetests
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"testing"
+
+	"github.com/fastly/go-fastly/v16/fastly"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+func TestAccFastlyServiceVCL_basicAndUpdate(t *testing.T) {
+	t.Parallel()
+
+	serviceName := fmt.Sprintf("tf-test-vcl-%s", acctest.RandString(10))
+	vclName := fmt.Sprintf("main_%s", acctest.RandString(10))
+	contentOne := readVCLFixture(t, "vcl/main.vcl")
+	contentTwo := vclBoilerplate("two")
+	vclFileOne := vclFixturePath(t, "vcl/main.vcl")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
+		CheckDestroy:             CheckServiceDestroy("fastly_service_cdn"),
+		Steps: []resource.TestStep{
+			{
+				Config: ConfigServiceVCLWithFile(serviceName, vclName, vclFileOne),
+				Check: resource.ComposeTestCheckFunc(
+					CheckServiceExists("fastly_service_cdn.test"),
+					CheckVCLExistsInFastly("fastly_service_cdn.test", vclName, 1),
+					resource.TestCheckResourceAttr("fastly_service_vcl.main", "name", vclName),
+					resource.TestCheckResourceAttr("fastly_service_vcl.main", "main", "true"),
+					resource.TestCheckResourceAttr("fastly_service_vcl.main", "version", "1"),
+					resource.TestCheckResourceAttrSet("fastly_service_vcl.main", "service_id"),
+					resource.TestCheckResourceAttrSet("fastly_service_vcl.main", "id"),
+					resource.TestCheckResourceAttr("fastly_service_vcl.main", "content", contentOne),
+				),
+			},
+			{
+				Config: ConfigServiceVCLInline(serviceName, vclName, contentTwo),
+				Check: resource.ComposeTestCheckFunc(
+					CheckVCLExistsInFastly("fastly_service_cdn.test", vclName, 1),
+					resource.TestCheckResourceAttr("fastly_service_vcl.main", "name", vclName),
+					resource.TestCheckResourceAttr("fastly_service_vcl.main", "main", "true"),
+					resource.TestCheckResourceAttr("fastly_service_vcl.main", "content", contentTwo),
+				),
+			},
+		},
+	})
+}
+
+func TestAccFastlyServiceCDNAuto_withVCLAndContentUpdate(t *testing.T) {
+	t.Parallel()
+
+	serviceName := fmt.Sprintf("tf-test-vcl-auto-%s", acctest.RandString(10))
+	domainName := fmt.Sprintf("%s.example.com", acctest.RandString(10))
+	backendName := fmt.Sprintf("backend-%s", acctest.RandString(10))
+	vclName := fmt.Sprintf("main_%s", acctest.RandString(10))
+	contentOne := readVCLFixture(t, "vcl/main.vcl")
+	contentTwo := vclBoilerplate("two")
+	vclFileOne := vclFixturePath(t, "vcl/main.vcl")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
+		CheckDestroy:             CheckServiceDestroy("fastly_service_cdn_auto"),
+		Steps: []resource.TestStep{
+			{
+				Config: ConfigCDNAutoWithVCLFile(serviceName, domainName, backendName, vclName, vclFileOne),
+				Check: resource.ComposeTestCheckFunc(
+					CheckServiceExists("fastly_service_cdn_auto.test"),
+					CheckVCLExistsInFastly("fastly_service_cdn_auto.test", vclName, 1),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "domain.#", "1"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "backend.#", "1"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "vcl.#", "1"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "vcl.0.name", vclName),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "vcl.0.main", "true"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "vcl.0.content", contentOne),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "active_version", "1"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "managed_version", "1"),
+				),
+			},
+			{
+				Config: ConfigCDNAutoWithVCLInline(serviceName, domainName, backendName, vclName, contentTwo),
+				Check: resource.ComposeTestCheckFunc(
+					CheckVCLExistsInFastly("fastly_service_cdn_auto.test", vclName, 2),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "vcl.#", "1"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "vcl.0.name", vclName),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "vcl.0.main", "true"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "vcl.0.content", contentTwo),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "active_version", "2"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "managed_version", "2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccFastlyServiceCDNAuto_withMultipleVCLFiles(t *testing.T) {
+	t.Parallel()
+
+	serviceName := fmt.Sprintf("tf-test-vcl-auto-%s", acctest.RandString(10))
+	domainName := fmt.Sprintf("%s.example.com", acctest.RandString(10))
+	backendName := fmt.Sprintf("backend-%s", acctest.RandString(10))
+	mainName := fmt.Sprintf("main_%s", acctest.RandString(10))
+	includeName := fmt.Sprintf("include_%s", acctest.RandString(10))
+	mainContent := fmt.Sprintf("include %q;\n%s", includeName, vclBoilerplate("multi"))
+	includeContent := `sub set_test_header {
+  set resp.http.X-Terraform-Include = "true";
+}
+`
+	mainFile := writeVCLFile(t, "auto-main-with-include.vcl", mainContent)
+	includeFile := writeVCLFile(t, "auto-include.vcl", includeContent)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
+		CheckDestroy:             CheckServiceDestroy("fastly_service_cdn_auto"),
+		Steps: []resource.TestStep{
+			{
+				Config: ConfigCDNAutoWithMultipleVCLFiles(serviceName, domainName, backendName, mainName, includeName, mainFile, includeFile),
+				Check: resource.ComposeTestCheckFunc(
+					CheckServiceExists("fastly_service_cdn_auto.test"),
+					CheckVCLExistsInFastly("fastly_service_cdn_auto.test", mainName, 1),
+					CheckVCLExistsInFastly("fastly_service_cdn_auto.test", includeName, 1),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "vcl.#", "2"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "vcl.0.name", mainName),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "vcl.0.main", "true"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "vcl.0.content", mainContent),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "vcl.1.name", includeName),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "vcl.1.main", "false"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "vcl.1.content", includeContent),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "active_version", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccFastlyServiceCDNAuto_VCLValidation(t *testing.T) {
+	t.Parallel()
+
+	serviceName := fmt.Sprintf("tf-test-vcl-invalid-%s", acctest.RandString(10))
+	domainName := fmt.Sprintf("%s.example.com", acctest.RandString(10))
+	backendName := fmt.Sprintf("backend-%s", acctest.RandString(10))
+	mainFile := writeVCLFile(t, "invalid-main-one.vcl", vclBoilerplate("one"))
+	secondMainFile := writeVCLFile(t, "invalid-main-two.vcl", vclBoilerplate("two"))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
+		CheckDestroy:             CheckServiceDestroy("fastly_service_cdn_auto"),
+		Steps: []resource.TestStep{
+			{
+				Config:      ConfigCDNAutoWithInvalidMultipleMainVCLFiles(serviceName, domainName, backendName, mainFile, secondMainFile),
+				ExpectError: regexp.MustCompile(`only one custom VCL file can have main = true`),
+			},
+		},
+	})
+}
+
+func TestAccFastlyServiceCDNAuto_VCLValidationNoMain(t *testing.T) {
+	t.Parallel()
+
+	serviceName := fmt.Sprintf("tf-test-vcl-invalid-%s", acctest.RandString(10))
+	domainName := fmt.Sprintf("%s.example.com", acctest.RandString(10))
+	backendName := fmt.Sprintf("backend-%s", acctest.RandString(10))
+	includeFile := writeVCLFile(t, "invalid-include-only.vcl", `sub set_test_header {
+  set resp.http.X-Terraform-Include = "true";
+}
+`)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
+		CheckDestroy:             CheckServiceDestroy("fastly_service_cdn_auto"),
+		Steps: []resource.TestStep{
+			{
+				Config:      ConfigCDNAutoWithInvalidNoMainVCLFile(serviceName, domainName, backendName, includeFile),
+				ExpectError: regexp.MustCompile(`one custom VCL file must have main = true`),
+			},
+		},
+	})
+}
+
+func vclFixturePath(t *testing.T, name string) string {
+	t.Helper()
+
+	path, err := filepath.Abs(filepath.Join("fixtures", name))
+	if err != nil {
+		t.Fatalf("failed to resolve VCL fixture path: %v", err)
+	}
+	return path
+}
+
+func readVCLFixture(t *testing.T, name string) string {
+	t.Helper()
+
+	content, err := os.ReadFile(vclFixturePath(t, name))
+	if err != nil {
+		t.Fatalf("failed to read VCL fixture file: %v", err)
+	}
+	return string(content)
+}
+
+func writeVCLFile(t *testing.T, name, content string) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), name)
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("failed to write VCL fixture file: %v", err)
+	}
+	return path
+}
+
+func CheckVCLExistsInFastly(serviceResourceName, vclName string, version int) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[serviceResourceName]
+		if !ok {
+			return fmt.Errorf("service not found: %s", serviceResourceName)
+		}
+
+		client, err := NewFastlyClient()
+		if err != nil {
+			return fmt.Errorf("error creating Fastly client: %w", err)
+		}
+
+		vcl, err := client.GetVCL(context.Background(), &fastly.GetVCLInput{
+			ServiceID:      rs.Primary.ID,
+			ServiceVersion: version,
+			Name:           vclName,
+		})
+		if err != nil {
+			return fmt.Errorf("error fetching custom VCL from Fastly: %w", err)
+		}
+
+		if vcl == nil {
+			return fmt.Errorf("custom VCL %s not found in Fastly", vclName)
+		}
+
+		return nil
+	}
+}
+
+func vclBoilerplate(marker string) string {
+	return fmt.Sprintf(`sub vcl_recv {
+#FASTLY recv
+  return(lookup);
+}
+
+sub vcl_hash {
+  set req.hash += req.url;
+  set req.hash += req.http.host;
+#FASTLY hash
+  return(hash);
+}
+
+sub vcl_hit {
+#FASTLY hit
+  return(deliver);
+}
+
+sub vcl_miss {
+#FASTLY miss
+  return(fetch);
+}
+
+sub vcl_pass {
+#FASTLY pass
+  return(pass);
+}
+
+sub vcl_fetch {
+#FASTLY fetch
+  return(deliver);
+}
+
+sub vcl_error {
+#FASTLY error
+  return(deliver);
+}
+
+sub vcl_deliver {
+#FASTLY deliver
+  set resp.http.X-Terraform-VCL-Test = %[1]q;
+  return(deliver);
+}
+
+sub vcl_log {
+#FASTLY log
+}
+`, marker)
+}

--- a/internal/acceptance_tests/vcl_test.go
+++ b/internal/acceptance_tests/vcl_test.go
@@ -8,7 +8,7 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/fastly/go-fastly/v16/fastly"
+	"github.com/fastly/go-fastly/v17/fastly"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"

--- a/internal/acceptance_tests/vcl_test.go
+++ b/internal/acceptance_tests/vcl_test.go
@@ -142,6 +142,41 @@ func TestAccFastlyServiceCDNAuto_withMultipleVCLFiles(t *testing.T) {
 	})
 }
 
+func TestAccFastlyServiceCDNAuto_withVCLHeredocContent(t *testing.T) {
+	t.Parallel()
+
+	serviceName := fmt.Sprintf("tf-test-vcl-auto-%s", acctest.RandString(10))
+	domainName := fmt.Sprintf("%s.example.com", acctest.RandString(10))
+	backendName := fmt.Sprintf("backend-%s", acctest.RandString(10))
+	vclName := fmt.Sprintf("main_%s", acctest.RandString(10))
+	content := vclBoilerplate("heredoc")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
+		CheckDestroy:             CheckServiceDestroy("fastly_service_cdn_auto"),
+		Steps: []resource.TestStep{
+			{
+				Config: ConfigCDNAutoWithVCLHeredoc(serviceName, domainName, backendName, vclName, content),
+				Check: resource.ComposeTestCheckFunc(
+					CheckServiceExists("fastly_service_cdn_auto.test"),
+					CheckVCLExistsInFastly("fastly_service_cdn_auto.test", vclName, 1),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "vcl.#", "1"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "vcl.0.name", vclName),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "vcl.0.main", "true"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "vcl.0.content", content),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "active_version", "1"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "managed_version", "1"),
+				),
+			},
+			{
+				Config:   ConfigCDNAutoWithVCLHeredoc(serviceName, domainName, backendName, vclName, content),
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
 func TestAccFastlyServiceCDNAuto_VCLValidation(t *testing.T) {
 	t.Parallel()
 

--- a/internal/acceptance_tests/vcl_test.go
+++ b/internal/acceptance_tests/vcl_test.go
@@ -188,6 +188,32 @@ func TestAccFastlyServiceCDNAuto_VCLValidationNoMain(t *testing.T) {
 	})
 }
 
+func TestAccFastlyServiceCDNAuto_VCLValidationInvalidSyntax(t *testing.T) {
+	t.Parallel()
+
+	serviceName := fmt.Sprintf("tf-test-vcl-invalid-%s", acctest.RandString(10))
+	domainName := fmt.Sprintf("%s.example.com", acctest.RandString(10))
+	backendName := fmt.Sprintf("backend-%s", acctest.RandString(10))
+	vclName := fmt.Sprintf("main_%s", acctest.RandString(10))
+	invalidContent := `sub vcl_recv {
+#FASTLY recv
+  this is not valid vcl
+}
+`
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
+		CheckDestroy:             CheckServiceDestroy("fastly_service_cdn_auto"),
+		Steps: []resource.TestStep{
+			{
+				Config:      ConfigCDNAutoWithVCLInline(serviceName, domainName, backendName, vclName, invalidContent),
+				ExpectError: regexp.MustCompile(`Error validating service version|VCL|invalid`),
+			},
+		},
+	})
+}
+
 func vclFixturePath(t *testing.T, name string) string {
 	t.Helper()
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -38,6 +38,7 @@ import (
 	"github.com/fastly/terraform-provider-fastly/internal/resources/servicecdnauto"
 	"github.com/fastly/terraform-provider-fastly/internal/resources/servicecompute"
 	"github.com/fastly/terraform-provider-fastly/internal/resources/servicecomputeauto"
+	"github.com/fastly/terraform-provider-fastly/internal/resources/vcl"
 	"github.com/fastly/terraform-provider-fastly/internal/version"
 )
 
@@ -114,6 +115,7 @@ func (p *fastlyProvider) Resources(_ context.Context) []func() resource.Resource
 		loggingnewrelicotlp.NewResource,
 		loggings3.NewResource,
 		kvstore.NewResource,
+		vcl.NewResource,
 		productenablement.NewFanoutResource,
 		productenablement.NewBrotliCompressionResource,
 		productenablement.NewImageOptimizerResource,
@@ -149,6 +151,7 @@ func (p *fastlyProvider) ListResources(_ context.Context) []func() list.ListReso
 		condition.NewListResource,
 		domain.NewListResource,
 		loggingnewrelicotlp.NewListResource,
+		vcl.NewListResource,
 		loggings3.NewListResource,
 		servicecdn.NewListResource,
 		servicecompute.NewListResource,

--- a/internal/resources/servicecdnauto/resource.go
+++ b/internal/resources/servicecdnauto/resource.go
@@ -42,6 +42,7 @@ const imageOptimizerImportedPrivateKey = "image_optimizer_default_settings_impor
 var _ resource.Resource = &Resource{}
 var _ resource.ResourceWithConfigure = &Resource{}
 var _ resource.ResourceWithImportState = &Resource{}
+var _ resource.ResourceWithValidateConfig = &Resource{}
 
 func NewResource() resource.Resource {
 	return &Resource{}
@@ -136,6 +137,22 @@ func (r *Resource) Configure(_ context.Context, req resource.ConfigureRequest, r
 	r.providerData = data
 }
 
+func (r *Resource) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+	var config Model
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if err := vcl.ValidateConfig(config.VCL); err != nil {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("vcl"),
+			"Invalid custom VCL configuration",
+			err.Error(),
+		)
+	}
+}
+
 func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var plan Model
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
@@ -144,7 +161,11 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 	}
 
 	if err := vcl.Validate(plan.VCL); err != nil {
-		resp.Diagnostics.AddError("Invalid custom VCL configuration", err.Error())
+		resp.Diagnostics.AddAttributeError(
+			path.Root("vcl"),
+			"Invalid custom VCL configuration",
+			err.Error(),
+		)
 		return
 	}
 
@@ -266,13 +287,13 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 	plan.ImageOptimizerDefaultSettings = imageOptimizerDefaultSettings
 
 	if err := vcl.Reconcile(ctx, r.providerData.AutoClient(), serviceID, version, plan.VCL); err != nil {
-		resp.Diagnostics.AddError("Error reconciling custom VCL", err.Error())
+		resp.Diagnostics.AddError("Error reconciling custom VCL files", err.Error())
 		return
 	}
 
 	vcls, err := vcl.ReadForVersion(ctx, r.providerData.AutoClient(), serviceID, version)
 	if err != nil {
-		resp.Diagnostics.AddError("Error reading custom VCL", err.Error())
+		resp.Diagnostics.AddError("Error reading custom VCL files", err.Error())
 		return
 	}
 	plan.VCL = vcl.MatchOrderPreservePlanContent(vcls, plan.VCL)
@@ -380,12 +401,6 @@ func (r *Resource) Read(ctx context.Context, req resource.ReadRequest, resp *res
 		resp.Diagnostics.AddError("Error reading New Relic OTLP logging endpoints", err.Error())
 		return
 	}
-	vcls, err := vcl.ReadForVersion(ctx, r.providerData.AutoClient(), state.ID.ValueString(), readVersion)
-	if err != nil {
-		resp.Diagnostics.AddError("Error reading custom VCL", err.Error())
-		return
-	}
-
 	state.Domain = domain.MatchOrder(domains, state.Domain)
 	state.Backend = backend.MatchOrder(backends, state.Backend)
 	state.ACL = cdnacl.MatchOrder(acls, state.ACL)
@@ -393,6 +408,12 @@ func (r *Resource) Read(ctx context.Context, req resource.ReadRequest, resp *res
 	state.Gzip = gzip.MatchOrder(gzips, state.Gzip)
 	state.LoggingS3 = loggings3.MatchOrder(loggingS3s, state.LoggingS3)
 	state.LoggingNewRelicOTLP = loggingnewrelicotlp.MatchOrder(loggingNewRelicOTLPs, state.LoggingNewRelicOTLP)
+
+	vcls, err := vcl.ReadForVersion(ctx, r.providerData.AutoClient(), state.ID.ValueString(), readVersion)
+	if err != nil {
+		resp.Diagnostics.AddError("Error reading custom VCL files", err.Error())
+		return
+	}
 	state.VCL = vcl.MatchOrder(vcls, state.VCL)
 
 	importedBytes, diags := req.Private.GetKey(ctx, imageOptimizerImportedPrivateKey)
@@ -426,7 +447,11 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 	}
 
 	if err := vcl.Validate(plan.VCL); err != nil {
-		resp.Diagnostics.AddError("Invalid custom VCL configuration", err.Error())
+		resp.Diagnostics.AddAttributeError(
+			path.Root("vcl"),
+			"Invalid custom VCL configuration",
+			err.Error(),
+		)
 		return
 	}
 
@@ -579,13 +604,13 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 		plan.ImageOptimizerDefaultSettings = imageOptimizerDefaultSettings
 
 		if err := vcl.Reconcile(ctx, r.providerData.AutoClient(), serviceID, targetVersion, plan.VCL); err != nil {
-			resp.Diagnostics.AddError("Error reconciling custom VCL", err.Error())
+			resp.Diagnostics.AddError("Error reconciling custom VCL files", err.Error())
 			return
 		}
 
 		vcls, err := vcl.ReadForVersion(ctx, r.providerData.AutoClient(), serviceID, targetVersion)
 		if err != nil {
-			resp.Diagnostics.AddError("Error reading custom VCL", err.Error())
+			resp.Diagnostics.AddError("Error reading custom VCL files", err.Error())
 			return
 		}
 		plan.VCL = vcl.MatchOrderPreservePlanContent(vcls, plan.VCL)

--- a/internal/resources/servicecdnauto/resource.go
+++ b/internal/resources/servicecdnauto/resource.go
@@ -14,6 +14,7 @@ import (
 	"github.com/fastly/terraform-provider-fastly/internal/resources/imageoptimizerdefaultsettings"
 	"github.com/fastly/terraform-provider-fastly/internal/resources/loggingnewrelicotlp"
 	"github.com/fastly/terraform-provider-fastly/internal/resources/loggings3"
+	"github.com/fastly/terraform-provider-fastly/internal/resources/vcl"
 	"github.com/fastly/terraform-provider-fastly/internal/service"
 
 	fastly "github.com/fastly/go-fastly/v17/fastly"
@@ -62,6 +63,7 @@ type Model struct {
 	LoggingS3                     []loggings3.NestedModel                     `tfsdk:"logging_s3"`
 	LoggingNewRelicOTLP           []loggingnewrelicotlp.NestedModel           `tfsdk:"logging_newrelicotlp"`
 	ImageOptimizerDefaultSettings []imageoptimizerdefaultsettings.NestedModel `tfsdk:"image_optimizer_default_settings"`
+	VCL                           []vcl.NestedModel                           `tfsdk:"vcl"`
 }
 
 func (r *Resource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -119,6 +121,7 @@ func (r *Resource) Schema(_ context.Context, _ resource.SchemaRequest, resp *res
 			"logging_s3":                       loggings3.NestedBlockSchema(),
 			"logging_newrelicotlp":             loggingnewrelicotlp.NestedBlockSchema(),
 			"image_optimizer_default_settings": imageoptimizerdefaultsettings.NestedBlockSchema(),
+			"vcl":                              vcl.NestedBlockSchema(),
 		},
 	}
 }
@@ -137,6 +140,11 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 	var plan Model
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if err := vcl.Validate(plan.VCL); err != nil {
+		resp.Diagnostics.AddError("Invalid custom VCL configuration", err.Error())
 		return
 	}
 
@@ -257,6 +265,18 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 	}
 	plan.ImageOptimizerDefaultSettings = imageOptimizerDefaultSettings
 
+	if err := vcl.Reconcile(ctx, r.providerData.AutoClient(), serviceID, version, plan.VCL); err != nil {
+		resp.Diagnostics.AddError("Error reconciling custom VCL", err.Error())
+		return
+	}
+
+	vcls, err := vcl.ReadForVersion(ctx, r.providerData.AutoClient(), serviceID, version)
+	if err != nil {
+		resp.Diagnostics.AddError("Error reading custom VCL", err.Error())
+		return
+	}
+	plan.VCL = vcl.MatchOrderPreservePlanContent(vcls, plan.VCL)
+
 	if err := service.ValidateVersion(ctx, r.providerData.AutoClient(), serviceID, version); err != nil {
 		resp.Diagnostics.AddError("Error validating service version", err.Error())
 		return
@@ -360,6 +380,12 @@ func (r *Resource) Read(ctx context.Context, req resource.ReadRequest, resp *res
 		resp.Diagnostics.AddError("Error reading New Relic OTLP logging endpoints", err.Error())
 		return
 	}
+	vcls, err := vcl.ReadForVersion(ctx, r.providerData.AutoClient(), state.ID.ValueString(), readVersion)
+	if err != nil {
+		resp.Diagnostics.AddError("Error reading custom VCL", err.Error())
+		return
+	}
+
 	state.Domain = domain.MatchOrder(domains, state.Domain)
 	state.Backend = backend.MatchOrder(backends, state.Backend)
 	state.ACL = cdnacl.MatchOrder(acls, state.ACL)
@@ -367,6 +393,7 @@ func (r *Resource) Read(ctx context.Context, req resource.ReadRequest, resp *res
 	state.Gzip = gzip.MatchOrder(gzips, state.Gzip)
 	state.LoggingS3 = loggings3.MatchOrder(loggingS3s, state.LoggingS3)
 	state.LoggingNewRelicOTLP = loggingnewrelicotlp.MatchOrder(loggingNewRelicOTLPs, state.LoggingNewRelicOTLP)
+	state.VCL = vcl.MatchOrder(vcls, state.VCL)
 
 	importedBytes, diags := req.Private.GetKey(ctx, imageOptimizerImportedPrivateKey)
 	resp.Diagnostics.Append(diags...)
@@ -398,6 +425,11 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 		return
 	}
 
+	if err := vcl.Validate(plan.VCL); err != nil {
+		resp.Diagnostics.AddError("Invalid custom VCL configuration", err.Error())
+		return
+	}
+
 	serviceID := state.ID.ValueString()
 
 	if err := service.UpdateMetadataIfChanged(
@@ -413,7 +445,7 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 		return
 	}
 
-	nestedChanged := !domain.Equal(plan.Domain, state.Domain) || !backend.Equal(plan.Backend, state.Backend) || !cdnacl.Equal(plan.ACL, state.ACL) || !condition.Equal(plan.Condition, state.Condition) || !gzip.Equal(plan.Gzip, state.Gzip) || !loggings3.Equal(plan.LoggingS3, state.LoggingS3) || !loggingnewrelicotlp.Equal(plan.LoggingNewRelicOTLP, state.LoggingNewRelicOTLP) || !imageoptimizerdefaultsettings.Equal(plan.ImageOptimizerDefaultSettings, state.ImageOptimizerDefaultSettings)
+	nestedChanged := !domain.Equal(plan.Domain, state.Domain) || !backend.Equal(plan.Backend, state.Backend) || !cdnacl.Equal(plan.ACL, state.ACL) || !condition.Equal(plan.Condition, state.Condition) || !gzip.Equal(plan.Gzip, state.Gzip) || !loggings3.Equal(plan.LoggingS3, state.LoggingS3) || !loggingnewrelicotlp.Equal(plan.LoggingNewRelicOTLP, state.LoggingNewRelicOTLP) || !imageoptimizerdefaultsettings.Equal(plan.ImageOptimizerDefaultSettings, state.ImageOptimizerDefaultSettings) || !vcl.Equal(plan.VCL, state.VCL)
 	needsVersionChange := nestedChanged
 
 	targetVersion := 0
@@ -546,6 +578,18 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 		}
 		plan.ImageOptimizerDefaultSettings = imageOptimizerDefaultSettings
 
+		if err := vcl.Reconcile(ctx, r.providerData.AutoClient(), serviceID, targetVersion, plan.VCL); err != nil {
+			resp.Diagnostics.AddError("Error reconciling custom VCL", err.Error())
+			return
+		}
+
+		vcls, err := vcl.ReadForVersion(ctx, r.providerData.AutoClient(), serviceID, targetVersion)
+		if err != nil {
+			resp.Diagnostics.AddError("Error reading custom VCL", err.Error())
+			return
+		}
+		plan.VCL = vcl.MatchOrderPreservePlanContent(vcls, plan.VCL)
+
 		if err := service.ValidateVersion(ctx, r.providerData.AutoClient(), serviceID, targetVersion); err != nil {
 			resp.Diagnostics.AddError("Error validating service version", err.Error())
 			return
@@ -574,6 +618,7 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 		plan.LoggingS3 = loggings3.MatchOrder(state.LoggingS3, plan.LoggingS3)
 		plan.LoggingNewRelicOTLP = loggingnewrelicotlp.MatchOrder(state.LoggingNewRelicOTLP, plan.LoggingNewRelicOTLP)
 		plan.ImageOptimizerDefaultSettings = state.ImageOptimizerDefaultSettings
+		plan.VCL = vcl.MatchOrderPreservePlanContent(state.VCL, plan.VCL)
 	}
 
 	plan.ID = state.ID

--- a/internal/resources/vcl/expand.go
+++ b/internal/resources/vcl/expand.go
@@ -3,7 +3,7 @@ package vcl
 import (
 	"github.com/fastly/terraform-provider-fastly/internal/service"
 
-	fastly "github.com/fastly/go-fastly/v16/fastly"
+	fastly "github.com/fastly/go-fastly/v17/fastly"
 )
 
 func BuildCreateInput(serviceID string, version int, m NestedModel) *fastly.CreateVCLInput {

--- a/internal/resources/vcl/expand.go
+++ b/internal/resources/vcl/expand.go
@@ -1,0 +1,32 @@
+package vcl
+
+import (
+	"github.com/fastly/terraform-provider-fastly/internal/service"
+
+	fastly "github.com/fastly/go-fastly/v16/fastly"
+)
+
+func BuildCreateInput(serviceID string, version int, m NestedModel) *fastly.CreateVCLInput {
+	name := service.StringValue(m.Name)
+	content := service.StringValue(m.Content)
+	main := service.BoolValue(m.Main)
+
+	return &fastly.CreateVCLInput{
+		ServiceID:      serviceID,
+		ServiceVersion: version,
+		Name:           &name,
+		Content:        &content,
+		Main:           &main,
+	}
+}
+
+func BuildUpdateInput(serviceID string, version int, m NestedModel) *fastly.UpdateVCLInput {
+	content := service.StringValue(m.Content)
+
+	return &fastly.UpdateVCLInput{
+		ServiceID:      serviceID,
+		ServiceVersion: version,
+		Name:           service.StringValue(m.Name),
+		Content:        &content,
+	}
+}

--- a/internal/resources/vcl/flatten.go
+++ b/internal/resources/vcl/flatten.go
@@ -1,0 +1,29 @@
+package vcl
+
+import (
+	"context"
+
+	fastly "github.com/fastly/go-fastly/v16/fastly"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+func flatten(ctx context.Context, v *fastly.VCL, m *Model) {
+	if v == nil {
+		tflog.Warn(ctx, "flatten called with nil VCL")
+		return
+	}
+
+	m.ID = types.StringValue(ID(fastly.ToValue(v.ServiceID), fastly.ToValue(v.ServiceVersion), fastly.ToValue(v.Name)))
+	m.Service = types.StringValue(fastly.ToValue(v.ServiceID))
+	m.Version = types.Int64Value(int64(fastly.ToValue(v.ServiceVersion)))
+	m.NestedModel = FlattenToNestedModel(v)
+
+	tflog.Debug(ctx, "Flattened custom VCL state", map[string]any{
+		"id":      m.ID.ValueString(),
+		"service": m.Service.ValueString(),
+		"version": m.Version.ValueInt64(),
+		"name":    m.Name.ValueString(),
+		"main":    m.Main.ValueBool(),
+	})
+}

--- a/internal/resources/vcl/flatten.go
+++ b/internal/resources/vcl/flatten.go
@@ -3,7 +3,7 @@ package vcl
 import (
 	"context"
 
-	fastly "github.com/fastly/go-fastly/v16/fastly"
+	fastly "github.com/fastly/go-fastly/v17/fastly"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )

--- a/internal/resources/vcl/list.go
+++ b/internal/resources/vcl/list.go
@@ -1,0 +1,133 @@
+package vcl
+
+import (
+	"context"
+
+	fastlyclient "github.com/fastly/terraform-provider-fastly/internal/client"
+	"github.com/fastly/terraform-provider-fastly/internal/service"
+
+	fastly "github.com/fastly/go-fastly/v16/fastly"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/list"
+	listschema "github.com/hashicorp/terraform-plugin-framework/list/schema"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+var _ list.ListResource = &ListResource{}
+var _ list.ListResourceWithConfigure = &ListResource{}
+
+type ListResource struct {
+	client *fastly.Client
+}
+
+func NewListResource() list.ListResource {
+	return &ListResource{}
+}
+
+func (l *ListResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_service_vcl"
+}
+
+func (l *ListResource) ListResourceConfigSchema(_ context.Context, _ list.ListResourceSchemaRequest, resp *list.ListResourceSchemaResponse) {
+	resp.Schema = listschema.Schema{
+		Description: "List all custom VCL files across all Fastly CDN services at their active version, or latest version when no active version exists.",
+		Attributes:  map[string]listschema.Attribute{},
+	}
+}
+
+func (l *ListResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	data, diags := fastlyclient.FromProviderData(req.ProviderData)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() || data == nil {
+		return
+	}
+
+	l.client = data.Client
+}
+
+func (l *ListResource) List(ctx context.Context, req list.ListRequest, stream *list.ListResultsStream) {
+	tflog.Debug(ctx, "Listing Fastly custom VCL files")
+
+	services, err := l.client.ListServices(ctx, &fastly.ListServicesInput{})
+	if err != nil {
+		stream.Results = list.ListResultsStreamDiagnostics(diag.Diagnostics{
+			diag.NewErrorDiagnostic("Error listing Fastly services", err.Error()),
+		})
+		return
+	}
+
+	stream.Results = func(push func(list.ListResult) bool) {
+		var count int64
+		for _, svc := range services {
+			if svc == nil || svc.Type == nil || *svc.Type != service.TypeVCL {
+				continue
+			}
+			serviceID := fastly.ToValue(svc.ServiceID)
+			if serviceID == "" {
+				continue
+			}
+
+			version, _, err := service.SelectReadVersionFromServiceSummary(ctx, l.client, svc)
+			if err != nil {
+				tflog.Warn(ctx, "Error selecting service version for query", map[string]any{
+					"service_id": serviceID,
+					"error":      err.Error(),
+				})
+				continue
+			}
+
+			vcls, err := l.client.ListVCLs(ctx, &fastly.ListVCLsInput{
+				ServiceID:      serviceID,
+				ServiceVersion: version,
+			})
+			if err != nil {
+				tflog.Warn(ctx, "Error listing custom VCL files for service", map[string]any{
+					"service_id": serviceID,
+					"error":      err.Error(),
+				})
+				continue
+			}
+
+			for _, v := range vcls {
+				if v == nil || v.Name == nil {
+					continue
+				}
+				if req.Limit > 0 && count >= req.Limit {
+					return
+				}
+				count++
+
+				result := req.NewListResult(ctx)
+				result.DisplayName = service.ToGeneratedResourceName(fastly.ToValue(svc.Name), serviceID, *v.Name)
+
+				result.Diagnostics.Append(result.Identity.SetAttribute(ctx, path.Root("service_id"), serviceID)...)
+				result.Diagnostics.Append(result.Identity.SetAttribute(ctx, path.Root("version"), int64(version))...)
+				result.Diagnostics.Append(result.Identity.SetAttribute(ctx, path.Root("name"), *v.Name)...)
+
+				if req.IncludeResource {
+					result.Diagnostics.Append(setResourceAttrs(ctx, &result, v, serviceID, version)...)
+				}
+
+				if !push(result) {
+					return
+				}
+			}
+		}
+	}
+}
+
+func setResourceAttrs(ctx context.Context, result *list.ListResult, v *fastly.VCL, serviceID string, version int) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	model := Model{
+		NestedModel: FlattenToNestedModel(v),
+		ID:          types.StringValue(ID(serviceID, version, fastly.ToValue(v.Name))),
+		Service:     types.StringValue(serviceID),
+		Version:     types.Int64Value(int64(version)),
+	}
+	diags.Append(result.Resource.Set(ctx, &model)...)
+	return diags
+}

--- a/internal/resources/vcl/list.go
+++ b/internal/resources/vcl/list.go
@@ -6,7 +6,7 @@ import (
 	fastlyclient "github.com/fastly/terraform-provider-fastly/internal/client"
 	"github.com/fastly/terraform-provider-fastly/internal/service"
 
-	fastly "github.com/fastly/go-fastly/v16/fastly"
+	fastly "github.com/fastly/go-fastly/v17/fastly"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/list"
 	listschema "github.com/hashicorp/terraform-plugin-framework/list/schema"

--- a/internal/resources/vcl/model.go
+++ b/internal/resources/vcl/model.go
@@ -37,6 +37,55 @@ func FlattenToNestedModel(api *fastly.VCL) NestedModel {
 	}
 }
 
+// ValidateConfig performs plan-time custom VCL validation while tolerating
+// unknown values. Terraform's schema validation will handle required/null
+// attributes, and apply-time Validate handles fully known values before API
+// reconciliation.
+func ValidateConfig(vcls []NestedModel) error {
+	if len(vcls) == 0 {
+		return nil
+	}
+
+	seenNames := make(map[string]struct{}, len(vcls))
+	mainCount := 0
+	allMainKnown := true
+
+	for _, item := range vcls {
+		if item.Name.IsUnknown() || item.Name.IsNull() {
+			continue
+		}
+
+		name := strings.TrimSpace(item.Name.ValueString())
+		if name == "" {
+			return fmt.Errorf("custom VCL name cannot be empty")
+		}
+
+		if _, ok := seenNames[name]; ok {
+			return fmt.Errorf("duplicate custom VCL name %q; names must be unique within a service version", name)
+		}
+		seenNames[name] = struct{}{}
+
+		if item.Main.IsUnknown() || item.Main.IsNull() {
+			allMainKnown = false
+			continue
+		}
+
+		if item.Main.ValueBool() {
+			mainCount++
+		}
+	}
+
+	if mainCount > 1 {
+		return fmt.Errorf("only one custom VCL file can have main = true")
+	}
+
+	if allMainKnown && mainCount == 0 {
+		return fmt.Errorf("one custom VCL file must have main = true")
+	}
+
+	return nil
+}
+
 func Validate(vcls []NestedModel) error {
 	if len(vcls) == 0 {
 		return nil

--- a/internal/resources/vcl/model.go
+++ b/internal/resources/vcl/model.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/fastly/terraform-provider-fastly/internal/service"
 
-	fastly "github.com/fastly/go-fastly/v16/fastly"
+	fastly "github.com/fastly/go-fastly/v17/fastly"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 

--- a/internal/resources/vcl/model.go
+++ b/internal/resources/vcl/model.go
@@ -1,0 +1,95 @@
+package vcl
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/fastly/terraform-provider-fastly/internal/service"
+
+	fastly "github.com/fastly/go-fastly/v16/fastly"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+const (
+	DefaultMain = false
+)
+
+// ContentEqual compares VCL source using Fastly's harmless trailing-newline
+// round-trip behavior as equivalent while preserving all internal whitespace.
+//
+// The provider must not rewrite configured VCL source during planning, because
+// content is a user-configured string. This helper is only used for provider-side
+// reconciliation decisions so an API round trip that differs only by trailing
+// newlines does not force an unnecessary service-version clone.
+func ContentEqual(a, b string) bool {
+	return strings.TrimRight(a, "\n") == strings.TrimRight(b, "\n")
+}
+
+func FlattenToNestedModel(api *fastly.VCL) NestedModel {
+	if api == nil {
+		return NestedModel{}
+	}
+
+	return NestedModel{
+		Name:    types.StringValue(fastly.ToValue(api.Name)),
+		Content: types.StringValue(fastly.ToValue(api.Content)),
+		Main:    service.BoolPointerOrDefault(api.Main, DefaultMain),
+	}
+}
+
+func Validate(vcls []NestedModel) error {
+	if len(vcls) == 0 {
+		return nil
+	}
+
+	seenNames := make(map[string]struct{}, len(vcls))
+	mainCount := 0
+
+	for _, item := range vcls {
+		name := strings.TrimSpace(service.StringValue(item.Name))
+		if name == "" {
+			return fmt.Errorf("custom VCL name cannot be empty")
+		}
+
+		if _, ok := seenNames[name]; ok {
+			return fmt.Errorf("duplicate custom VCL name %q; names must be unique within a service version", name)
+		}
+		seenNames[name] = struct{}{}
+
+		if service.BoolValue(item.Main) {
+			mainCount++
+		}
+	}
+
+	if mainCount == 0 {
+		return fmt.Errorf("one custom VCL file must have main = true")
+	}
+
+	if mainCount > 1 {
+		return fmt.Errorf("only one custom VCL file can have main = true")
+	}
+
+	return nil
+}
+
+func ID(serviceID string, version int, name string) string {
+	return fmt.Sprintf("%s-%d-%s", serviceID, version, name)
+}
+
+func MatchOrderPreservePlanContent(items, plan []NestedModel) []NestedModel {
+	ordered := MatchOrder(items, plan)
+
+	planByName := make(map[string]NestedModel, len(plan))
+	for _, item := range plan {
+		planByName[service.StringValue(item.Name)] = item
+	}
+
+	for i := range ordered {
+		name := service.StringValue(ordered[i].Name)
+		if planned, ok := planByName[name]; ok {
+			ordered[i].Content = planned.Content
+		}
+	}
+
+	return ordered
+}

--- a/internal/resources/vcl/model.go
+++ b/internal/resources/vcl/model.go
@@ -51,6 +51,12 @@ func ValidateConfig(vcls []NestedModel) error {
 	allMainKnown := true
 
 	for _, item := range vcls {
+		if item.Main.IsUnknown() || item.Main.IsNull() {
+			allMainKnown = false
+		} else if item.Main.ValueBool() {
+			mainCount++
+		}
+
 		if item.Name.IsUnknown() || item.Name.IsNull() {
 			continue
 		}
@@ -64,15 +70,6 @@ func ValidateConfig(vcls []NestedModel) error {
 			return fmt.Errorf("duplicate custom VCL name %q; names must be unique within a service version", name)
 		}
 		seenNames[name] = struct{}{}
-
-		if item.Main.IsUnknown() || item.Main.IsNull() {
-			allMainKnown = false
-			continue
-		}
-
-		if item.Main.ValueBool() {
-			mainCount++
-		}
 	}
 
 	if mainCount > 1 {

--- a/internal/resources/vcl/resource.go
+++ b/internal/resources/vcl/resource.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/terraform-provider-fastly/internal/service"
 	"github.com/fastly/terraform-provider-fastly/internal/validation"
 
-	fastly "github.com/fastly/go-fastly/v16/fastly"
+	fastly "github.com/fastly/go-fastly/v17/fastly"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"

--- a/internal/resources/vcl/resource.go
+++ b/internal/resources/vcl/resource.go
@@ -1,0 +1,243 @@
+package vcl
+
+import (
+	"context"
+
+	fastlyclient "github.com/fastly/terraform-provider-fastly/internal/client"
+	"github.com/fastly/terraform-provider-fastly/internal/errors"
+	"github.com/fastly/terraform-provider-fastly/internal/importutil"
+	"github.com/fastly/terraform-provider-fastly/internal/service"
+	"github.com/fastly/terraform-provider-fastly/internal/validation"
+
+	fastly "github.com/fastly/go-fastly/v16/fastly"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+var _ resource.Resource = &Resource{}
+var _ resource.ResourceWithImportState = &Resource{}
+
+type Resource struct {
+	providerData *fastlyclient.Data
+}
+
+func NewResource() resource.Resource {
+	return &Resource{}
+}
+
+type Model struct {
+	NestedModel
+	ID      types.String `tfsdk:"id"`
+	Service types.String `tfsdk:"service_id"`
+	Version types.Int64  `tfsdk:"version"`
+}
+
+func (r *Resource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_service_vcl"
+}
+
+func (r *Resource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Fastly custom VCL file resource. Writes directly to the specified writable CDN service version.",
+		Attributes:  ResourceAttributes(),
+	}
+}
+
+func (r *Resource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	data, diags := fastlyclient.FromProviderData(req.ProviderData)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() || data == nil {
+		return
+	}
+
+	r.providerData = data
+}
+
+func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan Model
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if err := validation.EnsureServiceTypeSupported(ctx, r.providerData.ServiceTypeChecker, plan.Service.ValueString(), "fastly_service_vcl", service.TypeVCL); err != nil {
+		resp.Diagnostics.AddError("Unsupported Fastly service type", err.Error())
+		return
+	}
+
+	resp.Diagnostics.Append(r.providerData.VersionChecker.EnsureMutable(ctx, plan.Service.ValueString(), int(plan.Version.ValueInt64()))...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	tflog.Debug(ctx, "Creating Fastly custom VCL", map[string]any{
+		"service_id": plan.Service.ValueString(),
+		"version":    plan.Version.ValueInt64(),
+		"name":       service.StringValue(plan.Name),
+		"main":       service.BoolValue(plan.Main),
+	})
+
+	v, err := r.providerData.Client.CreateVCL(ctx, BuildCreateInput(plan.Service.ValueString(), int(plan.Version.ValueInt64()), plan.NestedModel))
+	if err != nil {
+		resp.Diagnostics.AddError("Error creating custom VCL", err.Error())
+		return
+	}
+
+	plannedContent := plan.Content
+	flatten(ctx, v, &plan)
+	plan.Content = plannedContent
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+func (r *Resource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var state Model
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	tflog.Debug(ctx, "Reading Fastly custom VCL from API", map[string]any{
+		"service_id": state.Service.ValueString(),
+		"version":    state.Version.ValueInt64(),
+		"name":       state.Name.ValueString(),
+	})
+
+	v, err := r.providerData.Client.GetVCL(ctx, &fastly.GetVCLInput{
+		ServiceID:      state.Service.ValueString(),
+		ServiceVersion: int(state.Version.ValueInt64()),
+		Name:           state.Name.ValueString(),
+	})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			tflog.Warn(ctx, "Custom VCL not found, removing from state", map[string]any{
+				"service_id": state.Service.ValueString(),
+				"version":    state.Version.ValueInt64(),
+				"name":       state.Name.ValueString(),
+			})
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.AddError("Error reading custom VCL", err.Error())
+		return
+	}
+
+	flatten(ctx, v, &state)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var plan Model
+	var state Model
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if err := validation.EnsureServiceTypeSupported(ctx, r.providerData.ServiceTypeChecker, plan.Service.ValueString(), "fastly_service_vcl", service.TypeVCL); err != nil {
+		resp.Diagnostics.AddError("Unsupported Fastly service type", err.Error())
+		return
+	}
+
+	resp.Diagnostics.Append(r.providerData.VersionChecker.EnsureMutable(ctx, plan.Service.ValueString(), int(plan.Version.ValueInt64()))...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	tflog.Debug(ctx, "Updating Fastly custom VCL", map[string]any{
+		"service_id": plan.Service.ValueString(),
+		"version":    plan.Version.ValueInt64(),
+		"name":       service.StringValue(plan.Name),
+	})
+
+	v, err := r.providerData.Client.UpdateVCL(ctx, BuildUpdateInput(plan.Service.ValueString(), int(plan.Version.ValueInt64()), plan.NestedModel))
+	if err != nil {
+		resp.Diagnostics.AddError("Error updating custom VCL", err.Error())
+		return
+	}
+
+	plannedContent := plan.Content
+	flatten(ctx, v, &plan)
+	plan.ID = state.ID
+	plan.Content = plannedContent
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+func (r *Resource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var state Model
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	tflog.Debug(ctx, "Deleting Fastly custom VCL", map[string]any{
+		"service_id": state.Service.ValueString(),
+		"version":    state.Version.ValueInt64(),
+		"name":       state.Name.ValueString(),
+	})
+
+	if err := validation.EnsureServiceTypeSupported(ctx, r.providerData.ServiceTypeChecker, state.Service.ValueString(), "fastly_service_vcl", service.TypeVCL); err != nil {
+		if errors.IsNotFound(err) {
+			return
+		}
+		resp.Diagnostics.AddError("Unsupported Fastly service type", err.Error())
+		return
+	}
+
+	notFound, diags := r.providerData.VersionChecker.EnsureMutableForDelete(ctx, state.Service.ValueString(), int(state.Version.ValueInt64()))
+	resp.Diagnostics.Append(diags...)
+	if notFound || resp.Diagnostics.HasError() {
+		return
+	}
+
+	err := r.providerData.Client.DeleteVCL(ctx, &fastly.DeleteVCLInput{
+		ServiceID:      state.Service.ValueString(),
+		ServiceVersion: int(state.Version.ValueInt64()),
+		Name:           state.Name.ValueString(),
+	})
+	if err != nil && !errors.IsNotFound(err) {
+		resp.Diagnostics.AddError("Error deleting custom VCL", err.Error())
+	}
+}
+
+func (r *Resource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	serviceID, version, name, err := importutil.ParseCompositeID(req.ID)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Invalid Import ID",
+			"Expected import ID in format: service_id/version/name\n"+
+				"For example: service123/3/main\n\n"+
+				"Error: "+err.Error(),
+		)
+		return
+	}
+
+	tflog.Debug(ctx, "Importing custom VCL", map[string]any{
+		"service_id": serviceID,
+		"version":    version,
+		"name":       name,
+	})
+
+	v, err := r.providerData.Client.GetVCL(ctx, &fastly.GetVCLInput{
+		ServiceID:      serviceID,
+		ServiceVersion: version,
+		Name:           name,
+	})
+	if err != nil {
+		resp.Diagnostics.AddError("Error importing custom VCL", err.Error())
+		return
+	}
+
+	var state Model
+	state.Service = types.StringValue(serviceID)
+	state.Version = types.Int64Value(int64(version))
+	flatten(ctx, v, &state)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}

--- a/internal/resources/vcl/schema.go
+++ b/internal/resources/vcl/schema.go
@@ -37,7 +37,7 @@ func CommonAttributes() map[string]schema.Attribute {
 		},
 		"content": schema.StringAttribute{
 			Required:    true,
-			Description: "The custom VCL source code to upload. Commonly configured with file(\"${path.module}/main.vcl\") or templatefile(...).",
+			Description: "The custom VCL source code to upload. Can configured with file(\"${path.module}/main.vcl\") or templatefile(...).",
 		},
 		"main": schema.BoolAttribute{
 			Optional:    true,

--- a/internal/resources/vcl/schema.go
+++ b/internal/resources/vcl/schema.go
@@ -7,7 +7,7 @@ import (
 	"github.com/fastly/terraform-provider-fastly/internal/reconcile"
 	"github.com/fastly/terraform-provider-fastly/internal/service"
 
-	fastly "github.com/fastly/go-fastly/v16/fastly"
+	fastly "github.com/fastly/go-fastly/v17/fastly"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"

--- a/internal/resources/vcl/schema.go
+++ b/internal/resources/vcl/schema.go
@@ -1,0 +1,200 @@
+package vcl
+
+import (
+	"context"
+	"maps"
+
+	"github.com/fastly/terraform-provider-fastly/internal/reconcile"
+	"github.com/fastly/terraform-provider-fastly/internal/service"
+
+	fastly "github.com/fastly/go-fastly/v16/fastly"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+type NestedModel struct {
+	Name    types.String `tfsdk:"name"`
+	Content types.String `tfsdk:"content"`
+	Main    types.Bool   `tfsdk:"main"`
+}
+
+func (n NestedModel) ModelsEqual(other NestedModel) bool {
+	return service.StringValue(n.Name) == service.StringValue(other.Name) &&
+		ContentEqual(service.StringValue(n.Content), service.StringValue(other.Content)) &&
+		service.BoolValue(n.Main) == service.BoolValue(other.Main)
+}
+
+func CommonAttributes() map[string]schema.Attribute {
+	return map[string]schema.Attribute{
+		"name": schema.StringAttribute{
+			Required:    true,
+			Description: "A unique name for this custom VCL file. Included VCL files must be referenced by this exact name from the main VCL file.",
+		},
+		"content": schema.StringAttribute{
+			Required:    true,
+			Description: "The custom VCL source code to upload. Commonly configured with file(\"${path.module}/main.vcl\") or templatefile(...).",
+		},
+		"main": schema.BoolAttribute{
+			Optional:    true,
+			Computed:    true,
+			Default:     booldefault.StaticBool(DefaultMain),
+			Description: "Whether this custom VCL file is the main configuration. Exactly one configured custom VCL file must be marked as main.",
+		},
+	}
+}
+
+func ResourceAttributes() map[string]schema.Attribute {
+	attrs := map[string]schema.Attribute{
+		"id": schema.StringAttribute{
+			Computed:    true,
+			Description: "Terraform resource identifier.",
+		},
+		"service_id": schema.StringAttribute{
+			Required:    true,
+			Description: "Fastly service ID.",
+			PlanModifiers: []planmodifier.String{
+				stringplanmodifier.RequiresReplace(),
+			},
+		},
+		"version": schema.Int64Attribute{
+			Required:    true,
+			Description: "Writable Fastly service version to modify.",
+			PlanModifiers: []planmodifier.Int64{
+				int64planmodifier.RequiresReplace(),
+			},
+		},
+	}
+	maps.Copy(attrs, CommonAttributes())
+
+	nameAttr := attrs["name"].(schema.StringAttribute)
+	nameAttr.PlanModifiers = []planmodifier.String{
+		stringplanmodifier.RequiresReplace(),
+	}
+	attrs["name"] = nameAttr
+
+	mainAttr := attrs["main"].(schema.BoolAttribute)
+	mainAttr.PlanModifiers = []planmodifier.Bool{
+		boolplanmodifier.RequiresReplace(),
+	}
+	attrs["main"] = mainAttr
+
+	return attrs
+}
+
+func NestedBlockSchema() schema.ListNestedBlock {
+	return schema.ListNestedBlock{
+		Description: "Custom VCL files attached to this service. This is modeled as a list so Terraform can render changes to `content` as an in-place string diff instead of a whole set element delete/add.",
+		NestedObject: schema.NestedBlockObject{
+			Attributes: CommonAttributes(),
+		},
+	}
+}
+
+type ops struct{}
+
+func (o ops) List(ctx context.Context, client *fastly.Client, serviceID string, version int) ([]*fastly.VCL, error) {
+	return client.ListVCLs(ctx, &fastly.ListVCLsInput{
+		ServiceID:      serviceID,
+		ServiceVersion: version,
+	})
+}
+
+func (o ops) GetName(api *fastly.VCL) string {
+	return fastly.ToValue(api.Name)
+}
+
+func (o ops) Delete(ctx context.Context, client *fastly.Client, serviceID string, version int, name string) error {
+	return client.DeleteVCL(ctx, &fastly.DeleteVCLInput{
+		ServiceID:      serviceID,
+		ServiceVersion: version,
+		Name:           name,
+	})
+}
+
+func (o ops) Create(ctx context.Context, client *fastly.Client, serviceID string, version int, desired NestedModel) (*fastly.VCL, error) {
+	return create(ctx, client, serviceID, version, desired)
+}
+
+func (o ops) Equal(desired NestedModel, remote *fastly.VCL) bool {
+	return desired.ModelsEqual(FlattenToNestedModel(remote))
+}
+
+func (o ops) Update(ctx context.Context, client *fastly.Client, serviceID string, version int, desired NestedModel) (*fastly.VCL, error) {
+	remote, err := client.GetVCL(ctx, &fastly.GetVCLInput{
+		ServiceID:      serviceID,
+		ServiceVersion: version,
+		Name:           service.StringValue(desired.Name),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// go-fastly's UpdateVCLInput updates content but not main. When the main flag
+	// changes inside an automatic service resource, recreate the file with the
+	// desired flag while keeping Terraform's user-visible diff focused on the
+	// changed nested attributes.
+	if service.BoolValue(desired.Main) != service.BoolValue(FlattenToNestedModel(remote).Main) {
+		if err := o.Delete(ctx, client, serviceID, version, service.StringValue(desired.Name)); err != nil {
+			return nil, err
+		}
+		return o.Create(ctx, client, serviceID, version, desired)
+	}
+
+	content := service.StringValue(desired.Content)
+	return client.UpdateVCL(ctx, &fastly.UpdateVCLInput{
+		ServiceID:      serviceID,
+		ServiceVersion: version,
+		Name:           service.StringValue(desired.Name),
+		Content:        &content,
+	})
+}
+
+func (o ops) ToModel(api *fastly.VCL) NestedModel {
+	return FlattenToNestedModel(api)
+}
+
+var reconciler = &reconcile.Resource[NestedModel, fastly.VCL]{
+	Ops: ops{},
+	GetName: func(m NestedModel) string {
+		return service.StringValue(m.Name)
+	},
+	Sortable: true,
+}
+
+func ReadForVersion(ctx context.Context, client *fastly.Client, serviceID string, version int) ([]NestedModel, error) {
+	return reconciler.ReadForVersion(ctx, client, serviceID, version)
+}
+
+func Reconcile(ctx context.Context, client *fastly.Client, serviceID string, version int, desired []NestedModel) error {
+	if err := Validate(desired); err != nil {
+		return err
+	}
+	return reconciler.Run(ctx, client, serviceID, version, desired)
+}
+
+func Equal(a, b []NestedModel) bool {
+	return reconcile.ModelsEqual(a, b, func(m NestedModel) string { return service.StringValue(m.Name) }, NestedModel.ModelsEqual, true)
+}
+
+func MatchOrder(items, order []NestedModel) []NestedModel {
+	return reconcile.MatchOrder(items, order, func(m NestedModel) string { return service.StringValue(m.Name) })
+}
+
+func create(ctx context.Context, client *fastly.Client, serviceID string, version int, desired NestedModel) (*fastly.VCL, error) {
+	name := service.StringValue(desired.Name)
+	content := service.StringValue(desired.Content)
+	main := service.BoolValue(desired.Main)
+
+	return client.CreateVCL(ctx, &fastly.CreateVCLInput{
+		ServiceID:      serviceID,
+		ServiceVersion: version,
+		Name:           &name,
+		Content:        &content,
+		Main:           &main,
+	})
+}

--- a/internal/resources/vcl/schema.go
+++ b/internal/resources/vcl/schema.go
@@ -88,7 +88,7 @@ func ResourceAttributes() map[string]schema.Attribute {
 
 func NestedBlockSchema() schema.ListNestedBlock {
 	return schema.ListNestedBlock{
-		Description: "Custom VCL files attached to this service. This is modeled as a list so Terraform can render changes to `content` as an in-place string diff instead of a whole set element delete/add.",
+		Description: "Custom VCL files attached to this service.",
 		NestedObject: schema.NestedBlockObject{
 			Attributes: CommonAttributes(),
 		},

--- a/internal/resources/vcl/vcl_test.go
+++ b/internal/resources/vcl/vcl_test.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"testing"
 
-	fastly "github.com/fastly/go-fastly/v16/fastly"
+	fastly "github.com/fastly/go-fastly/v17/fastly"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflogtest"
 	"github.com/stretchr/testify/assert"

--- a/internal/resources/vcl/vcl_test.go
+++ b/internal/resources/vcl/vcl_test.go
@@ -1,0 +1,357 @@
+package vcl
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	fastly "github.com/fastly/go-fastly/v16/fastly"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflogtest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func minimalNestedModel() NestedModel {
+	return NestedModel{
+		Name:    types.StringValue("main"),
+		Content: types.StringValue("sub vcl_recv {\n#FASTLY recv\n  return(lookup);\n}\n"),
+		Main:    types.BoolValue(true),
+	}
+}
+
+func includedNestedModel() NestedModel {
+	return NestedModel{
+		Name:    types.StringValue("routing"),
+		Content: types.StringValue("sub route_request {\n}\n"),
+		Main:    types.BoolValue(false),
+	}
+}
+
+func TestFlattenToNestedModel(t *testing.T) {
+	t.Run("nil VCL returns zero model", func(t *testing.T) {
+		model := FlattenToNestedModel(nil)
+
+		assert.Equal(t, types.String{}, model.Name)
+		assert.Equal(t, types.String{}, model.Content)
+		assert.Equal(t, types.Bool{}, model.Main)
+	})
+
+	t.Run("full VCL", func(t *testing.T) {
+		api := &fastly.VCL{
+			Name:    fastly.ToPointer("main"),
+			Content: fastly.ToPointer("sub vcl_recv {\n#FASTLY recv\n}\n"),
+			Main:    fastly.ToPointer(true),
+		}
+
+		model := FlattenToNestedModel(api)
+
+		assert.Equal(t, types.StringValue("main"), model.Name)
+		assert.Equal(t, types.StringValue("sub vcl_recv {\n#FASTLY recv\n}\n"), model.Content)
+		assert.Equal(t, types.BoolValue(true), model.Main)
+	})
+
+	t.Run("nil main defaults to false", func(t *testing.T) {
+		api := &fastly.VCL{
+			Name:    fastly.ToPointer("include"),
+			Content: fastly.ToPointer("sub helper {}\n"),
+		}
+
+		model := FlattenToNestedModel(api)
+
+		assert.Equal(t, types.BoolValue(false), model.Main)
+	})
+}
+
+func TestFlatten(t *testing.T) {
+	t.Run("nil VCL logs warning", func(t *testing.T) {
+		var buf bytes.Buffer
+		ctx := tflogtest.RootLogger(context.Background(), &buf)
+		m := &Model{}
+
+		flatten(ctx, nil, m)
+
+		assert.Equal(t, types.String{}, m.ID)
+		assert.Equal(t, types.String{}, m.Service)
+		assert.Equal(t, types.Int64{}, m.Version)
+		assert.Equal(t, types.String{}, m.Name)
+		assert.Equal(t, types.String{}, m.Content)
+		assert.Equal(t, types.Bool{}, m.Main)
+
+		entries, err := tflogtest.MultilineJSONDecode(&buf)
+		require.NoError(t, err)
+		require.NotEmpty(t, entries)
+
+		foundWarning := false
+		for _, entry := range entries {
+			if entry["@level"] == "warn" && entry["@message"] == "flatten called with nil VCL" {
+				foundWarning = true
+				break
+			}
+		}
+		assert.True(t, foundWarning)
+	})
+
+	t.Run("full VCL", func(t *testing.T) {
+		ctx := context.Background()
+		api := &fastly.VCL{
+			ServiceID:      fastly.ToPointer("svc-123"),
+			ServiceVersion: fastly.ToPointer(5),
+			Name:           fastly.ToPointer("main"),
+			Content:        fastly.ToPointer("sub vcl_recv {\n#FASTLY recv\n}\n"),
+			Main:           fastly.ToPointer(true),
+		}
+		m := &Model{}
+
+		flatten(ctx, api, m)
+
+		assert.Equal(t, types.StringValue("svc-123-5-main"), m.ID)
+		assert.Equal(t, types.StringValue("svc-123"), m.Service)
+		assert.Equal(t, types.Int64Value(5), m.Version)
+		assert.Equal(t, types.StringValue("main"), m.Name)
+		assert.Equal(t, types.StringValue("sub vcl_recv {\n#FASTLY recv\n}\n"), m.Content)
+		assert.Equal(t, types.BoolValue(true), m.Main)
+	})
+}
+
+func TestBuildCreateInput(t *testing.T) {
+	model := Model{
+		Service: types.StringValue("svc-123"),
+		Version: types.Int64Value(7),
+		NestedModel: NestedModel{
+			Name:    types.StringValue("main"),
+			Content: types.StringValue("vcl content"),
+			Main:    types.BoolValue(true),
+		},
+	}
+
+	input := BuildCreateInput(model.Service.ValueString(), int(model.Version.ValueInt64()), model.NestedModel)
+
+	assert.Equal(t, "svc-123", input.ServiceID)
+	assert.Equal(t, 7, input.ServiceVersion)
+	assert.Equal(t, "main", *input.Name)
+	assert.Equal(t, "vcl content", *input.Content)
+	assert.Equal(t, true, *input.Main)
+}
+
+func TestBuildUpdateInput(t *testing.T) {
+	model := Model{
+		Service: types.StringValue("svc-123"),
+		Version: types.Int64Value(7),
+		NestedModel: NestedModel{
+			Name:    types.StringValue("main"),
+			Content: types.StringValue("updated vcl content"),
+			Main:    types.BoolValue(true),
+		},
+	}
+
+	input := BuildUpdateInput(model.Service.ValueString(), int(model.Version.ValueInt64()), model.NestedModel)
+
+	assert.Equal(t, "svc-123", input.ServiceID)
+	assert.Equal(t, 7, input.ServiceVersion)
+	assert.Equal(t, "main", input.Name)
+	assert.Equal(t, "updated vcl content", *input.Content)
+}
+
+func TestValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		vcls    []NestedModel
+		wantErr string
+	}{
+		{
+			name: "empty VCL list is valid",
+			vcls: nil,
+		},
+		{
+			name: "single main VCL is valid",
+			vcls: []NestedModel{minimalNestedModel()},
+		},
+		{
+			name: "main plus include is valid",
+			vcls: []NestedModel{
+				minimalNestedModel(),
+				includedNestedModel(),
+			},
+		},
+		{
+			name: "duplicate names are invalid",
+			vcls: []NestedModel{
+				minimalNestedModel(),
+				{
+					Name:    types.StringValue("main"),
+					Content: types.StringValue("different"),
+					Main:    types.BoolValue(false),
+				},
+			},
+			wantErr: `duplicate custom VCL name "main"`,
+		},
+		{
+			name: "missing main is invalid",
+			vcls: []NestedModel{
+				includedNestedModel(),
+			},
+			wantErr: "one custom VCL file must have main = true",
+		},
+		{
+			name: "multiple mains are invalid",
+			vcls: []NestedModel{
+				minimalNestedModel(),
+				{
+					Name:    types.StringValue("other-main"),
+					Content: types.StringValue("sub vcl_recv {}\n"),
+					Main:    types.BoolValue(true),
+				},
+			},
+			wantErr: "only one custom VCL file can have main = true",
+		},
+		{
+			name: "blank name is invalid",
+			vcls: []NestedModel{
+				{
+					Name:    types.StringValue("  "),
+					Content: types.StringValue("sub vcl_recv {}\n"),
+					Main:    types.BoolValue(true),
+				},
+			},
+			wantErr: "custom VCL name cannot be empty",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := Validate(tt.vcls)
+			if tt.wantErr == "" {
+				assert.NoError(t, err)
+				return
+			}
+
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
+func TestEqual(t *testing.T) {
+	tests := []struct {
+		name     string
+		a        []NestedModel
+		b        []NestedModel
+		expected bool
+	}{
+		{
+			name:     "both empty",
+			a:        []NestedModel{},
+			b:        []NestedModel{},
+			expected: true,
+		},
+		{
+			name:     "identical single element",
+			a:        []NestedModel{minimalNestedModel()},
+			b:        []NestedModel{minimalNestedModel()},
+			expected: true,
+		},
+		{
+			name: "different order but same content",
+			a: []NestedModel{
+				{Name: types.StringValue("routing"), Content: types.StringValue("include"), Main: types.BoolValue(false)},
+				{Name: types.StringValue("main"), Content: types.StringValue("main"), Main: types.BoolValue(true)},
+			},
+			b: []NestedModel{
+				{Name: types.StringValue("main"), Content: types.StringValue("main"), Main: types.BoolValue(true)},
+				{Name: types.StringValue("routing"), Content: types.StringValue("include"), Main: types.BoolValue(false)},
+			},
+			expected: true,
+		},
+		{
+			name: "different content",
+			a: []NestedModel{
+				{Name: types.StringValue("main"), Content: types.StringValue("old"), Main: types.BoolValue(true)},
+			},
+			b: []NestedModel{
+				{Name: types.StringValue("main"), Content: types.StringValue("new"), Main: types.BoolValue(true)},
+			},
+			expected: false,
+		},
+		{
+			name: "different main flag",
+			a: []NestedModel{
+				{Name: types.StringValue("main"), Content: types.StringValue("content"), Main: types.BoolValue(true)},
+			},
+			b: []NestedModel{
+				{Name: types.StringValue("main"), Content: types.StringValue("content"), Main: types.BoolValue(false)},
+			},
+			expected: false,
+		},
+		{
+			name: "different names",
+			a: []NestedModel{
+				{Name: types.StringValue("main"), Content: types.StringValue("content"), Main: types.BoolValue(true)},
+			},
+			b: []NestedModel{
+				{Name: types.StringValue("other"), Content: types.StringValue("content"), Main: types.BoolValue(true)},
+			},
+			expected: false,
+		},
+		{
+			name: "different lengths",
+			a: []NestedModel{
+				minimalNestedModel(),
+			},
+			b: []NestedModel{
+				minimalNestedModel(),
+				includedNestedModel(),
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, Equal(tt.a, tt.b))
+		})
+	}
+}
+
+func TestContentEqual(t *testing.T) {
+	assert.True(t, ContentEqual("sub vcl_recv {}\n", "sub vcl_recv {}\n\n"))
+	assert.True(t, ContentEqual("sub vcl_recv {}", "sub vcl_recv {}\n"))
+	assert.False(t, ContentEqual("sub vcl_recv { return(lookup); }\n", "sub vcl_recv { return(pass); }\n"))
+}
+
+func TestMatchOrderPreservePlanContent(t *testing.T) {
+	remote := []NestedModel{
+		{Name: types.StringValue("main"), Content: types.StringValue("api content\n\n"), Main: types.BoolValue(true)},
+	}
+	plan := []NestedModel{
+		{Name: types.StringValue("main"), Content: types.StringValue("planned content\n"), Main: types.BoolValue(true)},
+	}
+
+	got := MatchOrderPreservePlanContent(remote, plan)
+
+	require.Len(t, got, 1)
+	assert.Equal(t, types.StringValue("planned content\n"), got[0].Content)
+}
+
+func TestMatchOrder(t *testing.T) {
+	items := []NestedModel{
+		{Name: types.StringValue("a"), Content: types.StringValue("a"), Main: types.BoolValue(false)},
+		{Name: types.StringValue("b"), Content: types.StringValue("b"), Main: types.BoolValue(true)},
+		{Name: types.StringValue("c"), Content: types.StringValue("c"), Main: types.BoolValue(false)},
+	}
+	order := []NestedModel{
+		{Name: types.StringValue("c")},
+		{Name: types.StringValue("a")},
+	}
+
+	got := MatchOrder(items, order)
+
+	require.Len(t, got, 3)
+	assert.Equal(t, "c", got[0].Name.ValueString())
+	assert.Equal(t, "a", got[1].Name.ValueString())
+	assert.Equal(t, "b", got[2].Name.ValueString())
+}
+
+func TestID(t *testing.T) {
+	assert.Equal(t, "svc-123-5-main", ID("svc-123", 5, "main"))
+}

--- a/internal/resources/vcl/vcl_test.go
+++ b/internal/resources/vcl/vcl_test.go
@@ -232,6 +232,98 @@ func TestValidate(t *testing.T) {
 	}
 }
 
+func TestValidateConfig(t *testing.T) {
+	tests := []struct {
+		name    string
+		vcls    []NestedModel
+		wantErr string
+	}{
+		{
+			name: "empty VCL list is valid",
+			vcls: nil,
+		},
+		{
+			name: "single main VCL is valid",
+			vcls: []NestedModel{minimalNestedModel()},
+		},
+		{
+			name: "duplicate known names are invalid",
+			vcls: []NestedModel{
+				minimalNestedModel(),
+				{
+					Name:    types.StringValue("main"),
+					Content: types.StringValue("different"),
+					Main:    types.BoolValue(false),
+				},
+			},
+			wantErr: `duplicate custom VCL name "main"`,
+		},
+		{
+			name: "missing main is invalid when all main values are known",
+			vcls: []NestedModel{
+				includedNestedModel(),
+			},
+			wantErr: "one custom VCL file must have main = true",
+		},
+		{
+			name: "multiple known mains are invalid",
+			vcls: []NestedModel{
+				minimalNestedModel(),
+				{
+					Name:    types.StringValue("other-main"),
+					Content: types.StringValue("sub vcl_recv {}\n"),
+					Main:    types.BoolValue(true),
+				},
+			},
+			wantErr: "only one custom VCL file can have main = true",
+		},
+		{
+			name: "blank known name is invalid",
+			vcls: []NestedModel{
+				{
+					Name:    types.StringValue("  "),
+					Content: types.StringValue("sub vcl_recv {}\n"),
+					Main:    types.BoolValue(true),
+				},
+			},
+			wantErr: "custom VCL name cannot be empty",
+		},
+		{
+			name: "unknown name is deferred",
+			vcls: []NestedModel{
+				{
+					Name:    types.StringUnknown(),
+					Content: types.StringValue("sub vcl_recv {}\n"),
+					Main:    types.BoolValue(true),
+				},
+			},
+		},
+		{
+			name: "unknown main defers missing main validation",
+			vcls: []NestedModel{
+				{
+					Name:    types.StringValue("include"),
+					Content: types.StringValue("sub helper {}\n"),
+					Main:    types.BoolUnknown(),
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateConfig(tt.vcls)
+			if tt.wantErr == "" {
+				assert.NoError(t, err)
+				return
+			}
+
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
 func TestEqual(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/templates/list-resources/service_vcl.md.tmpl
+++ b/templates/list-resources/service_vcl.md.tmpl
@@ -1,0 +1,13 @@
+---
+page_title: "fastly_service_vcl List Resource - fastly"
+subcategory: ""
+description: |-
+  List all custom VCL files across all Fastly CDN services at their active version, or latest version when no active version exists.
+---
+
+# fastly_service_vcl (List Resource)
+
+List all custom VCL files across all Fastly CDN services at their active version,
+or latest version when no active version exists.
+
+{{ .SchemaMarkdown | trimspace }}

--- a/templates/resources/service_vcl.md.tmpl
+++ b/templates/resources/service_vcl.md.tmpl
@@ -1,0 +1,70 @@
+---
+page_title: "fastly_service_vcl Resource - fastly"
+subcategory: ""
+description: |-
+  Fastly custom VCL file resource. Writes directly to the specified writable CDN service version.
+---
+
+# fastly_service_vcl (Resource)
+
+Fastly custom VCL file resource. Writes directly to the specified writable CDN service version.
+
+This resource is part of the explicit/default first-class resource family. It
+manages a custom VCL file on the configured CDN service version. It does not
+clone, activate, or stage service versions.
+
+Use this resource when you want to manage custom VCL files explicitly against a
+known writable service version. For automatic service version cloning,
+validation, and activation, use the nested `vcl` block on
+`fastly_service_cdn_auto`.
+
+## Example Usage
+
+```terraform
+resource "fastly_service_cdn" "example" {
+  name = "example"
+
+  domain {
+    name = "www.example.com"
+  }
+
+  backend {
+    name    = "origin"
+    address = "origin.example.com"
+    port    = 443
+    use_ssl = true
+  }
+
+  force_destroy = true
+}
+
+resource "fastly_service_vcl" "main" {
+  service_id = fastly_service_cdn.example.id
+  version    = 1
+  name       = "main"
+  main       = true
+  content    = file("${path.module}/main.vcl")
+}
+```
+
+{{ .SchemaMarkdown | trimspace }}
+
+## Import
+
+Import requires the service ID, service version, and custom VCL file name:
+
+```shell
+terraform import fastly_service_vcl.main SERVICE_ID/VERSION/VCL_NAME
+```
+
+Example:
+
+```shell
+terraform import fastly_service_vcl.main SU1Z0isxPaozGVKXdv0eY/3/main
+```
+
+## Version lifecycle
+
+This resource does not clone, activate, or stage service versions. Use explicit
+service-version lifecycle actions to clone, validate, stage, or activate a
+service version.


### PR DESCRIPTION
### Change summary

This PR adds custom VCL support to the dual-model provider.

It introduces:

- a new explicit `fastly_service_vcl` resource
- a nested `vcl` block for `fastly_service_cdn_auto`
- reconciliation of custom VCL files by `name`
- validation for duplicate VCL names and invalid `main` selection
- support for both inline VCL content and `file(...)`-backed VCL content
- unit and acceptance test coverage for explicit and automatic resource families
- generated documentation and documentation templates for `fastly_service_vcl`

## Improved VCL diffs

The current SDKv2 provider models custom VCL blocks as a set. Because set element
identity includes the VCL content, changing one line in a VCL file causes
Terraform to render the whole block as removed and re-added.

The dual-model implementation uses named nested VCL blocks and reconciles them by
`name`, which produces a focused in-place content diff.

Local test output after changing one line in a VCL file:

```diff
Terraform will perform the following actions:

  # fastly_service_cdn_auto.vcl_diff_demo will be updated in-place
  ~ resource "fastly_service_cdn_auto" "vcl_diff_demo" {
      ~ active_version  = 1 -> (known after apply)
        id              = "LhwYo8IyY5cuqeA6DerybP"
      ~ managed_version = 1 -> (known after apply)
        name            = "tf-vcl-diff-demo"
        # (3 unchanged attributes hidden)

      ~ vcl {
          ~ content = <<-EOT
                sub vcl_recv {
                #FASTLY recv
                  return(lookup);
                }

                sub vcl_hash {
                  set req.hash += req.url;
                  set req.hash += req.http.host;
                #FASTLY hash
                  return(hash);
                }

                sub vcl_hit {
                #FASTLY hit
                  return(deliver);
                }

                sub vcl_miss {
                #FASTLY miss
                  return(fetch);
                }

                sub vcl_pass {
                #FASTLY pass
                  return(pass);
                }

                sub vcl_fetch {
                #FASTLY fetch
                  return(deliver);
                }

                sub vcl_error {
                #FASTLY error
                  return(deliver);
                }

                sub vcl_deliver {
                #FASTLY deliver
              -   set resp.http.X-VCL-Diff-Demo = "before";
              +   set resp.http.X-VCL-Diff-Demo = "after";
                  return(deliver);
                }

                sub vcl_log {
                #FASTLY log
                }
            EOT
            name    = "main"
            # (1 unchanged attribute hidden)
        }

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

### New Feature Submissions:

* [x] Does your submission pass tests?
* [x] Post the output of your test runs


```
=== RUN   TestAccFastlyServiceVCL_basicAndUpdate
=== PAUSE TestAccFastlyServiceVCL_basicAndUpdate
=== RUN   TestAccFastlyServiceCDNAuto_withVCLAndContentUpdate
=== PAUSE TestAccFastlyServiceCDNAuto_withVCLAndContentUpdate
=== RUN   TestAccFastlyServiceCDNAuto_withMultipleVCLFiles
=== PAUSE TestAccFastlyServiceCDNAuto_withMultipleVCLFiles
=== RUN   TestAccFastlyServiceCDNAuto_VCLValidation
=== PAUSE TestAccFastlyServiceCDNAuto_VCLValidation
=== RUN   TestAccFastlyServiceCDNAuto_VCLValidationNoMain
=== PAUSE TestAccFastlyServiceCDNAuto_VCLValidationNoMain
=== RUN   TestAccFastlyServiceCDNAuto_VCLValidationInvalidSyntax
=== PAUSE TestAccFastlyServiceCDNAuto_VCLValidationInvalidSyntax
=== CONT  TestAccFastlyServiceVCL_basicAndUpdate
=== CONT  TestAccFastlyServiceCDNAuto_VCLValidation
=== CONT  TestAccFastlyServiceCDNAuto_withMultipleVCLFiles
=== CONT  TestAccFastlyServiceCDNAuto_VCLValidationInvalidSyntax
=== CONT  TestAccFastlyServiceCDNAuto_VCLValidationNoMain
=== CONT  TestAccFastlyServiceCDNAuto_withVCLAndContentUpdate
--- PASS: TestAccFastlyServiceCDNAuto_VCLValidation (0.51s)
--- PASS: TestAccFastlyServiceCDNAuto_VCLValidationNoMain (0.50s)
--- PASS: TestAccFastlyServiceCDNAuto_VCLValidationInvalidSyntax (39.40s)
--- PASS: TestAccFastlyServiceVCL_basicAndUpdate (54.97s)
--- PASS: TestAccFastlyServiceCDNAuto_withMultipleVCLFiles (71.42s)
--- PASS: TestAccFastlyServiceCDNAuto_withVCLAndContentUpdate (100.49s)
```