### PR TITLE
fix(logging): Ensure VCL specific fields are defaulted on WASM services

### DIFF
--- a/internal/acceptance_tests/blocks/logging_newrelicotlp_compute.tf
+++ b/internal/acceptance_tests/blocks/logging_newrelicotlp_compute.tf
@@ -1,0 +1,6 @@
+resource "fastly_service_logging_newrelicotlp" "test" {
+  service_id = fastly_service_compute.test.id
+  version    = {{.SERVICE_VERSION}}
+  name       = "{{.LOGGING_NEWRELIC_NAME}}"
+  token      = "test-insert-key"
+}

--- a/internal/acceptance_tests/blocks/logging_s3_compute.tf
+++ b/internal/acceptance_tests/blocks/logging_s3_compute.tf
@@ -1,0 +1,10 @@
+resource "fastly_service_logging_s3" "test" {
+  service_id  = fastly_service_compute.test.id
+  version     = {{.SERVICE_VERSION}}
+  name        = "{{.LOGGING_S3_NAME}}"
+  bucket_name = "{{.BUCKET_NAME}}"
+  authentication = {
+    access_key = "AKIAIOSFODNN7EXAMPLE"
+    secret_key = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+  }
+}

--- a/internal/acceptance_tests/logging_newrelicotlp_test.go
+++ b/internal/acceptance_tests/logging_newrelicotlp_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+
+	"github.com/fastly/terraform-provider-fastly/internal/constants"
 )
 
 func TestAccFastlyServiceLoggingNewRelicOTLP_basic(t *testing.T) {
@@ -316,6 +318,47 @@ func TestAccFastlyServiceLoggingNewRelicOTLP_computeRejectsVCLOnlyFields(t *test
 			{
 				Config:      ConfigLoggingNewRelicOTLPComputeFormat(serviceName, loggerName),
 				ExpectError: regexp.MustCompile("VCL-only attributes not supported on Compute services"),
+			},
+		},
+	})
+}
+
+// TestAccFastlyServiceLoggingNewRelicOTLP_computeConsistentAfterApply covers the
+// whole plan -> API response -> flatten -> state path on a Compute service, which
+// the unit tests cannot reach. The VCL-only attributes are never sent for
+// Compute, but their schema defaults still land in the plan, so the API's own
+// values (a different default format, and placement forced to "none" on wasm)
+// used to be read back into state and fail Terraform's post-apply consistency
+// check with "Provider produced inconsistent result after apply". The trailing
+// PlanOnly step then proves the same values survive a refresh with no residual
+// diff.
+func TestAccFastlyServiceLoggingNewRelicOTLP_computeConsistentAfterApply(t *testing.T) {
+	t.Parallel()
+	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	loggerName := fmt.Sprintf("newrelic-logger-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
+		CheckDestroy:             CheckServiceDestroy("fastly_service_compute"),
+		Steps: []resource.TestStep{
+			{
+				Config: ConfigLoggingNewRelicOTLPCompute(serviceName, loggerName),
+				Check: resource.ComposeTestCheckFunc(
+					CheckServiceExists("fastly_service_compute.test"),
+					CheckLoggingNewRelicOTLPExistsInFastly("fastly_service_compute.test", loggerName, 1),
+					resource.TestCheckResourceAttr("fastly_service_logging_newrelicotlp.test", "name", loggerName),
+					// The VCL-only attributes must hold their schema defaults, not
+					// whatever the API returned for the wasm service.
+					resource.TestCheckResourceAttr("fastly_service_logging_newrelicotlp.test", "format", constants.LoggingNewRelicOTLPDefaultFormat),
+					resource.TestCheckResourceAttr("fastly_service_logging_newrelicotlp.test", "format_version", "2"),
+					resource.TestCheckResourceAttr("fastly_service_logging_newrelicotlp.test", "response_condition", ""),
+					resource.TestCheckNoResourceAttr("fastly_service_logging_newrelicotlp.test", "placement"),
+				),
+			},
+			{
+				Config:   ConfigLoggingNewRelicOTLPCompute(serviceName, loggerName),
+				PlanOnly: true,
 			},
 		},
 	})

