### PR TITLE
Apply versionless metadata regardless of activation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### BUG FIXES:
 
+- fix(service): update versionless `name` and `comment` attributes regardless of `activate` and `stage` settings ([#1369](https://github.com/fastly/terraform-provider-fastly/pull/1369))
+
 ### Dependencies
 - build(deps): `google.golang.org/grpc` from 1.79.3 to 1.82.1 ([#1360](https://github.com/fastly/terraform-provider-fastly/pull/1360))
 

--- a/docs/resources/service_compute.md
+++ b/docs/resources/service_compute.md
@@ -38,6 +38,10 @@ set to `true`. While this combination will not cause any harm to the
 service, there is no logical reason to both stage and activate every
 set of applied changes.
 
+The `activate` and `stage` attributes only control version lifecycle operations.
+Versionless service attributes, including `name` and `comment`, are updated
+immediately during `terraform apply` regardless of these settings.
+
 ## Example Usage
 
 Basic usage:
@@ -98,13 +102,13 @@ $ terraform import fastly_service_compute.demo xxxxxxxxxxxxxxxxxxxx@2
 
 ### Required
 
-- `name` (String) The unique name for the Service to create
+- `name` (String) The unique name for the Service to create. This versionless attribute is updated regardless of the `activate` and `stage` settings
 
 ### Optional
 
-- `activate` (Boolean) Conditionally prevents new service versions from being activated. The apply step will create a new draft version but will not activate it if this is set to `false`. Default `true`
+- `activate` (Boolean) Controls whether newly created service versions are activated. When versioned configuration changes, the apply step creates a draft version but does not activate it if this is set to `false`. Versionless service attributes, such as `name` and `comment`, are updated regardless of this setting. Default `true`
 - `backend` (Block Set) (see [below for nested schema](#nestedblock--backend))
-- `comment` (String) Description field for the service. Default `Managed by Terraform`
+- `comment` (String) Description field for the service. This versionless attribute is updated regardless of the `activate` and `stage` settings. Default `Managed by Terraform`
 - `dictionary` (Block Set) (see [below for nested schema](#nestedblock--dictionary))
 - `domain` (Block Set) A set of Domain names to serve as entry points for your Service (see [below for nested schema](#nestedblock--domain))
 - `force_destroy` (Boolean) Services that are active cannot be destroyed. In order to destroy the Service, set `force_destroy` to `true`. Default `false`
@@ -142,7 +146,7 @@ $ terraform import fastly_service_compute.demo xxxxxxxxxxxxxxxxxxxx@2
 - `product_enablement` (Block Set, Max: 1) (see [below for nested schema](#nestedblock--product_enablement))
 - `resource_link` (Block Set) A resource link represents a link between a shared resource (such as an KV Store or Config Store) and a service version. (see [below for nested schema](#nestedblock--resource_link))
 - `reuse` (Boolean) Services that are active cannot be destroyed. If set to `true` a service Terraform intends to destroy will instead be deactivated (allowing it to be reused by importing it into another Terraform project). If `false`, attempting to destroy an active service will cause an error. Default `false`
-- `stage` (Boolean) Conditionally enables new service versions to be staged. If set to `true`, all changes made by an `apply` step will be staged, even if `apply` did not create a new draft version. Default `false`
+- `stage` (Boolean) Conditionally enables new service versions to be staged. If set to `true`, versioned changes made by an `apply` step will be staged, even if `apply` did not create a new draft version. Versionless service attributes, such as `name` and `comment`, are updated regardless of this setting. Default `false`
 - `version_comment` (String) Description field for the version
 
 ### Read-Only

--- a/docs/resources/service_vcl.md
+++ b/docs/resources/service_vcl.md
@@ -40,6 +40,10 @@ set to `true`. While this combination will not cause any harm to the
 service, there is no logical reason to both stage and activate every
 set of applied changes.
 
+The `activate` and `stage` attributes only control version lifecycle operations.
+Versionless service attributes, including `name` and `comment`, are updated
+immediately during `terraform apply` regardless of these settings.
+
 ## Example Usage
 
 Basic usage:
@@ -217,15 +221,15 @@ $ terraform import fastly_service_vcl.demo xxxxxxxxxxxxxxxxxxxx@2
 
 ### Required
 
-- `name` (String) The unique name for the Service to create
+- `name` (String) The unique name for the Service to create. This versionless attribute is updated regardless of the `activate` and `stage` settings
 
 ### Optional
 
 - `acl` (Block Set) (see [below for nested schema](#nestedblock--acl))
-- `activate` (Boolean) Conditionally prevents new service versions from being activated. The apply step will create a new draft version but will not activate it if this is set to `false`. Default `true`
+- `activate` (Boolean) Controls whether newly created service versions are activated. When versioned configuration changes, the apply step creates a draft version but does not activate it if this is set to `false`. Versionless service attributes, such as `name` and `comment`, are updated regardless of this setting. Default `true`
 - `backend` (Block Set) (see [below for nested schema](#nestedblock--backend))
 - `cache_setting` (Block Set) (see [below for nested schema](#nestedblock--cache_setting))
-- `comment` (String) Description field for the service. Default `Managed by Terraform`
+- `comment` (String) Description field for the service. This versionless attribute is updated regardless of the `activate` and `stage` settings. Default `Managed by Terraform`
 - `condition` (Block Set) (see [below for nested schema](#nestedblock--condition))
 - `default_host` (String) The default hostname
 - `default_ttl` (Number) The default Time-to-live (TTL) for requests
@@ -273,7 +277,7 @@ $ terraform import fastly_service_vcl.demo xxxxxxxxxxxxxxxxxxxx@2
 - `response_object` (Block Set) (see [below for nested schema](#nestedblock--response_object))
 - `reuse` (Boolean) Services that are active cannot be destroyed. If set to `true` a service Terraform intends to destroy will instead be deactivated (allowing it to be reused by importing it into another Terraform project). If `false`, attempting to destroy an active service will cause an error. Default `false`
 - `snippet` (Block Set) (see [below for nested schema](#nestedblock--snippet))
-- `stage` (Boolean) Conditionally enables new service versions to be staged. If set to `true`, all changes made by an `apply` step will be staged, even if `apply` did not create a new draft version. Default `false`
+- `stage` (Boolean) Conditionally enables new service versions to be staged. If set to `true`, versioned changes made by an `apply` step will be staged, even if `apply` did not create a new draft version. Versionless service attributes, such as `name` and `comment`, are updated regardless of this setting. Default `false`
 - `stale_if_error` (Boolean) Enables serving a stale object if there is an error
 - `stale_if_error_ttl` (Number) The default time-to-live (TTL) for serving the stale object for the version
 - `vcl` (Block Set) (see [below for nested schema](#nestedblock--vcl))

--- a/fastly/base_fastly_service.go
+++ b/fastly/base_fastly_service.go
@@ -90,7 +90,7 @@ func resourceService(serviceDef ServiceDefinition) *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"activate": {
 				Type:        schema.TypeBool,
-				Description: "Conditionally prevents new service versions from being activated. The apply step will create a new draft version but will not activate it if this is set to `false`. Default `true`",
+				Description: "Controls whether newly created service versions are activated. When versioned configuration changes, the apply step creates a draft version but does not activate it if this is set to `false`. Versionless service attributes, such as `name` and `comment`, are updated regardless of this setting. Default `true`",
 				Default:     true,
 				Optional:    true,
 			},
@@ -119,7 +119,7 @@ func resourceService(serviceDef ServiceDefinition) *schema.Resource {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Default:     "Managed by Terraform",
-				Description: "Description field for the service. Default `Managed by Terraform`",
+				Description: "Description field for the service. This versionless attribute is updated regardless of the `activate` and `stage` settings. Default `Managed by Terraform`",
 			},
 			"force_destroy": {
 				Type:          schema.TypeBool,
@@ -140,7 +140,7 @@ func resourceService(serviceDef ServiceDefinition) *schema.Resource {
 			"name": {
 				Type:        schema.TypeString,
 				Required:    true,
-				Description: "The unique name for the Service to create",
+				Description: "The unique name for the Service to create. This versionless attribute is updated regardless of the `activate` and `stage` settings",
 			},
 			"reuse": {
 				Type:          schema.TypeBool,
@@ -150,7 +150,7 @@ func resourceService(serviceDef ServiceDefinition) *schema.Resource {
 			},
 			"stage": {
 				Type:        schema.TypeBool,
-				Description: "Conditionally enables new service versions to be staged. If set to `true`, all changes made by an `apply` step will be staged, even if `apply` did not create a new draft version. Default `false`",
+				Description: "Conditionally enables new service versions to be staged. If set to `true`, versioned changes made by an `apply` step will be staged, even if `apply` did not create a new draft version. Versionless service attributes, such as `name` and `comment`, are updated regardless of this setting. Default `false`",
 				Default:     false,
 				Optional:    true,
 			},
@@ -321,8 +321,10 @@ func resourceServiceUpdate(ctx context.Context, d *schema.ResourceData, meta any
 	conn := meta.(*APIClient).conn
 
 	shouldActivate := d.Get("activate").(bool)
-	// Update Name and/or Comment. No new version is required for this.
-	if d.HasChanges("name", "comment") && shouldActivate {
+
+	// Update versionless service attributes independently of version activation
+	// and staging. No new version is required for this.
+	if d.HasChanges("name", "comment") {
 		_, err := conn.UpdateService(gofastly.NewContextForResourceID(ctx, d.Id()), &gofastly.UpdateServiceInput{
 			ServiceID: d.Id(),
 			Name:      gofastly.ToPointer(d.Get("name").(string)),
@@ -544,8 +546,6 @@ func resourceServiceRead(ctx context.Context, d *schema.ResourceData, meta any, 
 
 	conn := meta.(*APIClient).conn
 
-	var diags diag.Diagnostics
-
 	s, err := conn.GetServiceDetails(gofastly.NewContextForResourceID(ctx, d.Id()), &gofastly.GetServiceDetailsInput{
 		ServiceID: d.Id(),
 	})
@@ -633,18 +633,6 @@ func resourceServiceRead(ctx context.Context, d *schema.ResourceData, meta any, 
 		}
 	}
 
-	// NOTE: service "name" and "comment" are versionless (mutable).
-	// Therefore, we only allow them to be updated if "activate = true".
-	// Unfortunately, with our current resource design, it's not easy to show
-	// a warning message upon plan, and so this warning will only appear upon applying.
-	if d.HasChanges("name", "comment") && !d.Get("activate").(bool) {
-		diags = append(diags, diag.Diagnostic{
-			Severity: diag.Warning,
-			Summary:  "Some changes are ignored",
-			Detail:   "'name' and 'comment' attributes can only be updated with 'activate = true'",
-		})
-	}
-
 	// If cloned_version is not set, and there is no active version, temporarily
 	// set the service.ActiveVersion number to the latest version supplied via
 	// the get service version details call. This is to ensure we still read all
@@ -730,7 +718,7 @@ func resourceServiceRead(ctx context.Context, d *schema.ResourceData, meta any, 
 		return diag.FromErr(err)
 	}
 
-	return diags
+	return nil
 }
 
 // resourceServiceDelete provides service resource Delete functionality.

--- a/fastly/resource_fastly_service_compute_test.go
+++ b/fastly/resource_fastly_service_compute_test.go
@@ -16,6 +16,8 @@ import (
 func TestAccFastlyServiceCompute_basic(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	updatedName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	comment := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	domainName1 := fmt.Sprintf("fastly-test1.tf-%s.com", acctest.RandString(10))
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -26,7 +28,7 @@ func TestAccFastlyServiceCompute_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckServiceComputeDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccServiceComputeConfig(name, domainName1),
+				Config: testAccServiceComputeConfig(name, "Managed by Terraform", domainName1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceExists("fastly_service_compute.foo", &service),
 					resource.TestCheckResourceAttr("fastly_service_compute.foo", "name", name),
@@ -38,6 +40,16 @@ func TestAccFastlyServiceCompute_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("fastly_service_compute.foo", "healthcheck.0.name", "healthCheckTest"),
 					resource.TestCheckResourceAttr("fastly_service_compute.foo", "healthcheck.0.host", "example.com"),
 					resource.TestCheckResourceAttr("fastly_service_compute.foo", "healthcheck.0.path", "/health"),
+				),
+			},
+			{
+				// Versionless service metadata is updated even when activation is disabled.
+				Config: testAccServiceComputeConfig(updatedName, comment, domainName1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceExists("fastly_service_compute.foo", &service),
+					resource.TestCheckResourceAttr("fastly_service_compute.foo", "name", updatedName),
+					resource.TestCheckResourceAttr("fastly_service_compute.foo", "comment", comment),
+					resource.TestCheckResourceAttr("fastly_service_compute.foo", "cloned_version", "1"),
 				),
 			},
 			{
@@ -211,7 +223,7 @@ func testAccCheckServiceComputeDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccServiceComputeConfig(name, domain string) string {
+func testAccServiceComputeConfig(name, comment, domain string) string {
 	return fmt.Sprintf(`
 data "fastly_package_hash" "example" {
   filename = "./test_fixtures/package/valid.tar.gz"
@@ -219,6 +231,7 @@ data "fastly_package_hash" "example" {
 
 resource "fastly_service_compute" "foo" {
   name = "%s"
+  comment = "%s"
 
   domain {
     name    = "%s"
@@ -239,5 +252,5 @@ resource "fastly_service_compute" "foo" {
   }
   force_destroy = true
   activate = false
-}`, name, domain)
+}`, name, comment, domain)
 }

--- a/fastly/resource_fastly_service_vcl_test.go
+++ b/fastly/resource_fastly_service_vcl_test.go
@@ -296,6 +296,7 @@ func TestAccFastlyServiceVCL_createServiceWithStaticBackend(t *testing.T) {
 func TestAccFastlyServiceVCL_basic(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	updatedName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	comment := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	versionComment1 := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	versionComment2 := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
@@ -323,14 +324,15 @@ func TestAccFastlyServiceVCL_basic(t *testing.T) {
 				),
 			},
 			{
-				// updating service comment with "activate = false" will be ignored
-				Config: testAccServiceVCLConfigUpdateServiceComment(name, "new service comment", domainName1, false),
+				// Versionless service metadata is updated even when activation is disabled.
+				Config: testAccServiceVCLConfigUpdateServiceMetadata(updatedName, comment, versionComment1, domainName1, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceExists("fastly_service_vcl.foo", &service),
+					resource.TestCheckResourceAttr("fastly_service_vcl.foo", "name", updatedName),
+					resource.TestCheckResourceAttr("fastly_service_vcl.foo", "comment", comment),
 					resource.TestCheckResourceAttr("fastly_service_vcl.foo", "active_version", "1"),
-					resource.TestCheckResourceAttr("fastly_service_vcl.foo", "comment", "Managed by Terraform"),
+					resource.TestCheckResourceAttr("fastly_service_vcl.foo", "cloned_version", "1"),
 				),
-				ExpectNonEmptyPlan: true,
 			},
 			{
 				Config: testAccServiceVCLConfigBasicUpdate(name, comment, versionComment2, domainName2),
@@ -770,11 +772,12 @@ resource "fastly_service_vcl" "foo" {
 }`, name, domain)
 }
 
-func testAccServiceVCLConfigUpdateServiceComment(name, comment string, domain string, activate bool) string {
+func testAccServiceVCLConfigUpdateServiceMetadata(name, comment, versionComment, domain string, activate bool) string {
 	return fmt.Sprintf(`
 resource "fastly_service_vcl" "foo" {
   name = "%s"
   comment = "%s"
+  version_comment = "%s"
   http3 = true
 
   domain {
@@ -789,7 +792,7 @@ resource "fastly_service_vcl" "foo" {
 
   activate = %t
   force_destroy = true
-}`, name, comment, domain, activate)
+}`, name, comment, versionComment, domain, activate)
 }
 
 func testAccServiceVCLConfigInitWithVersionComment(name, versionComment, domain string) string {

--- a/templates/resources/service_compute.md.tmpl
+++ b/templates/resources/service_compute.md.tmpl
@@ -38,6 +38,10 @@ set to `true`. While this combination will not cause any harm to the
 service, there is no logical reason to both stage and activate every
 set of applied changes.
 
+The `activate` and `stage` attributes only control version lifecycle operations.
+Versionless service attributes, including `name` and `comment`, are updated
+immediately during `terraform apply` regardless of these settings.
+
 ## Example Usage
 
 Basic usage:

--- a/templates/resources/service_vcl.md.tmpl
+++ b/templates/resources/service_vcl.md.tmpl
@@ -40,6 +40,10 @@ set to `true`. While this combination will not cause any harm to the
 service, there is no logical reason to both stage and activate every
 set of applied changes.
 
+The `activate` and `stage` attributes only control version lifecycle operations.
+Versionless service attributes, including `name` and `comment`, are updated
+immediately during `terraform apply` regardless of these settings.
+
 ## Example Usage
 
 Basic usage:


### PR DESCRIPTION
### Change summary

Updates versionless service metadata whenever Terraform detects a change, regardless of the `activate` and `stage` settings.

Previously, changes to a service's `name` or `comment` were silently skipped when `activate = false`. The remote value was then restored during refresh, resulting in the same change appearing in every subsequent Terraform plan.

This change:

* Updates `name` and `comment` independently of service version activation and staging.
* Removes the apply-time warning for ignored metadata changes.
* Preserves the existing behavior for versioned service configuration.
* Adds VCL and Compute acceptance coverage confirming that metadata-only updates do not clone or activate a service version.
* Clarifies the behavior in the generated provider documentation.

This pull request reverts the implementation introduced in #481. The Internal discussion on this issue can be found [here](https://fastly.slack.com/archives/C01E7FV8P5H/p1785352421738579).

 All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/terraform-provider-fastly/pulls) for the same update/change?

### Changes to Core Features:

* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

```
=== RUN   TestAccFastlyServiceVCL_basic
=== PAUSE TestAccFastlyServiceVCL_basic
=== CONT  TestAccFastlyServiceVCL_basic
--- PASS: TestAccFastlyServiceVCL_basic (71.70s)
```

```
=== RUN   TestAccFastlyServiceCompute_basic
=== PAUSE TestAccFastlyServiceCompute_basic
=== CONT  TestAccFastlyServiceCompute_basic
--- PASS: TestAccFastlyServiceCompute_basic (30.79s)
```

### User Impact

Users can now update a service's versionless `name` and `comment` attributes while keeping `activate = false`.

This resolves the perpetual plan behavior where Terraform repeatedly proposed a metadata change but the provider did not apply it. Because these attributes are versionless, their updates take effect immediately and do not clone, stage, or activate a service version.

### Are there any considerations that need to be addressed for release?

This is a behavior change for configurations that set `activate = false` and have a `name` or `comment` value that differs from the remote service.

After upgrading, the next `terraform apply` will update those versionless service attributes even though version activation remains disabled.

No configuration changes or state migration are required.