### PR TITLE
Skip redundant metadata updates

### DIFF
--- a/internal/resources/servicecdnauto/resource.go
+++ b/internal/resources/servicecdnauto/resource.go
@@ -376,13 +376,15 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 
 	serviceID := state.ID.ValueString()
 
-	// Update service metadata in place. Name and comment are versionless service fields.
-	_, err := r.providerData.AutoClient().UpdateService(ctx, &fastly.UpdateServiceInput{
-		ServiceID: serviceID,
-		Name:      new(plan.Name.ValueString()),
-		Comment:   new(plan.Comment.ValueString()),
-	})
-	if err != nil {
+	if err := service.UpdateMetadataIfChanged(
+		ctx,
+		r.providerData.AutoClient(),
+		serviceID,
+		plan.Name,
+		plan.Comment,
+		state.Name,
+		state.Comment,
+	); err != nil {
 		resp.Diagnostics.AddError("Error updating Fastly CDN service", err.Error())
 		return
 	}

--- a/internal/resources/servicecomputeauto/resource.go
+++ b/internal/resources/servicecomputeauto/resource.go
@@ -353,13 +353,15 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 
 	serviceID := state.ID.ValueString()
 
-	// Update service metadata in place. Name and comment are versionless service fields.
-	_, err := r.providerData.AutoClient().UpdateService(ctx, &fastly.UpdateServiceInput{
-		ServiceID: serviceID,
-		Name:      new(plan.Name.ValueString()),
-		Comment:   new(plan.Comment.ValueString()),
-	})
-	if err != nil {
+	if err := service.UpdateMetadataIfChanged(
+		ctx,
+		r.providerData.AutoClient(),
+		serviceID,
+		plan.Name,
+		plan.Comment,
+		state.Name,
+		state.Comment,
+	); err != nil {
 		resp.Diagnostics.AddError("Error updating Fastly Compute service", err.Error())
 		return
 	}

--- a/internal/service/shared.go
+++ b/internal/service/shared.go
@@ -1,9 +1,11 @@
 package service
 
 import (
+	"context"
 	"regexp"
 	"strings"
 
+	"github.com/fastly/go-fastly/v17/fastly"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -72,6 +74,35 @@ func ToGeneratedResourceName(parts ...string) string {
 		return "resource"
 	}
 	return id
+}
+
+// MetadataChanged reports whether versionless service metadata differs between
+// the planned and current Terraform values.
+func MetadataChanged(planName, planComment, stateName, stateComment types.String) bool {
+	return !planName.Equal(stateName) || !planComment.Equal(stateComment)
+}
+
+// UpdateMetadataIfChanged updates versionless service metadata only when the
+// planned name or comment differs from the current Terraform state.
+func UpdateMetadataIfChanged(
+	ctx context.Context,
+	client *fastly.Client,
+	serviceID string,
+	planName, planComment, stateName, stateComment types.String,
+) error {
+	if !MetadataChanged(planName, planComment, stateName, stateComment) {
+		return nil
+	}
+
+	name := planName.ValueString()
+	comment := planComment.ValueString()
+
+	_, err := client.UpdateService(ctx, &fastly.UpdateServiceInput{
+		ServiceID: serviceID,
+		Name:      &name,
+		Comment:   &comment,
+	})
+	return err
 }
 
 func StringValue(v types.String) string {

--- a/internal/service/shared_test.go
+++ b/internal/service/shared_test.go
@@ -1,0 +1,161 @@
+package service
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/fastly/go-fastly/v17/fastly"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestMetadataChanged(t *testing.T) {
+	tests := []struct {
+		name         string
+		planName     types.String
+		planComment  types.String
+		stateName    types.String
+		stateComment types.String
+		want         bool
+	}{
+		{
+			name:         "unchanged metadata",
+			planName:     types.StringValue("service"),
+			planComment:  types.StringValue("comment"),
+			stateName:    types.StringValue("service"),
+			stateComment: types.StringValue("comment"),
+			want:         false,
+		},
+		{
+			name:         "name changed",
+			planName:     types.StringValue("updated-service"),
+			planComment:  types.StringValue("comment"),
+			stateName:    types.StringValue("service"),
+			stateComment: types.StringValue("comment"),
+			want:         true,
+		},
+		{
+			name:         "comment changed",
+			planName:     types.StringValue("service"),
+			planComment:  types.StringValue("updated comment"),
+			stateName:    types.StringValue("service"),
+			stateComment: types.StringValue("comment"),
+			want:         true,
+		},
+		{
+			name:         "both changed",
+			planName:     types.StringValue("updated-service"),
+			planComment:  types.StringValue("updated comment"),
+			stateName:    types.StringValue("service"),
+			stateComment: types.StringValue("comment"),
+			want:         true,
+		},
+		{
+			name:         "null comments unchanged",
+			planName:     types.StringValue("service"),
+			planComment:  types.StringNull(),
+			stateName:    types.StringValue("service"),
+			stateComment: types.StringNull(),
+			want:         false,
+		},
+		{
+			name:         "null comment changed to empty",
+			planName:     types.StringValue("service"),
+			planComment:  types.StringValue(""),
+			stateName:    types.StringValue("service"),
+			stateComment: types.StringNull(),
+			want:         true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := MetadataChanged(tt.planName, tt.planComment, tt.stateName, tt.stateComment)
+			if got != tt.want {
+				t.Fatalf("MetadataChanged() = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestUpdateMetadataIfChanged(t *testing.T) {
+	tests := []struct {
+		name         string
+		planName     types.String
+		planComment  types.String
+		stateName    types.String
+		stateComment types.String
+		wantRequests int
+	}{
+		{
+			name:         "unchanged metadata skips UpdateService",
+			planName:     types.StringValue("service"),
+			planComment:  types.StringValue("comment"),
+			stateName:    types.StringValue("service"),
+			stateComment: types.StringValue("comment"),
+			wantRequests: 0,
+		},
+		{
+			name:         "changed name calls UpdateService",
+			planName:     types.StringValue("updated-service"),
+			planComment:  types.StringValue("comment"),
+			stateName:    types.StringValue("service"),
+			stateComment: types.StringValue("comment"),
+			wantRequests: 1,
+		},
+		{
+			name:         "changed comment calls UpdateService",
+			planName:     types.StringValue("service"),
+			planComment:  types.StringValue("updated comment"),
+			stateName:    types.StringValue("service"),
+			stateComment: types.StringValue("comment"),
+			wantRequests: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			transport := &countingTransport{}
+			client, err := fastly.NewClient("test-token")
+			if err != nil {
+				t.Fatalf("fastly.NewClient() error = %v", err)
+			}
+			client.HTTPClient = &http.Client{Transport: transport}
+
+			err = UpdateMetadataIfChanged(
+				context.Background(),
+				client,
+				"test-service",
+				tt.planName,
+				tt.planComment,
+				tt.stateName,
+				tt.stateComment,
+			)
+			if err != nil {
+				t.Fatalf("UpdateMetadataIfChanged() unexpected error = %v", err)
+			}
+
+			if transport.requests != tt.wantRequests {
+				t.Fatalf("UpdateService requests = %d, want %d", transport.requests, tt.wantRequests)
+			}
+		})
+	}
+}
+
+type countingTransport struct {
+	requests int
+}
+
+func (t *countingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	t.requests++
+
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Status:     "200 OK",
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(`{}`)),
+		Request:    req,
+	}, nil
+}


### PR DESCRIPTION
### Change summary

Avoids unnecessary service metadata API requests from the automatic-lifecycle CDN and Compute resources.

Previously, every resource update called `UpdateService`, even when only nested versioned configuration, `force_destroy`, or `reuse` had changed. The resources now compare the planned `name` and `comment` values with the current Terraform state and call `UpdateService` only when either value differs.

A shared metadata update helper and unit coverage are included. The tests verify both the Terraform value comparison behavior and that unchanged metadata results in no service update API request.

 All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/terraform-provider-fastly/pulls) for the same update/change?

### Changes to Core Features:

* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

```
=== RUN   TestMetadataChanged
=== RUN   TestMetadataChanged/unchanged_metadata
=== RUN   TestMetadataChanged/name_changed
=== RUN   TestMetadataChanged/comment_changed
=== RUN   TestMetadataChanged/both_changed
=== RUN   TestMetadataChanged/null_comments_unchanged
=== RUN   TestMetadataChanged/null_comment_changed_to_empty
--- PASS: TestMetadataChanged (0.00s)
    --- PASS: TestMetadataChanged/unchanged_metadata (0.00s)
    --- PASS: TestMetadataChanged/name_changed (0.00s)
    --- PASS: TestMetadataChanged/comment_changed (0.00s)
    --- PASS: TestMetadataChanged/both_changed (0.00s)
    --- PASS: TestMetadataChanged/null_comments_unchanged (0.00s)
    --- PASS: TestMetadataChanged/null_comment_changed_to_empty (0.00s)
=== RUN   TestUpdateMetadataIfChanged
=== RUN   TestUpdateMetadataIfChanged/unchanged_metadata_skips_UpdateService
=== RUN   TestUpdateMetadataIfChanged/changed_name_calls_UpdateService
=== RUN   TestUpdateMetadataIfChanged/changed_comment_calls_UpdateService
--- PASS: TestUpdateMetadataIfChanged (0.00s)
    --- PASS: TestUpdateMetadataIfChanged/unchanged_metadata_skips_UpdateService (0.00s)
    --- PASS: TestUpdateMetadataIfChanged/changed_name_calls_UpdateService (0.00s)
    --- PASS: TestUpdateMetadataIfChanged/changed_comment_calls_UpdateService (0.00s)
PASS
```