--- a/internal/acceptance_tests/logging_s3_test.go
+++ b/internal/acceptance_tests/logging_s3_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+
+	"github.com/fastly/terraform-provider-fastly/internal/constants"
 )
 
 func TestAccFastlyServiceLoggingS3_basic(t *testing.T) {
@@ -497,6 +499,49 @@ func TestAccFastlyServiceLoggingS3_computeRejectsVCLOnlyFields(t *testing.T) {
 			{
 				Config:      ConfigLoggingS3ComputeFormat(serviceName, loggerName, bucketName),
 				ExpectError: regexp.MustCompile("VCL-only attributes not supported on Compute services"),
+			},
+		},
+	})
+}
+
+// TestAccFastlyServiceLoggingS3_computeConsistentAfterApply covers the whole
+// plan -> API response -> flatten -> state path on a Compute service, which the
+// unit tests cannot reach. The VCL-only attributes are never sent for Compute,
+// but their schema defaults still land in the plan, so the API's own values
+// (a different default format, and placement forced to "none" on wasm) used to
+// be read back into state and fail Terraform's post-apply consistency check
+// with "Provider produced inconsistent result after apply". The trailing
+// PlanOnly step then proves the same values survive a refresh with no residual
+// diff.
+func TestAccFastlyServiceLoggingS3_computeConsistentAfterApply(t *testing.T) {
+	t.Parallel()
+	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	loggerName := fmt.Sprintf("s3-logger-%s", acctest.RandString(10))
+	bucketName := fmt.Sprintf("tf-test-bucket-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
+		CheckDestroy:             CheckServiceDestroy("fastly_service_compute"),
+		Steps: []resource.TestStep{
+			{
+				Config: ConfigLoggingS3Compute(serviceName, loggerName, bucketName),
+				Check: resource.ComposeTestCheckFunc(
+					CheckServiceExists("fastly_service_compute.test"),
+					CheckLoggingS3ExistsInFastly("fastly_service_compute.test", loggerName, 1),
+					resource.TestCheckResourceAttr("fastly_service_logging_s3.test", "name", loggerName),
+					resource.TestCheckResourceAttr("fastly_service_logging_s3.test", "bucket_name", bucketName),
+					// The VCL-only attributes must hold their schema defaults, not
+					// whatever the API returned for the wasm service.
+					resource.TestCheckResourceAttr("fastly_service_logging_s3.test", "format", constants.LoggingS3DefaultFormat),
+					resource.TestCheckResourceAttr("fastly_service_logging_s3.test", "format_version", "2"),
+					resource.TestCheckResourceAttr("fastly_service_logging_s3.test", "response_condition", ""),
+					resource.TestCheckNoResourceAttr("fastly_service_logging_s3.test", "placement"),
+				),
+			},
+			{
+				Config:   ConfigLoggingS3Compute(serviceName, loggerName, bucketName),
+				PlanOnly: true,
 			},
 		},
 	})

--- a/internal/acceptance_tests/test_helpers.go
+++ b/internal/acceptance_tests/test_helpers.go
@@ -1866,6 +1866,23 @@ func ConfigLoggingS3ForImport(serviceName, domainName, loggerName, bucketName st
 	)
 }
 
+// ConfigLoggingS3Compute returns a config attaching fastly_service_logging_s3 to
+// an explicit Compute service with none of the VCL-only attributes set, which is
+// the only shape a Compute service can be configured in.
+func ConfigLoggingS3Compute(serviceName, loggerName, bucketName string) string {
+	return BuildConfig(
+		ServiceCompute,
+		map[string]string{
+			"SERVICE_NAME":    serviceName,
+			"SERVICE_COMMENT": "",
+			"SERVICE_VERSION": "1",
+			"LOGGING_S3_NAME": loggerName,
+			"BUCKET_NAME":     bucketName,
+		},
+		"internal/acceptance_tests/blocks/logging_s3_compute.tf",
+	)
+}
+
 // ConfigLoggingS3ComputeFormat returns a config attaching fastly_service_logging_s3
 // to an explicit Compute service with format set, a VCL-only attribute. Unlike the
 // nested blocks, the standalone resource's schema is shared by both service types, so
