### PR TITLE
add optional enabled attribute to toggle products in-place

### DIFF
--- a/docs/resources/service_product_api_discovery.md
+++ b/docs/resources/service_product_api_discovery.md
@@ -18,6 +18,10 @@ Enables API Discovery on a service. Product Enablement operates on the service d
 
 - `service_id` (String) The ID of the service to enable API Discovery on. Changing this value will delete and recreate this resource against the new service.
 
+### Optional
+
+- `enabled` (Boolean) Whether API Discovery is enabled on the service. Defaults to `true`.
+
 ### Read-Only
 
 - `id` (String) The ID of this resource (identical to `service_id`).

--- a/docs/resources/service_product_bot_management.md
+++ b/docs/resources/service_product_bot_management.md
@@ -19,6 +19,10 @@ Enables Bot Management on a service. Product Enablement operates on the service 
 - `contentguard` (String) ContentGuard status. Can be either `off` or `on`.
 - `service_id` (String) The ID of the service to enable Bot Management on. Changing this value will delete and recreate this resource against the new service.
 
+### Optional
+
+- `enabled` (Boolean) Whether Bot Management is enabled on the service. Defaults to `true`.
+
 ### Read-Only
 
 - `id` (String) The ID of this resource (identical to `service_id`).

--- a/docs/resources/service_product_brotli_compression.md
+++ b/docs/resources/service_product_brotli_compression.md
@@ -18,6 +18,10 @@ Enables Brotli Compression on a service. Product Enablement operates on the serv
 
 - `service_id` (String) The ID of the service to enable Brotli Compression on. Changing this value will delete and recreate this resource against the new service.
 
+### Optional
+
+- `enabled` (Boolean) Whether Brotli Compression is enabled on the service. Defaults to `true`.
+
 ### Read-Only
 
 - `id` (String) The ID of this resource (identical to `service_id`).

--- a/docs/resources/service_product_ddos_protection.md
+++ b/docs/resources/service_product_ddos_protection.md
@@ -19,6 +19,10 @@ Enables DDoS Protection on a service. Product Enablement operates on the service
 - `mode` (String) Operation mode. Can be `off`, `log`, or `block`.
 - `service_id` (String) The ID of the service to enable DDoS Protection on. Changing this value will delete and recreate this resource against the new service.
 
+### Optional
+
+- `enabled` (Boolean) Whether DDoS Protection is enabled on the service. Defaults to `true`.
+
 ### Read-Only
 
 - `id` (String) The ID of this resource (identical to `service_id`).

--- a/docs/resources/service_product_domain_inspector.md
+++ b/docs/resources/service_product_domain_inspector.md
@@ -18,6 +18,10 @@ Enables Domain Inspector on a service. Product Enablement operates on the servic
 
 - `service_id` (String) The ID of the service to enable Domain Inspector on. Changing this value will delete and recreate this resource against the new service.
 
+### Optional
+
+- `enabled` (Boolean) Whether Domain Inspector is enabled on the service. Defaults to `true`.
+
 ### Read-Only
 
 - `id` (String) The ID of this resource (identical to `service_id`).

--- a/docs/resources/service_product_fanout.md
+++ b/docs/resources/service_product_fanout.md
@@ -18,6 +18,10 @@ Enables Fanout on a service. Product Enablement operates on the service directly
 
 - `service_id` (String) The ID of the service to enable Fanout on. Changing this value will delete and recreate this resource against the new service.
 
+### Optional
+
+- `enabled` (Boolean) Whether Fanout is enabled on the service. Defaults to `true`.
+
 ### Read-Only
 
 - `id` (String) The ID of this resource (identical to `service_id`).

--- a/docs/resources/service_product_image_optimizer.md
+++ b/docs/resources/service_product_image_optimizer.md
@@ -18,6 +18,10 @@ Enables Image Optimizer on a service. Product Enablement operates on the service
 
 - `service_id` (String) The ID of the service to enable Image Optimizer on. Changing this value will delete and recreate this resource against the new service.
 
+### Optional
+
+- `enabled` (Boolean) Whether Image Optimizer is enabled on the service. Defaults to `true`.
+
 ### Read-Only
 
 - `id` (String) The ID of this resource (identical to `service_id`).

--- a/docs/resources/service_product_log_explorer_insights.md
+++ b/docs/resources/service_product_log_explorer_insights.md
@@ -18,6 +18,10 @@ Enables Log Explorer & Insights on a service. Product Enablement operates on the
 
 - `service_id` (String) The ID of the service to enable Log Explorer & Insights on. Changing this value will delete and recreate this resource against the new service.
 
+### Optional
+
+- `enabled` (Boolean) Whether Log Explorer & Insights is enabled on the service. Defaults to `true`.
+
 ### Read-Only
 
 - `id` (String) The ID of this resource (identical to `service_id`).

--- a/docs/resources/service_product_ngwaf.md
+++ b/docs/resources/service_product_ngwaf.md
@@ -21,6 +21,7 @@ Enables Next-Gen WAF on a service. Product Enablement operates on the service di
 
 ### Optional
 
+- `enabled` (Boolean) Whether Next-Gen WAF is enabled on the service. Defaults to `true`.
 - `traffic_ramp` (Number) The percentage of traffic to inspect. Only supported for CDN services; defaults to 100.
 
 ### Read-Only

--- a/docs/resources/service_product_origin_inspector.md
+++ b/docs/resources/service_product_origin_inspector.md
@@ -18,6 +18,10 @@ Enables Origin Inspector on a service. Product Enablement operates on the servic
 
 - `service_id` (String) The ID of the service to enable Origin Inspector on. Changing this value will delete and recreate this resource against the new service.
 
+### Optional
+
+- `enabled` (Boolean) Whether Origin Inspector is enabled on the service. Defaults to `true`.
+
 ### Read-Only
 
 - `id` (String) The ID of this resource (identical to `service_id`).

--- a/docs/resources/service_product_websockets.md
+++ b/docs/resources/service_product_websockets.md
@@ -18,6 +18,10 @@ Enables WebSockets on a service. Product Enablement operates on the service dire
 
 - `service_id` (String) The ID of the service to enable WebSockets on. Changing this value will delete and recreate this resource against the new service.
 
+### Optional
+
+- `enabled` (Boolean) Whether WebSockets is enabled on the service. Defaults to `true`.
+
 ### Read-Only
 
 - `id` (String) The ID of this resource (identical to `service_id`).

--- a/internal/acceptance_tests/blocks/service_product_bot_management.tf
+++ b/internal/acceptance_tests/blocks/service_product_bot_management.tf
@@ -1,4 +1,5 @@
 resource "fastly_service_product_bot_management" "test" {
   service_id   = {{.SERVICE_ID_REF}}
   contentguard = "{{.CONTENT_GUARD}}"
+  {{if .ENABLED}}enabled = {{.ENABLED}}{{end}}
 }

--- a/internal/acceptance_tests/blocks/service_product_ddos_protection.tf
+++ b/internal/acceptance_tests/blocks/service_product_ddos_protection.tf
@@ -1,4 +1,5 @@
 resource "fastly_service_product_ddos_protection" "test" {
   service_id = {{.SERVICE_ID_REF}}
   mode       = "{{.DDOS_MODE}}"
+  {{if .ENABLED}}enabled = {{.ENABLED}}{{end}}
 }

