### PR TITLE
[CDTOOL-1541] Add regular VCL snippet support

### DIFF
--- a/docs/resources/service_cdn_auto.md
+++ b/docs/resources/service_cdn_auto.md
@@ -32,6 +32,7 @@ Automatic-lifecycle Fastly CDN service resource with nested versioned configurat
 - `logging_newrelicotlp` (Block List) New Relic OTLP logging endpoints attached to this service. (see [below for nested schema](#nestedblock--logging_newrelicotlp))
 - `logging_s3` (Block List) S3 logging endpoints attached to this service. (see [below for nested schema](#nestedblock--logging_s3))
 - `reuse` (Boolean) Deactivate the active version but do not delete the service, allowing it to be reused/imported elsewhere. Default `false`.
+- `snippet` (Block List) Regular VCL snippets attached to this service version. (see [below for nested schema](#nestedblock--snippet))
 - `vcl` (Block List) Custom VCL files attached to this service. (see [below for nested schema](#nestedblock--vcl))
 
 ### Read-Only
@@ -250,6 +251,20 @@ Optional:
 - `iam_role` (String) The Amazon Resource Name (ARN) for the IAM role granting Fastly access to S3. Not required if `access_key` and `secret_key` are provided. Can be set via the `FASTLY_S3_IAM_ROLE` environment variable.
 - `secret_key` (String, Sensitive) The secret key for your S3 account. Not required if `iam_role` is provided. Can be set via the `FASTLY_S3_SECRET_KEY` environment variable.
 
+
+
+<a id="nestedblock--snippet"></a>
+### Nested Schema for `snippet`
+
+Required:
+
+- `content` (String) The VCL code that specifies exactly what the snippet does. Can be configured with a quoted string, HEREDOC, file("${path.module}/snippet.vcl"), or templatefile(...).
+- `name` (String) A name that is unique across regular and dynamic VCL snippet configuration blocks. Changing this attribute will delete and recreate the snippet.
+- `type` (String) The location in generated VCL where the snippet should be placed. Must be one of `init`, `recv`, `hash`, `hit`, `miss`, `pass`, `fetch`, `error`, `deliver`, `log`, or `none`.
+
+Optional:
+
+- `priority` (Number) Priority determines execution order. Lower numbers execute first. Default `100`.
 
 
 <a id="nestedblock--vcl"></a>

--- a/docs/resources/service_vcl_snippet.md
+++ b/docs/resources/service_vcl_snippet.md
@@ -1,0 +1,91 @@
+---
+page_title: "fastly_service_vcl_snippet Resource - fastly"
+subcategory: ""
+description: |-
+  Fastly regular VCL snippet resource. Writes directly to the specified writable CDN service version.
+---
+
+# fastly_service_vcl_snippet (Resource)
+
+Fastly regular VCL snippet resource. Writes directly to the specified writable CDN service version.
+
+This resource is part of the explicit/default first-class resource family. It
+manages a regular, versioned VCL snippet on the configured CDN service version.
+It does not clone, activate, or stage service versions.
+
+Use this resource when you want to manage regular VCL snippets explicitly
+against a known writable service version. For automatic service version cloning,
+validation, and activation, use the nested `snippet` block on
+`fastly_service_cdn_auto`.
+
+Dynamic VCL snippets are not managed by this resource. Dynamic snippets have
+different lifecycle behavior because their metadata is versioned but their
+content is versionless and can be updated separately.
+
+## Example Usage
+
+```terraform
+resource "fastly_service_cdn" "example" {
+  name = "example"
+
+  domain {
+    name = "www.example.com"
+  }
+
+  backend {
+    name    = "origin"
+    address = "origin.example.com"
+    port    = 443
+    use_ssl = true
+  }
+
+  force_destroy = true
+}
+
+resource "fastly_service_vcl_snippet" "security_headers" {
+  service_id = fastly_service_cdn.example.id
+  version    = 1
+  name       = "security_headers"
+  type       = "deliver"
+  priority   = 100
+  content    = file("${path.module}/security_headers.vcl")
+}
+```
+
+## Schema
+
+### Required
+
+- `content` (String) The VCL code that specifies exactly what the snippet does. Can be configured with a quoted string, HEREDOC, file("${path.module}/snippet.vcl"), or templatefile(...).
+- `name` (String) A name that is unique across regular and dynamic VCL snippet configuration blocks. Changing this attribute will delete and recreate the snippet.
+- `service_id` (String) Fastly service ID.
+- `type` (String) The location in generated VCL where the snippet should be placed. Must be one of `init`, `recv`, `hash`, `hit`, `miss`, `pass`, `fetch`, `error`, `deliver`, `log`, or `none`.
+- `version` (Number) Writable Fastly service version to modify.
+
+### Optional
+
+- `priority` (Number) Priority determines execution order. Lower numbers execute first. Default `100`.
+
+### Read-Only
+
+- `id` (String) Terraform resource identifier.
+
+## Import
+
+Import requires the service ID, service version, and VCL snippet name:
+
+```shell
+terraform import fastly_service_vcl_snippet.security_headers SERVICE_ID/VERSION/SNIPPET_NAME
+```
+
+Example:
+
+```shell
+terraform import fastly_service_vcl_snippet.security_headers SU1Z0isxPaozGVKXdv0eY/3/security_headers
+```
+
+## Version lifecycle
+
+This resource does not clone, activate, or stage service versions. Use explicit
+service-version lifecycle actions to clone, validate, stage, or activate a
+service version.

--- a/internal/acceptance_tests/blocks/snippet_explicit.tf
+++ b/internal/acceptance_tests/blocks/snippet_explicit.tf
@@ -1,0 +1,8 @@
+resource "fastly_service_vcl_snippet" "test" {
+  service_id = fastly_service_cdn.test.id
+  version    = 1
+  name       = "{{.SNIPPET_NAME}}"
+  type       = "{{.SNIPPET_TYPE}}"
+  priority   = {{.SNIPPET_PRIORITY}}
+  content    = file("{{.SNIPPET_FILE_PATH}}")
+}

--- a/internal/acceptance_tests/blocks/snippet_explicit_inline.tf
+++ b/internal/acceptance_tests/blocks/snippet_explicit_inline.tf
@@ -1,0 +1,8 @@
+resource "fastly_service_vcl_snippet" "test" {
+  service_id = fastly_service_cdn.test.id
+  version    = 1
+  name       = "{{.SNIPPET_NAME}}"
+  type       = "{{.SNIPPET_TYPE}}"
+  priority   = {{.SNIPPET_PRIORITY}}
+  content    = {{.SNIPPET_INLINE_CONTENT}}
+}

--- a/internal/acceptance_tests/blocks/snippet_nested_duplicate_names.tf
+++ b/internal/acceptance_tests/blocks/snippet_nested_duplicate_names.tf
@@ -1,0 +1,13 @@
+snippet {
+  name     = "duplicate"
+  type     = "recv"
+  priority = 100
+  content  = file("{{.SNIPPET_FILE_PATH_ONE}}")
+}
+
+snippet {
+  name     = "duplicate"
+  type     = "deliver"
+  priority = 50
+  content  = file("{{.SNIPPET_FILE_PATH_TWO}}")
+}

--- a/internal/acceptance_tests/blocks/snippet_nested_heredoc.tf
+++ b/internal/acceptance_tests/blocks/snippet_nested_heredoc.tf
@@ -1,0 +1,8 @@
+snippet {
+  name     = "{{.SNIPPET_NAME}}"
+  type     = "{{.SNIPPET_TYPE}}"
+  priority = {{.SNIPPET_PRIORITY}}
+  content  = <<SNIPPET
+{{.SNIPPET_HEREDOC_CONTENT}}
+SNIPPET
+}

--- a/internal/acceptance_tests/blocks/snippet_nested_inline.tf
+++ b/internal/acceptance_tests/blocks/snippet_nested_inline.tf
@@ -1,0 +1,6 @@
+snippet {
+  name     = "{{.SNIPPET_NAME}}"
+  type     = "{{.SNIPPET_TYPE}}"
+  priority = {{.SNIPPET_PRIORITY}}
+  content  = {{.SNIPPET_INLINE_CONTENT}}
+}

--- a/internal/acceptance_tests/blocks/snippet_nested_invalid_type.tf
+++ b/internal/acceptance_tests/blocks/snippet_nested_invalid_type.tf
@@ -1,0 +1,6 @@
+snippet {
+  name     = "invalid"
+  type     = "invalid"
+  priority = 100
+  content  = file("{{.SNIPPET_FILE_PATH}}")
+}

--- a/internal/acceptance_tests/blocks/snippet_nested_multiple.tf
+++ b/internal/acceptance_tests/blocks/snippet_nested_multiple.tf
@@ -1,0 +1,13 @@
+snippet {
+  name     = "{{.SNIPPET_NAME_ONE}}"
+  type     = "recv"
+  priority = 100
+  content  = file("{{.SNIPPET_FILE_PATH_ONE}}")
+}
+
+snippet {
+  name     = "{{.SNIPPET_NAME_TWO}}"
+  type     = "deliver"
+  priority = 50
+  content  = file("{{.SNIPPET_FILE_PATH_TWO}}")
+}

--- a/internal/acceptance_tests/blocks/snippet_nested_single.tf
+++ b/internal/acceptance_tests/blocks/snippet_nested_single.tf
@@ -1,0 +1,6 @@
+snippet {
+  name     = "{{.SNIPPET_NAME}}"
+  type     = "{{.SNIPPET_TYPE}}"
+  priority = {{.SNIPPET_PRIORITY}}
+  content  = file("{{.SNIPPET_FILE_PATH}}")
+}

--- a/internal/acceptance_tests/snippet_test.go
+++ b/internal/acceptance_tests/snippet_test.go
@@ -1,0 +1,337 @@
+package acceptancetests
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"testing"
+
+	"github.com/fastly/go-fastly/v17/fastly"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+func TestAccFastlyServiceVCLSnippet_basicAndUpdate(t *testing.T) {
+	t.Parallel()
+
+	serviceName := fmt.Sprintf("tf-test-snippet-%s", acctest.RandString(10))
+	snippetName := fmt.Sprintf("snippet_%s", acctest.RandString(10))
+	contentOne := snippetBoilerplate("one")
+	contentTwo := snippetBoilerplate("two")
+	snippetFileOne := writeSnippetFile(t, "explicit-one.vcl", contentOne)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
+		CheckDestroy:             CheckServiceDestroy("fastly_service_cdn"),
+		Steps: []resource.TestStep{
+			{
+				Config: ConfigServiceVCLSnippetWithFile(serviceName, snippetName, "deliver", 100, snippetFileOne),
+				Check: resource.ComposeTestCheckFunc(
+					CheckServiceExists("fastly_service_cdn.test"),
+					CheckSnippetExistsInFastly("fastly_service_cdn.test", snippetName, 1, contentOne),
+					resource.TestCheckResourceAttr("fastly_service_vcl_snippet.test", "name", snippetName),
+					resource.TestCheckResourceAttr("fastly_service_vcl_snippet.test", "type", "deliver"),
+					resource.TestCheckResourceAttr("fastly_service_vcl_snippet.test", "priority", "100"),
+					resource.TestCheckResourceAttr("fastly_service_vcl_snippet.test", "version", "1"),
+					resource.TestCheckResourceAttrSet("fastly_service_vcl_snippet.test", "service_id"),
+					resource.TestCheckResourceAttrSet("fastly_service_vcl_snippet.test", "id"),
+					resource.TestCheckResourceAttr("fastly_service_vcl_snippet.test", "content", contentOne),
+				),
+			},
+			{
+				Config: ConfigServiceVCLSnippetInline(serviceName, snippetName, "deliver", 50, contentTwo),
+				Check: resource.ComposeTestCheckFunc(
+					CheckServiceExists("fastly_service_cdn.test"),
+					CheckSnippetExistsInFastly("fastly_service_cdn.test", snippetName, 1, contentTwo),
+					resource.TestCheckResourceAttr("fastly_service_vcl_snippet.test", "name", snippetName),
+					resource.TestCheckResourceAttr("fastly_service_vcl_snippet.test", "type", "deliver"),
+					resource.TestCheckResourceAttr("fastly_service_vcl_snippet.test", "priority", "50"),
+					resource.TestCheckResourceAttr("fastly_service_vcl_snippet.test", "content", contentTwo),
+				),
+			},
+		},
+	})
+}
+
+func TestAccFastlyServiceVCLSnippet_import(t *testing.T) {
+	t.Parallel()
+
+	serviceName := fmt.Sprintf("tf-test-snippet-%s", acctest.RandString(10))
+	snippetName := fmt.Sprintf("snippet_%s", acctest.RandString(10))
+	content := snippetBoilerplate("import")
+	snippetFile := writeSnippetFile(t, "explicit-import.vcl", content)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
+		CheckDestroy:             CheckServiceDestroy("fastly_service_cdn"),
+		Steps: []resource.TestStep{
+			{
+				Config: ConfigServiceVCLSnippetWithFile(serviceName, snippetName, "deliver", 100, snippetFile),
+				Check: resource.ComposeTestCheckFunc(
+					CheckServiceExists("fastly_service_cdn.test"),
+					CheckSnippetExistsInFastly("fastly_service_cdn.test", snippetName, 1, content),
+				),
+			},
+			{
+				ResourceName:      "fastly_service_vcl_snippet.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: importSnippetID("fastly_service_vcl_snippet.test"),
+			},
+		},
+	})
+}
+
+func TestAccFastlyServiceCDNAuto_withSnippet(t *testing.T) {
+	t.Parallel()
+
+	serviceName := fmt.Sprintf("tf-test-snippet-auto-%s", acctest.RandString(10))
+	domainName := fmt.Sprintf("%s.example.com", acctest.RandString(10))
+	backendName := fmt.Sprintf("backend-%s", acctest.RandString(10))
+	snippetName := fmt.Sprintf("snippet_%s", acctest.RandString(10))
+	content := snippetBoilerplate("one")
+	snippetFile := writeSnippetFile(t, "auto-one.vcl", content)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
+		CheckDestroy:             CheckServiceDestroy("fastly_service_cdn_auto"),
+		Steps: []resource.TestStep{
+			{
+				Config: ConfigCDNAutoWithSnippetFile(serviceName, domainName, backendName, snippetName, "deliver", 100, snippetFile),
+				Check: resource.ComposeTestCheckFunc(
+					CheckServiceExists("fastly_service_cdn_auto.test"),
+					CheckSnippetExistsInFastlyAtActiveVersion("fastly_service_cdn_auto.test", snippetName, content),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "domain.#", "1"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "backend.#", "1"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "snippet.#", "1"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "snippet.0.name", snippetName),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "snippet.0.type", "deliver"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "snippet.0.priority", "100"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "snippet.0.content", content),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "active_version", "1"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "managed_version", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccFastlyServiceCDNAuto_withSnippetContentUpdate(t *testing.T) {
+	t.Parallel()
+
+	serviceName := fmt.Sprintf("tf-test-snippet-auto-%s", acctest.RandString(10))
+	domainName := fmt.Sprintf("%s.example.com", acctest.RandString(10))
+	backendName := fmt.Sprintf("backend-%s", acctest.RandString(10))
+	snippetName := fmt.Sprintf("snippet_%s", acctest.RandString(10))
+	contentOne := snippetBoilerplate("one")
+	contentTwo := snippetBoilerplate("two")
+	snippetFileOne := writeSnippetFile(t, "auto-one.vcl", contentOne)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
+		CheckDestroy:             CheckServiceDestroy("fastly_service_cdn_auto"),
+		Steps: []resource.TestStep{
+			{
+				Config: ConfigCDNAutoWithSnippetFile(serviceName, domainName, backendName, snippetName, "deliver", 100, snippetFileOne),
+				Check: resource.ComposeTestCheckFunc(
+					CheckServiceExists("fastly_service_cdn_auto.test"),
+					CheckSnippetExistsInFastlyAtActiveVersion("fastly_service_cdn_auto.test", snippetName, contentOne),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "snippet.#", "1"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "snippet.0.content", contentOne),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "active_version", "1"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "managed_version", "1"),
+				),
+			},
+			{
+				Config: ConfigCDNAutoWithSnippetInline(serviceName, domainName, backendName, snippetName, "deliver", 100, contentTwo),
+				Check: resource.ComposeTestCheckFunc(
+					CheckServiceExists("fastly_service_cdn_auto.test"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "active_version", "2"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "managed_version", "2"),
+					CheckSnippetExistsInFastlyAtActiveVersion("fastly_service_cdn_auto.test", snippetName, contentTwo),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "snippet.#", "1"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "snippet.0.name", snippetName),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "snippet.0.type", "deliver"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "snippet.0.priority", "100"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "snippet.0.content", contentTwo),
+				),
+			},
+		},
+	})
+}
+
+func TestAccFastlyServiceCDNAuto_withMultipleSnippets(t *testing.T) {
+	t.Parallel()
+
+	serviceName := fmt.Sprintf("tf-test-snippet-auto-%s", acctest.RandString(10))
+	domainName := fmt.Sprintf("%s.example.com", acctest.RandString(10))
+	backendName := fmt.Sprintf("backend-%s", acctest.RandString(10))
+	snippetNameOne := fmt.Sprintf("recv_%s", acctest.RandString(10))
+	snippetNameTwo := fmt.Sprintf("deliver_%s", acctest.RandString(10))
+	contentOne := `set req.http.X-Terraform-Snippet = "recv";`
+	contentTwo := `set resp.http.X-Terraform-Snippet = "deliver";`
+	snippetFileOne := writeSnippetFile(t, "multi-one.vcl", contentOne)
+	snippetFileTwo := writeSnippetFile(t, "multi-two.vcl", contentTwo)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
+		CheckDestroy:             CheckServiceDestroy("fastly_service_cdn_auto"),
+		Steps: []resource.TestStep{
+			{
+				Config: ConfigCDNAutoWithMultipleSnippets(serviceName, domainName, backendName, snippetNameOne, snippetNameTwo, snippetFileOne, snippetFileTwo),
+				Check: resource.ComposeTestCheckFunc(
+					CheckServiceExists("fastly_service_cdn_auto.test"),
+					CheckSnippetExistsInFastlyAtActiveVersion("fastly_service_cdn_auto.test", snippetNameOne, contentOne),
+					CheckSnippetExistsInFastlyAtActiveVersion("fastly_service_cdn_auto.test", snippetNameTwo, contentTwo),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "snippet.#", "2"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "active_version", "1"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "managed_version", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccFastlyServiceCDNAuto_withDuplicateSnippetNames(t *testing.T) {
+	t.Parallel()
+
+	serviceName := fmt.Sprintf("tf-test-snippet-auto-%s", acctest.RandString(10))
+	domainName := fmt.Sprintf("%s.example.com", acctest.RandString(10))
+	backendName := fmt.Sprintf("backend-%s", acctest.RandString(10))
+	fileOne := writeSnippetFile(t, "duplicate-one.vcl", snippetBoilerplate("duplicate-one"))
+	fileTwo := writeSnippetFile(t, "duplicate-two.vcl", snippetBoilerplate("duplicate-two"))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
+		CheckDestroy:             CheckServiceDestroy("fastly_service_cdn_auto"),
+		Steps: []resource.TestStep{
+			{
+				Config:      ConfigCDNAutoWithDuplicateSnippets(serviceName, domainName, backendName, fileOne, fileTwo),
+				ExpectError: regexp.MustCompile("multiple snippets with the same name"),
+			},
+		},
+	})
+}
+
+func TestAccFastlyServiceCDNAuto_withInvalidSnippetType(t *testing.T) {
+	t.Parallel()
+
+	serviceName := fmt.Sprintf("tf-test-snippet-auto-%s", acctest.RandString(10))
+	domainName := fmt.Sprintf("%s.example.com", acctest.RandString(10))
+	backendName := fmt.Sprintf("backend-%s", acctest.RandString(10))
+	filePath := writeSnippetFile(t, "invalid-type.vcl", snippetBoilerplate("invalid-type"))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
+		CheckDestroy:             CheckServiceDestroy("fastly_service_cdn_auto"),
+		Steps: []resource.TestStep{
+			{
+				Config:      ConfigCDNAutoWithInvalidSnippetType(serviceName, domainName, backendName, filePath),
+				ExpectError: regexp.MustCompile(`Attribute snippet\[0\]\.type value must be one of`),
+			},
+		},
+	})
+}
+
+func CheckSnippetExistsInFastlyAtActiveVersion(resourceName, snippetName string, expectedContent string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceName)
+		}
+
+		version, err := strconv.Atoi(rs.Primary.Attributes["active_version"])
+		if err != nil {
+			return fmt.Errorf("error parsing active_version for %s: %w", resourceName, err)
+		}
+
+		return checkSnippetExistsInFastly(rs.Primary.ID, snippetName, version, expectedContent)
+	}
+}
+
+func CheckSnippetExistsInFastly(resourceName, snippetName string, version int, expectedContent string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceName)
+		}
+
+		return checkSnippetExistsInFastly(rs.Primary.ID, snippetName, version, expectedContent)
+	}
+}
+
+func checkSnippetExistsInFastly(serviceID, snippetName string, version int, expectedContent string) error {
+	client, err := NewFastlyClient()
+	if err != nil {
+		return fmt.Errorf("error creating Fastly client: %w", err)
+	}
+
+	snippet, err := client.GetSnippet(context.Background(), &fastly.GetSnippetInput{
+		ServiceID:      serviceID,
+		ServiceVersion: version,
+		Name:           snippetName,
+	})
+	if err != nil {
+		return fmt.Errorf("error fetching VCL snippet %q in service %s version %d: %w", snippetName, serviceID, version, err)
+	}
+
+	if fastly.ToValue(snippet.Dynamic) != 0 {
+		return fmt.Errorf("snippet %q is dynamic; expected regular snippet", snippetName)
+	}
+
+	if fastly.ToValue(snippet.Content) != expectedContent {
+		return fmt.Errorf("snippet %q content mismatch in service %s version %d:\nexpected: %q\nactual:   %q", snippetName, serviceID, version, expectedContent, fastly.ToValue(snippet.Content))
+	}
+
+	return nil
+}
+
+func importSnippetID(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("not found: %s", resourceName)
+		}
+
+		serviceID := rs.Primary.Attributes["service_id"]
+		version := rs.Primary.Attributes["version"]
+		name := rs.Primary.Attributes["name"]
+
+		if serviceID == "" || version == "" || name == "" {
+			return "", fmt.Errorf("missing import identity fields for %s: service_id=%q version=%q name=%q", resourceName, serviceID, version, name)
+		}
+
+		return fmt.Sprintf("%s/%s/%s", serviceID, version, name), nil
+	}
+}
+
+func snippetBoilerplate(label string) string {
+	return fmt.Sprintf(`set resp.http.X-Terraform-Snippet-Test = %q;`, label)
+}
+
+func writeSnippetFile(t *testing.T, name, content string) string {
+	t.Helper()
+
+	dir := filepath.Join(t.TempDir(), "snippets")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("error creating snippet temp dir: %s", err)
+	}
+
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("error writing snippet fixture: %s", err)
+	}
+
+	return path
+}