@@ -1942,6 +1959,23 @@ func ConfigLoggingNewRelicOTLPForImport(serviceName, domainName, loggerName stri
 		},
 		"internal/acceptance_tests/blocks/service_cdn_domain.tf",
 		"internal/acceptance_tests/blocks/logging_newrelicotlp_basic.tf",
+	)
+}
+
+// ConfigLoggingNewRelicOTLPCompute returns a config attaching
+// fastly_service_logging_newrelicotlp to an explicit Compute service with none of
+// the VCL-only attributes set, which is the only shape a Compute service can be
+// configured in.
+func ConfigLoggingNewRelicOTLPCompute(serviceName, loggerName string) string {
+	return BuildConfig(
+		ServiceCompute,
+		map[string]string{
+			"SERVICE_NAME":          serviceName,
+			"SERVICE_COMMENT":       "",
+			"SERVICE_VERSION":       "1",
+			"LOGGING_NEWRELIC_NAME": loggerName,
+		},
+		"internal/acceptance_tests/blocks/logging_newrelicotlp_compute.tf",
 	)
 }
 

--- a/internal/resources/loggingnewrelicotlp/flatten.go
+++ b/internal/resources/loggingnewrelicotlp/flatten.go
@@ -32,6 +32,16 @@ func FlattenToNestedModel(n *fastly.NewRelicOTLP) NestedModel {
 	return m
 }
 