--- a/internal/acceptance_tests/blocks/service_product_ngwaf.tf
+++ b/internal/acceptance_tests/blocks/service_product_ngwaf.tf
@@ -2,4 +2,5 @@ resource "fastly_service_product_ngwaf" "test" {
   service_id   = {{.SERVICE_ID_REF}}
   workspace_id = "{{.NGWAF_WORKSPACE_ID}}"
 {{if .NGWAF_TRAFFIC_RAMP}}  traffic_ramp = {{.NGWAF_TRAFFIC_RAMP}}
+{{end}}{{if .ENABLED}}  enabled = {{.ENABLED}}
 {{end}}}

--- a/internal/acceptance_tests/blocks/service_product_origin_inspector.tf
+++ b/internal/acceptance_tests/blocks/service_product_origin_inspector.tf
@@ -1,3 +1,4 @@
 resource "fastly_service_product_origin_inspector" "test" {
   service_id = {{.SERVICE_ID_REF}}
+  {{if .ENABLED}}enabled = {{.ENABLED}}{{end}}
 }

--- a/internal/acceptance_tests/product_enablement_test.go
+++ b/internal/acceptance_tests/product_enablement_test.go
@@ -472,6 +472,159 @@ func TestAccFastlyProductEnablement_ngwafUpdateWorkspaceAndRamp(t *testing.T) {
 	})
 }
 
+// TestAccFastlyProductEnablement_ddosEnabledToggle verifies that toggling
+// the enabled attribute on fastly_service_product_ddos_protection through
+// true -> false -> true re-enables the product via the Enable API on the
+// false -> true transition, rather than leaving it disabled because Update
+// only called UpdateConfiguration.
+func TestAccFastlyProductEnablement_ddosEnabledToggle(t *testing.T) {
+	t.Parallel()
+	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	domainName := fmt.Sprintf("%s.example.com", acctest.RandString(10))
+	backendName := fmt.Sprintf("backend-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
+		CheckDestroy:             CheckServiceDestroy("fastly_service_cdn_auto"),
+		Steps: []resource.TestStep{
+			{
+				Config: ConfigProductEnablementDDoSEnabledToggle(serviceName, domainName, backendName, "block", true),
+				Check: resource.ComposeTestCheckFunc(
+					CheckServiceExists("fastly_service_cdn_auto.test"),
+					resource.TestCheckResourceAttr("fastly_service_product_ddos_protection.test", "enabled", "true"),
+					resource.TestCheckResourceAttr("fastly_service_product_ddos_protection.test", "mode", "block"),
+				),
+			},
+			{
+				Config: ConfigProductEnablementDDoSEnabledToggle(serviceName, domainName, backendName, "block", false),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("fastly_service_product_ddos_protection.test", plancheck.ResourceActionUpdate),
+					},
+				},
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("fastly_service_product_ddos_protection.test", "enabled", "false"),
+				),
+			},
+			{
+				Config: ConfigProductEnablementDDoSEnabledToggle(serviceName, domainName, backendName, "block", true),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("fastly_service_product_ddos_protection.test", plancheck.ResourceActionUpdate),
+					},
+				},
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("fastly_service_product_ddos_protection.test", "enabled", "true"),
+					resource.TestCheckResourceAttr("fastly_service_product_ddos_protection.test", "mode", "block"),
+				),
+			},
+		},
+	})
+}
+
+// TestAccFastlyProductEnablement_botManagementEnabledToggle verifies that
+// toggling the enabled attribute on fastly_service_product_bot_management
+// through true -> false -> true re-enables the product via the Enable API
+// on the false -> true transition, rather than leaving it disabled because
+// Update only called UpdateConfiguration.
+func TestAccFastlyProductEnablement_botManagementEnabledToggle(t *testing.T) {
+	t.Parallel()
+	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	domainName := fmt.Sprintf("%s.example.com", acctest.RandString(10))
+	backendName := fmt.Sprintf("backend-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
+		CheckDestroy:             CheckServiceDestroy("fastly_service_cdn_auto"),
+		Steps: []resource.TestStep{
+			{
+				Config: ConfigProductEnablementBotManagementEnabledToggle(serviceName, domainName, backendName, "on", true),
+				Check: resource.ComposeTestCheckFunc(
+					CheckServiceExists("fastly_service_cdn_auto.test"),
+					resource.TestCheckResourceAttr("fastly_service_product_bot_management.test", "enabled", "true"),
+					resource.TestCheckResourceAttr("fastly_service_product_bot_management.test", "contentguard", "on"),
+				),
+			},
+			{
+				Config: ConfigProductEnablementBotManagementEnabledToggle(serviceName, domainName, backendName, "on", false),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("fastly_service_product_bot_management.test", plancheck.ResourceActionUpdate),
+					},
+				},
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("fastly_service_product_bot_management.test", "enabled", "false"),
+				),
+			},
+			{
+				Config: ConfigProductEnablementBotManagementEnabledToggle(serviceName, domainName, backendName, "on", true),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("fastly_service_product_bot_management.test", plancheck.ResourceActionUpdate),
+					},
+				},
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("fastly_service_product_bot_management.test", "enabled", "true"),
+					resource.TestCheckResourceAttr("fastly_service_product_bot_management.test", "contentguard", "on"),
+				),
+			},
+		},
+	})
+}
+
+// TestAccFastlyProductEnablement_ngwafEnabledToggle verifies that toggling
+// the enabled attribute on fastly_service_product_ngwaf through
+// true -> false -> true re-enables the product via the Enable API on the
+// false -> true transition, rather than leaving it disabled because Update
+// only called UpdateConfiguration.
+func TestAccFastlyProductEnablement_ngwafEnabledToggle(t *testing.T) {
+	t.Parallel()
+	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	domainName := fmt.Sprintf("%s.example.com", acctest.RandString(10))
+	backendName := fmt.Sprintf("backend-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
+		CheckDestroy:             CheckServiceDestroy("fastly_service_cdn_auto"),
+		Steps: []resource.TestStep{
+			{
+				Config: ConfigProductEnablementNGWAFEnabledToggle(serviceName, domainName, backendName, testNGWAFWorkspaceID, true),
+				Check: resource.ComposeTestCheckFunc(
+					CheckServiceExists("fastly_service_cdn_auto.test"),
+					resource.TestCheckResourceAttr("fastly_service_product_ngwaf.test", "enabled", "true"),
+					resource.TestCheckResourceAttr("fastly_service_product_ngwaf.test", "workspace_id", testNGWAFWorkspaceID),
+				),
+			},
+			{
+				Config: ConfigProductEnablementNGWAFEnabledToggle(serviceName, domainName, backendName, testNGWAFWorkspaceID, false),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("fastly_service_product_ngwaf.test", plancheck.ResourceActionUpdate),
+					},
+				},
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("fastly_service_product_ngwaf.test", "enabled", "false"),
+				),
+			},
+			{
+				Config: ConfigProductEnablementNGWAFEnabledToggle(serviceName, domainName, backendName, testNGWAFWorkspaceID, true),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("fastly_service_product_ngwaf.test", plancheck.ResourceActionUpdate),
+					},
+				},
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("fastly_service_product_ngwaf.test", "enabled", "true"),
+					resource.TestCheckResourceAttr("fastly_service_product_ngwaf.test", "workspace_id", testNGWAFWorkspaceID),
+				),
+			},
+		},
+	})
+}
+
 // TestAccFastlyProductEnablement_serviceIDForcesReplace verifies that
 // changing service_id forces replacement of the resource (destroy against
 // the old service, create against the new one) rather than an in-place