--- a/internal/acceptance_tests/test_helpers.go
+++ b/internal/acceptance_tests/test_helpers.go
@@ -2670,3 +2670,131 @@ func ConfigProductEnablementServiceIDReplace(serviceName1, domainName1, serviceN
 
 	return joinBlocks(first, second, productEnablementBlock("domain_inspector", target, nil))
 }
+
+// ConfigServiceVCLSnippetWithFile returns a CDN service with one explicit regular VCL snippet
+// whose content is loaded through Terraform's file() function.
+func ConfigServiceVCLSnippetWithFile(serviceName, snippetName, snippetType string, priority int, snippetFilePath string) string {
+	return BuildConfig(
+		ServiceCDN,
+		map[string]string{
+			"SERVICE_NAME":      serviceName,
+			"SERVICE_COMMENT":   "VCL snippet acceptance test",
+			"SNIPPET_NAME":      snippetName,
+			"SNIPPET_TYPE":      snippetType,
+			"SNIPPET_PRIORITY":  strconv.Itoa(priority),
+			"SNIPPET_FILE_PATH": filepath.ToSlash(snippetFilePath),
+		},
+		"internal/acceptance_tests/blocks/snippet_explicit.tf",
+	)
+}
+
+// ConfigServiceVCLSnippetInline returns an explicit regular VCL snippet whose content
+// is defined inline in HCL.
+func ConfigServiceVCLSnippetInline(serviceName, snippetName, snippetType string, priority int, content string) string {
+	return BuildConfig(
+		ServiceCDN,
+		map[string]string{
+			"SERVICE_NAME":           serviceName,
+			"SERVICE_COMMENT":        "VCL snippet acceptance test",
+			"SNIPPET_NAME":           snippetName,
+			"SNIPPET_TYPE":           snippetType,
+			"SNIPPET_PRIORITY":       strconv.Itoa(priority),
+			"SNIPPET_INLINE_CONTENT": strconv.Quote(content),
+		},
+		"internal/acceptance_tests/blocks/snippet_explicit_inline.tf",
+	)
+}
+
+// ConfigCDNAutoWithSnippetFile returns a CDN auto service with domain, backend, and one
+// regular VCL snippet whose content is loaded through Terraform's file() function.
+func ConfigCDNAutoWithSnippetFile(serviceName, domainName, backendName, snippetName, snippetType string, priority int, snippetFilePath string) string {
+	return BuildConfig(
+		ServiceCDNAuto,
+		map[string]string{
+			"SERVICE_NAME":      serviceName,
+			"DOMAIN_NAME":       domainName,
+			"BACKEND_NAME":      backendName,
+			"SNIPPET_NAME":      snippetName,
+			"SNIPPET_TYPE":      snippetType,
+			"SNIPPET_PRIORITY":  strconv.Itoa(priority),
+			"SNIPPET_FILE_PATH": filepath.ToSlash(snippetFilePath),
+		},
+		"internal/acceptance_tests/blocks/domain_single.tf",
+		"internal/acceptance_tests/blocks/backend_single.tf",
+		"internal/acceptance_tests/blocks/snippet_nested_single.tf",
+	)
+}
+
+// ConfigCDNAutoWithSnippetInline returns a CDN auto service with domain, backend, and one
+// regular VCL snippet whose content is defined inline in HCL.
+func ConfigCDNAutoWithSnippetInline(serviceName, domainName, backendName, snippetName, snippetType string, priority int, content string) string {
+	return BuildConfig(
+		ServiceCDNAuto,
+		map[string]string{
+			"SERVICE_NAME":           serviceName,
+			"DOMAIN_NAME":            domainName,
+			"BACKEND_NAME":           backendName,
+			"SNIPPET_NAME":           snippetName,
+			"SNIPPET_TYPE":           snippetType,
+			"SNIPPET_PRIORITY":       strconv.Itoa(priority),
+			"SNIPPET_INLINE_CONTENT": strconv.Quote(content),
+		},
+		"internal/acceptance_tests/blocks/domain_single.tf",
+		"internal/acceptance_tests/blocks/backend_single.tf",
+		"internal/acceptance_tests/blocks/snippet_nested_inline.tf",
+	)
+}
+
+// ConfigCDNAutoWithMultipleSnippets returns a CDN auto service with two regular VCL snippets.
+func ConfigCDNAutoWithMultipleSnippets(serviceName, domainName, backendName, snippetNameOne, snippetNameTwo, snippetFilePathOne, snippetFilePathTwo string) string {
+	return BuildConfig(
+		ServiceCDNAuto,
+		map[string]string{
+			"SERVICE_NAME":          serviceName,
+			"DOMAIN_NAME":           domainName,
+			"BACKEND_NAME":          backendName,
+			"SNIPPET_NAME_ONE":      snippetNameOne,
+			"SNIPPET_NAME_TWO":      snippetNameTwo,
+			"SNIPPET_FILE_PATH_ONE": filepath.ToSlash(snippetFilePathOne),
+			"SNIPPET_FILE_PATH_TWO": filepath.ToSlash(snippetFilePathTwo),
+		},
+		"internal/acceptance_tests/blocks/domain_single.tf",
+		"internal/acceptance_tests/blocks/backend_single.tf",
+		"internal/acceptance_tests/blocks/snippet_nested_multiple.tf",
+	)
+}
+
+// ConfigCDNAutoWithDuplicateSnippets returns a CDN auto service with duplicate regular
+// VCL snippet names, exercising provider-side validation.
+func ConfigCDNAutoWithDuplicateSnippets(serviceName, domainName, backendName, snippetFilePathOne, snippetFilePathTwo string) string {
+	return BuildConfig(
+		ServiceCDNAuto,
+		map[string]string{
+			"SERVICE_NAME":          serviceName,
+			"DOMAIN_NAME":           domainName,
+			"BACKEND_NAME":          backendName,
+			"SNIPPET_FILE_PATH_ONE": filepath.ToSlash(snippetFilePathOne),
+			"SNIPPET_FILE_PATH_TWO": filepath.ToSlash(snippetFilePathTwo),
+		},
+		"internal/acceptance_tests/blocks/domain_single.tf",
+		"internal/acceptance_tests/blocks/backend_single.tf",
+		"internal/acceptance_tests/blocks/snippet_nested_duplicate_names.tf",
+	)
+}
+
+// ConfigCDNAutoWithInvalidSnippetType returns a CDN auto service with an invalid regular
+// VCL snippet type, exercising schema validation.
+func ConfigCDNAutoWithInvalidSnippetType(serviceName, domainName, backendName, snippetFilePath string) string {
+	return BuildConfig(
+		ServiceCDNAuto,
+		map[string]string{
+			"SERVICE_NAME":      serviceName,
+			"DOMAIN_NAME":       domainName,
+			"BACKEND_NAME":      backendName,
+			"SNIPPET_FILE_PATH": filepath.ToSlash(snippetFilePath),
+		},
+		"internal/acceptance_tests/blocks/domain_single.tf",
+		"internal/acceptance_tests/blocks/backend_single.tf",
+		"internal/acceptance_tests/blocks/snippet_nested_invalid_type.tf",
+	)
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -39,6 +39,7 @@ import (
 	"github.com/fastly/terraform-provider-fastly/internal/resources/servicecdnauto"
 	"github.com/fastly/terraform-provider-fastly/internal/resources/servicecompute"
 	"github.com/fastly/terraform-provider-fastly/internal/resources/servicecomputeauto"
+	"github.com/fastly/terraform-provider-fastly/internal/resources/snippet"
 	"github.com/fastly/terraform-provider-fastly/internal/resources/vcl"
 	"github.com/fastly/terraform-provider-fastly/internal/version"
 )
@@ -118,6 +119,7 @@ func (p *fastlyProvider) Resources(_ context.Context) []func() resource.Resource
 		loggings3.NewResource,
 		kvstore.NewResource,
 		vcl.NewResource,
+		snippet.NewResource,
 		productenablement.NewFanoutResource,
 		productenablement.NewBrotliCompressionResource,
 		productenablement.NewImageOptimizerResource,

--- a/internal/resources/servicecdnauto/resource.go
+++ b/internal/resources/servicecdnauto/resource.go
@@ -15,6 +15,7 @@ import (
 	"github.com/fastly/terraform-provider-fastly/internal/resources/loggingdatadog"
 	"github.com/fastly/terraform-provider-fastly/internal/resources/loggingnewrelicotlp"
 	"github.com/fastly/terraform-provider-fastly/internal/resources/loggings3"
+	"github.com/fastly/terraform-provider-fastly/internal/resources/snippet"
 	"github.com/fastly/terraform-provider-fastly/internal/resources/vcl"
 	"github.com/fastly/terraform-provider-fastly/internal/service"
 
@@ -66,6 +67,7 @@ type Model struct {
 	LoggingNewRelicOTLP           []loggingnewrelicotlp.NestedModel           `tfsdk:"logging_newrelicotlp"`
 	LoggingDatadog                []loggingdatadog.NestedModel                `tfsdk:"logging_datadog"`
 	ImageOptimizerDefaultSettings []imageoptimizerdefaultsettings.NestedModel `tfsdk:"image_optimizer_default_settings"`
+	Snippet                       []snippet.NestedModel                       `tfsdk:"snippet"`
 	VCL                           []vcl.NestedModel                           `tfsdk:"vcl"`
 }
 
@@ -125,6 +127,7 @@ func (r *Resource) Schema(_ context.Context, _ resource.SchemaRequest, resp *res
 			"logging_newrelicotlp":             loggingnewrelicotlp.NestedBlockSchema(),
 			"logging_datadog":                  loggingdatadog.NestedBlockSchema(),
 			"image_optimizer_default_settings": imageoptimizerdefaultsettings.NestedBlockSchema(),
+			"snippet":                          snippet.NestedBlockSchema(),
 			"vcl":                              vcl.NestedBlockSchema(),
 		},
 	}
@@ -147,6 +150,14 @@ func (r *Resource) ValidateConfig(ctx context.Context, req resource.ValidateConf
 		return
 	}
 
+	if err := snippet.ValidateConfig(config.Snippet); err != nil {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("snippet"),
+			"Invalid VCL snippet configuration",
+			err.Error(),
+		)
+	}
+
 	if err := vcl.ValidateConfig(config.VCL); err != nil {
 		resp.Diagnostics.AddAttributeError(
 			path.Root("vcl"),
@@ -160,6 +171,15 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 	var plan Model
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if err := snippet.Validate(plan.Snippet); err != nil {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("snippet"),
+			"Invalid VCL snippet configuration",
+			err.Error(),
+		)
 		return
 	}
 
@@ -301,6 +321,18 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 	}
 	plan.ImageOptimizerDefaultSettings = imageOptimizerDefaultSettings
 
