### PR TITLE
[CDTOOL-1706] Ensure that Compute and VCL attribute blocks are sequenced correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### ENHANCEMENTS:
 
 ### BUG FIXES:
+- fix(service_compute): process `healthcheck` blocks before `backend` blocks so backends referencing a healthcheck created in the same apply do not fail with `No healthcheck named '<name>'`
 
 ### Dependencies
 - build(deps): `github.com/fastly/go-fastly/v17` from 17.1.0 to 17.2.0 ([#1382](https://github.com/fastly/terraform-provider-fastly/pull/1382))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### BUG FIXES:
 - fix(service_compute): process `healthcheck` blocks before `backend` blocks so backends referencing a healthcheck created in the same apply do not fail with `No healthcheck named '<name>'` ([#1384](https://github.com/fastly/terraform-provider-fastly/pull/1384))
-- fix(service_vcl): process `dictionary` and `response_object` blocks before `rate_limiter` blocks so a rate limiter referencing a dictionary or response object created in the same apply does not fail with a 400 error ([#1384](https://github.com/fastly/terraform-provider-fastly/pull/1384))
+- fix(service_vcl): process `dictionary` and `response_object` blocks before `rate_limiter` blocks so a rate limiter referencing a dictionary or response object created in the same apply does not fail ([#1384](https://github.com/fastly/terraform-provider-fastly/pull/1384))
 
 ### Dependencies
 - build(deps): `github.com/fastly/go-fastly/v17` from 17.1.0 to 17.2.0 ([#1382](https://github.com/fastly/terraform-provider-fastly/pull/1382))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### BUG FIXES:
 - fix(service_compute): process `healthcheck` blocks before `backend` blocks so backends referencing a healthcheck created in the same apply do not fail with `No healthcheck named '<name>'` ([#1384](https://github.com/fastly/terraform-provider-fastly/pull/1384))
+- fix(service_vcl): process `dictionary` and `response_object` blocks before `rate_limiter` blocks so a rate limiter referencing a dictionary or response object created in the same apply does not fail with a 400 error ([#1384](https://github.com/fastly/terraform-provider-fastly/pull/1384))
 
 ### Dependencies
 - build(deps): `github.com/fastly/go-fastly/v17` from 17.1.0 to 17.2.0 ([#1382](https://github.com/fastly/terraform-provider-fastly/pull/1382))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### ENHANCEMENTS:
 
 ### BUG FIXES:
-- fix(service_compute): process `healthcheck` blocks before `backend` blocks so backends referencing a healthcheck created in the same apply do not fail with `No healthcheck named '<name>'`
+- fix(service_compute): process `healthcheck` blocks before `backend` blocks so backends referencing a healthcheck created in the same apply do not fail with `No healthcheck named '<name>'` ([#1384](https://github.com/fastly/terraform-provider-fastly/pull/1384))
 
 ### Dependencies
 - build(deps): `github.com/fastly/go-fastly/v17` from 17.1.0 to 17.2.0 ([#1382](https://github.com/fastly/terraform-provider-fastly/pull/1382))

--- a/fastly/block_fastly_service_ratelimiter_test.go
+++ b/fastly/block_fastly_service_ratelimiter_test.go
@@ -203,6 +203,71 @@ func TestAccFastlyServiceVCLRateLimiter_basic(t *testing.T) {
 	})
 }
 
+// TestAccFastlyServiceVCLRateLimiter_orderingRegression verifies that a
+// rate_limiter can reference a response_object (via response_object_name) and
+// a dictionary (via uri_dictionary_name) created in the same apply.
+func TestAccFastlyServiceVCLRateLimiter_orderingRegression(t *testing.T) {
+	var service gofastly.ServiceDetail
+	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	domainName := fmt.Sprintf("fastly-test.tf-%s.com", acctest.RandString(10))
+	rateLimiterName := fmt.Sprintf("rate_limiter_tf_%s", acctest.RandString(10))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckServiceVCLDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServiceVCLRateLimiterOrderingRegression(serviceName, domainName, rateLimiterName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceExists("fastly_service_vcl.example", &service),
+					resource.TestCheckResourceAttr("fastly_service_vcl.example", "rate_limiter.#", "1"),
+					resource.TestCheckResourceAttr("fastly_service_vcl.example", "rate_limiter.0.response_object_name", rateLimiterName+"_robj"),
+					resource.TestCheckResourceAttr("fastly_service_vcl.example", "rate_limiter.0.uri_dictionary_name", rateLimiterName+"_dict"),
+				),
+			},
+		},
+	})
+}
+
+func testAccServiceVCLRateLimiterOrderingRegression(serviceName, domainName, rateLimiterName string) string {
+	return fmt.Sprintf(`
+resource "fastly_service_vcl" "example" {
+  name = "%s"
+
+  domain {
+    name    = "%s"
+    comment = "demo"
+  }
+
+  dictionary {
+    name = "%s_dict"
+  }
+
+  response_object {
+    name    = "%s_robj"
+    status  = 429
+    content = "rate limited"
+  }
+
+  rate_limiter {
+    action                = "response_object"
+    client_key             = "req.http.Fastly-Client-IP"
+    http_methods           = "GET"
+    name                   = "%s"
+    penalty_box_duration   = 30
+    response_object_name   = "%s_robj"
+    uri_dictionary_name    = "%s_dict"
+    rps_limit              = 100
+    window_size            = 60
+  }
+
+  force_destroy = true
+}`, serviceName, domainName, rateLimiterName, rateLimiterName, rateLimiterName, rateLimiterName, rateLimiterName)
+}
+
 func testAccServiceVCLRateLimiter(serviceName, domainName, rateLimiterName string) string {
 	return fmt.Sprintf(`
 variable "mydict" {

--- a/fastly/resource_fastly_service_compute.go
+++ b/fastly/resource_fastly_service_compute.go
@@ -15,8 +15,8 @@ var computeService = &BaseServiceDefinition{
 	Type: computeAttributes.serviceType,
 	Attributes: []ServiceAttributeDefinition{
 		NewServiceDomain(computeAttributes),
-		NewServiceBackend(computeAttributes),
 		NewServiceHealthCheck(computeAttributes),
+		NewServiceBackend(computeAttributes),
 		NewServiceProductEnablement(computeAttributes),
 		NewServiceImageOptimizerDefaultSettings(vclAttributes),
 		NewServiceLoggingS3(computeAttributes),

--- a/fastly/resource_fastly_service_compute_test.go
+++ b/fastly/resource_fastly_service_compute_test.go
@@ -100,8 +100,9 @@ resource "fastly_service_compute" "foo" {
 
   {{ range .Backends }}
   backend {
-    address = "{{ . }}"
-    name    = "tf-test backend {{ . }}"
+    address     = "{{ . }}"
+    name        = "tf-test backend {{ . }}"
+    healthcheck = "{{ $.HealthcheckName }}"
   }
   {{ end }}
 
@@ -238,8 +239,9 @@ resource "fastly_service_compute" "foo" {
     comment = "tf-testing-domain"
   }
   backend {
-    address = "aws.amazon.com"
-    name    = "amazon docs"
+    address     = "test.mytest.com"
+    name        = "my testing site"
+    healthcheck = "healthCheckTest"
   }
   healthcheck {
     name = "healthCheckTest"

--- a/fastly/resource_fastly_service_vcl.go
+++ b/fastly/resource_fastly_service_vcl.go
@@ -52,15 +52,15 @@ var vclService = &BaseServiceDefinition{
 		NewServiceLoggingDigitalOcean(vclAttributes),
 		NewServiceLoggingCloudfiles(vclAttributes),
 		NewServiceLoggingKinesis(vclAttributes),
-		NewServiceRateLimiter(vclAttributes),
+		NewServiceDictionary(vclAttributes),
 		NewServiceResponseObject(vclAttributes),
+		NewServiceRateLimiter(vclAttributes),
 		NewServiceRequestSetting(vclAttributes),
 		NewServiceVCL(vclAttributes),
 		NewServiceSnippet(vclAttributes),
 		NewServiceDynamicSnippet(vclAttributes),
 		NewServiceCacheSetting(vclAttributes),
 		NewServiceACL(),
-		NewServiceDictionary(vclAttributes),
 	},
 }
 


### PR DESCRIPTION
### Change summary

This PR addresses an issue where adding a `healthcheck` block to a Compute resources while assigning said healthcheck to a `backend` block results in the incorrect sequencing order where the backend changes are processed first - resulting in a API `400` with a `  Detail: No healthcheck named ...` error. 

We are addressing this with a simple changing of lowering the order of which we process `backend` blocks for Compute services, ensuring that healthchecks fire off first. 

-- 

Upon further codebase review, another discrepancy was found with VCL services: `rate_limiter` blocks were processed before the `dictionary` / `response_object` blocks in which they referenced by name, so referencing one created in the same apply would also fail. This has also been addressed. 

 All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/terraform-provider-fastly/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

* [x] Does your submission pass tests?
* [x] Post the output of your test runs

```
TF_ACC=1  go test ./fastly/ -run 'TestAccFastlyServiceCompute_basic|TestAccFastlyServiceCompute_stage'
ok      github.com/fastly/terraform-provider-fastly/fastly      51.495s
```
```
TF_ACC=1  go test ./fastly/ -run 'TestAccFastlyServiceVCLRateLimiter_orderingRegression'
ok      github.com/fastly/terraform-provider-fastly/fastly      15.441s
```

### Changes to Core Features:

* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### User Impact

- Users can now define and assign healthchecks on Compute services in the same apply without facing errors. 
- Users can now define rate_limiter blocks that reference a dictionary or response_object created in the same apply on VCL services without encountering errors.