--- a/internal/acceptance_tests/product_enablement_test.go
+++ b/internal/acceptance_tests/product_enablement_test.go
@@ -513,3 +513,50 @@ func TestAccFastlyProductEnablement_serviceIDForcesReplace(t *testing.T) {
 		},
 	})
 }
+
+// TestAccFastlyProductEnablement_simpleProductEnabledToggle verifies that
+// toggling the enabled attribute on a simple product (origin_inspector)
+// between false and true correctly disables and re-enables the product.
+func TestAccFastlyProductEnablement_simpleProductEnabledToggle(t *testing.T) {
+	t.Parallel()
+	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	domainName := fmt.Sprintf("%s.example.com", acctest.RandString(10))
+	backendName := fmt.Sprintf("backend-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
+		CheckDestroy:             CheckServiceDestroy("fastly_service_cdn_auto"),
+		Steps: []resource.TestStep{
+			{
+				Config: ConfigProductEnablementSimpleEnabledToggle(serviceName, domainName, backendName, true),
+				Check: resource.ComposeTestCheckFunc(
+					CheckServiceExists("fastly_service_cdn_auto.test"),
+					resource.TestCheckResourceAttr("fastly_service_product_origin_inspector.test", "enabled", "true"),
+				),
+			},
+			{
+				Config: ConfigProductEnablementSimpleEnabledToggle(serviceName, domainName, backendName, false),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("fastly_service_product_origin_inspector.test", plancheck.ResourceActionUpdate),
+					},
+				},
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("fastly_service_product_origin_inspector.test", "enabled", "false"),
+				),
+			},
+			{
+				Config: ConfigProductEnablementSimpleEnabledToggle(serviceName, domainName, backendName, true),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("fastly_service_product_origin_inspector.test", plancheck.ResourceActionUpdate),
+					},
+				},
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("fastly_service_product_origin_inspector.test", "enabled", "true"),
+				),
+			},
+		},
+	})
+}

--- a/internal/acceptance_tests/product_enablement_test.go
+++ b/internal/acceptance_tests/product_enablement_test.go
@@ -508,6 +508,16 @@ func TestAccFastlyProductEnablement_ddosEnabledToggle(t *testing.T) {
 				),
 			},
 			{
+				// Exercises Read against a disabled product: the API returns
+				// a 400 "no product on service" rather than a 404, which
+				// Read must recognize via isProductDisabledError rather than
+				// surfacing as a read error.
+				RefreshState: true,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("fastly_service_product_ddos_protection.test", "enabled", "false"),
+				),
+			},
+			{
 				Config: ConfigProductEnablementDDoSEnabledToggle(serviceName, domainName, backendName, "block", true),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
@@ -559,6 +569,16 @@ func TestAccFastlyProductEnablement_botManagementEnabledToggle(t *testing.T) {
 				),
 			},
 			{
+				// Exercises Read against a disabled product: the API returns
+				// a 400 "no product on service" rather than a 404, which
+				// Read must recognize via isProductDisabledError rather than
+				// surfacing as a read error.
+				RefreshState: true,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("fastly_service_product_bot_management.test", "enabled", "false"),
+				),
+			},
+			{
 				Config: ConfigProductEnablementBotManagementEnabledToggle(serviceName, domainName, backendName, "on", true),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
@@ -605,6 +625,16 @@ func TestAccFastlyProductEnablement_ngwafEnabledToggle(t *testing.T) {
 						plancheck.ExpectResourceAction("fastly_service_product_ngwaf.test", plancheck.ResourceActionUpdate),
 					},
 				},
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("fastly_service_product_ngwaf.test", "enabled", "false"),
+				),
+			},
+			{
+				// Exercises Read against a disabled product: the API returns
+				// a 400 "no product on service" rather than a 404, which
+				// Read must recognize via isProductDisabledError rather than
+				// surfacing as a read error.
+				RefreshState: true,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("fastly_service_product_ngwaf.test", "enabled", "false"),
 				),

--- a/internal/acceptance_tests/test_helpers.go
+++ b/internal/acceptance_tests/test_helpers.go
@@ -2647,6 +2647,46 @@ func ConfigProductEnablementNGWAFOnly(serviceName, domainName, backendName, work
 		})
 }
 
+// ConfigProductEnablementDDoSEnabledToggle returns a CDN auto service paired
+// with fastly_service_product_ddos_protection at the given mode, explicitly
+// setting the enabled attribute, used to verify that toggling enabled
+// between true and false re-enables the product (via the Enable API) rather
+// than leaving it disabled after a false -> true transition.
+func ConfigProductEnablementDDoSEnabledToggle(serviceName, domainName, backendName, mode string, enabled bool) string {
+	return ConfigProductEnablementCDNEmpty(serviceName, domainName, backendName) + "\n" +
+		productEnablementBlock("ddos_protection", "fastly_service_cdn_auto.test.id", map[string]string{
+			"DDOS_MODE": mode,
+			"ENABLED":   strconv.FormatBool(enabled),
+		})
+}
+
+// ConfigProductEnablementBotManagementEnabledToggle returns a CDN auto
+// service paired with fastly_service_product_bot_management at the given
+// contentguard value, explicitly setting the enabled attribute, used to
+// verify that toggling enabled between true and false re-enables the
+// product (via the Enable API) rather than leaving it disabled after a
+// false -> true transition.
+func ConfigProductEnablementBotManagementEnabledToggle(serviceName, domainName, backendName, contentGuard string, enabled bool) string {
+	return ConfigProductEnablementCDNEmpty(serviceName, domainName, backendName) + "\n" +
+		productEnablementBlock("bot_management", "fastly_service_cdn_auto.test.id", map[string]string{
+			"CONTENT_GUARD": contentGuard,
+			"ENABLED":       strconv.FormatBool(enabled),
+		})
+}
+
+// ConfigProductEnablementNGWAFEnabledToggle returns a CDN auto service
+// paired with fastly_service_product_ngwaf at the given workspace_id,
+// explicitly setting the enabled attribute, used to verify that toggling
+// enabled between true and false re-enables the product (via the Enable
+// API) rather than leaving it disabled after a false -> true transition.
+func ConfigProductEnablementNGWAFEnabledToggle(serviceName, domainName, backendName, workspaceID string, enabled bool) string {
+	return ConfigProductEnablementCDNEmpty(serviceName, domainName, backendName) + "\n" +
+		productEnablementBlock("ngwaf", "fastly_service_cdn_auto.test.id", map[string]string{
+			"NGWAF_WORKSPACE_ID": workspaceID,
+			"ENABLED":            strconv.FormatBool(enabled),
+		})
+}
+
 // ConfigProductEnablementSimpleEnabledToggle returns a CDN auto service paired
 // with a simple product (origin_inspector) that explicitly sets the enabled
 // attribute to the given value, used to verify that toggling enabled between

--- a/internal/acceptance_tests/test_helpers.go
+++ b/internal/acceptance_tests/test_helpers.go
@@ -2647,6 +2647,19 @@ func ConfigProductEnablementNGWAFOnly(serviceName, domainName, backendName, work
 		})
 }
 