+// ResetVCLOnlyToDefaults restores the VCL-only fields to their schema defaults
+// after a flatten. On a Compute service they are never sent, so the API's own
+// values are discarded rather than reported as a diff against the plan.
+func ResetVCLOnlyToDefaults(m *NestedModel) {
+	m.Format = types.StringValue(constants.LoggingNewRelicOTLPDefaultFormat)
+	m.FormatVersion = types.Int64Value(DefaultFormatVersion)
+	m.Placement = types.StringNull()
+	m.ResponseCondition = types.StringValue(DefaultResponseCondition)
+}
+
 // FlattenToComputeNestedModel is FlattenToNestedModel for Compute services: it
 // carries over only the attributes ComputeNestedModel exposes.
 func FlattenToComputeNestedModel(n *fastly.NewRelicOTLP) ComputeNestedModel {

--- a/internal/resources/loggingnewrelicotlp/loggingnewrelicotlp_test.go
+++ b/internal/resources/loggingnewrelicotlp/loggingnewrelicotlp_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 
 	fastly "github.com/fastly/go-fastly/v17/fastly"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	fwdefaults "github.com/hashicorp/terraform-plugin-framework/resource/schema/defaults"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/stretchr/testify/assert"
 
@@ -455,4 +457,64 @@ func TestMatchOrder(t *testing.T) {
 	assert.Len(t, result, 2)
 	assert.Equal(t, "a", result[0].Name.ValueString())
 	assert.Equal(t, "b", result[1].Name.ValueString())
+}
+
+// TestResetVCLOnlyToDefaults covers the Compute read-back path. On a Compute
+// service the VCL-only fields are never sent, so the API reports its own
+// server-side values — notably placement forced to "none" on wasm services.
+// Adopting those breaks consistency-after-apply, so they must be reset to
+// exactly the values a plan produces.
+func TestResetVCLOnlyToDefaults(t *testing.T) {
+	m := FlattenToNestedModel(&fastly.NewRelicOTLP{
+		Name:              new("test-newrelic"),
+		Token:             new("insert-api-key"),
+		Region:            new("US"),
+		URL:               new("https://otlp.nr-data.net"),
+		ProcessingRegion:  new("none"),
+		Format:            new("something-the-server-chose"),
+		FormatVersion:     new(1),
+		Placement:         new("none"),
+		ResponseCondition: new("some-condition"),
+	})
+
+	ResetVCLOnlyToDefaults(&m)
+
+	assert.Equal(t, constants.LoggingNewRelicOTLPDefaultFormat, m.Format.ValueString())
+	assert.Equal(t, int64(DefaultFormatVersion), m.FormatVersion.ValueInt64())
+	assert.True(t, m.Placement.IsNull(), "placement must go back to unset, not the API's forced \"none\"")
+	assert.Equal(t, DefaultResponseCondition, m.ResponseCondition.ValueString())
+
+	// Non-VCL-only fields must survive untouched.
+	assert.Equal(t, "test-newrelic", m.Name.ValueString())
+	assert.Equal(t, "insert-api-key", m.Token.ValueString())
+	assert.Equal(t, "US", m.Region.ValueString())
+	assert.Equal(t, "https://otlp.nr-data.net", m.URL.ValueString())
+	assert.Equal(t, "none", m.ProcessingRegion.ValueString())
+}
+
+// TestResetVCLOnlyToDefaultsMatchesPlannedDefaults ties the reset to the schema
+// itself: the values it writes must equal the schema's declared defaults, or
+// Create/Update would still disagree with the plan.
+func TestResetVCLOnlyToDefaultsMatchesPlannedDefaults(t *testing.T) {
+	var m NestedModel
+	ResetVCLOnlyToDefaults(&m)
+
+	attrs := CommonAttributes()
+
+	var fResp fwdefaults.StringResponse
+	attrs["format"].(schema.StringAttribute).Default.DefaultString(context.Background(), fwdefaults.StringRequest{}, &fResp)
+	assert.Equal(t, fResp.PlanValue, m.Format, "format must match its schema default")
+
+	var fvResp fwdefaults.Int64Response
+	attrs["format_version"].(schema.Int64Attribute).Default.DefaultInt64(context.Background(), fwdefaults.Int64Request{}, &fvResp)
+	assert.Equal(t, fvResp.PlanValue, m.FormatVersion, "format_version must match its schema default")
+
+	var rcResp fwdefaults.StringResponse
+	attrs["response_condition"].(schema.StringAttribute).Default.DefaultString(context.Background(), fwdefaults.StringRequest{}, &rcResp)
+	assert.Equal(t, rcResp.PlanValue, m.ResponseCondition, "response_condition must match its schema default")
+
+	// placement is Optional-only with no Default, so an absent config value plans
+	// as null — the reset has to produce null, not "".
+	assert.Nil(t, attrs["placement"].(schema.StringAttribute).Default)
+	assert.True(t, m.Placement.IsNull())
 }

--- a/internal/resources/loggingnewrelicotlp/resource.go
+++ b/internal/resources/loggingnewrelicotlp/resource.go
@@ -102,6 +102,9 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 	}
 
 	flatten(ctx, n, &plan)
