### PR TITLE
[dual-provider] Ensure that logging `format` defaults doesn't drift from the API

### DIFF
--- a/internal/acceptance_tests/logging_newrelicotlp_test.go
+++ b/internal/acceptance_tests/logging_newrelicotlp_test.go
@@ -323,6 +323,76 @@ func TestAccFastlyServiceLoggingNewRelicOTLP_computeRejectsVCLOnlyFields(t *test
 	})
 }
 
+// TestAccFastlyServiceLoggingNewRelicOTLP_formatDefault catches upstream changes
+// to the format Fastly assigns when none is sent, which would leave
+// constants.LoggingNewRelicOTLPDefaultFormat stale. Compute is used because it's
+// the only path that omits format from the request - on VCL the schema default is
+// always sent, so the API just echoes our own constant back.
+func TestAccFastlyServiceLoggingNewRelicOTLP_formatDefault(t *testing.T) {
+	t.Parallel()
+	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	loggerName := fmt.Sprintf("newrelic-logger-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
+		CheckDestroy:             CheckServiceDestroy("fastly_service_compute"),
+		Steps: []resource.TestStep{
+			{
+				Config: ConfigLoggingNewRelicOTLPCompute(serviceName, loggerName),
+				Check: resource.ComposeTestCheckFunc(
+					CheckServiceExists("fastly_service_compute.test"),
+					CheckLoggingNewRelicOTLPFormatDefault("fastly_service_compute.test", loggerName, 1),
+				),
+			},
+		},
+	})
+}
+
+// CheckLoggingNewRelicOTLPFormatDefault fails if the format Fastly reports for a
+// logging endpoint differs from constants.LoggingNewRelicOTLPDefaultFormat. Reads
+// the API directly, since ResetVCLOnlyToDefaults writes the constant into state
+// without consulting the response. Only meaningful on an endpoint created without
+// a format in the request.
+func CheckLoggingNewRelicOTLPFormatDefault(serviceName, loggerName string, version int) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[serviceName]
+		if !ok {
+			return fmt.Errorf("service not found: %s", serviceName)
+		}
+
+		client, err := NewFastlyClient()
+		if err != nil {
+			return fmt.Errorf("error creating Fastly client: %w", err)
+		}
+
+		logger, err := client.GetNewRelicOTLP(context.Background(), &fastly.GetNewRelicOTLPInput{
+			ServiceID:      rs.Primary.ID,
+			ServiceVersion: version,
+			Name:           loggerName,
+		})
+		if err != nil {
+			return fmt.Errorf("error fetching New Relic OTLP logging endpoint from Fastly: %w", err)
+		}
+		if logger == nil {
+			return fmt.Errorf("New Relic OTLP logging endpoint %s not found in Fastly", loggerName)
+		}
+
+		if logger.Format == nil {
+			return fmt.Errorf("Fastly returned a null format for New Relic OTLP logging endpoint %s, expected its default format", loggerName)
+		}
+
+		if got := *logger.Format; got != constants.LoggingNewRelicOTLPDefaultFormat {
+			return fmt.Errorf(
+				"constants.LoggingNewRelicOTLPDefaultFormat no longer matches the format Fastly assigns by default\ngot from API: %q\nconstant:     %q",
+				got, constants.LoggingNewRelicOTLPDefaultFormat,
+			)
+		}
+
+		return nil
+	}
+}
+
 // TestAccFastlyServiceLoggingNewRelicOTLP_computeConsistentAfterApply covers the
 // whole plan -> API response -> flatten -> state path on a Compute service, which
 // the unit tests cannot reach. The VCL-only attributes are never sent for

--- a/internal/acceptance_tests/logging_s3_test.go
+++ b/internal/acceptance_tests/logging_s3_test.go
@@ -504,6 +504,77 @@ func TestAccFastlyServiceLoggingS3_computeRejectsVCLOnlyFields(t *testing.T) {
 	})
 }
 
