### PR TITLE
[CDTOOL-1708] Ensure `deception_type` and `allow_interactive` fields persist update operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### ENHANCEMENTS:
 
 ### BUG FIXES:
+- fix(ngwaf/rules):  corrects a bug where rules with a `deception` action had their `deception_type` and `allow_interactive` fields omitted from update operations, causing an error on subsequent applies ([#1396](https://github.com/fastly/terraform-provider-fastly/pull/1396))
 
 ### Dependencies
 - build(deps): `github.com/hashicorp/terraform-plugin-log` from 0.10.0 to 0.11.0 ([#1392](https://github.com/fastly/terraform-provider-fastly/pull/1392))

--- a/fastly/ngwaf_rule_expand.go
+++ b/fastly/ngwaf_rule_expand.go
@@ -147,6 +147,12 @@ func expandNGWAFRuleUpdateActions(raw []any, scopeType string) []*rules.UpdateAc
 			action.Signal = gofastly.ToPointer(v.(string))
 		}
 		if scopeType == "workspace" {
+			if v, ok := m["allow_interactive"]; ok && v.(bool) {
+				action.AllowInteractive = gofastly.ToPointer(v.(bool))
+			}
+			if v, ok := m["deception_type"]; ok && v != "" {
+				action.DeceptionType = gofastly.ToPointer(v.(string))
+			}
 			if v, ok := m["redirect_url"]; ok {
 				action.RedirectURL = gofastly.ToPointer(v.(string))
 			}

--- a/fastly/resource_fastly_ngwaf_workspace_rule_test.go
+++ b/fastly/resource_fastly_ngwaf_workspace_rule_test.go
@@ -219,6 +219,45 @@ func TestFlattenNGWAFRuleResponse(t *testing.T) {
 	require.Equal(t, "X-API-Key", multivalConds[1].(map[string]any)["value"])
 }
 
+// TestExpandNGWAFRuleUpdateActions_Deception guards against a regression where
+// deception_type (and allow_interactive) were dropped from update requests,
+// causing the API to reject a second apply with "invalid deception type: ".
+func TestExpandNGWAFRuleUpdateActions_Deception(t *testing.T) {
+	raw := []any{
+		map[string]any{
+			"type":              "deception",
+			"deception_type":    "invalid_login_response",
+			"allow_interactive": false,
+			"signal":            "",
+			"redirect_url":      "",
+			"response_code":     0,
+		},
+	}
+
+	actions := expandNGWAFRuleUpdateActions(raw, "workspace")
+	require.Len(t, actions, 1)
+	require.NotNil(t, actions[0].DeceptionType)
+	require.Equal(t, "invalid_login_response", *actions[0].DeceptionType)
+}
+
+func TestExpandNGWAFRuleUpdateActions_AllowInteractive(t *testing.T) {
+	raw := []any{
+		map[string]any{
+			"type":              "browser_challenge",
+			"allow_interactive": true,
+			"deception_type":    "",
+			"signal":            "",
+			"redirect_url":      "",
+			"response_code":     0,
+		},
+	}
+
+	actions := expandNGWAFRuleUpdateActions(raw, "workspace")
+	require.Len(t, actions, 1)
+	require.NotNil(t, actions[0].AllowInteractive)
+	require.True(t, *actions[0].AllowInteractive)
+}
+
 func TestAccFastlyNGWAFWorkspaceRule_basic(t *testing.T) {
 	workspaceName := fmt.Sprintf("Test WAF Workspace %s", acctest.RandString(5))
 	ruleDescription := fmt.Sprintf("Terraform Rule %s", acctest.RandString(5))


### PR DESCRIPTION
### Change summary

This PR fixes a bug reported in https://github.com/fastly/terraform-provider-fastly/issues/1395 where rules with a `deception` action had their `deception_type` (and `allow_interactive`) fields omitted from update operations, causing a 400 error on subsequent applies.

 All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/terraform-provider-fastly/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

* [x] Does your submission pass tests?
* [x] Post the output of your test runs

```
=== RUN   TestExpandNGWAFRuleUpdateActions_AllowInteractive
--- PASS: TestExpandNGWAFRuleUpdateActions_AllowInteractive (0.00s)
PASS
ok  

=== RUN   TestExpandNGWAFRuleUpdateActions_Deception
--- PASS: TestExpandNGWAFRuleUpdateActions_Deception (0.00s)
PASS
ok 
```

### Changes to Core Features:

* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