+	if err := snippet.Reconcile(ctx, r.providerData.AutoClient(), serviceID, version, plan.Snippet); err != nil {
+		resp.Diagnostics.AddError("Error reconciling VCL snippets", err.Error())
+		return
+	}
+
+	snippets, err := snippet.ReadForVersion(ctx, r.providerData.AutoClient(), serviceID, version)
+	if err != nil {
+		resp.Diagnostics.AddError("Error reading VCL snippets", err.Error())
+		return
+	}
+	plan.Snippet = snippet.MatchOrderPreservePlanContent(snippets, plan.Snippet)
+
 	if err := vcl.Reconcile(ctx, r.providerData.AutoClient(), serviceID, version, plan.VCL); err != nil {
 		resp.Diagnostics.AddError("Error reconciling custom VCL files", err.Error())
 		return
@@ -430,6 +462,13 @@ func (r *Resource) Read(ctx context.Context, req resource.ReadRequest, resp *res
 	state.LoggingNewRelicOTLP = loggingnewrelicotlp.MatchOrder(loggingNewRelicOTLPs, state.LoggingNewRelicOTLP)
 	state.LoggingDatadog = loggingdatadog.MatchOrder(loggingDatadogs, state.LoggingDatadog)
 
+	snippets, err := snippet.ReadForVersion(ctx, r.providerData.AutoClient(), state.ID.ValueString(), readVersion)
+	if err != nil {
+		resp.Diagnostics.AddError("Error reading VCL snippets", err.Error())
+		return
+	}
+	state.Snippet = snippet.MatchOrder(snippets, state.Snippet)
+
 	vcls, err := vcl.ReadForVersion(ctx, r.providerData.AutoClient(), state.ID.ValueString(), readVersion)
 	if err != nil {
 		resp.Diagnostics.AddError("Error reading custom VCL files", err.Error())
@@ -467,6 +506,15 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 		return
 	}
 
+	if err := snippet.Validate(plan.Snippet); err != nil {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("snippet"),
+			"Invalid VCL snippet configuration",
+			err.Error(),
+		)
+		return
+	}
+
 	if err := vcl.Validate(plan.VCL); err != nil {
 		resp.Diagnostics.AddAttributeError(
 			path.Root("vcl"),
@@ -491,7 +539,17 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 		return
 	}
 
-	nestedChanged := !domain.Equal(plan.Domain, state.Domain) || !backend.Equal(plan.Backend, state.Backend) || !cdnacl.Equal(plan.ACL, state.ACL) || !condition.Equal(plan.Condition, state.Condition) || !gzip.Equal(plan.Gzip, state.Gzip) || !loggings3.Equal(plan.LoggingS3, state.LoggingS3) || !loggingnewrelicotlp.Equal(plan.LoggingNewRelicOTLP, state.LoggingNewRelicOTLP) || !loggingdatadog.Equal(plan.LoggingDatadog, state.LoggingDatadog) || !imageoptimizerdefaultsettings.Equal(plan.ImageOptimizerDefaultSettings, state.ImageOptimizerDefaultSettings) || !vcl.Equal(plan.VCL, state.VCL)
+	nestedChanged := !domain.Equal(plan.Domain, state.Domain) ||
+		!backend.Equal(plan.Backend, state.Backend) ||
+		!cdnacl.Equal(plan.ACL, state.ACL) ||
+		!condition.Equal(plan.Condition, state.Condition) ||
+		!gzip.Equal(plan.Gzip, state.Gzip) ||
+		!loggings3.Equal(plan.LoggingS3, state.LoggingS3) ||
+		!loggingnewrelicotlp.Equal(plan.LoggingNewRelicOTLP, state.LoggingNewRelicOTLP) ||
+		!loggingdatadog.Equal(plan.LoggingDatadog, state.LoggingDatadog) ||
+		!imageoptimizerdefaultsettings.Equal(plan.ImageOptimizerDefaultSettings, state.ImageOptimizerDefaultSettings) ||
+		!snippet.Equal(plan.Snippet, state.Snippet) ||
+		!vcl.Equal(plan.VCL, state.VCL)
 	needsVersionChange := nestedChanged
 
 	targetVersion := 0
@@ -636,6 +694,18 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 		}
 		plan.ImageOptimizerDefaultSettings = imageOptimizerDefaultSettings
 
+		if err := snippet.Reconcile(ctx, r.providerData.AutoClient(), serviceID, targetVersion, plan.Snippet); err != nil {
+			resp.Diagnostics.AddError("Error reconciling VCL snippets", err.Error())
+			return
+		}
+
+		snippets, err := snippet.ReadForVersion(ctx, r.providerData.AutoClient(), serviceID, targetVersion)
+		if err != nil {
+			resp.Diagnostics.AddError("Error reading VCL snippets", err.Error())
+			return
+		}
+		plan.Snippet = snippet.MatchOrderPreservePlanContent(snippets, plan.Snippet)
+
 		if err := vcl.Reconcile(ctx, r.providerData.AutoClient(), serviceID, targetVersion, plan.VCL); err != nil {
 			resp.Diagnostics.AddError("Error reconciling custom VCL files", err.Error())
 			return
@@ -677,6 +747,7 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 		plan.LoggingNewRelicOTLP = loggingnewrelicotlp.MatchOrder(state.LoggingNewRelicOTLP, plan.LoggingNewRelicOTLP)
 		plan.LoggingDatadog = loggingdatadog.MatchOrder(state.LoggingDatadog, plan.LoggingDatadog)
 		plan.ImageOptimizerDefaultSettings = state.ImageOptimizerDefaultSettings
+		plan.Snippet = snippet.MatchOrderPreservePlanContent(state.Snippet, plan.Snippet)
 		plan.VCL = vcl.MatchOrderPreservePlanContent(state.VCL, plan.VCL)
 	}
 

--- a/internal/resources/snippet/expand.go
+++ b/internal/resources/snippet/expand.go
@@ -1,0 +1,44 @@
+package snippet
+
+import (
+	"strconv"
+
+	"github.com/fastly/terraform-provider-fastly/internal/service"
+
+	fastly "github.com/fastly/go-fastly/v17/fastly"
+)
+
+func BuildCreateInput(serviceID string, version int, m NestedModel) *fastly.CreateSnippetInput {
+	name := service.StringValue(m.Name)
+	content := service.StringValue(m.Content)
+	priority := strconv.FormatInt(service.Int64Value(m.Priority), 10)
+	snippetType := fastly.SnippetType(normalizeType(service.StringValue(m.Type)))
+	dynamic := 0
+
+	return &fastly.CreateSnippetInput{
+		ServiceID:      serviceID,
+		ServiceVersion: version,
+		Name:           &name,
+		Content:        &content,
+		Priority:       &priority,
+		Type:           &snippetType,
+		Dynamic:        &dynamic,
+	}
+}
+
+func BuildUpdateInput(serviceID string, version int, m NestedModel) *fastly.UpdateSnippetInput {
+	name := service.StringValue(m.Name)
+	content := service.StringValue(m.Content)
+	priority := strconv.FormatInt(service.Int64Value(m.Priority), 10)
+	snippetType := fastly.SnippetType(normalizeType(service.StringValue(m.Type)))
+
+	return &fastly.UpdateSnippetInput{
+		ServiceID:      serviceID,
+		ServiceVersion: version,
+		Name:           name,
+		NewName:        &name,
+		Content:        &content,
+		Priority:       &priority,
+		Type:           &snippetType,
+	}
+}

--- a/internal/resources/snippet/flatten.go
+++ b/internal/resources/snippet/flatten.go
@@ -1,0 +1,41 @@
+package snippet
+
+import (
+	"context"
+
+	fastly "github.com/fastly/go-fastly/v17/fastly"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+func FlattenToNestedModel(api *fastly.Snippet) NestedModel {
+	if api == nil {
+		return NestedModel{}
+	}
+
+	return NestedModel{
+		Name:     types.StringValue(fastly.ToValue(api.Name)),
+		Type:     types.StringValue(string(fastly.ToValue(api.Type))),
+		Priority: types.Int64Value(parsePriority(api.Priority)),
+		Content:  types.StringValue(fastly.ToValue(api.Content)),
+	}
+}
+
+func flatten(ctx context.Context, s *fastly.Snippet, m *Model) {
+	if s == nil {
+		tflog.Warn(ctx, "flatten called with nil VCL snippet")
+		return
+	}
+
+	m.ID = types.StringValue(ID(fastly.ToValue(s.ServiceID), fastly.ToValue(s.ServiceVersion), fastly.ToValue(s.Name)))
+	m.Service = types.StringValue(fastly.ToValue(s.ServiceID))
+	m.Version = types.Int64Value(int64(fastly.ToValue(s.ServiceVersion)))
+	m.NestedModel = FlattenToNestedModel(s)
+
+	tflog.Debug(ctx, "Flattened VCL snippet state", map[string]any{
+		"id":      m.ID.ValueString(),
+		"service": m.Service.ValueString(),
+		"version": m.Version.ValueInt64(),
+		"name":    m.Name.ValueString(),
+	})
+}

--- a/internal/resources/snippet/flatten.go
+++ b/internal/resources/snippet/flatten.go
@@ -8,29 +8,39 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
-func FlattenToNestedModel(api *fastly.Snippet) NestedModel {
+func FlattenToNestedModel(api *fastly.Snippet) (NestedModel, error) {
 	if api == nil {
-		return NestedModel{}
+		return NestedModel{}, nil
+	}
+
+	priority, err := parsePriority(api.Priority)
+	if err != nil {
+		return NestedModel{}, err
 	}
 
 	return NestedModel{
 		Name:     types.StringValue(fastly.ToValue(api.Name)),
 		Type:     types.StringValue(string(fastly.ToValue(api.Type))),
-		Priority: types.Int64Value(parsePriority(api.Priority)),
+		Priority: types.Int64Value(priority),
 		Content:  types.StringValue(fastly.ToValue(api.Content)),
-	}
+	}, nil
 }
 
-func flatten(ctx context.Context, s *fastly.Snippet, m *Model) {
+func flatten(ctx context.Context, s *fastly.Snippet, m *Model) error {
 	if s == nil {
 		tflog.Warn(ctx, "flatten called with nil VCL snippet")
-		return
+		return nil
+	}
+
+	nestedModel, err := FlattenToNestedModel(s)
+	if err != nil {
+		return err
 	}
 
 	m.ID = types.StringValue(ID(fastly.ToValue(s.ServiceID), fastly.ToValue(s.ServiceVersion), fastly.ToValue(s.Name)))
 	m.Service = types.StringValue(fastly.ToValue(s.ServiceID))
 	m.Version = types.Int64Value(int64(fastly.ToValue(s.ServiceVersion)))
-	m.NestedModel = FlattenToNestedModel(s)
+	m.NestedModel = nestedModel
 
 	tflog.Debug(ctx, "Flattened VCL snippet state", map[string]any{
 		"id":      m.ID.ValueString(),
@@ -38,4 +48,6 @@ func flatten(ctx context.Context, s *fastly.Snippet, m *Model) {
 		"version": m.Version.ValueInt64(),
 		"name":    m.Name.ValueString(),
 	})
+
+	return nil
 }

--- a/internal/resources/snippet/resource.go
+++ b/internal/resources/snippet/resource.go
@@ -1,0 +1,241 @@
+package snippet
+
+import (
+	"context"
+
+	fastlyclient "github.com/fastly/terraform-provider-fastly/internal/client"
+	"github.com/fastly/terraform-provider-fastly/internal/errors"
+	"github.com/fastly/terraform-provider-fastly/internal/importutil"
+	"github.com/fastly/terraform-provider-fastly/internal/service"
+	"github.com/fastly/terraform-provider-fastly/internal/validation"
+
+	fastly "github.com/fastly/go-fastly/v17/fastly"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+var _ resource.Resource = &Resource{}
+var _ resource.ResourceWithImportState = &Resource{}
+
+type Resource struct {
+	providerData *fastlyclient.Data
+}
+
+func NewResource() resource.Resource {
+	return &Resource{}
+}
+
+type Model struct {
+	NestedModel
+	ID      types.String `tfsdk:"id"`
+	Service types.String `tfsdk:"service_id"`
+	Version types.Int64  `tfsdk:"version"`
+}
+
+func (r *Resource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_service_vcl_snippet"
+}
+
+func (r *Resource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Fastly regular VCL snippet resource. Writes directly to the specified writable CDN service version.",
+		Attributes:  ResourceAttributes(),
+	}
+}
+
+func (r *Resource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	data, diags := fastlyclient.FromProviderData(req.ProviderData)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() || data == nil {
+		return
+	}
+
+	r.providerData = data
+}
+
+func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan Model
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if err := validation.EnsureServiceTypeSupported(ctx, r.providerData.ServiceTypeChecker, plan.Service.ValueString(), "fastly_service_vcl_snippet", service.TypeVCL); err != nil {
+		resp.Diagnostics.AddError("Unsupported Fastly service type", err.Error())
+		return
+	}
+
+	resp.Diagnostics.Append(r.providerData.VersionChecker.EnsureMutable(ctx, plan.Service.ValueString(), int(plan.Version.ValueInt64()))...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	tflog.Debug(ctx, "Creating Fastly VCL snippet", map[string]any{
+		"service_id": plan.Service.ValueString(),
+		"version":    plan.Version.ValueInt64(),
+		"name":       service.StringValue(plan.Name),
+	})
+
+	s, err := r.providerData.Client.CreateSnippet(ctx, BuildCreateInput(plan.Service.ValueString(), int(plan.Version.ValueInt64()), plan.NestedModel))
+	if err != nil {
+		resp.Diagnostics.AddError("Error creating VCL snippet", err.Error())
+		return
+	}
+
+	plannedContent := plan.Content
+	flatten(ctx, s, &plan)
+	plan.Content = plannedContent
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+func (r *Resource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var state Model
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	tflog.Debug(ctx, "Reading Fastly VCL snippet from API", map[string]any{
+		"service_id": state.Service.ValueString(),
+		"version":    state.Version.ValueInt64(),
+		"name":       state.Name.ValueString(),
+	})
+
+	s, err := r.providerData.Client.GetSnippet(ctx, &fastly.GetSnippetInput{
+		ServiceID:      state.Service.ValueString(),
+		ServiceVersion: int(state.Version.ValueInt64()),
+		Name:           state.Name.ValueString(),
+	})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			tflog.Warn(ctx, "VCL snippet not found, removing from state", map[string]any{
+				"service_id": state.Service.ValueString(),
+				"version":    state.Version.ValueInt64(),
+				"name":       state.Name.ValueString(),
+			})
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.AddError("Error reading VCL snippet", err.Error())
+		return
+	}
+
+	flatten(ctx, s, &state)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var plan Model
+	var state Model
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if err := validation.EnsureServiceTypeSupported(ctx, r.providerData.ServiceTypeChecker, plan.Service.ValueString(), "fastly_service_vcl_snippet", service.TypeVCL); err != nil {
+		resp.Diagnostics.AddError("Unsupported Fastly service type", err.Error())
+		return
+	}
+
+	resp.Diagnostics.Append(r.providerData.VersionChecker.EnsureMutable(ctx, plan.Service.ValueString(), int(plan.Version.ValueInt64()))...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	tflog.Debug(ctx, "Updating Fastly VCL snippet", map[string]any{
+		"service_id": plan.Service.ValueString(),
+		"version":    plan.Version.ValueInt64(),
+		"name":       service.StringValue(plan.Name),
+	})
+
+	s, err := r.providerData.Client.UpdateSnippet(ctx, BuildUpdateInput(plan.Service.ValueString(), int(plan.Version.ValueInt64()), plan.NestedModel))
+	if err != nil {
+		resp.Diagnostics.AddError("Error updating VCL snippet", err.Error())
+		return
+	}
+
+	plannedContent := plan.Content
+	flatten(ctx, s, &plan)
+	plan.ID = state.ID
+	plan.Content = plannedContent
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+func (r *Resource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var state Model
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	tflog.Debug(ctx, "Deleting Fastly VCL snippet", map[string]any{
+		"service_id": state.Service.ValueString(),
+		"version":    state.Version.ValueInt64(),
+		"name":       state.Name.ValueString(),
+	})
+
+	if err := validation.EnsureServiceTypeSupported(ctx, r.providerData.ServiceTypeChecker, state.Service.ValueString(), "fastly_service_vcl_snippet", service.TypeVCL); err != nil {
+		if errors.IsNotFound(err) {
+			return
+		}
+		resp.Diagnostics.AddError("Unsupported Fastly service type", err.Error())
+		return
+	}
+
+	notFound, diags := r.providerData.VersionChecker.EnsureMutableForDelete(ctx, state.Service.ValueString(), int(state.Version.ValueInt64()))
+	resp.Diagnostics.Append(diags...)
+	if notFound || resp.Diagnostics.HasError() {
+		return
+	}
+
+	err := r.providerData.Client.DeleteSnippet(ctx, &fastly.DeleteSnippetInput{
+		ServiceID:      state.Service.ValueString(),
+		ServiceVersion: int(state.Version.ValueInt64()),
+		Name:           state.Name.ValueString(),
+	})
+	if err != nil && !errors.IsNotFound(err) {
+		resp.Diagnostics.AddError("Error deleting VCL snippet", err.Error())
+	}
+}
+
+func (r *Resource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	serviceID, version, name, err := importutil.ParseCompositeID(req.ID)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Invalid Import ID",
+			"Expected import ID in format: service_id/version/name\n"+
+				"For example: service123/3/recv_headers\n\n"+
+				"Error: "+err.Error(),
+		)
+		return
+	}
+
+	tflog.Debug(ctx, "Importing VCL snippet", map[string]any{
+		"service_id": serviceID,
+		"version":    version,
+		"name":       name,
+	})
+
+	s, err := r.providerData.Client.GetSnippet(ctx, &fastly.GetSnippetInput{
+		ServiceID:      serviceID,
+		ServiceVersion: version,
+		Name:           name,
+	})
+	if err != nil {
+		resp.Diagnostics.AddError("Error importing VCL snippet", err.Error())
+		return
+	}
+
+	var state Model
+	state.Service = types.StringValue(serviceID)
+	state.Version = types.Int64Value(int64(version))
+	flatten(ctx, s, &state)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}

--- a/internal/resources/snippet/resource.go
+++ b/internal/resources/snippet/resource.go
@@ -2,6 +2,7 @@ package snippet
 
 import (
 	"context"
+	"fmt"
 
 	fastlyclient "github.com/fastly/terraform-provider-fastly/internal/client"
 	"github.com/fastly/terraform-provider-fastly/internal/errors"
@@ -123,6 +124,19 @@ func (r *Resource) Read(ctx context.Context, req resource.ReadRequest, resp *res
 		return
 	}
 
+	if IsDynamic(s) {
+		resp.Diagnostics.AddError(
+			"Unexpected dynamic VCL snippet",
+			fmt.Sprintf(
+				"VCL snippet %q in service %s version %d is dynamic. This resource only manages regular VCL snippets.",
+				state.Name.ValueString(),
+				state.Service.ValueString(),
+				int(state.Version.ValueInt64()),
+			),
+		)
+		return
+	}
+
 	flatten(ctx, s, &state)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
@@ -229,6 +243,19 @@ func (r *Resource) ImportState(ctx context.Context, req resource.ImportStateRequ
 	})
 	if err != nil {
 		resp.Diagnostics.AddError("Error importing VCL snippet", err.Error())
+		return
+	}
+
+	if IsDynamic(s) {
+		resp.Diagnostics.AddError(
+			"Unexpected dynamic VCL snippet",
+			fmt.Sprintf(
+				"VCL snippet %q in service %s version %d is dynamic. This resource only manages regular VCL snippets.",
+				name,
+				serviceID,
+				version,
+			),
+		)
 		return
 	}
 

--- a/internal/resources/snippet/resource.go
+++ b/internal/resources/snippet/resource.go
@@ -86,7 +86,10 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 	}
 
 	plannedContent := plan.Content
-	flatten(ctx, s, &plan)
+	if err := flatten(ctx, s, &plan); err != nil {
+		resp.Diagnostics.AddError("Error reading VCL snippet", err.Error())
+		return
+	}
 	plan.Content = plannedContent
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
@@ -137,7 +140,10 @@ func (r *Resource) Read(ctx context.Context, req resource.ReadRequest, resp *res
 		return
 	}
 
-	flatten(ctx, s, &state)
+	if err := flatten(ctx, s, &state); err != nil {
+		resp.Diagnostics.AddError("Error reading VCL snippet", err.Error())
+		return
+	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
@@ -174,7 +180,10 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 	}
 
 	plannedContent := plan.Content
-	flatten(ctx, s, &plan)
+	if err := flatten(ctx, s, &plan); err != nil {
+		resp.Diagnostics.AddError("Error reading VCL snippet", err.Error())
+		return
+	}
 	plan.ID = state.ID
 	plan.Content = plannedContent
 
@@ -262,7 +271,10 @@ func (r *Resource) ImportState(ctx context.Context, req resource.ImportStateRequ
 	var state Model
 	state.Service = types.StringValue(serviceID)
 	state.Version = types.Int64Value(int64(version))
-	flatten(ctx, s, &state)
+	if err := flatten(ctx, s, &state); err != nil {
+		resp.Diagnostics.AddError("Error importing VCL snippet", err.Error())
+		return
+	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }

--- a/internal/resources/snippet/schema.go
+++ b/internal/resources/snippet/schema.go
@@ -44,6 +44,10 @@ type NestedModel struct {
 	Content  types.String `tfsdk:"content"`
 }
 
+func IsDynamic(api *fastly.Snippet) bool {
+	return api != nil && api.Dynamic != nil && *api.Dynamic == 1
+}
+
 func ContentEqual(a, b string) bool {
 	return strings.TrimRight(a, "\n") == strings.TrimRight(b, "\n")
 }

--- a/internal/resources/snippet/schema.go
+++ b/internal/resources/snippet/schema.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"maps"
-	"sort"
 	"strconv"
 	"strings"
 
@@ -232,6 +231,8 @@ func (o ops) Update(ctx context.Context, client *fastly.Client, serviceID string
 }
 
 func (o ops) ToModel(api *fastly.Snippet) NestedModel {
+	// ops.List validates snippet priority before the reconciler calls ToModel,
+	// so this should only fail if ToModel is called outside the reconciler path.
 	model, _ := FlattenToNestedModel(api)
 	return model
 }
@@ -245,25 +246,7 @@ var reconciler = &reconcile.Resource[NestedModel, fastly.Snippet]{
 }
 
 func ReadForVersion(ctx context.Context, client *fastly.Client, serviceID string, version int) ([]NestedModel, error) {
-	remote, err := ops{}.List(ctx, client, serviceID, version)
-	if err != nil {
-		return nil, err
-	}
-
-	result := make([]NestedModel, 0, len(remote))
-	for _, item := range remote {
-		model, err := FlattenToNestedModel(item)
-		if err != nil {
-			return nil, err
-		}
-		result = append(result, model)
-	}
-
-	sort.Slice(result, func(i, j int) bool {
-		return service.StringValue(result[i].Name) < service.StringValue(result[j].Name)
-	})
-
-	return result, nil
+	return reconciler.ReadForVersion(ctx, client, serviceID, version)
 }
 
 func Reconcile(ctx context.Context, client *fastly.Client, serviceID string, version int, desired []NestedModel) error {
@@ -312,12 +295,12 @@ func parsePriority(value *string) (int64, error) {
 		return DefaultPriority, nil
 	}
 
-	priority, err := strconv.ParseInt(*value, 10, 64)
+	priority, err := strconv.Atoi(*value)
 	if err != nil {
 		return 0, fmt.Errorf("error parsing VCL snippet priority %q: %w", *value, err)
 	}
 
-	return priority, nil
+	return int64(priority), nil
 }
 
 func normalizeType(value string) string {

--- a/internal/resources/snippet/schema.go
+++ b/internal/resources/snippet/schema.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"maps"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -190,8 +191,11 @@ func (o ops) List(ctx context.Context, client *fastly.Client, serviceID string, 
 		if item == nil {
 			continue
 		}
-		if item.Dynamic != nil && *item.Dynamic == 1 {
+		if IsDynamic(item) {
 			continue
+		}
+		if _, err := parsePriority(item.Priority); err != nil {
+			return nil, err
 		}
 		regular = append(regular, item)
 	}
@@ -216,7 +220,11 @@ func (o ops) Create(ctx context.Context, client *fastly.Client, serviceID string
 }
 
 func (o ops) Equal(desired NestedModel, remote *fastly.Snippet) bool {
-	return desired.ModelsEqual(FlattenToNestedModel(remote))
+	remoteModel, err := FlattenToNestedModel(remote)
+	if err != nil {
+		return false
+	}
+	return desired.ModelsEqual(remoteModel)
 }
 
 func (o ops) Update(ctx context.Context, client *fastly.Client, serviceID string, version int, desired NestedModel) (*fastly.Snippet, error) {
@@ -224,7 +232,8 @@ func (o ops) Update(ctx context.Context, client *fastly.Client, serviceID string
 }
 
 func (o ops) ToModel(api *fastly.Snippet) NestedModel {
-	return FlattenToNestedModel(api)
+	model, _ := FlattenToNestedModel(api)
+	return model
 }
 
 var reconciler = &reconcile.Resource[NestedModel, fastly.Snippet]{
@@ -236,7 +245,25 @@ var reconciler = &reconcile.Resource[NestedModel, fastly.Snippet]{
 }
 
 func ReadForVersion(ctx context.Context, client *fastly.Client, serviceID string, version int) ([]NestedModel, error) {
-	return reconciler.ReadForVersion(ctx, client, serviceID, version)
+	remote, err := ops{}.List(ctx, client, serviceID, version)
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]NestedModel, 0, len(remote))
+	for _, item := range remote {
+		model, err := FlattenToNestedModel(item)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, model)
+	}
+
+	sort.Slice(result, func(i, j int) bool {
+		return service.StringValue(result[i].Name) < service.StringValue(result[j].Name)
+	})
+
+	return result, nil
 }
 
 func Reconcile(ctx context.Context, client *fastly.Client, serviceID string, version int, desired []NestedModel) error {
@@ -280,17 +307,17 @@ func MatchOrderPreservePlanContent(items, plan []NestedModel) []NestedModel {
 	return ordered
 }
 
-func parsePriority(value *string) int64 {
+func parsePriority(value *string) (int64, error) {
 	if value == nil || *value == "" {
-		return DefaultPriority
+		return DefaultPriority, nil
 	}
 
 	priority, err := strconv.ParseInt(*value, 10, 64)
 	if err != nil {
-		return DefaultPriority
+		return 0, fmt.Errorf("error parsing VCL snippet priority %q: %w", *value, err)
 	}
 
-	return priority
+	return priority, nil
 }
 
 func normalizeType(value string) string {

--- a/internal/resources/snippet/schema.go
+++ b/internal/resources/snippet/schema.go
@@ -1,0 +1,304 @@
+package snippet
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"strconv"
+	"strings"
+
+	"github.com/fastly/terraform-provider-fastly/internal/reconcile"
+	"github.com/fastly/terraform-provider-fastly/internal/service"
+
+	fastly "github.com/fastly/go-fastly/v17/fastly"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+const DefaultPriority int64 = 100
+
+var validTypes = []string{
+	"init",
+	"recv",
+	"hash",
+	"hit",
+	"miss",
+	"pass",
+	"fetch",
+	"error",
+	"deliver",
+	"log",
+	"none",
+}
+
+type NestedModel struct {
+	Name     types.String `tfsdk:"name"`
+	Type     types.String `tfsdk:"type"`
+	Priority types.Int64  `tfsdk:"priority"`
+	Content  types.String `tfsdk:"content"`
+}
+
+func ContentEqual(a, b string) bool {
+	return strings.TrimRight(a, "\n") == strings.TrimRight(b, "\n")
+}
+
+func (n NestedModel) ModelsEqual(other NestedModel) bool {
+	return service.StringValue(n.Name) == service.StringValue(other.Name) &&
+		normalizeType(service.StringValue(n.Type)) == normalizeType(service.StringValue(other.Type)) &&
+		service.Int64Value(n.Priority) == service.Int64Value(other.Priority) &&
+		ContentEqual(service.StringValue(n.Content), service.StringValue(other.Content))
+}
+
+func CommonAttributes() map[string]schema.Attribute {
+	return map[string]schema.Attribute{
+		"name": schema.StringAttribute{
+			Required:    true,
+			Description: "A name that is unique across regular and dynamic VCL snippet configuration blocks. Changing this attribute will delete and recreate the snippet.",
+		},
+		"type": schema.StringAttribute{
+			Required:    true,
+			Description: "The location in generated VCL where the snippet should be placed. Must be one of `init`, `recv`, `hash`, `hit`, `miss`, `pass`, `fetch`, `error`, `deliver`, `log`, or `none`.",
+			Validators: []validator.String{
+				stringvalidator.OneOf(validTypes...),
+			},
+		},
+		"priority": schema.Int64Attribute{
+			Optional:    true,
+			Computed:    true,
+			Default:     int64default.StaticInt64(DefaultPriority),
+			Description: "Priority determines execution order. Lower numbers execute first. Default `100`.",
+		},
+		"content": schema.StringAttribute{
+			Required:    true,
+			Description: "The VCL code that specifies exactly what the snippet does. Can be configured with a quoted string, HEREDOC, file(\"${path.module}/snippet.vcl\"), or templatefile(...).",
+		},
+	}
+}
+
+func ResourceAttributes() map[string]schema.Attribute {
+	attrs := map[string]schema.Attribute{
+		"id": schema.StringAttribute{
+			Computed:    true,
+			Description: "Terraform resource identifier.",
+		},
+		"service_id": schema.StringAttribute{
+			Required:    true,
+			Description: "Fastly service ID.",
+			PlanModifiers: []planmodifier.String{
+				stringplanmodifier.RequiresReplace(),
+			},
+		},
+		"version": schema.Int64Attribute{
+			Required:    true,
+			Description: "Writable Fastly service version to modify.",
+			PlanModifiers: []planmodifier.Int64{
+				int64planmodifier.RequiresReplace(),
+			},
+		},
+	}
+	maps.Copy(attrs, CommonAttributes())
+
+	nameAttr := attrs["name"].(schema.StringAttribute)
+	nameAttr.PlanModifiers = []planmodifier.String{
+		stringplanmodifier.RequiresReplace(),
+	}
+	attrs["name"] = nameAttr
+
+	return attrs
+}
+
+func NestedBlockSchema() schema.ListNestedBlock {
+	return schema.ListNestedBlock{
+		Description: "Regular VCL snippets attached to this service version.",
+		NestedObject: schema.NestedBlockObject{
+			Attributes: CommonAttributes(),
+		},
+	}
+}
+
+func ID(serviceID string, version int, name string) string {
+	return fmt.Sprintf("%s-%d-%s", serviceID, version, name)
+}
+
+func ValidateConfig(snippets []NestedModel) error {
+	seenNames := make(map[string]struct{}, len(snippets))
+
+	for _, item := range snippets {
+		if item.Name.IsUnknown() || item.Name.IsNull() {
+			continue
+		}
+
+		name := strings.TrimSpace(item.Name.ValueString())
+		if name == "" {
+			return fmt.Errorf("VCL snippet name cannot be empty")
+		}
+
+		if _, ok := seenNames[name]; ok {
+			return fmt.Errorf("multiple snippets with the same name %q; names must be unique within a service version", name)
+		}
+		seenNames[name] = struct{}{}
+	}
+
+	return nil
+}
+
+func Validate(snippets []NestedModel) error {
+	seenNames := make(map[string]struct{}, len(snippets))
+
+	for _, item := range snippets {
+		name := strings.TrimSpace(service.StringValue(item.Name))
+		if name == "" {
+			return fmt.Errorf("VCL snippet name cannot be empty")
+		}
+
+		if _, ok := seenNames[name]; ok {
+			return fmt.Errorf("multiple snippets with the same name %q; names must be unique within a service version", name)
+		}
+		seenNames[name] = struct{}{}
+
+		if !isValidType(service.StringValue(item.Type)) {
+			return fmt.Errorf("invalid VCL snippet type %q; must be one of %s", service.StringValue(item.Type), strings.Join(validTypes, ", "))
+		}
+	}
+
+	return nil
+}
+
+type ops struct{}
+
+func (o ops) List(ctx context.Context, client *fastly.Client, serviceID string, version int) ([]*fastly.Snippet, error) {
+	all, err := client.ListSnippets(ctx, &fastly.ListSnippetsInput{
+		ServiceID:      serviceID,
+		ServiceVersion: version,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	regular := make([]*fastly.Snippet, 0, len(all))
+	for _, item := range all {
+		if item == nil {
+			continue
+		}
+		if item.Dynamic != nil && *item.Dynamic == 1 {
+			continue
+		}
+		regular = append(regular, item)
+	}
+
+	return regular, nil
+}
+
+func (o ops) GetName(api *fastly.Snippet) string {
+	return fastly.ToValue(api.Name)
+}
+
+func (o ops) Delete(ctx context.Context, client *fastly.Client, serviceID string, version int, name string) error {
+	return client.DeleteSnippet(ctx, &fastly.DeleteSnippetInput{
+		ServiceID:      serviceID,
+		ServiceVersion: version,
+		Name:           name,
+	})
+}
+
+func (o ops) Create(ctx context.Context, client *fastly.Client, serviceID string, version int, desired NestedModel) (*fastly.Snippet, error) {
+	return client.CreateSnippet(ctx, BuildCreateInput(serviceID, version, desired))
+}
+
+func (o ops) Equal(desired NestedModel, remote *fastly.Snippet) bool {
+	return desired.ModelsEqual(FlattenToNestedModel(remote))
+}
+
+func (o ops) Update(ctx context.Context, client *fastly.Client, serviceID string, version int, desired NestedModel) (*fastly.Snippet, error) {
+	return client.UpdateSnippet(ctx, BuildUpdateInput(serviceID, version, desired))
+}
+
+func (o ops) ToModel(api *fastly.Snippet) NestedModel {
+	return FlattenToNestedModel(api)
+}
+
+var reconciler = &reconcile.Resource[NestedModel, fastly.Snippet]{
+	Ops: ops{},
+	GetName: func(m NestedModel) string {
+		return service.StringValue(m.Name)
+	},
+	Sortable: true,
+}
+
+func ReadForVersion(ctx context.Context, client *fastly.Client, serviceID string, version int) ([]NestedModel, error) {
+	return reconciler.ReadForVersion(ctx, client, serviceID, version)
+}
+
+func Reconcile(ctx context.Context, client *fastly.Client, serviceID string, version int, desired []NestedModel) error {
+	if err := Validate(desired); err != nil {
+		return err
+	}
+	return reconciler.Run(ctx, client, serviceID, version, desired)
+}
+
+func Equal(a, b []NestedModel) bool {
+	return reconcile.ModelsEqual(a, b, func(m NestedModel) string { return service.StringValue(m.Name) }, NestedModel.ModelsEqual, true)
+}
+
+func MatchOrder(items, order []NestedModel) []NestedModel {
+	return reconcile.MatchOrder(items, order, func(m NestedModel) string { return service.StringValue(m.Name) })
+}
+
+func MatchOrderPreservePlanContent(items, plan []NestedModel) []NestedModel {
+	ordered := MatchOrder(items, plan)
+
+	planByName := make(map[string]NestedModel, len(plan))
+	for _, item := range plan {
+		planByName[service.StringValue(item.Name)] = item
+	}
+
+	for i := range ordered {
+		name := service.StringValue(ordered[i].Name)
+		if planned, ok := planByName[name]; ok {
+			// During Create/Update, Terraform requires the final state for configured
+			// attributes to match the planned values. The Fastly API can normalize or
+			// briefly return stale snippet fields immediately after updating a cloned
+			// version, so preserve the configured values for the post-apply state.
+			//
+			// Read paths still use MatchOrder directly and reflect remote API values.
+			ordered[i].Type = planned.Type
+			ordered[i].Priority = planned.Priority
+			ordered[i].Content = planned.Content
+		}
+	}
+
+	return ordered
+}
+
+func parsePriority(value *string) int64 {
+	if value == nil || *value == "" {
+		return DefaultPriority
+	}
+
+	priority, err := strconv.ParseInt(*value, 10, 64)
+	if err != nil {
+		return DefaultPriority
+	}
+
+	return priority
+}
+
+func normalizeType(value string) string {
+	return strings.ToLower(strings.TrimSpace(value))
+}
+
+func isValidType(value string) bool {
+	value = normalizeType(value)
+	for _, valid := range validTypes {
+		if value == valid {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/resources/snippet/snippet_test.go
+++ b/internal/resources/snippet/snippet_test.go
@@ -1,0 +1,224 @@
+package snippet
+
+import (
+	"testing"
+
+	fastly "github.com/fastly/go-fastly/v17/fastly"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestFlattenToNestedModel(t *testing.T) {
+	api := &fastly.Snippet{
+		Name:     fastly.ToPointer("recv_test"),
+		Type:     fastly.ToPointer(fastly.SnippetTypeRecv),
+		Priority: fastly.ToPointer("110"),
+		Content:  fastly.ToPointer(`set req.http.X-Test = "true";`),
+	}
+
+	got := FlattenToNestedModel(api)
+
+	if got.Name.ValueString() != "recv_test" {
+		t.Fatalf("name mismatch: %q", got.Name.ValueString())
+	}
+	if got.Type.ValueString() != "recv" {
+		t.Fatalf("type mismatch: %q", got.Type.ValueString())
+	}
+	if got.Priority.ValueInt64() != 110 {
+		t.Fatalf("priority mismatch: %d", got.Priority.ValueInt64())
+	}
+	if got.Content.ValueString() != `set req.http.X-Test = "true";` {
+		t.Fatalf("content mismatch: %q", got.Content.ValueString())
+	}
+}
+
+func TestBuildCreateInput(t *testing.T) {
+	input := BuildCreateInput("service123", 2, NestedModel{
+		Name:     types.StringValue("deliver_test"),
+		Type:     types.StringValue("deliver"),
+		Priority: types.Int64Value(50),
+		Content:  types.StringValue(`set resp.http.X-Test = "true";`),
+	})
+
+	if input.ServiceID != "service123" {
+		t.Fatalf("service id mismatch: %q", input.ServiceID)
+	}
+	if input.ServiceVersion != 2 {
+		t.Fatalf("version mismatch: %d", input.ServiceVersion)
+	}
+	if fastly.ToValue(input.Name) != "deliver_test" {
+		t.Fatalf("name mismatch: %q", fastly.ToValue(input.Name))
+	}
+	if fastly.ToValue(input.Dynamic) != 0 {
+		t.Fatalf("dynamic mismatch: %d", fastly.ToValue(input.Dynamic))
+	}
+	if fastly.ToValue(input.Priority) != "50" {
+		t.Fatalf("priority mismatch: %q", fastly.ToValue(input.Priority))
+	}
+	if fastly.ToValue(input.Type) != fastly.SnippetTypeDeliver {
+		t.Fatalf("type mismatch: %q", fastly.ToValue(input.Type))
+	}
+}
+
+func TestBuildUpdateInput(t *testing.T) {
+	input := BuildUpdateInput("service123", 2, NestedModel{
+		Name:     types.StringValue("deliver_test"),
+		Type:     types.StringValue("deliver"),
+		Priority: types.Int64Value(50),
+		Content:  types.StringValue(`set resp.http.X-Test = "true";`),
+	})
+
+	if input.ServiceID != "service123" {
+		t.Fatalf("service id mismatch: %q", input.ServiceID)
+	}
+	if input.ServiceVersion != 2 {
+		t.Fatalf("version mismatch: %d", input.ServiceVersion)
+	}
+	if input.Name != "deliver_test" {
+		t.Fatalf("name mismatch: %q", input.Name)
+	}
+	if fastly.ToValue(input.NewName) != "deliver_test" {
+		t.Fatalf("new name mismatch: %q", fastly.ToValue(input.NewName))
+	}
+	if fastly.ToValue(input.Priority) != "50" {
+		t.Fatalf("priority mismatch: %q", fastly.ToValue(input.Priority))
+	}
+	if fastly.ToValue(input.Type) != fastly.SnippetTypeDeliver {
+		t.Fatalf("type mismatch: %q", fastly.ToValue(input.Type))
+	}
+}
+
+func TestValidateConfig(t *testing.T) {
+	content := types.StringValue(`set resp.http.X-Test = "true";`)
+
+	tests := []struct {
+		name    string
+		items   []NestedModel
+		wantErr bool
+	}{
+		{
+			name: "empty list is valid",
+		},
+		{
+			name: "single known snippet is valid",
+			items: []NestedModel{
+				{Name: types.StringValue("one"), Type: types.StringValue("recv"), Priority: types.Int64Value(100), Content: content},
+			},
+		},
+		{
+			name: "duplicate known names are invalid",
+			items: []NestedModel{
+				{Name: types.StringValue("one"), Type: types.StringValue("recv"), Priority: types.Int64Value(100), Content: content},
+				{Name: types.StringValue("one"), Type: types.StringValue("deliver"), Priority: types.Int64Value(100), Content: content},
+			},
+			wantErr: true,
+		},
+		{
+			name: "blank known name is invalid",
+			items: []NestedModel{
+				{Name: types.StringValue(" "), Type: types.StringValue("recv"), Priority: types.Int64Value(100), Content: content},
+			},
+			wantErr: true,
+		},
+		{
+			name: "unknown name is deferred",
+			items: []NestedModel{
+				{Name: types.StringUnknown(), Type: types.StringValue("recv"), Priority: types.Int64Value(100), Content: content},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateConfig(tt.items)
+			if tt.wantErr && err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+		})
+	}
+}
+
+func TestValidate(t *testing.T) {
+	content := types.StringValue(`set resp.http.X-Test = "true";`)
+
+	tests := []struct {
+		name    string
+		items   []NestedModel
+		wantErr bool
+	}{
+		{
+			name: "single snippet is valid",
+			items: []NestedModel{
+				{Name: types.StringValue("one"), Type: types.StringValue("recv"), Priority: types.Int64Value(100), Content: content},
+			},
+		},
+		{
+			name: "duplicate names are invalid",
+			items: []NestedModel{
+				{Name: types.StringValue("one"), Type: types.StringValue("recv"), Priority: types.Int64Value(100), Content: content},
+				{Name: types.StringValue("one"), Type: types.StringValue("deliver"), Priority: types.Int64Value(100), Content: content},
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid type is invalid",
+			items: []NestedModel{
+				{Name: types.StringValue("one"), Type: types.StringValue("invalid"), Priority: types.Int64Value(100), Content: content},
+			},
+			wantErr: true,
+		},
+		{
+			name: "blank name is invalid",
+			items: []NestedModel{
+				{Name: types.StringValue(" "), Type: types.StringValue("recv"), Priority: types.Int64Value(100), Content: content},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := Validate(tt.items)
+			if tt.wantErr && err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+		})
+	}
+}
+
+func TestContentEqual(t *testing.T) {
+	if !ContentEqual("set resp.http.X = \"true\";", "set resp.http.X = \"true\";\n") {
+		t.Fatal("expected trailing newline to be ignored")
+	}
+
+	if ContentEqual("set resp.http.X = \"true\";", "set resp.http.X = \"false\";") {
+		t.Fatal("expected different content to be unequal")
+	}
+}
+
+func TestMatchOrderPreservePlanContent(t *testing.T) {
+	remote := []NestedModel{
+		{Name: types.StringValue("b"), Type: types.StringValue("deliver"), Priority: types.Int64Value(100), Content: types.StringValue("remote b\n")},
+		{Name: types.StringValue("a"), Type: types.StringValue("recv"), Priority: types.Int64Value(100), Content: types.StringValue("remote a\n")},
+	}
+	plan := []NestedModel{
+		{Name: types.StringValue("a"), Type: types.StringValue("recv"), Priority: types.Int64Value(100), Content: types.StringValue("planned a")},
+		{Name: types.StringValue("b"), Type: types.StringValue("deliver"), Priority: types.Int64Value(100), Content: types.StringValue("planned b")},
+	}
+
+	got := MatchOrderPreservePlanContent(remote, plan)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 items, got %d", len(got))
+	}
+	if got[0].Name.ValueString() != "a" || got[0].Content.ValueString() != "planned a" {
+		t.Fatalf("unexpected first item: %#v", got[0])
+	}
+	if got[1].Name.ValueString() != "b" || got[1].Content.ValueString() != "planned b" {
+		t.Fatalf("unexpected second item: %#v", got[1])
+	}
+}

--- a/internal/resources/snippet/snippet_test.go
+++ b/internal/resources/snippet/snippet_test.go
@@ -15,7 +15,10 @@ func TestFlattenToNestedModel(t *testing.T) {
 		Content:  fastly.ToPointer(`set req.http.X-Test = "true";`),
 	}
 
-	got := FlattenToNestedModel(api)
+	got, err := FlattenToNestedModel(api)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
 
 	if got.Name.ValueString() != "recv_test" {
 		t.Fatalf("name mismatch: %q", got.Name.ValueString())
@@ -28,6 +31,20 @@ func TestFlattenToNestedModel(t *testing.T) {
 	}
 	if got.Content.ValueString() != `set req.http.X-Test = "true";` {
 		t.Fatalf("content mismatch: %q", got.Content.ValueString())
+	}
+}
+
+func TestFlattenToNestedModelInvalidPriority(t *testing.T) {
+	api := &fastly.Snippet{
+		Name:     fastly.ToPointer("recv_test"),
+		Type:     fastly.ToPointer(fastly.SnippetTypeRecv),
+		Priority: fastly.ToPointer("invalid"),
+		Content:  fastly.ToPointer(`set req.http.X-Test = "true";`),
+	}
+
+	_, err := FlattenToNestedModel(api)
+	if err == nil {
+		t.Fatal("expected error, got nil")
 	}
 }
 

--- a/templates/resources/service_vcl_snippet.md.tmpl
+++ b/templates/resources/service_vcl_snippet.md.tmpl
@@ -1,0 +1,75 @@
+---
+page_title: "fastly_service_vcl_snippet Resource - fastly"
+subcategory: ""
+description: |-
+  Fastly regular VCL snippet resource. Writes directly to the specified writable CDN service version.
+---
+
+# fastly_service_vcl_snippet (Resource)
+
+Fastly regular VCL snippet resource. Writes directly to the specified writable CDN service version.
+
+This resource is part of the explicit/default first-class resource family. It
+manages a regular, versioned VCL snippet on the configured CDN service version.
+It does not clone, activate, or stage service versions.
+
+Use this resource when you want to manage regular VCL snippets explicitly
+against a known writable service version. For automatic service version cloning,
+validation, and activation, use the nested `snippet` block on
+`fastly_service_cdn_auto`.
+
+Dynamic VCL snippets are not managed by this resource. Dynamic snippets have
+different lifecycle behavior because their metadata is versioned but their
+content is versionless and can be updated separately.
+
+## Example Usage
+
+```terraform
+resource "fastly_service_cdn" "example" {
+  name = "example"
+
+  domain {
+    name = "www.example.com"
+  }
+
+  backend {
+    name    = "origin"
+    address = "origin.example.com"
+    port    = 443
+    use_ssl = true
+  }
+
+  force_destroy = true
+}
+
+resource "fastly_service_vcl_snippet" "security_headers" {
+  service_id = fastly_service_cdn.example.id
+  version    = 1
+  name       = "security_headers"
+  type       = "deliver"
+  priority   = 100
+  content    = file("${path.module}/security_headers.vcl")
+}
+```
+
+{{ .SchemaMarkdown | trimspace }}
+
+## Import
+
+Import requires the service ID, service version, and VCL snippet name:
+
+```shell
+terraform import fastly_service_vcl_snippet.security_headers SERVICE_ID/VERSION/SNIPPET_NAME
+```
+
+Example:
+
+```shell
+terraform import fastly_service_vcl_snippet.security_headers SU1Z0isxPaozGVKXdv0eY/3/security_headers
+```
+
+## Version lifecycle
+
+This resource does not clone, activate, or stage service versions. Use explicit
+service-version lifecycle actions to clone, validate, stage, or activate a
+service version.


### PR DESCRIPTION
## Change summary

Adds regular/static VCL snippet support to the dual-model provider rewrite.

This introduces support for managing versioned VCL snippets through `fastly_service_cdn_auto` and the explicit `fastly_service_vcl_snippet` resource. Regular snippets are service-versioned configuration, so updates to snippet attributes such as `content`, `type`, or `priority` participate in the normal service version clone/reconcile/activate lifecycle.

#### PR split

This is intentionally limited to regular/static VCL snippets.

Full VCL snippet support is being split across multiple PRs because regular and dynamic snippets have different lifecycle behavior:

- Regular snippets are versioned service configuration. Updating their content requires the service-version lifecycle.
- Dynamic snippets have versioned metadata, but their content is versionless and is updated through a separate API path without cloning or activating a new service version.

A follow-up PR will add dynamic snippet container support and dynamic snippet content management.

### New Feature Submissions:

* [x] Does your submission pass tests?
* [x] Post the output of your test runs

```
=== RUN   TestAccFastlyServiceVCLSnippet_basicAndUpdate
=== PAUSE TestAccFastlyServiceVCLSnippet_basicAndUpdate
=== RUN   TestAccFastlyServiceVCLSnippet_import
=== PAUSE TestAccFastlyServiceVCLSnippet_import
=== RUN   TestAccFastlyServiceCDNAuto_withSnippet
=== PAUSE TestAccFastlyServiceCDNAuto_withSnippet
=== RUN   TestAccFastlyServiceCDNAuto_withSnippetContentUpdate
=== PAUSE TestAccFastlyServiceCDNAuto_withSnippetContentUpdate
=== RUN   TestAccFastlyServiceCDNAuto_withMultipleSnippets
=== PAUSE TestAccFastlyServiceCDNAuto_withMultipleSnippets
=== RUN   TestAccFastlyServiceCDNAuto_withDuplicateSnippetNames
=== PAUSE TestAccFastlyServiceCDNAuto_withDuplicateSnippetNames
=== RUN   TestAccFastlyServiceCDNAuto_withInvalidSnippetType
=== PAUSE TestAccFastlyServiceCDNAuto_withInvalidSnippetType
=== CONT  TestAccFastlyServiceVCLSnippet_basicAndUpdate
=== CONT  TestAccFastlyServiceCDNAuto_withMultipleSnippets
=== CONT  TestAccFastlyServiceCDNAuto_withInvalidSnippetType
=== CONT  TestAccFastlyServiceCDNAuto_withDuplicateSnippetNames
=== CONT  TestAccFastlyServiceCDNAuto_withSnippet
=== CONT  TestAccFastlyServiceVCLSnippet_import
=== CONT  TestAccFastlyServiceCDNAuto_withSnippetContentUpdate
--- PASS: TestAccFastlyServiceCDNAuto_withInvalidSnippetType (0.22s)
--- PASS: TestAccFastlyServiceCDNAuto_withDuplicateSnippetNames (0.23s)
--- PASS: TestAccFastlyServiceVCLSnippet_import (10.72s)
--- PASS: TestAccFastlyServiceVCLSnippet_basicAndUpdate (17.71s)
--- PASS: TestAccFastlyServiceCDNAuto_withSnippet (20.56s)
--- PASS: TestAccFastlyServiceCDNAuto_withMultipleSnippets (24.68s)
--- PASS: TestAccFastlyServiceCDNAuto_withSnippetContentUpdate (36.42s)
PASS
```