+// TestAccFastlyServiceLoggingS3_formatDefault catches upstream changes to the
+// format Fastly assigns when none is sent, which would leave
+// constants.LoggingS3DefaultFormat stale. Compute is used because it's the only
+// path that omits format from the request - on VCL the schema default is always
+// sent, so the API just echoes our own constant back.
+func TestAccFastlyServiceLoggingS3_formatDefault(t *testing.T) {
+	t.Parallel()
+	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	loggerName := fmt.Sprintf("s3-logger-%s", acctest.RandString(10))
+	bucketName := fmt.Sprintf("tf-test-bucket-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
+		CheckDestroy:             CheckServiceDestroy("fastly_service_compute"),
+		Steps: []resource.TestStep{
+			{
+				Config: ConfigLoggingS3Compute(serviceName, loggerName, bucketName),
+				Check: resource.ComposeTestCheckFunc(
+					CheckServiceExists("fastly_service_compute.test"),
+					CheckLoggingS3FormatDefault("fastly_service_compute.test", loggerName, 1),
+				),
+			},
+		},
+	})
+}
+
+// CheckLoggingS3FormatDefault fails if the format Fastly reports for a logging
+// endpoint differs from constants.LoggingS3DefaultFormat. Reads the API directly,
+// since ResetVCLOnlyToDefaults writes the constant into state without consulting
+// the response. Only meaningful on an endpoint created without a format in the
+// request.
+func CheckLoggingS3FormatDefault(serviceName, loggerName string, version int) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[serviceName]
+		if !ok {
+			return fmt.Errorf("service not found: %s", serviceName)
+		}
+
+		client, err := NewFastlyClient()
+		if err != nil {
+			return fmt.Errorf("error creating Fastly client: %w", err)
+		}
+
+		logger, err := client.GetS3(context.Background(), &fastly.GetS3Input{
+			ServiceID:      rs.Primary.ID,
+			ServiceVersion: version,
+			Name:           loggerName,
+		})
+		if err != nil {
+			return fmt.Errorf("error fetching S3 logging endpoint from Fastly: %w", err)
+		}
+		if logger == nil {
+			return fmt.Errorf("S3 logging endpoint %s not found in Fastly", loggerName)
+		}
+
+		if logger.Format == nil {
+			return fmt.Errorf("Fastly returned a null format for S3 logging endpoint %s, expected its default format", loggerName)
+		}
+
+		if got := *logger.Format; got != constants.LoggingS3DefaultFormat {
+			return fmt.Errorf(
+				"constants.LoggingS3DefaultFormat no longer matches the format Fastly assigns by default\ngot from API: %q\nconstant:     %q",
+				got, constants.LoggingS3DefaultFormat,
+			)
+		}
+
+		return nil
+	}
+}
+
 // TestAccFastlyServiceLoggingS3_computeConsistentAfterApply covers the whole
 // plan -> API response -> flatten -> state path on a Compute service, which the
 // unit tests cannot reach. The VCL-only attributes are never sent for Compute,


### PR DESCRIPTION
### Change summary

This PR is a follow up to the findings in https://github.com/fastly/terraform-provider-fastly/pull/1375 (https://github.com/fastly/terraform-provider-fastly/pull/1375#discussion_r3715514924) - where we identified that the API defaults for the `logging_datadog` resource `format` attribute have been updated on the API side, resulted in stale hard coded defaults in Terraform `constants.go`.  We are implementing tests to continually check for API drifts around this default to ensure that we keep our constants references up to date. 

_This change is only for the dual-model provider._

 All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/terraform-provider-fastly/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

* [x] Does your submission pass tests?
* [x] Post the output of your test runs

```
=== RUN   TestAccFastlyServiceLoggingNewRelicOTLP_formatDefault
=== PAUSE TestAccFastlyServiceLoggingNewRelicOTLP_formatDefault
=== RUN   TestAccFastlyServiceLoggingS3_formatDefault
=== PAUSE TestAccFastlyServiceLoggingS3_formatDefault
=== CONT  TestAccFastlyServiceLoggingNewRelicOTLP_formatDefault
=== CONT  TestAccFastlyServiceLoggingS3_formatDefault
--- PASS: TestAccFastlyServiceLoggingS3_formatDefault (9.05s)
--- PASS: TestAccFastlyServiceLoggingNewRelicOTLP_formatDefault (9.69s)
PASS
ok  
```

### Changes to Core Features:

* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?