+// ConfigProductEnablementSimpleEnabledToggle returns a CDN auto service paired
+// with a simple product (origin_inspector) that explicitly sets the enabled
+// attribute to the given value, used to verify that toggling enabled between
+// true and false works correctly.
+func ConfigProductEnablementSimpleEnabledToggle(serviceName, domainName, backendName string, enabled bool) string {
+	enabledStr := "true"
+	if !enabled {
+		enabledStr = "false"
+	}
+	return ConfigProductEnablementCDNEmpty(serviceName, domainName, backendName) + "\n" +
+		productEnablementBlock("origin_inspector", "fastly_service_cdn_auto.test.id", map[string]string{"ENABLED": enabledStr})
+}
+
 // ConfigProductEnablementServiceIDReplace returns two CDN auto services and
 // a single fastly_service_product_domain_inspector resource whose
 // service_id points at either "first" or "second" depending on useSecond,

--- a/internal/resources/productenablement/bot_management.go
+++ b/internal/resources/productenablement/bot_management.go
@@ -121,7 +121,7 @@ func (r *BotManagementResource) Read(ctx context.Context, req resource.ReadReque
 	tflog.Debug(ctx, "Reading Fastly Product Enablement (bot_management)", map[string]any{"service_id": serviceID})
 
 	if _, err := botmanagement.Get(ctx, r.client, serviceID); err != nil {
-		if errors.IsNotFound(err) {
+		if errors.IsNotFound(err) || isProductDisabledError(err) {
 			tflog.Debug(ctx, "bot_management is disabled on service", map[string]any{"service_id": serviceID})
 			state.Enabled = types.BoolValue(false)
 		} else {

--- a/internal/resources/productenablement/bot_management.go
+++ b/internal/resources/productenablement/bot_management.go
@@ -157,6 +157,10 @@ func (r *BotManagementResource) Update(ctx context.Context, req resource.UpdateR
 	}
 
 	if enabled {
+		if _, err := botmanagement.Enable(ctx, r.client, serviceID); err != nil {
+			resp.Diagnostics.AddError("Error enabling bot_management", err.Error())
+			return
+		}
 		if _, err := botmanagement.UpdateConfiguration(ctx, r.client, serviceID, botmanagement.ConfigureInput{
 			ContentGuard: plan.ContentGuard.ValueString(),
 		}); err != nil {

--- a/internal/resources/productenablement/bot_management.go
+++ b/internal/resources/productenablement/bot_management.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -23,6 +24,7 @@ var _ resource.ResourceWithImportState = &BotManagementResource{}
 type BotManagementModel struct {
 	ID           types.String `tfsdk:"id"`
 	ServiceID    types.String `tfsdk:"service_id"`
+	Enabled      types.Bool   `tfsdk:"enabled"`
 	ContentGuard types.String `tfsdk:"contentguard"`
 }
 
@@ -44,6 +46,12 @@ func (r *BotManagementResource) Schema(_ context.Context, _ resource.SchemaReque
 		Attributes: map[string]schema.Attribute{
 			"id":         idAttribute(),
 			"service_id": serviceIDAttribute("Bot Management"),
+			"enabled": schema.BoolAttribute{
+				Optional:    true,
+				Computed:    true,
+				Default:     booldefault.StaticBool(true),
+				Description: "Whether Bot Management is enabled on the service. Defaults to `true`.",
+			},
 			"contentguard": schema.StringAttribute{
 				Required:    true,
 				Description: "ContentGuard status. Can be either `off` or `on`.",
@@ -74,18 +82,31 @@ func (r *BotManagementResource) Create(ctx context.Context, req resource.CreateR
 	serviceID := plan.ServiceID.ValueString()
 	tflog.Debug(ctx, "Creating Fastly Product Enablement (bot_management)", map[string]any{"service_id": serviceID})
 
-	if _, err := botmanagement.Enable(ctx, r.client, serviceID); err != nil {
-		resp.Diagnostics.AddError("Error enabling bot_management", err.Error())
-		return
+	enabled := true
+	if !plan.Enabled.IsNull() {
+		enabled = plan.Enabled.ValueBool()
 	}
-	if _, err := botmanagement.UpdateConfiguration(ctx, r.client, serviceID, botmanagement.ConfigureInput{
-		ContentGuard: plan.ContentGuard.ValueString(),
-	}); err != nil {
-		resp.Diagnostics.AddError("Error configuring bot_management", err.Error())
-		return
+
+	if enabled {
+		if _, err := botmanagement.Enable(ctx, r.client, serviceID); err != nil {
+			resp.Diagnostics.AddError("Error enabling bot_management", err.Error())
+			return
+		}
+		if _, err := botmanagement.UpdateConfiguration(ctx, r.client, serviceID, botmanagement.ConfigureInput{
+			ContentGuard: plan.ContentGuard.ValueString(),
+		}); err != nil {
+			resp.Diagnostics.AddError("Error configuring bot_management", err.Error())
+			return
+		}
+	} else {
+		if err := botmanagement.Disable(ctx, r.client, serviceID); err != nil && !isEntitlementError(err) && !errors.IsNotFound(err) {
+			resp.Diagnostics.AddError("Error disabling bot_management", err.Error())
+			return
+		}
 	}
 
 	plan.ID = plan.ServiceID
+	plan.Enabled = types.BoolValue(enabled)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 
@@ -101,19 +122,21 @@ func (r *BotManagementResource) Read(ctx context.Context, req resource.ReadReque
 
 	if _, err := botmanagement.Get(ctx, r.client, serviceID); err != nil {
 		if errors.IsNotFound(err) {
-			resp.State.RemoveResource(ctx)
+			tflog.Debug(ctx, "bot_management is disabled on service", map[string]any{"service_id": serviceID})
+			state.Enabled = types.BoolValue(false)
+		} else {
+			resp.Diagnostics.AddError("Error reading bot_management", err.Error())
 			return
 		}
-		resp.Diagnostics.AddError("Error reading bot_management", err.Error())
-		return
+	} else {
+		state.Enabled = types.BoolValue(true)
+		cfg, err := botmanagement.GetConfiguration(ctx, r.client, serviceID)
+		if err != nil {
+			resp.Diagnostics.AddError("Error reading bot_management configuration", err.Error())
+			return
+		}
+		state.ContentGuard = types.StringPointerValue(cfg.Configuration.ContentGuard)
 	}
-
-	cfg, err := botmanagement.GetConfiguration(ctx, r.client, serviceID)
-	if err != nil {
-		resp.Diagnostics.AddError("Error reading bot_management configuration", err.Error())
-		return
-	}
-	state.ContentGuard = types.StringPointerValue(cfg.Configuration.ContentGuard)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
@@ -128,14 +151,27 @@ func (r *BotManagementResource) Update(ctx context.Context, req resource.UpdateR
 	serviceID := plan.ServiceID.ValueString()
 	tflog.Debug(ctx, "Updating Fastly Product Enablement (bot_management)", map[string]any{"service_id": serviceID})
 
-	if _, err := botmanagement.UpdateConfiguration(ctx, r.client, serviceID, botmanagement.ConfigureInput{
-		ContentGuard: plan.ContentGuard.ValueString(),
-	}); err != nil {
-		resp.Diagnostics.AddError("Error configuring bot_management", err.Error())
-		return
+	enabled := true
+	if !plan.Enabled.IsNull() {
+		enabled = plan.Enabled.ValueBool()
+	}
+
+	if enabled {
+		if _, err := botmanagement.UpdateConfiguration(ctx, r.client, serviceID, botmanagement.ConfigureInput{
+			ContentGuard: plan.ContentGuard.ValueString(),
+		}); err != nil {
+			resp.Diagnostics.AddError("Error configuring bot_management", err.Error())
+			return
+		}
+	} else {
+		if err := botmanagement.Disable(ctx, r.client, serviceID); err != nil && !isEntitlementError(err) && !errors.IsNotFound(err) {
+			resp.Diagnostics.AddError("Error disabling bot_management", err.Error())
+			return
+		}
 	}
 
 	plan.ID = plan.ServiceID
+	plan.Enabled = types.BoolValue(enabled)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 
@@ -149,8 +185,15 @@ func (r *BotManagementResource) Delete(ctx context.Context, req resource.DeleteR
 	serviceID := state.ServiceID.ValueString()
 	tflog.Debug(ctx, "Deleting Fastly Product Enablement (bot_management)", map[string]any{"service_id": serviceID})
 
-	if err := botmanagement.Disable(ctx, r.client, serviceID); err != nil && !isEntitlementError(err) && !errors.IsNotFound(err) {
-		resp.Diagnostics.AddError("Error disabling bot_management", err.Error())
+	enabled := true
+	if !state.Enabled.IsNull() {
+		enabled = state.Enabled.ValueBool()
+	}
+
+	if enabled {
+		if err := botmanagement.Disable(ctx, r.client, serviceID); err != nil && !isEntitlementError(err) && !errors.IsNotFound(err) {
+			resp.Diagnostics.AddError("Error disabling bot_management", err.Error())
+		}
 	}
 }
 

--- a/internal/resources/productenablement/ddos_protection.go
+++ b/internal/resources/productenablement/ddos_protection.go
@@ -117,7 +117,7 @@ func (r *DDoSProtectionResource) Read(ctx context.Context, req resource.ReadRequ
 	tflog.Debug(ctx, "Reading Fastly Product Enablement (ddos_protection)", map[string]any{"service_id": serviceID})
 
 	if _, err := ddosprotection.Get(ctx, r.client, serviceID); err != nil {
-		if errors.IsNotFound(err) {
+		if errors.IsNotFound(err) || isProductDisabledError(err) {
 			tflog.Debug(ctx, "ddos_protection is disabled on service", map[string]any{"service_id": serviceID})
 			state.Enabled = types.BoolValue(false)
 		} else {

--- a/internal/resources/productenablement/ddos_protection.go
+++ b/internal/resources/productenablement/ddos_protection.go
@@ -153,10 +153,10 @@ func (r *DDoSProtectionResource) Update(ctx context.Context, req resource.Update
 	}
 
 	if enabled {
-		if _, err := ddosprotection.UpdateConfiguration(ctx, r.client, serviceID, ddosprotection.ConfigureInput{
+		if _, err := ddosprotection.Enable(ctx, r.client, serviceID, ddosprotection.EnableInput{
 			Mode: plan.Mode.ValueString(),
 		}); err != nil {
-			resp.Diagnostics.AddError("Error configuring ddos_protection", err.Error())
+			resp.Diagnostics.AddError("Error enabling ddos_protection", err.Error())
 			return
 		}
 	} else {

--- a/internal/resources/productenablement/ddos_protection.go
+++ b/internal/resources/productenablement/ddos_protection.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -23,6 +24,7 @@ var _ resource.ResourceWithImportState = &DDoSProtectionResource{}
 type DDoSProtectionModel struct {
 	ID        types.String `tfsdk:"id"`
 	ServiceID types.String `tfsdk:"service_id"`
+	Enabled   types.Bool   `tfsdk:"enabled"`
 	Mode      types.String `tfsdk:"mode"`
 }
 
@@ -44,6 +46,12 @@ func (r *DDoSProtectionResource) Schema(_ context.Context, _ resource.SchemaRequ
 		Attributes: map[string]schema.Attribute{
 			"id":         idAttribute(),
 			"service_id": serviceIDAttribute("DDoS Protection"),
+			"enabled": schema.BoolAttribute{
+				Optional:    true,
+				Computed:    true,
+				Default:     booldefault.StaticBool(true),
+				Description: "Whether DDoS Protection is enabled on the service. Defaults to `true`.",
+			},
 			"mode": schema.StringAttribute{
 				Required:    true,
 				Description: "Operation mode. Can be `off`, `log`, or `block`.",
@@ -74,14 +82,27 @@ func (r *DDoSProtectionResource) Create(ctx context.Context, req resource.Create
 	serviceID := plan.ServiceID.ValueString()
 	tflog.Debug(ctx, "Creating Fastly Product Enablement (ddos_protection)", map[string]any{"service_id": serviceID})
 
-	if _, err := ddosprotection.Enable(ctx, r.client, serviceID, ddosprotection.EnableInput{
-		Mode: plan.Mode.ValueString(),
-	}); err != nil {
-		resp.Diagnostics.AddError("Error enabling ddos_protection", err.Error())
-		return
+	enabled := true
+	if !plan.Enabled.IsNull() {
+		enabled = plan.Enabled.ValueBool()
+	}
+
+	if enabled {
+		if _, err := ddosprotection.Enable(ctx, r.client, serviceID, ddosprotection.EnableInput{
+			Mode: plan.Mode.ValueString(),
+		}); err != nil {
+			resp.Diagnostics.AddError("Error enabling ddos_protection", err.Error())
+			return
+		}
+	} else {
+		if err := ddosprotection.Disable(ctx, r.client, serviceID); err != nil && !isEntitlementError(err) && !errors.IsNotFound(err) {
+			resp.Diagnostics.AddError("Error disabling ddos_protection", err.Error())
+			return
+		}
 	}
 
 	plan.ID = plan.ServiceID
+	plan.Enabled = types.BoolValue(enabled)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 
@@ -97,19 +118,21 @@ func (r *DDoSProtectionResource) Read(ctx context.Context, req resource.ReadRequ
 
 	if _, err := ddosprotection.Get(ctx, r.client, serviceID); err != nil {
 		if errors.IsNotFound(err) {
-			resp.State.RemoveResource(ctx)
+			tflog.Debug(ctx, "ddos_protection is disabled on service", map[string]any{"service_id": serviceID})
+			state.Enabled = types.BoolValue(false)
+		} else {
+			resp.Diagnostics.AddError("Error reading ddos_protection", err.Error())
 			return
 		}
-		resp.Diagnostics.AddError("Error reading ddos_protection", err.Error())
-		return
+	} else {
+		state.Enabled = types.BoolValue(true)
+		cfg, err := ddosprotection.GetConfiguration(ctx, r.client, serviceID)
+		if err != nil {
+			resp.Diagnostics.AddError("Error reading ddos_protection configuration", err.Error())
+			return
+		}
+		state.Mode = types.StringPointerValue(cfg.Configuration.Mode)
 	}
-
-	cfg, err := ddosprotection.GetConfiguration(ctx, r.client, serviceID)
-	if err != nil {
-		resp.Diagnostics.AddError("Error reading ddos_protection configuration", err.Error())
-		return
-	}
-	state.Mode = types.StringPointerValue(cfg.Configuration.Mode)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
@@ -124,14 +147,27 @@ func (r *DDoSProtectionResource) Update(ctx context.Context, req resource.Update
 	serviceID := plan.ServiceID.ValueString()
 	tflog.Debug(ctx, "Updating Fastly Product Enablement (ddos_protection)", map[string]any{"service_id": serviceID})
 
-	if _, err := ddosprotection.UpdateConfiguration(ctx, r.client, serviceID, ddosprotection.ConfigureInput{
-		Mode: plan.Mode.ValueString(),
-	}); err != nil {
-		resp.Diagnostics.AddError("Error configuring ddos_protection", err.Error())
-		return
+	enabled := true
+	if !plan.Enabled.IsNull() {
+		enabled = plan.Enabled.ValueBool()
+	}
+
+	if enabled {
+		if _, err := ddosprotection.UpdateConfiguration(ctx, r.client, serviceID, ddosprotection.ConfigureInput{
+			Mode: plan.Mode.ValueString(),
+		}); err != nil {
+			resp.Diagnostics.AddError("Error configuring ddos_protection", err.Error())
+			return
+		}
+	} else {
+		if err := ddosprotection.Disable(ctx, r.client, serviceID); err != nil && !isEntitlementError(err) && !errors.IsNotFound(err) {
+			resp.Diagnostics.AddError("Error disabling ddos_protection", err.Error())
+			return
+		}
 	}
 
 	plan.ID = plan.ServiceID
+	plan.Enabled = types.BoolValue(enabled)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 
@@ -145,8 +181,15 @@ func (r *DDoSProtectionResource) Delete(ctx context.Context, req resource.Delete
 	serviceID := state.ServiceID.ValueString()
 	tflog.Debug(ctx, "Deleting Fastly Product Enablement (ddos_protection)", map[string]any{"service_id": serviceID})
 
-	if err := ddosprotection.Disable(ctx, r.client, serviceID); err != nil && !isEntitlementError(err) && !errors.IsNotFound(err) {
-		resp.Diagnostics.AddError("Error disabling ddos_protection", err.Error())
+	enabled := true
+	if !state.Enabled.IsNull() {
+		enabled = state.Enabled.ValueBool()
+	}
+
+	if enabled {
+		if err := ddosprotection.Disable(ctx, r.client, serviceID); err != nil && !isEntitlementError(err) && !errors.IsNotFound(err) {
+			resp.Diagnostics.AddError("Error disabling ddos_protection", err.Error())
+		}
 	}
 }
 

--- a/internal/resources/productenablement/ngwaf.go
+++ b/internal/resources/productenablement/ngwaf.go
@@ -263,6 +263,13 @@ func (r *NGWAFResource) Update(ctx context.Context, req resource.UpdateRequest, 
 			return
 		}
 
+		if _, err := ngwafproduct.Enable(ctx, r.client, serviceID, ngwafproduct.EnableInput{
+			WorkspaceID: plan.WorkspaceID.ValueString(),
+		}); err != nil {
+			resp.Diagnostics.AddError("Error enabling ngwaf", err.Error())
+			return
+		}
+
 		trafficRamp := "100"
 		if serviceType == service.TypeVCL && !plan.TrafficRamp.IsNull() {
 			trafficRamp = strconv.FormatInt(plan.TrafficRamp.ValueInt64(), 10)

--- a/internal/resources/productenablement/ngwaf.go
+++ b/internal/resources/productenablement/ngwaf.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -28,6 +29,7 @@ var _ resource.ResourceWithModifyPlan = &NGWAFResource{}
 type NGWAFModel struct {
 	ID          types.String `tfsdk:"id"`
 	ServiceID   types.String `tfsdk:"service_id"`
+	Enabled     types.Bool   `tfsdk:"enabled"`
 	WorkspaceID types.String `tfsdk:"workspace_id"`
 	TrafficRamp types.Int64  `tfsdk:"traffic_ramp"`
 }
@@ -51,6 +53,12 @@ func (r *NGWAFResource) Schema(_ context.Context, _ resource.SchemaRequest, resp
 		Attributes: map[string]schema.Attribute{
 			"id":         idAttribute(),
 			"service_id": serviceIDAttribute("Next-Gen WAF"),
+			"enabled": schema.BoolAttribute{
+				Optional:    true,
+				Computed:    true,
+				Default:     booldefault.StaticBool(true),
+				Description: "Whether Next-Gen WAF is enabled on the service. Defaults to `true`.",
+			},
 			"workspace_id": schema.StringAttribute{
 				Required:    true,
 				Description: "The Next-Gen WAF workspace to link.",
@@ -125,35 +133,48 @@ func (r *NGWAFResource) Create(ctx context.Context, req resource.CreateRequest, 
 	serviceID := plan.ServiceID.ValueString()
 	tflog.Debug(ctx, "Creating Fastly Product Enablement (ngwaf)", map[string]any{"service_id": serviceID})
 
-	serviceType, err := r.typeChecker.GetType(ctx, serviceID)
-	if err != nil {
-		resp.Diagnostics.AddError("Error looking up service type", err.Error())
-		return
+	enabled := true
+	if !plan.Enabled.IsNull() {
+		enabled = plan.Enabled.ValueBool()
 	}
 
-	resp.Diagnostics.Append(validateNGWAFTrafficRamp(&plan, serviceType)...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
+	if enabled {
+		serviceType, err := r.typeChecker.GetType(ctx, serviceID)
+		if err != nil {
+			resp.Diagnostics.AddError("Error looking up service type", err.Error())
+			return
+		}
 
-	if _, err := ngwafproduct.Enable(ctx, r.client, serviceID, ngwafproduct.EnableInput{
-		WorkspaceID: plan.WorkspaceID.ValueString(),
-	}); err != nil {
-		resp.Diagnostics.AddError("Error enabling ngwaf", err.Error())
-		return
-	}
+		resp.Diagnostics.Append(validateNGWAFTrafficRamp(&plan, serviceType)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 
-	if serviceType == service.TypeVCL && !plan.TrafficRamp.IsNull() && plan.TrafficRamp.ValueInt64() != 100 {
-		if _, err := ngwafproduct.UpdateConfiguration(ctx, r.client, serviceID, ngwafproduct.ConfigureInput{
+		if _, err := ngwafproduct.Enable(ctx, r.client, serviceID, ngwafproduct.EnableInput{
 			WorkspaceID: plan.WorkspaceID.ValueString(),
-			TrafficRamp: strconv.FormatInt(plan.TrafficRamp.ValueInt64(), 10),
 		}); err != nil {
-			resp.Diagnostics.AddError("Error configuring ngwaf", err.Error())
+			resp.Diagnostics.AddError("Error enabling ngwaf", err.Error())
+			return
+		}
+
+		if serviceType == service.TypeVCL && !plan.TrafficRamp.IsNull() && plan.TrafficRamp.ValueInt64() != 100 {
+			if _, err := ngwafproduct.UpdateConfiguration(ctx, r.client, serviceID, ngwafproduct.ConfigureInput{
+				WorkspaceID: plan.WorkspaceID.ValueString(),
+				TrafficRamp: strconv.FormatInt(plan.TrafficRamp.ValueInt64(), 10),
+			}); err != nil {
+				resp.Diagnostics.AddError("Error configuring ngwaf", err.Error())
+				return
+			}
+		}
+	} else {
+		if err := ngwafproduct.Disable(ctx, r.client, serviceID); err != nil && !isEntitlementError(err) && !errors.IsNotFound(err) {
+			resp.Diagnostics.AddError("Error disabling ngwaf", err.Error())
 			return
 		}
 	}
 
 	plan.ID = plan.ServiceID
+	plan.Enabled = types.BoolValue(enabled)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 
@@ -169,45 +190,47 @@ func (r *NGWAFResource) Read(ctx context.Context, req resource.ReadRequest, resp
 
 	if _, err := ngwafproduct.Get(ctx, r.client, serviceID); err != nil {
 		if errors.IsNotFound(err) {
-			resp.State.RemoveResource(ctx)
+			tflog.Debug(ctx, "ngwaf is disabled on service", map[string]any{"service_id": serviceID})
+			state.Enabled = types.BoolValue(false)
+		} else {
+			resp.Diagnostics.AddError("Error reading ngwaf", err.Error())
 			return
 		}
-		resp.Diagnostics.AddError("Error reading ngwaf", err.Error())
-		return
-	}
-
-	serviceType, err := r.typeChecker.GetType(ctx, serviceID)
-	if err != nil {
-		resp.Diagnostics.AddError("Error looking up service type", err.Error())
-		return
-	}
-
-	cfg, err := ngwafproduct.GetConfiguration(ctx, r.client, serviceID)
-	if err != nil {
-		resp.Diagnostics.AddError("Error reading ngwaf configuration", err.Error())
-		return
-	}
-
-	if cfg.Configuration.WorkspaceID != nil {
-		state.WorkspaceID = types.StringValue(*cfg.Configuration.WorkspaceID)
-	}
-
-	// traffic_ramp is schema-defaulted to 100 regardless of service type
-	// (Terraform Core applies the default before Create/Update ever runs),
-	// but it only has an effect for CDN services. Pinning it to 100 for
-	// Compute rather than leaving it null keeps refresh consistent with
-	// that plan-time default and avoids perpetual drift; ModifyPlan already
-	// rejects any other value on a Compute service.
-	switch {
-	case serviceType == service.TypeVCL && cfg.Configuration.TrafficRamp != nil:
-		tr, err := strconv.ParseInt(*cfg.Configuration.TrafficRamp, 10, 64)
+	} else {
+		state.Enabled = types.BoolValue(true)
+		serviceType, err := r.typeChecker.GetType(ctx, serviceID)
 		if err != nil {
-			resp.Diagnostics.AddError("Error parsing ngwaf traffic_ramp", err.Error())
+			resp.Diagnostics.AddError("Error looking up service type", err.Error())
 			return
 		}
-		state.TrafficRamp = types.Int64Value(tr)
-	case serviceType != service.TypeVCL:
-		state.TrafficRamp = types.Int64Value(100)
+
+		cfg, err := ngwafproduct.GetConfiguration(ctx, r.client, serviceID)
+		if err != nil {
+			resp.Diagnostics.AddError("Error reading ngwaf configuration", err.Error())
+			return
+		}
+
+		if cfg.Configuration.WorkspaceID != nil {
+			state.WorkspaceID = types.StringValue(*cfg.Configuration.WorkspaceID)
+		}
+
+		// traffic_ramp is schema-defaulted to 100 regardless of service type
+		// (Terraform Core applies the default before Create/Update ever runs),
+		// but it only has an effect for CDN services. Pinning it to 100 for
+		// Compute rather than leaving it null keeps refresh consistent with
+		// that plan-time default and avoids perpetual drift; ModifyPlan already
+		// rejects any other value on a Compute service.
+		switch {
+		case serviceType == service.TypeVCL && cfg.Configuration.TrafficRamp != nil:
+			tr, err := strconv.ParseInt(*cfg.Configuration.TrafficRamp, 10, 64)
+			if err != nil {
+				resp.Diagnostics.AddError("Error parsing ngwaf traffic_ramp", err.Error())
+				return
+			}
+			state.TrafficRamp = types.Int64Value(tr)
+		case serviceType != service.TypeVCL:
+			state.TrafficRamp = types.Int64Value(100)
+		}
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
@@ -223,31 +246,44 @@ func (r *NGWAFResource) Update(ctx context.Context, req resource.UpdateRequest, 
 	serviceID := plan.ServiceID.ValueString()
 	tflog.Debug(ctx, "Updating Fastly Product Enablement (ngwaf)", map[string]any{"service_id": serviceID})
 
-	serviceType, err := r.typeChecker.GetType(ctx, serviceID)
-	if err != nil {
-		resp.Diagnostics.AddError("Error looking up service type", err.Error())
-		return
+	enabled := true
+	if !plan.Enabled.IsNull() {
+		enabled = plan.Enabled.ValueBool()
 	}
 
-	resp.Diagnostics.Append(validateNGWAFTrafficRamp(&plan, serviceType)...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
+	if enabled {
+		serviceType, err := r.typeChecker.GetType(ctx, serviceID)
+		if err != nil {
+			resp.Diagnostics.AddError("Error looking up service type", err.Error())
+			return
+		}
 
-	trafficRamp := "100"
-	if serviceType == service.TypeVCL && !plan.TrafficRamp.IsNull() {
-		trafficRamp = strconv.FormatInt(plan.TrafficRamp.ValueInt64(), 10)
-	}
+		resp.Diagnostics.Append(validateNGWAFTrafficRamp(&plan, serviceType)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 
-	if _, err := ngwafproduct.UpdateConfiguration(ctx, r.client, serviceID, ngwafproduct.ConfigureInput{
-		WorkspaceID: plan.WorkspaceID.ValueString(),
-		TrafficRamp: trafficRamp,
-	}); err != nil {
-		resp.Diagnostics.AddError("Error configuring ngwaf", err.Error())
-		return
+		trafficRamp := "100"
+		if serviceType == service.TypeVCL && !plan.TrafficRamp.IsNull() {
+			trafficRamp = strconv.FormatInt(plan.TrafficRamp.ValueInt64(), 10)
+		}
+
+		if _, err := ngwafproduct.UpdateConfiguration(ctx, r.client, serviceID, ngwafproduct.ConfigureInput{
+			WorkspaceID: plan.WorkspaceID.ValueString(),
+			TrafficRamp: trafficRamp,
+		}); err != nil {
+			resp.Diagnostics.AddError("Error configuring ngwaf", err.Error())
+			return
+		}
+	} else {
+		if err := ngwafproduct.Disable(ctx, r.client, serviceID); err != nil && !isEntitlementError(err) && !errors.IsNotFound(err) {
+			resp.Diagnostics.AddError("Error disabling ngwaf", err.Error())
+			return
+		}
 	}
 
 	plan.ID = plan.ServiceID
+	plan.Enabled = types.BoolValue(enabled)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 
@@ -261,8 +297,15 @@ func (r *NGWAFResource) Delete(ctx context.Context, req resource.DeleteRequest, 
 	serviceID := state.ServiceID.ValueString()
 	tflog.Debug(ctx, "Deleting Fastly Product Enablement (ngwaf)", map[string]any{"service_id": serviceID})
 
-	if err := ngwafproduct.Disable(ctx, r.client, serviceID); err != nil && !isEntitlementError(err) && !errors.IsNotFound(err) {
-		resp.Diagnostics.AddError("Error disabling ngwaf", err.Error())
+	enabled := true
+	if !state.Enabled.IsNull() {
+		enabled = state.Enabled.ValueBool()
+	}
+
+	if enabled {
+		if err := ngwafproduct.Disable(ctx, r.client, serviceID); err != nil && !isEntitlementError(err) && !errors.IsNotFound(err) {
+			resp.Diagnostics.AddError("Error disabling ngwaf", err.Error())
+		}
 	}
 }
 

--- a/internal/resources/productenablement/ngwaf.go
+++ b/internal/resources/productenablement/ngwaf.go
@@ -189,7 +189,7 @@ func (r *NGWAFResource) Read(ctx context.Context, req resource.ReadRequest, resp
 	tflog.Debug(ctx, "Reading Fastly Product Enablement (ngwaf)", map[string]any{"service_id": serviceID})
 
 	if _, err := ngwafproduct.Get(ctx, r.client, serviceID); err != nil {
-		if errors.IsNotFound(err) {
+		if errors.IsNotFound(err) || isProductDisabledError(err) {
 			tflog.Debug(ctx, "ngwaf is disabled on service", map[string]any{"service_id": serviceID})
 			state.Enabled = types.BoolValue(false)
 		} else {

--- a/internal/resources/productenablement/shared.go
+++ b/internal/resources/productenablement/shared.go
@@ -59,3 +59,21 @@ func isEntitlementError(err error) bool {
 	}
 	return false
 }
+
+// isProductDisabledError reports whether err indicates the product is not
+// enabled on the service (returned when trying to read a disabled product).
+func isProductDisabledError(err error) bool {
+	var httpErr *fastly.HTTPError
+	if !errors.As(err, &httpErr) {
+		return false
+	}
+	if httpErr.StatusCode != http.StatusBadRequest {
+		return false
+	}
+	for _, e := range httpErr.Errors {
+		if strings.Contains(e.Title, "no product on service") {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/resources/productenablement/simple.go
+++ b/internal/resources/productenablement/simple.go
@@ -22,6 +22,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
@@ -138,6 +139,7 @@ var _ resource.ResourceWithModifyPlan = &simpleProductResource{}
 type simpleProductModel struct {
 	ID        types.String `tfsdk:"id"`
 	ServiceID types.String `tfsdk:"service_id"`
+	Enabled   types.Bool   `tfsdk:"enabled"`
 }
 
 type simpleProductResource struct {
@@ -164,6 +166,12 @@ func (r *simpleProductResource) Schema(_ context.Context, _ resource.SchemaReque
 		Attributes: map[string]schema.Attribute{
 			"id":         idAttribute(),
 			"service_id": serviceIDAttribute(r.spec.displayName),
+			"enabled": schema.BoolAttribute{
+				Optional:    true,
+				Computed:    true,
+				Default:     booldefault.StaticBool(true),
+				Description: fmt.Sprintf("Whether %s is enabled on the service. Defaults to `true`.", r.spec.displayName),
+			},
 		},
 	}
 }
@@ -249,12 +257,25 @@ func (r *simpleProductResource) Create(ctx context.Context, req resource.CreateR
 		}
 	}
 
-	if _, err := r.spec.enable(ctx, r.client, serviceID); err != nil {
-		resp.Diagnostics.AddError(fmt.Sprintf("Error enabling %s", r.spec.attrName), err.Error())
-		return
+	enabled := true
+	if !plan.Enabled.IsNull() {
+		enabled = plan.Enabled.ValueBool()
+	}
+
+	if enabled {
+		if _, err := r.spec.enable(ctx, r.client, serviceID); err != nil {
+			resp.Diagnostics.AddError(fmt.Sprintf("Error enabling %s", r.spec.attrName), err.Error())
+			return
+		}
+	} else {
+		if err := r.spec.disable(ctx, r.client, serviceID); err != nil && !isEntitlementError(err) && !errors.IsNotFound(err) {
+			resp.Diagnostics.AddError(fmt.Sprintf("Error disabling %s", r.spec.attrName), err.Error())
+			return
+		}
 	}
 
 	plan.ID = plan.ServiceID
+	plan.Enabled = types.BoolValue(enabled)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 
@@ -277,36 +298,61 @@ func (r *simpleProductResource) Read(ctx context.Context, req resource.ReadReque
 	})
 
 	if _, err := r.spec.get(ctx, r.client, serviceID); err != nil {
-		if errors.IsNotFound(err) {
-			tflog.Warn(ctx, fmt.Sprintf("%s no longer enabled, removing from state", r.spec.attrName), map[string]any{
+		if errors.IsNotFound(err) || isProductDisabledError(err) {
+			tflog.Debug(ctx, fmt.Sprintf("%s is disabled on service", r.spec.attrName), map[string]any{
 				"service_id": serviceID,
 			})
-			resp.State.RemoveResource(ctx)
+			state.Enabled = types.BoolValue(false)
+		} else {
+			resp.Diagnostics.AddError(fmt.Sprintf("Error reading %s", r.spec.attrName), err.Error())
 			return
 		}
-		resp.Diagnostics.AddError(fmt.Sprintf("Error reading %s", r.spec.attrName), err.Error())
-		return
+	} else {
+		state.Enabled = types.BoolValue(true)
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
-// Update never runs in practice: service_id is the only attribute besides
-// the computed id, and changing it forces replacement. Implemented only to
-// satisfy the resource.Resource interface.
+// Update handles changes to the enabled attribute.
 func (r *simpleProductResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 	var plan simpleProductModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	serviceID := plan.ServiceID.ValueString()
+	enabled := true
+	if !plan.Enabled.IsNull() {
+		enabled = plan.Enabled.ValueBool()
+	}
+
+	tflog.Debug(ctx, fmt.Sprintf("Updating Fastly Product Enablement (%s)", r.spec.attrName), map[string]any{
+		"service_id": serviceID,
+		"enabled":    enabled,
+	})
+
+	if enabled {
+		if _, err := r.spec.enable(ctx, r.client, serviceID); err != nil {
+			resp.Diagnostics.AddError(fmt.Sprintf("Error enabling %s", r.spec.attrName), err.Error())
+			return
+		}
+	} else {
+		if err := r.spec.disable(ctx, r.client, serviceID); err != nil && !isEntitlementError(err) && !errors.IsNotFound(err) {
+			resp.Diagnostics.AddError(fmt.Sprintf("Error disabling %s", r.spec.attrName), err.Error())
+			return
+		}
+	}
+
+	plan.Enabled = types.BoolValue(enabled)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 
-// Delete disables the product. Entitlement-related errors (accounts that
-// can't self-service disable a product) and a since-deleted service are
-// both treated as success so that `terraform destroy` can still complete
-// and leave a clean state.
+// Delete disables the product if enabled was true. Entitlement-related errors
+// (accounts that can't self-service disable a product) and a since-deleted
+// service are both treated as success so that `terraform destroy` can still
+// complete and leave a clean state.
 func (r *simpleProductResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
 	var state simpleProductModel
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
@@ -320,8 +366,15 @@ func (r *simpleProductResource) Delete(ctx context.Context, req resource.DeleteR
 		"service_id": serviceID,
 	})
 
-	if err := r.spec.disable(ctx, r.client, serviceID); err != nil && !isEntitlementError(err) && !errors.IsNotFound(err) {
-		resp.Diagnostics.AddError(fmt.Sprintf("Error disabling %s", r.spec.attrName), err.Error())
+	enabled := true
+	if !state.Enabled.IsNull() {
+		enabled = state.Enabled.ValueBool()
+	}
+
+	if enabled {
+		if err := r.spec.disable(ctx, r.client, serviceID); err != nil && !isEntitlementError(err) && !errors.IsNotFound(err) {
+			resp.Diagnostics.AddError(fmt.Sprintf("Error disabling %s", r.spec.attrName), err.Error())
+		}
 	}
 }
 


### PR DESCRIPTION
### Change summary

Adds an `enabled` bool (default true) to bot_management, ddos_protection, ngwaf, and the simple product resources so they can be disabled/re-enabled via update instead of requiring create/destroy.

 All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/terraform-provider-fastly/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

* [x] Does your submission pass tests?
* [x] Post the output of your test runs
<img width="887" height="463" alt="Screenshot 2026-08-07 at 2 18 11 PM" src="https://github.com/user-attachments/assets/42d72124-455f-4af7-86b4-aa23104d6821" />