+	if serviceType == service.TypeCompute {
+		ResetVCLOnlyToDefaults(&plan.NestedModel)
+	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 
@@ -136,7 +139,18 @@ func (r *Resource) Read(ctx context.Context, req resource.ReadRequest, resp *res
 		return
 	}
 
+	// The endpoint Get above succeeded, so the service exists and this is a cached
+	// lookup in all but the first call per service.
+	serviceType, err := r.providerData.ServiceTypeChecker.GetType(ctx, state.Service.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Error determining service type", err.Error())
+		return
+	}
+
 	flatten(ctx, n, &state)
+	if serviceType == service.TypeCompute {
+		ResetVCLOnlyToDefaults(&state.NestedModel)
+	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
@@ -190,6 +204,9 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 	}
 
 	flatten(ctx, n, &plan)
+	if serviceType == service.TypeCompute {
+		ResetVCLOnlyToDefaults(&plan.NestedModel)
+	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 
@@ -258,10 +275,19 @@ func (r *Resource) ImportState(ctx context.Context, req resource.ImportStateRequ
 		return
 	}
 
+	serviceType, err := r.providerData.ServiceTypeChecker.GetType(ctx, serviceID)
+	if err != nil {
+		resp.Diagnostics.AddError("Error determining service type", err.Error())
+		return
+	}
+
 	var state Model
 	state.Service = types.StringValue(serviceID)
 	state.Version = types.Int64Value(int64(version))
 	flatten(ctx, n, &state)
+	if serviceType == service.TypeCompute {
+		ResetVCLOnlyToDefaults(&state.NestedModel)
+	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }

--- a/internal/resources/loggingnewrelicotlp/schema.go
+++ b/internal/resources/loggingnewrelicotlp/schema.go
@@ -167,11 +167,14 @@ func vclOnlyAttributes() map[string]schema.Attribute {
 		"placement": schema.StringAttribute{
 			// Not Computed: unset and explicitly "none" are distinct states on the
 			// API (unset lets the API auto-place the logging call; "none" suppresses
-			// it entirely), and the API always resolves to exactly what was
-			// configured — never some other server-computed value — so there is
-			// nothing for Computed to add. Keeping it plain Optional means removing
-			// placement from config is a real, visible diff from Terraform core's own
-			// plan proposal, with no plan modifier required to force it.
+			// it entirely). Keeping it plain Optional means removing placement from
+			// config is a real, visible diff from Terraform core's own plan proposal,
+			// with no plan modifier required to force it.
+			//
+			// On a VCL service the API resolves this to exactly what was configured.
+			// Compute (wasm) services are the exception — the API forces "none" there
+			// regardless of what was sent, which can never match the planned null, so
+			// ResetVCLOnlyToDefaults discards it after apply for those services.
 			Optional: true,
 			Validators: []validator.String{
 				stringvalidator.OneOf("none"),

--- a/internal/resources/loggings3/flatten.go
+++ b/internal/resources/loggings3/flatten.go
@@ -61,6 +61,16 @@ func FlattenToNestedModel(s *fastly.S3) NestedModel {
 	return m
 }
 
+// ResetVCLOnlyToDefaults restores the VCL-only fields to their schema defaults
+// after a flatten. On a Compute service they are never sent, so the API's own
+// values are discarded rather than reported as a diff against the plan.
+func ResetVCLOnlyToDefaults(m *NestedModel) {
+	m.Format = types.StringValue(constants.LoggingS3DefaultFormat)
+	m.FormatVersion = types.Int64Value(DefaultFormatVersion)
+	m.Placement = types.StringNull()
+	m.ResponseCondition = types.StringValue(DefaultResponseCondition)
+}
+
 // FlattenToComputeNestedModel is FlattenToNestedModel for Compute services: it
 // carries over only the attributes ComputeNestedModel exposes.
 func FlattenToComputeNestedModel(s *fastly.S3) ComputeNestedModel {

--- a/internal/resources/loggings3/loggings3_test.go
+++ b/internal/resources/loggings3/loggings3_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	fastly "github.com/fastly/go-fastly/v17/fastly"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	fwdefaults "github.com/hashicorp/terraform-plugin-framework/resource/schema/defaults"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/stretchr/testify/assert"
@@ -939,4 +940,60 @@ func TestAuthenticationEnvDefault_DefaultObject(t *testing.T) {
 			types.StringValue("arn:aws:iam::123456789012:role/FastlyS3Access"),
 		), resp.PlanValue)
 	})
+}
+
+// TestResetVCLOnlyToDefaults covers the Compute read-back path. On a Compute
+// service the VCL-only fields are never sent, so the API reports its own
+// server-side values — notably placement forced to "none" on wasm services.
+// Adopting those breaks consistency-after-apply, so they must be reset to
+// exactly the values a plan produces.
+func TestResetVCLOnlyToDefaults(t *testing.T) {
+	m := FlattenToNestedModel(&fastly.S3{
+		Name:              new("test-s3"),
+		BucketName:        new("test-bucket"),
+		ProcessingRegion:  new("none"),
+		Format:            new("something-the-server-chose"),
+		FormatVersion:     new(1),
+		Placement:         new("none"),
+		ResponseCondition: new("some-condition"),
+	})
+
+	ResetVCLOnlyToDefaults(&m)
+
+	assert.Equal(t, constants.LoggingS3DefaultFormat, m.Format.ValueString())
+	assert.Equal(t, int64(DefaultFormatVersion), m.FormatVersion.ValueInt64())
+	assert.True(t, m.Placement.IsNull(), "placement must go back to unset, not the API's forced \"none\"")
+	assert.Equal(t, DefaultResponseCondition, m.ResponseCondition.ValueString())
+
+	// Non-VCL-only fields must survive untouched.
+	assert.Equal(t, "test-s3", m.Name.ValueString())
+	assert.Equal(t, "test-bucket", m.BucketName.ValueString())
+	assert.Equal(t, "none", m.ProcessingRegion.ValueString())
+}
+
+// TestResetVCLOnlyToDefaultsMatchesPlannedDefaults ties the reset to the schema
+// itself: the values it writes must equal the schema's declared defaults, or
+// Create/Update would still disagree with the plan.
+func TestResetVCLOnlyToDefaultsMatchesPlannedDefaults(t *testing.T) {
+	var m NestedModel
+	ResetVCLOnlyToDefaults(&m)
+
+	attrs := CommonAttributes()
+
+	var fResp fwdefaults.StringResponse
+	attrs["format"].(schema.StringAttribute).Default.DefaultString(context.Background(), fwdefaults.StringRequest{}, &fResp)
+	assert.Equal(t, fResp.PlanValue, m.Format, "format must match its schema default")
+
+	var fvResp fwdefaults.Int64Response
+	attrs["format_version"].(schema.Int64Attribute).Default.DefaultInt64(context.Background(), fwdefaults.Int64Request{}, &fvResp)
+	assert.Equal(t, fvResp.PlanValue, m.FormatVersion, "format_version must match its schema default")
+
+	var rcResp fwdefaults.StringResponse
+	attrs["response_condition"].(schema.StringAttribute).Default.DefaultString(context.Background(), fwdefaults.StringRequest{}, &rcResp)
+	assert.Equal(t, rcResp.PlanValue, m.ResponseCondition, "response_condition must match its schema default")
+
+	// placement is Optional-only with no Default, so an absent config value plans
+	// as null — the reset has to produce null, not "".
+	assert.Nil(t, attrs["placement"].(schema.StringAttribute).Default)
+	assert.True(t, m.Placement.IsNull())
 }

--- a/internal/resources/loggings3/resource.go
+++ b/internal/resources/loggings3/resource.go
@@ -104,6 +104,9 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 	desired := plan.NestedModel
 	flatten(ctx, s, &plan)
 	preserveGzipSentinel(&plan.NestedModel, desired)
+	if serviceType == service.TypeCompute {
+		ResetVCLOnlyToDefaults(&plan.NestedModel)
+	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 
@@ -138,9 +141,20 @@ func (r *Resource) Read(ctx context.Context, req resource.ReadRequest, resp *res
 		return
 	}
 
+	// The endpoint Get above succeeded, so the service exists and this is a cached
+	// lookup in all but the first call per service.
+	serviceType, err := r.providerData.ServiceTypeChecker.GetType(ctx, state.Service.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Error determining service type", err.Error())
+		return
+	}
+
 	prior := state.NestedModel
 	flatten(ctx, s, &state)
 	preserveGzipSentinel(&state.NestedModel, prior)
+	if serviceType == service.TypeCompute {
+		ResetVCLOnlyToDefaults(&state.NestedModel)
+	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
@@ -196,6 +210,9 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 	desired := plan.NestedModel
 	flatten(ctx, s, &plan)
 	preserveGzipSentinel(&plan.NestedModel, desired)
+	if serviceType == service.TypeCompute {
+		ResetVCLOnlyToDefaults(&plan.NestedModel)
+	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 
@@ -264,11 +281,20 @@ func (r *Resource) ImportState(ctx context.Context, req resource.ImportStateRequ
 		return
 	}
 
+	serviceType, err := r.providerData.ServiceTypeChecker.GetType(ctx, serviceID)
+	if err != nil {
+		resp.Diagnostics.AddError("Error determining service type", err.Error())
+		return
+	}
+
 	var state Model
 	state.Service = types.StringValue(serviceID)
 	state.Version = types.Int64Value(int64(version))
 	flatten(ctx, s, &state)
 	inferGzipSentinelOnImport(&state.commonModel)
+	if serviceType == service.TypeCompute {
+		ResetVCLOnlyToDefaults(&state.NestedModel)
+	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }

--- a/internal/resources/loggings3/schema.go
+++ b/internal/resources/loggings3/schema.go
@@ -426,11 +426,14 @@ func vclOnlyAttributes() map[string]schema.Attribute {
 		"placement": schema.StringAttribute{
 			// Not Computed: unset and explicitly "none" are distinct states on the
 			// API (unset lets the API auto-place the logging call; "none" suppresses
-			// it entirely), and the API always resolves to exactly what was
-			// configured — never some other server-computed value — so there is
-			// nothing for Computed to add. Keeping it plain Optional means removing
-			// placement from config is a real, visible diff from Terraform core's own
-			// plan proposal, with no plan modifier required to force it.
+			// it entirely). Keeping it plain Optional means removing placement from
+			// config is a real, visible diff from Terraform core's own plan proposal,
+			// with no plan modifier required to force it.
+			//
+			// On a VCL service the API resolves this to exactly what was configured.
+			// Compute (wasm) services are the exception — the API forces "none" there
+			// regardless of what was sent, which can never match the planned null, so
+			// ResetVCLOnlyToDefaults discards it after apply for those services.
 			Optional: true,
 			Validators: []validator.String{
 				stringvalidator.OneOf("none"),


### PR DESCRIPTION
### Change summary

This PR is a follow up to the issues identified in #1375 in the dual-model branch, after the `go-fastly` `placement` changes in release `17.0.0`.

_Issue:_

  `format`, `format_version`, `placement`, and `response_condition` are VCL-only and are never sent to a Compute
  (WASM) service, however - the schema's Computed defaults still populate them in `plan`. After a Terraform `apply`,
  the `flatten` function adopts whatever the API returned instead - a different default format. The placement
  attribute is set to `"none"` on WASM. Neither matches the planned value, so the apply fails with `Provider produced inconsistent result after apply`.

_Solution:_

 Added `ResetVCLOnlyToDefaults` to `logging_s3` and `logging_newrelic_otlp`, which is called after `flatten` in `Create`, `Update`, `Read`, and `ImportState` when the service type is Compute, mirroring the existing `ClearVCLOnlyCreateFields` on the write side. `Read` and `ImportState` now resolve the service type via `ServiceTypeChecker.GetType` (cached after the first call per service).

  VCL services are unaffected. `placement` remains plain `Optional` with no default, so removing it from
  configuration is still a visible diff and it can still be reset to `null`.


 All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/terraform-provider-fastly/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

* [x] Does your submission pass tests?
* [x] Post the output of your test runs

```
=== RUN   TestClearVCLOnlyCreateFields
--- PASS: TestClearVCLOnlyCreateFields (0.00s)
=== RUN   TestClearVCLOnlyUpdateFields
--- PASS: TestClearVCLOnlyUpdateFields (0.00s)
=== RUN   TestResetVCLOnlyToDefaults
--- PASS: TestResetVCLOnlyToDefaults (0.00s)
=== RUN   TestResetVCLOnlyToDefaultsMatchesPlannedDefaults
--- PASS: TestResetVCLOnlyToDefaultsMatchesPlannedDefaults (0.00s)
PASS
ok      github.com/fastly/terraform-provider-fastly/internal/resources/loggings3        0.003s
=== RUN   TestClearVCLOnlyCreateFields
--- PASS: TestClearVCLOnlyCreateFields (0.00s)
=== RUN   TestClearVCLOnlyUpdateFields
--- PASS: TestClearVCLOnlyUpdateFields (0.00s)
=== RUN   TestResetVCLOnlyToDefaults
--- PASS: TestResetVCLOnlyToDefaults (0.00s)
=== RUN   TestResetVCLOnlyToDefaultsMatchesPlannedDefaults
--- PASS: TestResetVCLOnlyToDefaultsMatchesPlannedDefaults (0.00s)
PASS
ok  
```

### Changes to Core Features:

* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?