### PR TITLE
[CDTOOL-1503] Add dynamic VCL snippet support

### DIFF
--- a/docs/resources/service_cdn_auto.md
+++ b/docs/resources/service_cdn_auto.md
@@ -25,6 +25,7 @@ Automatic-lifecycle Fastly CDN service resource with nested versioned configurat
 - `comment` (String) Optional service comment.
 - `condition` (Block List) Conditions attached to this service. (see [below for nested schema](#nestedblock--condition))
 - `domain` (Block List) Domains attached to this service. (see [below for nested schema](#nestedblock--domain))
+- `dynamic_snippet` (Block List) Dynamic VCL snippet metadata attached to this service version. Dynamic snippet content is managed separately by `fastly_service_dynamic_snippet_content`. (see [below for nested schema](#nestedblock--dynamic_snippet))
 - `force_destroy` (Boolean) Deactivate the active version before deleting the service. Default `false`.
 - `gzip` (Block List) Gzip configurations attached to this service. (see [below for nested schema](#nestedblock--gzip))
 - `image_optimizer_default_settings` (Block List) Image Optimizer default settings for this service. At most one block is supported. The Image Optimizer product must already be enabled on the service (e.g. via `fastly_service_product_image_optimizer`) before these settings can be persisted; enabling the product and configuring this block cannot be done in the same initial `apply`, since this block is reconciled as part of this resource's own create step, before a separate product-enablement resource (which depends on this resource's `id`) can run. Enable the product in a prior `apply` first. (see [below for nested schema](#nestedblock--image_optimizer_default_settings))
@@ -129,6 +130,23 @@ Required:
 Optional:
 
 - `comment` (String) Optional comment for the domain.
+
+
+<a id="nestedblock--dynamic_snippet"></a>
+### Nested Schema for `dynamic_snippet`
+
+Required:
+
+- `name` (String) A name that is unique across regular and dynamic VCL snippet configuration blocks. Changing this attribute will delete and recreate the snippet.
+- `type` (String) The location in generated VCL where the dynamic snippet should be placed. Must be one of `init`, `recv`, `hash`, `hit`, `miss`, `pass`, `fetch`, `error`, `deliver`, `log`, or `none`.
+
+Optional:
+
+- `priority` (Number) Priority determines execution order. Lower numbers execute first. Default `100`.
+
+Read-Only:
+
+- `snippet_id` (String) The Fastly-generated dynamic snippet ID. Use this value with `fastly_service_dynamic_snippet_content` to manage versionless snippet code.
 
 
 <a id="nestedblock--gzip"></a>

--- a/docs/resources/service_dynamic_snippet_content.md
+++ b/docs/resources/service_dynamic_snippet_content.md
@@ -1,0 +1,129 @@
+---
+page_title: "fastly_service_dynamic_snippet_content Resource - fastly"
+subcategory: ""
+description: |-
+  Fastly dynamic VCL snippet content resource. Updates versionless dynamic snippet code directly by service ID and snippet ID.
+---
+
+# fastly_service_dynamic_snippet_content (Resource)
+
+Fastly dynamic VCL snippet content resource. Updates versionless dynamic snippet
+code directly by service ID and snippet ID.
+
+Dynamic VCL snippets have two lifecycle parts:
+
+- metadata such as `name`, `type`, and `priority`, which is versioned service
+  configuration
+- content, which is versionless and is managed by this resource
+
+In the automatic compatibility family, dynamic snippet metadata is managed by
+the `dynamic_snippet` block on `fastly_service_cdn_auto`.
+
+In the explicit/default first-class resource family, dynamic snippet metadata is
+managed by `fastly_service_dynamic_vcl_snippet`.
+
+Updating this resource's `content` does not clone, validate, stage, or activate a
+service version. Changes are applied immediately to the dynamic snippet.
+
+## Example Usage with automatic compatibility metadata
+
+```terraform
+resource "fastly_service_cdn_auto" "example" {
+  name = "example"
+
+  domain {
+    name = "www.example.com"
+  }
+
+  backend {
+    name    = "origin"
+    address = "origin.example.com"
+    port    = 443
+    use_ssl = true
+  }
+
+  dynamic_snippet {
+    name     = "block_scrapers"
+    type     = "recv"
+    priority = 100
+  }
+
+  force_destroy = true
+}
+
+resource "fastly_service_dynamic_snippet_content" "block_scrapers" {
+  service_id = fastly_service_cdn_auto.example.id
+  snippet_id = {
+    for s in fastly_service_cdn_auto.example.dynamic_snippet : s.name => s.snippet_id
+  }["block_scrapers"]
+
+  content = file("${path.module}/block_scrapers.vcl")
+}
+```
+
+## Example Usage with explicit/default metadata
+
+In the explicit/default workflow, dynamic snippet metadata is managed by
+`fastly_service_dynamic_vcl_snippet`. The content resource depends on the
+computed `snippet_id`, so Terraform creates the metadata container first and then
+applies versionless content.
+
+```terraform
+resource "fastly_service_cdn" "example" {
+  name = "example"
+
+  force_destroy = true
+}
+
+resource "fastly_service_dynamic_vcl_snippet" "block_scrapers" {
+  service_id = fastly_service_cdn.example.id
+  version    = 1
+
+  name     = "block_scrapers"
+  type     = "recv"
+  priority = 100
+}
+
+resource "fastly_service_dynamic_snippet_content" "block_scrapers" {
+  service_id = fastly_service_cdn.example.id
+  snippet_id = fastly_service_dynamic_vcl_snippet.block_scrapers.snippet_id
+
+  content = file("${path.module}/block_scrapers.vcl")
+}
+```
+
+## Schema
+
+### Required
+
+- `content` (String) The dynamic VCL snippet code. Updates are versionless and take effect immediately without cloning or activating a service version.
+- `service_id` (String) Fastly service ID.
+- `snippet_id` (String) The Fastly-generated ID of the dynamic VCL snippet whose content is managed by this resource.
+
+### Optional
+
+- `manage_snippets` (Boolean) Whether Terraform should re-apply content drift and clear snippet content on destroy. Default `false`.
+
+### Read-Only
+
+- `id` (String) Terraform resource identifier.
+
+## Import
+
+Import requires the service ID and dynamic snippet ID:
+
+```shell
+terraform import fastly_service_dynamic_snippet_content.block_scrapers SERVICE_ID/SNIPPET_ID
+```
+
+Example:
+
+```shell
+terraform import fastly_service_dynamic_snippet_content.block_scrapers SU1Z0isxPaozGVKXdv0eY/abc123
+```
+
+## Version lifecycle
+
+This resource does not clone, activate, or stage service versions. Dynamic
+snippet content is versionless and updates are applied directly to the dynamic
+snippet.

--- a/docs/resources/service_dynamic_vcl_snippet.md
+++ b/docs/resources/service_dynamic_vcl_snippet.md
@@ -1,0 +1,101 @@
+---
+page_title: "fastly_service_dynamic_vcl_snippet Resource - fastly"
+subcategory: ""
+description: |-
+  Fastly dynamic VCL snippet metadata resource. Writes the versioned dynamic snippet container directly to the specified writable CDN service version.
+---
+
+# fastly_service_dynamic_vcl_snippet (Resource)
+
+Fastly dynamic VCL snippet metadata resource. Writes the versioned dynamic
+snippet container directly to the specified writable CDN service version.
+
+This resource is part of the explicit/default first-class resource family. It
+manages the versioned metadata for a dynamic VCL snippet:
+
+- `name`
+- `type`
+- `priority`
+- computed `snippet_id`
+
+It does not manage dynamic snippet content. Dynamic snippet content is
+versionless and is managed separately with
+`fastly_service_dynamic_snippet_content`.
+
+Use this resource when you want to manage dynamic VCL snippet metadata explicitly
+against a known writable service version. For automatic service version cloning,
+validation, and activation, use the nested `dynamic_snippet` block on
+`fastly_service_cdn_auto`.
+
+## Example Usage
+
+```terraform
+resource "fastly_service_cdn" "example" {
+  name = "example"
+
+  force_destroy = true
+}
+
+resource "fastly_service_dynamic_vcl_snippet" "block_scrapers" {
+  service_id = fastly_service_cdn.example.id
+  version    = 1
+
+  name     = "block_scrapers"
+  type     = "recv"
+  priority = 100
+}
+
+resource "fastly_service_dynamic_snippet_content" "block_scrapers" {
+  service_id = fastly_service_cdn.example.id
+  snippet_id = fastly_service_dynamic_vcl_snippet.block_scrapers.snippet_id
+
+  content = file("${path.module}/block_scrapers.vcl")
+}
+```
+
+## Schema
+
+### Required
+
+- `name` (String) A name that is unique across regular and dynamic VCL snippet configuration blocks. Changing this attribute will delete and recreate the snippet.
+- `service_id` (String) Fastly service ID.
+- `type` (String) The location in generated VCL where the dynamic snippet should be placed. Must be one of `init`, `recv`, `hash`, `hit`, `miss`, `pass`, `fetch`, `error`, `deliver`, `log`, or `none`.
+- `version` (Number) Writable Fastly service version to modify.
+
+### Optional
+
+- `priority` (Number) Priority determines execution order. Lower numbers execute first. Default `100`.
+
+### Read-Only
+
+- `id` (String) Terraform resource identifier.
+- `snippet_id` (String) The Fastly-generated dynamic snippet ID. Use this value with `fastly_service_dynamic_snippet_content` to manage versionless snippet code.
+
+## Import
+
+Import requires the service ID, service version, and dynamic VCL snippet name:
+
+```shell
+terraform import fastly_service_dynamic_vcl_snippet.block_scrapers SERVICE_ID/VERSION/SNIPPET_NAME
+```
+
+Example:
+
+```shell
+terraform import fastly_service_dynamic_vcl_snippet.block_scrapers SU1Z0isxPaozGVKXdv0eY/3/block_scrapers
+```
+
+## Version lifecycle
+
+This resource does not clone, activate, or stage service versions. Use explicit
+service-version lifecycle actions to clone, validate, stage, or activate a
+service version.
+
+Only the dynamic snippet metadata is versioned. Dynamic snippet content is
+versionless and is managed separately with
+`fastly_service_dynamic_snippet_content`.
+
+Terraform can apply metadata and content in one run when the content resource
+references the computed `snippet_id`. The metadata resource still writes to the
+configured writable service version, while content updates are applied directly
+by snippet_id.

--- a/internal/acceptance_tests/blocks/dynamic_snippet_content.tf
+++ b/internal/acceptance_tests/blocks/dynamic_snippet_content.tf
@@ -1,0 +1,9 @@
+resource "fastly_service_dynamic_snippet_content" "test" {
+  service_id = fastly_service_cdn_auto.test.id
+  snippet_id = {
+    for s in fastly_service_cdn_auto.test.dynamic_snippet : s.name => s.snippet_id
+  }["{{.DYNAMIC_SNIPPET_NAME}}"]
+
+  content         = {{.DYNAMIC_SNIPPET_INLINE_CONTENT}}
+  manage_snippets = {{.MANAGE_SNIPPETS}}
+}

--- a/internal/acceptance_tests/blocks/dynamic_snippet_explicit.tf
+++ b/internal/acceptance_tests/blocks/dynamic_snippet_explicit.tf
@@ -1,0 +1,7 @@
+resource "fastly_service_dynamic_vcl_snippet" "test" {
+  service_id = fastly_service_cdn.test.id
+  version    = 1
+  name       = "{{.DYNAMIC_SNIPPET_NAME}}"
+  type       = "{{.DYNAMIC_SNIPPET_TYPE}}"
+  priority   = {{.DYNAMIC_SNIPPET_PRIORITY}}
+}

--- a/internal/acceptance_tests/blocks/dynamic_snippet_explicit_content.tf
+++ b/internal/acceptance_tests/blocks/dynamic_snippet_explicit_content.tf
@@ -1,0 +1,7 @@
+resource "fastly_service_dynamic_snippet_content" "test" {
+  service_id = fastly_service_cdn.test.id
+  snippet_id = fastly_service_dynamic_vcl_snippet.test.snippet_id
+
+  content         = {{.DYNAMIC_SNIPPET_INLINE_CONTENT}}
+  manage_snippets = {{.MANAGE_SNIPPETS}}
+}

--- a/internal/acceptance_tests/blocks/dynamic_snippet_nested.tf
+++ b/internal/acceptance_tests/blocks/dynamic_snippet_nested.tf
@@ -1,0 +1,5 @@
+dynamic_snippet {
+  name     = "{{.DYNAMIC_SNIPPET_NAME}}"
+  type     = "{{.DYNAMIC_SNIPPET_TYPE}}"
+  priority = {{.DYNAMIC_SNIPPET_PRIORITY}}
+}

--- a/internal/acceptance_tests/blocks/dynamic_snippet_nested_conflict.tf
+++ b/internal/acceptance_tests/blocks/dynamic_snippet_nested_conflict.tf
@@ -1,0 +1,12 @@
+snippet {
+  name     = "{{.SNIPPET_NAME}}"
+  type     = "recv"
+  priority = 100
+  content  = file("{{.SNIPPET_FILE_PATH}}")
+}
+
+dynamic_snippet {
+  name     = "{{.SNIPPET_NAME}}"
+  type     = "recv"
+  priority = 100
+}

--- a/internal/acceptance_tests/blocks/dynamic_snippet_nested_updated.tf
+++ b/internal/acceptance_tests/blocks/dynamic_snippet_nested_updated.tf
@@ -1,0 +1,5 @@
+dynamic_snippet {
+  name     = "{{.DYNAMIC_SNIPPET_NAME}}"
+  type     = "{{.DYNAMIC_SNIPPET_TYPE}}"
+  priority = {{.DYNAMIC_SNIPPET_PRIORITY}}
+}

--- a/internal/acceptance_tests/dynamic_snippet_test.go
+++ b/internal/acceptance_tests/dynamic_snippet_test.go
@@ -1,0 +1,363 @@
+package acceptancetests
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strconv"
+	"testing"
+
+	"github.com/fastly/go-fastly/v17/fastly"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+func TestAccFastlyServiceCDNAuto_withDynamicSnippet(t *testing.T) {
+	t.Parallel()
+
+	serviceName := fmt.Sprintf("tf-test-dynamic-snippet-auto-%s", acctest.RandString(10))
+	domainName := fmt.Sprintf("%s.example.com", acctest.RandString(10))
+	backendName := fmt.Sprintf("backend-%s", acctest.RandString(10))
+	snippetName := fmt.Sprintf("dynamic_%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
+		CheckDestroy:             CheckServiceDestroy("fastly_service_cdn_auto"),
+		Steps: []resource.TestStep{
+			{
+				Config: ConfigCDNAutoWithDynamicSnippet(serviceName, domainName, backendName, snippetName, "recv", 100),
+				Check: resource.ComposeTestCheckFunc(
+					CheckServiceExists("fastly_service_cdn_auto.test"),
+					CheckDynamicSnippetExistsInFastlyAtActiveVersion("fastly_service_cdn_auto.test", snippetName),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "dynamic_snippet.#", "1"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "dynamic_snippet.0.name", snippetName),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "dynamic_snippet.0.type", "recv"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "dynamic_snippet.0.priority", "100"),
+					resource.TestCheckResourceAttrSet("fastly_service_cdn_auto.test", "dynamic_snippet.0.snippet_id"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "active_version", "1"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "managed_version", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccFastlyServiceCDNAuto_withDynamicSnippetMetadataUpdate(t *testing.T) {
+	t.Parallel()
+
+	serviceName := fmt.Sprintf("tf-test-dynamic-snippet-auto-%s", acctest.RandString(10))
+	domainName := fmt.Sprintf("%s.example.com", acctest.RandString(10))
+	backendName := fmt.Sprintf("backend-%s", acctest.RandString(10))
+	snippetName := fmt.Sprintf("dynamic_%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
+		CheckDestroy:             CheckServiceDestroy("fastly_service_cdn_auto"),
+		Steps: []resource.TestStep{
+			{
+				Config: ConfigCDNAutoWithDynamicSnippet(serviceName, domainName, backendName, snippetName, "recv", 100),
+				Check: resource.ComposeTestCheckFunc(
+					CheckServiceExists("fastly_service_cdn_auto.test"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "active_version", "1"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "managed_version", "1"),
+				),
+			},
+			{
+				Config: ConfigCDNAutoWithDynamicSnippet(serviceName, domainName, backendName, snippetName, "deliver", 50),
+				Check: resource.ComposeTestCheckFunc(
+					CheckServiceExists("fastly_service_cdn_auto.test"),
+					CheckDynamicSnippetExistsInFastlyAtActiveVersion("fastly_service_cdn_auto.test", snippetName),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "dynamic_snippet.0.type", "deliver"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "dynamic_snippet.0.priority", "50"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "active_version", "2"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "managed_version", "2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccFastlyServiceDynamicSnippetContent_create(t *testing.T) {
+	t.Parallel()
+
+	serviceName := fmt.Sprintf("tf-test-dynamic-snippet-content-%s", acctest.RandString(10))
+	domainName := fmt.Sprintf("%s.example.com", acctest.RandString(10))
+	backendName := fmt.Sprintf("backend-%s", acctest.RandString(10))
+	snippetName := fmt.Sprintf("dynamic_%s", acctest.RandString(10))
+	content := dynamicSnippetBoilerplate("one")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
+		CheckDestroy:             CheckServiceDestroy("fastly_service_cdn_auto"),
+		Steps: []resource.TestStep{
+			{
+				Config: ConfigCDNAutoWithDynamicSnippetContent(serviceName, domainName, backendName, snippetName, "recv", 100, content, false),
+				Check: resource.ComposeTestCheckFunc(
+					CheckServiceExists("fastly_service_cdn_auto.test"),
+					CheckDynamicSnippetContentInFastly("fastly_service_cdn_auto.test", snippetName, content),
+					resource.TestCheckResourceAttr("fastly_service_dynamic_snippet_content.test", "content", content),
+					resource.TestCheckResourceAttr("fastly_service_dynamic_snippet_content.test", "manage_snippets", "false"),
+					resource.TestCheckResourceAttrSet("fastly_service_dynamic_snippet_content.test", "id"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccFastlyServiceDynamicSnippetContent_updateDoesNotCloneService(t *testing.T) {
+	t.Parallel()
+
+	serviceName := fmt.Sprintf("tf-test-dynamic-snippet-content-%s", acctest.RandString(10))
+	domainName := fmt.Sprintf("%s.example.com", acctest.RandString(10))
+	backendName := fmt.Sprintf("backend-%s", acctest.RandString(10))
+	snippetName := fmt.Sprintf("dynamic_%s", acctest.RandString(10))
+	contentOne := dynamicSnippetBoilerplate("one")
+	contentTwo := dynamicSnippetBoilerplate("two")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
+		CheckDestroy:             CheckServiceDestroy("fastly_service_cdn_auto"),
+		Steps: []resource.TestStep{
+			{
+				Config: ConfigCDNAutoWithDynamicSnippetContent(serviceName, domainName, backendName, snippetName, "recv", 100, contentOne, false),
+				Check: resource.ComposeTestCheckFunc(
+					CheckDynamicSnippetContentInFastly("fastly_service_cdn_auto.test", snippetName, contentOne),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "active_version", "1"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "managed_version", "1"),
+				),
+			},
+			{
+				Config: ConfigCDNAutoWithDynamicSnippetContent(serviceName, domainName, backendName, snippetName, "recv", 100, contentTwo, false),
+				Check: resource.ComposeTestCheckFunc(
+					CheckDynamicSnippetContentInFastly("fastly_service_cdn_auto.test", snippetName, contentTwo),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "active_version", "1"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "managed_version", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccFastlyServiceDynamicSnippetContent_import(t *testing.T) {
+	t.Parallel()
+
+	serviceName := fmt.Sprintf("tf-test-dynamic-snippet-content-%s", acctest.RandString(10))
+	domainName := fmt.Sprintf("%s.example.com", acctest.RandString(10))
+	backendName := fmt.Sprintf("backend-%s", acctest.RandString(10))
+	snippetName := fmt.Sprintf("dynamic_%s", acctest.RandString(10))
+	content := dynamicSnippetBoilerplate("import")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
+		CheckDestroy:             CheckServiceDestroy("fastly_service_cdn_auto"),
+		Steps: []resource.TestStep{
+			{
+				Config: ConfigCDNAutoWithDynamicSnippetContent(serviceName, domainName, backendName, snippetName, "recv", 100, content, false),
+				Check: resource.ComposeTestCheckFunc(
+					CheckDynamicSnippetContentInFastly("fastly_service_cdn_auto.test", snippetName, content),
+				),
+			},
+			{
+				ResourceName:      "fastly_service_dynamic_snippet_content.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: importDynamicSnippetContentID("fastly_service_dynamic_snippet_content.test"),
+			},
+		},
+	})
+}
+
+func TestAccFastlyServiceDynamicSnippetContent_deleteManageSnippetsTrue(t *testing.T) {
+	t.Parallel()
+
+	serviceName := fmt.Sprintf("tf-test-dynamic-snippet-content-%s", acctest.RandString(10))
+	domainName := fmt.Sprintf("%s.example.com", acctest.RandString(10))
+	backendName := fmt.Sprintf("backend-%s", acctest.RandString(10))
+	snippetName := fmt.Sprintf("dynamic_%s", acctest.RandString(10))
+	content := dynamicSnippetBoilerplate("delete")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
+		CheckDestroy:             CheckServiceDestroy("fastly_service_cdn_auto"),
+		Steps: []resource.TestStep{
+			{
+				Config: ConfigCDNAutoWithDynamicSnippetContent(serviceName, domainName, backendName, snippetName, "recv", 100, content, true),
+				Check:  CheckDynamicSnippetContentInFastly("fastly_service_cdn_auto.test", snippetName, content),
+			},
+			{
+				Config: ConfigCDNAutoWithDynamicSnippet(serviceName, domainName, backendName, snippetName, "recv", 100),
+				Check:  CheckDynamicSnippetContentInFastly("fastly_service_cdn_auto.test", snippetName, ""),
+			},
+		},
+	})
+}
+
+func TestAccFastlyServiceDynamicSnippetContent_deleteManageSnippetsFalse(t *testing.T) {
+	t.Parallel()
+
+	serviceName := fmt.Sprintf("tf-test-dynamic-snippet-content-%s", acctest.RandString(10))
+	domainName := fmt.Sprintf("%s.example.com", acctest.RandString(10))
+	backendName := fmt.Sprintf("backend-%s", acctest.RandString(10))
+	snippetName := fmt.Sprintf("dynamic_%s", acctest.RandString(10))
+	content := dynamicSnippetBoilerplate("delete")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
+		CheckDestroy:             CheckServiceDestroy("fastly_service_cdn_auto"),
+		Steps: []resource.TestStep{
+			{
+				Config: ConfigCDNAutoWithDynamicSnippetContent(serviceName, domainName, backendName, snippetName, "recv", 100, content, false),
+				Check:  CheckDynamicSnippetContentInFastly("fastly_service_cdn_auto.test", snippetName, content),
+			},
+			{
+				Config: ConfigCDNAutoWithDynamicSnippet(serviceName, domainName, backendName, snippetName, "recv", 100),
+				Check:  CheckDynamicSnippetContentInFastly("fastly_service_cdn_auto.test", snippetName, content),
+			},
+		},
+	})
+}
+
+func TestAccFastlyServiceCDNAuto_withRegularAndDynamicSnippetNameConflict(t *testing.T) {
+	t.Parallel()
+
+	serviceName := fmt.Sprintf("tf-test-dynamic-snippet-conflict-%s", acctest.RandString(10))
+	domainName := fmt.Sprintf("%s.example.com", acctest.RandString(10))
+	backendName := fmt.Sprintf("backend-%s", acctest.RandString(10))
+	snippetName := fmt.Sprintf("shared_%s", acctest.RandString(10))
+	filePath := writeSnippetFile(t, "dynamic-conflict.vcl", snippetBoilerplate("conflict"))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
+		CheckDestroy:             CheckServiceDestroy("fastly_service_cdn_auto"),
+		Steps: []resource.TestStep{
+			{
+				Config:      ConfigCDNAutoWithRegularAndDynamicSnippetConflict(serviceName, domainName, backendName, snippetName, filePath),
+				ExpectError: regexp.MustCompile(`used by both regular and dynamic\s+snippets`),
+			},
+		},
+	})
+}
+
+func CheckDynamicSnippetExistsInFastlyAtActiveVersion(resourceName, snippetName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceName)
+		}
+
+		version, err := strconv.Atoi(rs.Primary.Attributes["active_version"])
+		if err != nil {
+			return fmt.Errorf("error parsing active_version for %s: %w", resourceName, err)
+		}
+
+		client, err := NewFastlyClient()
+		if err != nil {
+			return fmt.Errorf("error creating Fastly client: %w", err)
+		}
+
+		snippet, err := client.GetSnippet(context.Background(), &fastly.GetSnippetInput{
+			ServiceID:      rs.Primary.ID,
+			ServiceVersion: version,
+			Name:           snippetName,
+		})
+		if err != nil {
+			return fmt.Errorf("error fetching dynamic VCL snippet %q in service %s version %d: %w", snippetName, rs.Primary.ID, version, err)
+		}
+
+		if fastly.ToValue(snippet.Dynamic) != 1 {
+			return fmt.Errorf("snippet %q is regular; expected dynamic snippet", snippetName)
+		}
+
+		if fastly.ToValue(snippet.SnippetID) == "" {
+			return fmt.Errorf("dynamic snippet %q has empty snippet_id", snippetName)
+		}
+
+		return nil
+	}
+}
+
+func CheckDynamicSnippetContentInFastly(resourceName, snippetName string, expectedContent string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		serviceID, snippetID, err := dynamicSnippetIdentityFromState(s, resourceName, snippetName)
+		if err != nil {
+			return err
+		}
+
+		client, err := NewFastlyClient()
+		if err != nil {
+			return fmt.Errorf("error creating Fastly client: %w", err)
+		}
+
+		dynamicSnippet, err := client.GetDynamicSnippet(context.Background(), &fastly.GetDynamicSnippetInput{
+			ServiceID: serviceID,
+			SnippetID: snippetID,
+		})
+		if err != nil {
+			return fmt.Errorf("error fetching dynamic VCL snippet content %q in service %s: %w", snippetID, serviceID, err)
+		}
+
+		if fastly.ToValue(dynamicSnippet.Content) != expectedContent {
+			return fmt.Errorf("dynamic snippet content mismatch for snippet %q in service %s:\nexpected: %q\nactual:   %q", snippetID, serviceID, expectedContent, fastly.ToValue(dynamicSnippet.Content))
+		}
+
+		return nil
+	}
+}
+
+func importDynamicSnippetContentID(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("not found: %s", resourceName)
+		}
+
+		serviceID := rs.Primary.Attributes["service_id"]
+		snippetID := rs.Primary.Attributes["snippet_id"]
+
+		if serviceID == "" || snippetID == "" {
+			return "", fmt.Errorf("missing import identity fields for %s: service_id=%q snippet_id=%q", resourceName, serviceID, snippetID)
+		}
+
+		return fmt.Sprintf("%s/%s", serviceID, snippetID), nil
+	}
+}
+
+func dynamicSnippetIdentityFromState(s *terraform.State, resourceName, snippetName string) (string, string, error) {
+	rs, ok := s.RootModule().Resources[resourceName]
+	if !ok {
+		return "", "", fmt.Errorf("not found: %s", resourceName)
+	}
+
+	for i := 0; ; i++ {
+		prefix := fmt.Sprintf("dynamic_snippet.%d.", i)
+		name, ok := rs.Primary.Attributes[prefix+"name"]
+		if !ok {
+			break
+		}
+		if name != snippetName {
+			continue
+		}
+
+		snippetID := rs.Primary.Attributes[prefix+"snippet_id"]
+		if snippetID == "" {
+			return "", "", fmt.Errorf("dynamic snippet %q has empty snippet_id", snippetName)
+		}
+
+		return rs.Primary.ID, snippetID, nil
+	}
+
+	return "", "", fmt.Errorf("dynamic snippet %q not found in state for %s", snippetName, resourceName)
+}
+
+func dynamicSnippetBoilerplate(label string) string {
+	return fmt.Sprintf(`set req.http.X-Terraform-Dynamic-Snippet-Test = %q;`, label)
+}

--- a/internal/acceptance_tests/dynamic_vcl_snippet_test.go
+++ b/internal/acceptance_tests/dynamic_vcl_snippet_test.go
@@ -1,0 +1,230 @@
+package acceptancetests
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strconv"
+	"testing"
+
+	"github.com/fastly/go-fastly/v17/fastly"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+func TestAccFastlyServiceDynamicSnippetMetadataExplicit_basicAndUpdate(t *testing.T) {
+	t.Parallel()
+
+	serviceName := fmt.Sprintf("tf-test-dynamic-vcl-snippet-%s", acctest.RandString(10))
+	snippetName := fmt.Sprintf("dynamic_%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
+		CheckDestroy:             CheckServiceDestroy("fastly_service_cdn"),
+		Steps: []resource.TestStep{
+			{
+				Config: ConfigServiceDynamicVCLSnippet(serviceName, snippetName, "recv", 100),
+				Check: resource.ComposeTestCheckFunc(
+					CheckServiceExists("fastly_service_cdn.test"),
+					CheckDynamicVCLSnippetExistsInFastly("fastly_service_cdn.test", snippetName, 1, "recv", 100),
+					resource.TestCheckResourceAttr("fastly_service_dynamic_vcl_snippet.test", "name", snippetName),
+					resource.TestCheckResourceAttr("fastly_service_dynamic_vcl_snippet.test", "type", "recv"),
+					resource.TestCheckResourceAttr("fastly_service_dynamic_vcl_snippet.test", "priority", "100"),
+					resource.TestCheckResourceAttr("fastly_service_dynamic_vcl_snippet.test", "version", "1"),
+					resource.TestCheckResourceAttrSet("fastly_service_dynamic_vcl_snippet.test", "service_id"),
+					resource.TestCheckResourceAttrSet("fastly_service_dynamic_vcl_snippet.test", "snippet_id"),
+					resource.TestCheckResourceAttrSet("fastly_service_dynamic_vcl_snippet.test", "id"),
+				),
+			},
+			{
+				Config: ConfigServiceDynamicVCLSnippet(serviceName, snippetName, "deliver", 50),
+				Check: resource.ComposeTestCheckFunc(
+					CheckServiceExists("fastly_service_cdn.test"),
+					CheckDynamicVCLSnippetExistsInFastly("fastly_service_cdn.test", snippetName, 1, "deliver", 50),
+					resource.TestCheckResourceAttr("fastly_service_dynamic_vcl_snippet.test", "name", snippetName),
+					resource.TestCheckResourceAttr("fastly_service_dynamic_vcl_snippet.test", "type", "deliver"),
+					resource.TestCheckResourceAttr("fastly_service_dynamic_vcl_snippet.test", "priority", "50"),
+					resource.TestCheckResourceAttrSet("fastly_service_dynamic_vcl_snippet.test", "snippet_id"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccFastlyServiceDynamicSnippetMetadataExplicit_import(t *testing.T) {
+	t.Parallel()
+
+	serviceName := fmt.Sprintf("tf-test-dynamic-vcl-snippet-%s", acctest.RandString(10))
+	snippetName := fmt.Sprintf("dynamic_%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
+		CheckDestroy:             CheckServiceDestroy("fastly_service_cdn"),
+		Steps: []resource.TestStep{
+			{
+				Config: ConfigServiceDynamicVCLSnippet(serviceName, snippetName, "recv", 100),
+				Check: resource.ComposeTestCheckFunc(
+					CheckServiceExists("fastly_service_cdn.test"),
+					CheckDynamicVCLSnippetExistsInFastly("fastly_service_cdn.test", snippetName, 1, "recv", 100),
+				),
+			},
+			{
+				ResourceName:      "fastly_service_dynamic_vcl_snippet.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: importDynamicVCLSnippetID("fastly_service_dynamic_vcl_snippet.test"),
+			},
+		},
+	})
+}
+
+func TestAccFastlyServiceDynamicSnippetMetadataExplicit_rejectsRegularSnippetOnImport(t *testing.T) {
+	t.Parallel()
+
+	serviceName := fmt.Sprintf("tf-test-dynamic-vcl-snippet-%s", acctest.RandString(10))
+	snippetName := fmt.Sprintf("regular_%s", acctest.RandString(10))
+	content := snippetBoilerplate("regular")
+	snippetFile := writeSnippetFile(t, "dynamic-import-regular.vcl", content)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
+		CheckDestroy:             CheckServiceDestroy("fastly_service_cdn"),
+		Steps: []resource.TestStep{
+			{
+				Config: ConfigServiceVCLSnippetWithFile(serviceName, snippetName, "recv", 100, snippetFile),
+				Check: resource.ComposeTestCheckFunc(
+					CheckServiceExists("fastly_service_cdn.test"),
+					CheckSnippetExistsInFastly("fastly_service_cdn.test", snippetName, 1, content),
+				),
+			},
+			{
+				Config:            ConfigServiceDynamicVCLSnippet(serviceName, snippetName, "recv", 100),
+				ResourceName:      "fastly_service_dynamic_vcl_snippet.test",
+				ImportState:       true,
+				ImportStateIdFunc: importRegularSnippetAsDynamicVCLSnippetID("fastly_service_vcl_snippet.test"),
+				ExpectError:       regexp.MustCompile(`regular.*expected dynamic snippet`),
+			},
+		},
+	})
+}
+
+func CheckDynamicVCLSnippetExistsInFastly(resourceName, snippetName string, version int, expectedType string, expectedPriority int) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceName)
+		}
+
+		client, err := NewFastlyClient()
+		if err != nil {
+			return fmt.Errorf("error creating Fastly client: %w", err)
+		}
+
+		snippet, err := client.GetSnippet(context.Background(), &fastly.GetSnippetInput{
+			ServiceID:      rs.Primary.ID,
+			ServiceVersion: version,
+			Name:           snippetName,
+		})
+		if err != nil {
+			return fmt.Errorf("error fetching dynamic VCL snippet %q in service %s version %d: %w", snippetName, rs.Primary.ID, version, err)
+		}
+
+		if fastly.ToValue(snippet.Dynamic) != 1 {
+			return fmt.Errorf("snippet %q is regular; expected dynamic snippet", snippetName)
+		}
+
+		if got := string(fastly.ToValue(snippet.Type)); got != expectedType {
+			return fmt.Errorf("dynamic snippet %q type = %q, want %q", snippetName, got, expectedType)
+		}
+
+		priority, err := strconv.Atoi(fastly.ToValue(snippet.Priority))
+		if err != nil {
+			return fmt.Errorf("error parsing dynamic snippet priority %q: %w", fastly.ToValue(snippet.Priority), err)
+		}
+		if priority != expectedPriority {
+			return fmt.Errorf("dynamic snippet %q priority = %d, want %d", snippetName, priority, expectedPriority)
+		}
+
+		if fastly.ToValue(snippet.SnippetID) == "" {
+			return fmt.Errorf("dynamic snippet %q has empty snippet_id", snippetName)
+		}
+
+		return nil
+	}
+}
+
+func CheckDynamicSnippetContentResourceInFastly(resourceName string, expectedContent string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceName)
+		}
+
+		serviceID := rs.Primary.Attributes["service_id"]
+		snippetID := rs.Primary.Attributes["snippet_id"]
+		if serviceID == "" || snippetID == "" {
+			return fmt.Errorf("missing dynamic snippet content identity fields for %s: service_id=%q snippet_id=%q", resourceName, serviceID, snippetID)
+		}
+
+		client, err := NewFastlyClient()
+		if err != nil {
+			return fmt.Errorf("error creating Fastly client: %w", err)
+		}
+
+		dynamicSnippet, err := client.GetDynamicSnippet(context.Background(), &fastly.GetDynamicSnippetInput{
+			ServiceID: serviceID,
+			SnippetID: snippetID,
+		})
+		if err != nil {
+			return fmt.Errorf("error fetching dynamic VCL snippet content %q in service %s: %w", snippetID, serviceID, err)
+		}
+
+		if fastly.ToValue(dynamicSnippet.Content) != expectedContent {
+			return fmt.Errorf("dynamic snippet content mismatch for snippet %q in service %s:\nexpected: %q\nactual:   %q", snippetID, serviceID, expectedContent, fastly.ToValue(dynamicSnippet.Content))
+		}
+
+		return nil
+	}
+}
+
+func importDynamicVCLSnippetID(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("not found: %s", resourceName)
+		}
+
+		serviceID := rs.Primary.Attributes["service_id"]
+		version := rs.Primary.Attributes["version"]
+		name := rs.Primary.Attributes["name"]
+
+		if serviceID == "" || version == "" || name == "" {
+			return "", fmt.Errorf("missing import identity fields for %s: service_id=%q version=%q name=%q", resourceName, serviceID, version, name)
+		}
+
+		return fmt.Sprintf("%s/%s/%s", serviceID, version, name), nil
+	}
+}
+
+func importRegularSnippetAsDynamicVCLSnippetID(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("not found: %s", resourceName)
+		}
+
+		serviceID := rs.Primary.Attributes["service_id"]
+		version := rs.Primary.Attributes["version"]
+		name := rs.Primary.Attributes["name"]
+
+		if serviceID == "" || version == "" || name == "" {
+			return "", fmt.Errorf("missing import identity fields for %s: service_id=%q version=%q name=%q", resourceName, serviceID, version, name)
+		}
+
+		return fmt.Sprintf("%s/%s/%s", serviceID, version, name), nil
+	}
+}

--- a/internal/acceptance_tests/test_helpers.go
+++ b/internal/acceptance_tests/test_helpers.go
@@ -2851,3 +2851,135 @@ func ConfigCDNAutoWithInvalidSnippetType(serviceName, domainName, backendName, s
 		"internal/acceptance_tests/blocks/snippet_nested_invalid_type.tf",
 	)
 }
+
+// ConfigCDNAutoWithDynamicSnippet returns a CDN auto service with domain, backend,
+// and one dynamic VCL snippet metadata block.
+func ConfigCDNAutoWithDynamicSnippet(serviceName, domainName, backendName, snippetName, snippetType string, priority int) string {
+	return BuildConfig(
+		ServiceCDNAuto,
+		map[string]string{
+			"SERVICE_NAME":             serviceName,
+			"DOMAIN_NAME":              domainName,
+			"BACKEND_NAME":             backendName,
+			"DYNAMIC_SNIPPET_NAME":     snippetName,
+			"DYNAMIC_SNIPPET_TYPE":     snippetType,
+			"DYNAMIC_SNIPPET_PRIORITY": strconv.Itoa(priority),
+		},
+		"internal/acceptance_tests/blocks/domain_single.tf",
+		"internal/acceptance_tests/blocks/backend_single.tf",
+		"internal/acceptance_tests/blocks/dynamic_snippet_nested.tf",
+	)
+}
+
+// ConfigCDNAutoWithDynamicSnippetContent returns a CDN auto service with one
+// dynamic VCL snippet and a separate versionless dynamic snippet content resource.
+func ConfigCDNAutoWithDynamicSnippetContent(serviceName, domainName, backendName, snippetName, snippetType string, priority int, content string, manageSnippets bool) string {
+	serviceConfig := BuildConfig(
+		ServiceCDNAuto,
+		map[string]string{
+			"SERVICE_NAME":             serviceName,
+			"DOMAIN_NAME":              domainName,
+			"BACKEND_NAME":             backendName,
+			"DYNAMIC_SNIPPET_NAME":     snippetName,
+			"DYNAMIC_SNIPPET_TYPE":     snippetType,
+			"DYNAMIC_SNIPPET_PRIORITY": strconv.Itoa(priority),
+		},
+		"internal/acceptance_tests/blocks/domain_single.tf",
+		"internal/acceptance_tests/blocks/backend_single.tf",
+		"internal/acceptance_tests/blocks/dynamic_snippet_nested.tf",
+	)
+
+	contentResource := renderDynamicSnippetContentBlock(map[string]string{
+		"DYNAMIC_SNIPPET_NAME":           snippetName,
+		"DYNAMIC_SNIPPET_INLINE_CONTENT": strconv.Quote(content),
+		"MANAGE_SNIPPETS":                strconv.FormatBool(manageSnippets),
+	})
+
+	return joinBlocks(serviceConfig, contentResource)
+}
+
+func renderDynamicSnippetContentBlock(values map[string]string) string {
+	data, err := os.ReadFile("blocks/dynamic_snippet_content.tf")
+	if err != nil {
+		panic(fmt.Sprintf("error reading dynamic snippet content fixture: %s", err))
+	}
+
+	replacements := make([]string, 0, len(values)*2)
+	for key, value := range values {
+		replacements = append(replacements, "{{."+key+"}}", value)
+	}
+
+	return strings.NewReplacer(replacements...).Replace(string(data))
+}
+
+// ConfigCDNAutoWithRegularAndDynamicSnippetConflict returns a CDN auto service
+// with regular and dynamic snippets using the same name.
+func ConfigCDNAutoWithRegularAndDynamicSnippetConflict(serviceName, domainName, backendName, snippetName, snippetFilePath string) string {
+	return BuildConfig(
+		ServiceCDNAuto,
+		map[string]string{
+			"SERVICE_NAME":      serviceName,
+			"DOMAIN_NAME":       domainName,
+			"BACKEND_NAME":      backendName,
+			"SNIPPET_NAME":      snippetName,
+			"SNIPPET_FILE_PATH": filepath.ToSlash(snippetFilePath),
+		},
+		"internal/acceptance_tests/blocks/domain_single.tf",
+		"internal/acceptance_tests/blocks/backend_single.tf",
+		"internal/acceptance_tests/blocks/dynamic_snippet_nested_conflict.tf",
+	)
+}
+
+// ConfigServiceDynamicVCLSnippet returns a CDN service with one explicit/default
+// first-class dynamic VCL snippet metadata resource.
+func ConfigServiceDynamicVCLSnippet(serviceName, snippetName, snippetType string, priority int) string {
+	return BuildConfig(
+		ServiceCDN,
+		map[string]string{
+			"SERVICE_NAME":             serviceName,
+			"SERVICE_COMMENT":          "Dynamic VCL snippet acceptance test",
+			"DYNAMIC_SNIPPET_NAME":     snippetName,
+			"DYNAMIC_SNIPPET_TYPE":     snippetType,
+			"DYNAMIC_SNIPPET_PRIORITY": strconv.Itoa(priority),
+		},
+		"internal/acceptance_tests/blocks/dynamic_snippet_explicit.tf",
+	)
+}
+
+// ConfigServiceDynamicVCLSnippetContent returns a CDN service with one
+// explicit/default first-class dynamic VCL snippet metadata resource and a
+// separate versionless dynamic snippet content resource.
+func ConfigServiceDynamicVCLSnippetContent(serviceName, snippetName, snippetType string, priority int, content string, manageSnippets bool) string {
+	serviceConfig := BuildConfig(
+		ServiceCDN,
+		map[string]string{
+			"SERVICE_NAME":             serviceName,
+			"SERVICE_COMMENT":          "Dynamic VCL snippet acceptance test",
+			"DYNAMIC_SNIPPET_NAME":     snippetName,
+			"DYNAMIC_SNIPPET_TYPE":     snippetType,
+			"DYNAMIC_SNIPPET_PRIORITY": strconv.Itoa(priority),
+		},
+		"internal/acceptance_tests/blocks/dynamic_snippet_explicit.tf",
+	)
+
+	contentResource := renderDynamicSnippetExplicitContentBlock(map[string]string{
+		"DYNAMIC_SNIPPET_INLINE_CONTENT": strconv.Quote(content),
+		"MANAGE_SNIPPETS":                strconv.FormatBool(manageSnippets),
+	})
+
+	return joinBlocks(serviceConfig, contentResource)
+}
+
+func renderDynamicSnippetExplicitContentBlock(values map[string]string) string {
+	data, err := os.ReadFile("blocks/dynamic_snippet_explicit_content.tf")
+	if err != nil {
+		panic(fmt.Sprintf("error reading explicit dynamic snippet content fixture: %s", err))
+	}
+
+	replacements := make([]string, 0, len(values)*2)
+	for key, value := range values {
+		replacements = append(replacements, "{{."+key+"}}", value)
+	}
+
+	return strings.NewReplacer(replacements...).Replace(string(data))
+}

--- a/internal/acceptance_tests/test_helpers.go
+++ b/internal/acceptance_tests/test_helpers.go
@@ -2889,27 +2889,13 @@ func ConfigCDNAutoWithDynamicSnippetContent(serviceName, domainName, backendName
 		"internal/acceptance_tests/blocks/dynamic_snippet_nested.tf",
 	)
 
-	contentResource := renderDynamicSnippetContentBlock(map[string]string{
+	contentResource := renderFixtureBlock("blocks/dynamic_snippet_content.tf", map[string]string{
 		"DYNAMIC_SNIPPET_NAME":           snippetName,
 		"DYNAMIC_SNIPPET_INLINE_CONTENT": strconv.Quote(content),
 		"MANAGE_SNIPPETS":                strconv.FormatBool(manageSnippets),
 	})
 
 	return joinBlocks(serviceConfig, contentResource)
-}
-
-func renderDynamicSnippetContentBlock(values map[string]string) string {
-	data, err := os.ReadFile("blocks/dynamic_snippet_content.tf")
-	if err != nil {
-		panic(fmt.Sprintf("error reading dynamic snippet content fixture: %s", err))
-	}
-
-	replacements := make([]string, 0, len(values)*2)
-	for key, value := range values {
-		replacements = append(replacements, "{{."+key+"}}", value)
-	}
-
-	return strings.NewReplacer(replacements...).Replace(string(data))
 }
 
 // ConfigCDNAutoWithRegularAndDynamicSnippetConflict returns a CDN auto service
@@ -2962,7 +2948,7 @@ func ConfigServiceDynamicVCLSnippetContent(serviceName, snippetName, snippetType
 		"internal/acceptance_tests/blocks/dynamic_snippet_explicit.tf",
 	)
 
-	contentResource := renderDynamicSnippetExplicitContentBlock(map[string]string{
+	contentResource := renderFixtureBlock("blocks/dynamic_snippet_explicit_content.tf", map[string]string{
 		"DYNAMIC_SNIPPET_INLINE_CONTENT": strconv.Quote(content),
 		"MANAGE_SNIPPETS":                strconv.FormatBool(manageSnippets),
 	})
@@ -2970,10 +2956,10 @@ func ConfigServiceDynamicVCLSnippetContent(serviceName, snippetName, snippetType
 	return joinBlocks(serviceConfig, contentResource)
 }
 
-func renderDynamicSnippetExplicitContentBlock(values map[string]string) string {
-	data, err := os.ReadFile("blocks/dynamic_snippet_explicit_content.tf")
+func renderFixtureBlock(path string, values map[string]string) string {
+	data, err := os.ReadFile(path)
 	if err != nil {
-		panic(fmt.Sprintf("error reading explicit dynamic snippet content fixture: %s", err))
+		panic(fmt.Sprintf("error reading fixture %s: %s", path, err))
 	}
 
 	replacements := make([]string, 0, len(values)*2)

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -29,6 +29,8 @@ import (
 	"github.com/fastly/terraform-provider-fastly/internal/resources/cdnaclentries"
 	"github.com/fastly/terraform-provider-fastly/internal/resources/condition"
 	"github.com/fastly/terraform-provider-fastly/internal/resources/domain"
+	"github.com/fastly/terraform-provider-fastly/internal/resources/dynamicsnippetcontent"
+	"github.com/fastly/terraform-provider-fastly/internal/resources/dynamicvclsnippet"
 	"github.com/fastly/terraform-provider-fastly/internal/resources/kvstore"
 	"github.com/fastly/terraform-provider-fastly/internal/resources/loggingdatadog"
 	"github.com/fastly/terraform-provider-fastly/internal/resources/loggingnewrelicotlp"
@@ -120,6 +122,8 @@ func (p *fastlyProvider) Resources(_ context.Context) []func() resource.Resource
 		kvstore.NewResource,
 		vcl.NewResource,
 		snippet.NewResource,
+		dynamicvclsnippet.NewResource,
+		dynamicsnippetcontent.NewResource,
 		productenablement.NewFanoutResource,
 		productenablement.NewBrotliCompressionResource,
 		productenablement.NewImageOptimizerResource,

--- a/internal/resources/dynamicsnippet/dynamicsnippet_test.go
+++ b/internal/resources/dynamicsnippet/dynamicsnippet_test.go
@@ -1,0 +1,87 @@
+package dynamicsnippet
+
+import (
+	"testing"
+
+	regularsnippet "github.com/fastly/terraform-provider-fastly/internal/resources/snippet"
+
+	fastly "github.com/fastly/go-fastly/v17/fastly"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestBuildCreateInput(t *testing.T) {
+	model := NestedModel{
+		Name:     types.StringValue("dynamic_recv"),
+		Type:     types.StringValue("recv"),
+		Priority: types.Int64Value(50),
+	}
+
+	input := BuildCreateInput("service-id", 1, model)
+
+	if input.ServiceID != "service-id" {
+		t.Fatalf("ServiceID = %q, want service-id", input.ServiceID)
+	}
+	if input.ServiceVersion != 1 {
+		t.Fatalf("ServiceVersion = %d, want 1", input.ServiceVersion)
+	}
+	if fastly.ToValue(input.Name) != "dynamic_recv" {
+		t.Fatalf("Name = %q, want dynamic_recv", fastly.ToValue(input.Name))
+	}
+	if fastly.ToValue(input.Dynamic) != 1 {
+		t.Fatalf("Dynamic = %d, want 1", fastly.ToValue(input.Dynamic))
+	}
+	if fastly.ToValue(input.Priority) != "50" {
+		t.Fatalf("Priority = %q, want 50", fastly.ToValue(input.Priority))
+	}
+}
+
+func TestFlattenToNestedModelRejectsRegularSnippet(t *testing.T) {
+	dynamic := 0
+	name := "regular_recv"
+
+	_, err := FlattenToNestedModel(&fastly.Snippet{
+		Name:    &name,
+		Dynamic: &dynamic,
+	})
+	if err == nil {
+		t.Fatal("expected regular snippet to be rejected")
+	}
+}
+
+func TestParsePriority(t *testing.T) {
+	value := "25"
+	got, err := parsePriority(&value)
+	if err != nil {
+		t.Fatalf("parsePriority returned error: %s", err)
+	}
+	if got != 25 {
+		t.Fatalf("parsePriority = %d, want 25", got)
+	}
+
+	empty := ""
+	got, err = parsePriority(&empty)
+	if err != nil {
+		t.Fatalf("parsePriority empty returned error: %s", err)
+	}
+	if got != DefaultPriority {
+		t.Fatalf("parsePriority empty = %d, want %d", got, DefaultPriority)
+	}
+
+	invalid := "invalid"
+	if _, err := parsePriority(&invalid); err == nil {
+		t.Fatal("expected invalid priority to return an error")
+	}
+}
+
+func TestValidateNoNameConflicts(t *testing.T) {
+	dynamic := []NestedModel{
+		{Name: types.StringValue("shared")},
+	}
+	regular := []regularsnippet.NestedModel{
+		{Name: types.StringValue("shared")},
+	}
+
+	if err := ValidateNoNameConflicts(dynamic, regular); err == nil {
+		t.Fatal("expected shared regular and dynamic snippet name to return an error")
+	}
+}

--- a/internal/resources/dynamicsnippet/expand.go
+++ b/internal/resources/dynamicsnippet/expand.go
@@ -1,0 +1,42 @@
+package dynamicsnippet
+
+import (
+	"strconv"
+
+	"github.com/fastly/terraform-provider-fastly/internal/service"
+
+	fastly "github.com/fastly/go-fastly/v17/fastly"
+)
+
+func BuildCreateInput(serviceID string, version int, m NestedModel) *fastly.CreateSnippetInput {
+	name := service.StringValue(m.Name)
+	content := ""
+	priority := strconv.FormatInt(service.Int64Value(m.Priority), 10)
+	snippetType := fastly.SnippetType(normalizeType(service.StringValue(m.Type)))
+	dynamic := 1
+
+	return &fastly.CreateSnippetInput{
+		ServiceID:      serviceID,
+		ServiceVersion: version,
+		Name:           &name,
+		Content:        &content,
+		Priority:       &priority,
+		Type:           &snippetType,
+		Dynamic:        &dynamic,
+	}
+}
+
+func BuildUpdateInput(serviceID string, version int, m NestedModel) *fastly.UpdateSnippetInput {
+	name := service.StringValue(m.Name)
+	priority := strconv.FormatInt(service.Int64Value(m.Priority), 10)
+	snippetType := fastly.SnippetType(normalizeType(service.StringValue(m.Type)))
+
+	return &fastly.UpdateSnippetInput{
+		ServiceID:      serviceID,
+		ServiceVersion: version,
+		Name:           name,
+		NewName:        &name,
+		Priority:       &priority,
+		Type:           &snippetType,
+	}
+}

--- a/internal/resources/dynamicsnippet/flatten.go
+++ b/internal/resources/dynamicsnippet/flatten.go
@@ -1,0 +1,32 @@
+package dynamicsnippet
+
+import (
+	"fmt"
+
+	regularsnippet "github.com/fastly/terraform-provider-fastly/internal/resources/snippet"
+
+	fastly "github.com/fastly/go-fastly/v17/fastly"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func FlattenToNestedModel(api *fastly.Snippet) (NestedModel, error) {
+	if api == nil {
+		return NestedModel{}, nil
+	}
+
+	if !regularsnippet.IsDynamic(api) {
+		return NestedModel{}, fmt.Errorf("VCL snippet %q is regular; expected dynamic snippet", fastly.ToValue(api.Name))
+	}
+
+	priority, err := parsePriority(api.Priority)
+	if err != nil {
+		return NestedModel{}, err
+	}
+
+	return NestedModel{
+		Name:      types.StringValue(fastly.ToValue(api.Name)),
+		Type:      types.StringValue(string(fastly.ToValue(api.Type))),
+		Priority:  types.Int64Value(priority),
+		SnippetID: types.StringValue(fastly.ToValue(api.SnippetID)),
+	}, nil
+}

--- a/internal/resources/dynamicsnippet/schema.go
+++ b/internal/resources/dynamicsnippet/schema.go
@@ -1,0 +1,307 @@
+package dynamicsnippet
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"strconv"
+	"strings"
+
+	"github.com/fastly/terraform-provider-fastly/internal/reconcile"
+	regularsnippet "github.com/fastly/terraform-provider-fastly/internal/resources/snippet"
+	"github.com/fastly/terraform-provider-fastly/internal/service"
+
+	fastly "github.com/fastly/go-fastly/v17/fastly"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+const DefaultPriority int64 = 100
+
+var validTypes = []string{
+	"init",
+	"recv",
+	"hash",
+	"hit",
+	"miss",
+	"pass",
+	"fetch",
+	"error",
+	"deliver",
+	"log",
+	"none",
+}
+
+type NestedModel struct {
+	Name      types.String `tfsdk:"name"`
+	Type      types.String `tfsdk:"type"`
+	Priority  types.Int64  `tfsdk:"priority"`
+	SnippetID types.String `tfsdk:"snippet_id"`
+}
+
+func (n NestedModel) ModelsEqual(other NestedModel) bool {
+	return service.StringValue(n.Name) == service.StringValue(other.Name) &&
+		normalizeType(service.StringValue(n.Type)) == normalizeType(service.StringValue(other.Type)) &&
+		service.Int64Value(n.Priority) == service.Int64Value(other.Priority)
+}
+
+func CommonAttributes() map[string]schema.Attribute {
+	return map[string]schema.Attribute{
+		"name": schema.StringAttribute{
+			Required:    true,
+			Description: "A name that is unique across regular and dynamic VCL snippet configuration blocks. Changing this attribute will delete and recreate the snippet.",
+		},
+		"type": schema.StringAttribute{
+			Required:    true,
+			Description: "The location in generated VCL where the dynamic snippet should be placed. Must be one of `init`, `recv`, `hash`, `hit`, `miss`, `pass`, `fetch`, `error`, `deliver`, `log`, or `none`.",
+			Validators: []validator.String{
+				stringvalidator.OneOf(validTypes...),
+			},
+		},
+		"priority": schema.Int64Attribute{
+			Optional:    true,
+			Computed:    true,
+			Default:     int64default.StaticInt64(DefaultPriority),
+			Description: "Priority determines execution order. Lower numbers execute first. Default `100`.",
+		},
+		"snippet_id": schema.StringAttribute{
+			Computed:    true,
+			Description: "The Fastly-generated dynamic snippet ID. Use this value with `fastly_service_dynamic_snippet_content` to manage versionless snippet code.",
+		},
+	}
+}
+
+func NestedBlockSchema() schema.ListNestedBlock {
+	return schema.ListNestedBlock{
+		Description: "Dynamic VCL snippet metadata attached to this service version. Dynamic snippet content is managed separately by `fastly_service_dynamic_snippet_content`.",
+		NestedObject: schema.NestedBlockObject{
+			Attributes: CommonAttributes(),
+		},
+	}
+}
+
+func ValidateConfig(snippets []NestedModel) error {
+	seenNames := make(map[string]struct{}, len(snippets))
+
+	for _, item := range snippets {
+		if item.Name.IsUnknown() || item.Name.IsNull() {
+			continue
+		}
+
+		name := strings.TrimSpace(item.Name.ValueString())
+		if name == "" {
+			return fmt.Errorf("dynamic VCL snippet name cannot be empty")
+		}
+
+		if _, ok := seenNames[name]; ok {
+			return fmt.Errorf("multiple dynamic snippets with the same name %q; names must be unique within a service version", name)
+		}
+		seenNames[name] = struct{}{}
+	}
+
+	return nil
+}
+
+func Validate(snippets []NestedModel) error {
+	seenNames := make(map[string]struct{}, len(snippets))
+
+	for _, item := range snippets {
+		name := strings.TrimSpace(service.StringValue(item.Name))
+		if name == "" {
+			return fmt.Errorf("dynamic VCL snippet name cannot be empty")
+		}
+
+		if _, ok := seenNames[name]; ok {
+			return fmt.Errorf("multiple dynamic snippets with the same name %q; names must be unique within a service version", name)
+		}
+		seenNames[name] = struct{}{}
+
+		if !isValidType(service.StringValue(item.Type)) {
+			return fmt.Errorf("invalid dynamic VCL snippet type %q; must be one of %s", service.StringValue(item.Type), strings.Join(validTypes, ", "))
+		}
+	}
+
+	return nil
+}
+
+func ValidateNoNameConflicts(dynamicSnippets []NestedModel, regularSnippets []regularsnippet.NestedModel) error {
+	regularByName := make(map[string]struct{}, len(regularSnippets))
+	for _, item := range regularSnippets {
+		if item.Name.IsUnknown() || item.Name.IsNull() {
+			continue
+		}
+		name := strings.TrimSpace(item.Name.ValueString())
+		if name == "" {
+			continue
+		}
+		regularByName[name] = struct{}{}
+	}
+
+	for _, item := range dynamicSnippets {
+		if item.Name.IsUnknown() || item.Name.IsNull() {
+			continue
+		}
+		name := strings.TrimSpace(item.Name.ValueString())
+		if name == "" {
+			continue
+		}
+		if _, ok := regularByName[name]; ok {
+			return fmt.Errorf("VCL snippet name %q is used by both regular and dynamic snippets; names must be unique within a service version", name)
+		}
+	}
+
+	return nil
+}
+
+type ops struct{}
+
+func (o ops) List(ctx context.Context, client *fastly.Client, serviceID string, version int) ([]*fastly.Snippet, error) {
+	all, err := client.ListSnippets(ctx, &fastly.ListSnippetsInput{
+		ServiceID:      serviceID,
+		ServiceVersion: version,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	dynamic := make([]*fastly.Snippet, 0, len(all))
+	for _, item := range all {
+		if item == nil {
+			continue
+		}
+		if !regularsnippet.IsDynamic(item) {
+			continue
+		}
+		if _, err := parsePriority(item.Priority); err != nil {
+			return nil, err
+		}
+		dynamic = append(dynamic, item)
+	}
+
+	return dynamic, nil
+}
+
+func (o ops) GetName(api *fastly.Snippet) string {
+	return fastly.ToValue(api.Name)
+}
+
+func (o ops) Delete(ctx context.Context, client *fastly.Client, serviceID string, version int, name string) error {
+	return client.DeleteSnippet(ctx, &fastly.DeleteSnippetInput{
+		ServiceID:      serviceID,
+		ServiceVersion: version,
+		Name:           name,
+	})
+}
+
+func (o ops) Create(ctx context.Context, client *fastly.Client, serviceID string, version int, desired NestedModel) (*fastly.Snippet, error) {
+	return client.CreateSnippet(ctx, BuildCreateInput(serviceID, version, desired))
+}
+
+func (o ops) Equal(desired NestedModel, remote *fastly.Snippet) bool {
+	remoteModel, err := FlattenToNestedModel(remote)
+	if err != nil {
+		return false
+	}
+	return desired.ModelsEqual(remoteModel)
+}
+
+func (o ops) Update(ctx context.Context, client *fastly.Client, serviceID string, version int, desired NestedModel) (*fastly.Snippet, error) {
+	return client.UpdateSnippet(ctx, BuildUpdateInput(serviceID, version, desired))
+}
+
+func (o ops) ToModel(api *fastly.Snippet) NestedModel {
+	// ops.List validates dynamic-ness and priority before the reconciler calls
+	// ToModel, so this should only fail if ToModel is called outside the
+	// reconciler read path.
+	model, _ := FlattenToNestedModel(api)
+	return model
+}
+
+var reconciler = &reconcile.Resource[NestedModel, fastly.Snippet]{
+	Ops: ops{},
+	GetName: func(m NestedModel) string {
+		return service.StringValue(m.Name)
+	},
+	Sortable: true,
+}
+
+func ReadForVersion(ctx context.Context, client *fastly.Client, serviceID string, version int) ([]NestedModel, error) {
+	return reconciler.ReadForVersion(ctx, client, serviceID, version)
+}
+
+func Reconcile(ctx context.Context, client *fastly.Client, serviceID string, version int, desired []NestedModel) error {
+	if err := Validate(desired); err != nil {
+		return err
+	}
+	return reconciler.Run(ctx, client, serviceID, version, desired)
+}
+
+func Equal(a, b []NestedModel) bool {
+	return reconcile.ModelsEqual(a, b, func(m NestedModel) string { return service.StringValue(m.Name) }, NestedModel.ModelsEqual, true)
+}
+
+func MatchOrder(items, order []NestedModel) []NestedModel {
+	return reconcile.MatchOrder(items, order, func(m NestedModel) string { return service.StringValue(m.Name) })
+}
+
+func MatchOrderPreservePlanFields(items, plan []NestedModel) []NestedModel {
+	ordered := MatchOrder(items, plan)
+
+	planByName := make(map[string]NestedModel, len(plan))
+	for _, item := range plan {
+		planByName[service.StringValue(item.Name)] = item
+	}
+
+	for i := range ordered {
+		name := service.StringValue(ordered[i].Name)
+		if planned, ok := planByName[name]; ok {
+			// During Create/Update, Terraform requires final state for configured
+			// attributes to match the plan. Keep snippet_id from the API because it
+			// is computed and is required by the dynamic snippet content resource.
+			ordered[i].Name = planned.Name
+			ordered[i].Type = planned.Type
+			ordered[i].Priority = planned.Priority
+		}
+	}
+
+	return ordered
+}
+
+func parsePriority(value *string) (int64, error) {
+	if value == nil || *value == "" {
+		return DefaultPriority, nil
+	}
+
+	priority, err := strconv.ParseInt(*value, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("error parsing dynamic VCL snippet priority %q: %w", *value, err)
+	}
+
+	return priority, nil
+}
+
+func normalizeType(value string) string {
+	return strings.ToLower(strings.TrimSpace(value))
+}
+
+func isValidType(value string) bool {
+	value = normalizeType(value)
+	for _, valid := range validTypes {
+		if value == valid {
+			return true
+		}
+	}
+	return false
+}
+
+// CopyCommonAttributes returns a copy of the shared attributes. This is useful
+// for tests and future explicit resources without allowing callers to mutate the
+// package-level schema maps returned by CommonAttributes.
+func CopyCommonAttributes() map[string]schema.Attribute {
+	attrs := map[string]schema.Attribute{}
+	maps.Copy(attrs, CommonAttributes())
+	return attrs
+}

--- a/internal/resources/dynamicsnippetcontent/dynamicsnippetcontent_test.go
+++ b/internal/resources/dynamicsnippetcontent/dynamicsnippetcontent_test.go
@@ -1,0 +1,28 @@
+package dynamicsnippetcontent
+
+import "testing"
+
+func TestID(t *testing.T) {
+	got := ID("service-id", "snippet-id")
+	want := "service-id/snippet-id"
+	if got != want {
+		t.Fatalf("ID = %q, want %q", got, want)
+	}
+}
+
+func TestParseImportID(t *testing.T) {
+	serviceID, snippetID, err := parseImportID("service-id/snippet-id")
+	if err != nil {
+		t.Fatalf("parseImportID returned error: %s", err)
+	}
+	if serviceID != "service-id" {
+		t.Fatalf("serviceID = %q, want service-id", serviceID)
+	}
+	if snippetID != "snippet-id" {
+		t.Fatalf("snippetID = %q, want snippet-id", snippetID)
+	}
+
+	if _, _, err := parseImportID("service-id"); err == nil {
+		t.Fatal("expected missing snippet_id to return an error")
+	}
+}

--- a/internal/resources/dynamicsnippetcontent/resource.go
+++ b/internal/resources/dynamicsnippetcontent/resource.go
@@ -7,6 +7,8 @@ import (
 
 	fastlyclient "github.com/fastly/terraform-provider-fastly/internal/client"
 	"github.com/fastly/terraform-provider-fastly/internal/errors"
+	"github.com/fastly/terraform-provider-fastly/internal/service"
+	"github.com/fastly/terraform-provider-fastly/internal/validation"
 
 	fastly "github.com/fastly/go-fastly/v17/fastly"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -48,10 +50,19 @@ func (r *Resource) Configure(_ context.Context, req resource.ConfigureRequest, r
 	r.providerData = data
 }
 
+func (r *Resource) ensureServiceTypeSupported(ctx context.Context, serviceID string) error {
+	return validation.EnsureServiceTypeSupported(ctx, r.providerData.ServiceTypeChecker, serviceID, "fastly_service_dynamic_snippet_content", service.TypeVCL)
+}
+
 func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var plan Model
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if err := r.ensureServiceTypeSupported(ctx, plan.Service.ValueString()); err != nil {
+		resp.Diagnostics.AddError("Unsupported Fastly service type", err.Error())
 		return
 	}
 
@@ -73,6 +84,15 @@ func (r *Resource) Read(ctx context.Context, req resource.ReadRequest, resp *res
 	var state Model
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if err := r.ensureServiceTypeSupported(ctx, state.Service.ValueString()); err != nil {
+		if errors.IsNotFound(err) {
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.AddError("Unsupported Fastly service type", err.Error())
 		return
 	}
 
@@ -109,6 +129,11 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 		return
 	}
 
+	if err := r.ensureServiceTypeSupported(ctx, plan.Service.ValueString()); err != nil {
+		resp.Diagnostics.AddError("Unsupported Fastly service type", err.Error())
+		return
+	}
+
 	tflog.Debug(ctx, "Updating Fastly dynamic VCL snippet content", map[string]any{
 		"service_id": plan.Service.ValueString(),
 		"snippet_id": plan.SnippetID.ValueString(),
@@ -127,6 +152,14 @@ func (r *Resource) Delete(ctx context.Context, req resource.DeleteRequest, resp 
 	var state Model
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if err := r.ensureServiceTypeSupported(ctx, state.Service.ValueString()); err != nil {
+		if errors.IsNotFound(err) {
+			return
+		}
+		resp.Diagnostics.AddError("Unsupported Fastly service type", err.Error())
 		return
 	}
 
@@ -152,6 +185,11 @@ func (r *Resource) ImportState(ctx context.Context, req resource.ImportStateRequ
 				"For example: service123/abc123\n\n"+
 				"Error: "+err.Error(),
 		)
+		return
+	}
+
+	if err := r.ensureServiceTypeSupported(ctx, serviceID); err != nil {
+		resp.Diagnostics.AddError("Unsupported Fastly service type", err.Error())
 		return
 	}
 

--- a/internal/resources/dynamicsnippetcontent/resource.go
+++ b/internal/resources/dynamicsnippetcontent/resource.go
@@ -1,0 +1,202 @@
+package dynamicsnippetcontent
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	fastlyclient "github.com/fastly/terraform-provider-fastly/internal/client"
+	"github.com/fastly/terraform-provider-fastly/internal/errors"
+
+	fastly "github.com/fastly/go-fastly/v17/fastly"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+var _ resource.Resource = &Resource{}
+var _ resource.ResourceWithConfigure = &Resource{}
+var _ resource.ResourceWithImportState = &Resource{}
+
+type Resource struct {
+	providerData *fastlyclient.Data
+}
+
+func NewResource() resource.Resource {
+	return &Resource{}
+}
+
+func (r *Resource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_service_dynamic_snippet_content"
+}
+
+func (r *Resource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Fastly dynamic VCL snippet content resource. Updates versionless dynamic snippet code directly by service ID and snippet ID.",
+		Attributes:  ResourceAttributes(),
+	}
+}
+
+func (r *Resource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	data, diags := fastlyclient.FromProviderData(req.ProviderData)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() || data == nil {
+		return
+	}
+
+	r.providerData = data
+}
+
+func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan Model
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	tflog.Debug(ctx, "Creating Fastly dynamic VCL snippet content", map[string]any{
+		"service_id": plan.Service.ValueString(),
+		"snippet_id": plan.SnippetID.ValueString(),
+	})
+
+	if err := r.updateContent(ctx, plan.Service.ValueString(), plan.SnippetID.ValueString(), plan.Content.ValueString()); err != nil {
+		resp.Diagnostics.AddError("Error creating dynamic VCL snippet content", err.Error())
+		return
+	}
+
+	plan.ID = types.StringValue(ID(plan.Service.ValueString(), plan.SnippetID.ValueString()))
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+func (r *Resource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var state Model
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	tflog.Debug(ctx, "Reading Fastly dynamic VCL snippet content", map[string]any{
+		"service_id": state.Service.ValueString(),
+		"snippet_id": state.SnippetID.ValueString(),
+	})
+
+	dynamicSnippet, err := r.providerData.Client.GetDynamicSnippet(ctx, &fastly.GetDynamicSnippetInput{
+		ServiceID: state.Service.ValueString(),
+		SnippetID: state.SnippetID.ValueString(),
+	})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.AddError("Error reading dynamic VCL snippet content", err.Error())
+		return
+	}
+
+	state.ID = types.StringValue(ID(state.Service.ValueString(), state.SnippetID.ValueString()))
+	if state.ManageSnippet.ValueBool() {
+		state.Content = types.StringValue(fastly.ToValue(dynamicSnippet.Content))
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var plan Model
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	tflog.Debug(ctx, "Updating Fastly dynamic VCL snippet content", map[string]any{
+		"service_id": plan.Service.ValueString(),
+		"snippet_id": plan.SnippetID.ValueString(),
+	})
+
+	if err := r.updateContent(ctx, plan.Service.ValueString(), plan.SnippetID.ValueString(), plan.Content.ValueString()); err != nil {
+		resp.Diagnostics.AddError("Error updating dynamic VCL snippet content", err.Error())
+		return
+	}
+
+	plan.ID = types.StringValue(ID(plan.Service.ValueString(), plan.SnippetID.ValueString()))
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+func (r *Resource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var state Model
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if state.ManageSnippet.ValueBool() {
+		tflog.Debug(ctx, "Clearing Fastly dynamic VCL snippet content", map[string]any{
+			"service_id": state.Service.ValueString(),
+			"snippet_id": state.SnippetID.ValueString(),
+		})
+
+		if err := r.updateContent(ctx, state.Service.ValueString(), state.SnippetID.ValueString(), ""); err != nil && !errors.IsNotFound(err) {
+			resp.Diagnostics.AddError("Error deleting dynamic VCL snippet content", err.Error())
+			return
+		}
+	}
+}
+
+func (r *Resource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	serviceID, snippetID, err := parseImportID(req.ID)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Invalid Import ID",
+			"Expected import ID in format: service_id/snippet_id\n"+
+				"For example: service123/abc123\n\n"+
+				"Error: "+err.Error(),
+		)
+		return
+	}
+
+	dynamicSnippet, err := r.providerData.Client.GetDynamicSnippet(ctx, &fastly.GetDynamicSnippetInput{
+		ServiceID: serviceID,
+		SnippetID: snippetID,
+	})
+	if err != nil {
+		resp.Diagnostics.AddError("Error importing dynamic VCL snippet content", err.Error())
+		return
+	}
+
+	state := Model{
+		ID:            types.StringValue(ID(serviceID, snippetID)),
+		Service:       types.StringValue(serviceID),
+		SnippetID:     types.StringValue(snippetID),
+		Content:       types.StringValue(fastly.ToValue(dynamicSnippet.Content)),
+		ManageSnippet: types.BoolValue(false),
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func (r *Resource) updateContent(ctx context.Context, serviceID string, snippetID string, content string) error {
+	_, err := r.providerData.Client.UpdateDynamicSnippet(ctx, &fastly.UpdateDynamicSnippetInput{
+		ServiceID: serviceID,
+		SnippetID: snippetID,
+		Content:   &content,
+	})
+	return err
+}
+
+func parseImportID(id string) (string, string, error) {
+	parts := strings.Split(id, "/")
+	if len(parts) != 2 {
+		return "", "", fmt.Errorf("invalid composite import ID format: expected service_id/snippet_id, got %q", id)
+	}
+
+	if parts[0] == "" {
+		return "", "", fmt.Errorf("service_id cannot be empty in import ID %q", id)
+	}
+
+	if parts[1] == "" {
+		return "", "", fmt.Errorf("snippet_id cannot be empty in import ID %q", id)
+	}
+
+	return parts[0], parts[1], nil
+}

--- a/internal/resources/dynamicsnippetcontent/schema.go
+++ b/internal/resources/dynamicsnippetcontent/schema.go
@@ -1,0 +1,54 @@
+package dynamicsnippetcontent
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+type Model struct {
+	ID            types.String `tfsdk:"id"`
+	Service       types.String `tfsdk:"service_id"`
+	SnippetID     types.String `tfsdk:"snippet_id"`
+	Content       types.String `tfsdk:"content"`
+	ManageSnippet types.Bool   `tfsdk:"manage_snippets"`
+}
+
+func ResourceAttributes() map[string]schema.Attribute {
+	return map[string]schema.Attribute{
+		"id": schema.StringAttribute{
+			Computed:    true,
+			Description: "Terraform resource identifier.",
+		},
+		"service_id": schema.StringAttribute{
+			Required:    true,
+			Description: "Fastly service ID.",
+			PlanModifiers: []planmodifier.String{
+				stringplanmodifier.RequiresReplace(),
+			},
+		},
+		"snippet_id": schema.StringAttribute{
+			Required:    true,
+			Description: "The Fastly-generated ID of the dynamic VCL snippet whose content is managed by this resource.",
+			PlanModifiers: []planmodifier.String{
+				stringplanmodifier.RequiresReplace(),
+			},
+		},
+		"content": schema.StringAttribute{
+			Required:    true,
+			Description: "The dynamic VCL snippet code. Updates are versionless and take effect immediately without cloning or activating a service version.",
+		},
+		"manage_snippets": schema.BoolAttribute{
+			Optional:    true,
+			Computed:    true,
+			Default:     booldefault.StaticBool(false),
+			Description: "Whether Terraform should re-apply content drift and clear snippet content on destroy. Default `false`.",
+		},
+	}
+}
+
+func ID(serviceID string, snippetID string) string {
+	return serviceID + "/" + snippetID
+}

--- a/internal/resources/dynamicvclsnippet/dynamicvclsnippet_test.go
+++ b/internal/resources/dynamicvclsnippet/dynamicvclsnippet_test.go
@@ -1,0 +1,12 @@
+package dynamicvclsnippet
+
+import "testing"
+
+func TestID(t *testing.T) {
+	got := ID("service123", 3, "block_scrapers")
+	want := "service123-3-block_scrapers"
+
+	if got != want {
+		t.Fatalf("ID() = %q, want %q", got, want)
+	}
+}

--- a/internal/resources/dynamicvclsnippet/resource.go
+++ b/internal/resources/dynamicvclsnippet/resource.go
@@ -1,0 +1,320 @@
+package dynamicvclsnippet
+
+import (
+	"context"
+	"fmt"
+	"maps"
+
+	fastlyclient "github.com/fastly/terraform-provider-fastly/internal/client"
+	"github.com/fastly/terraform-provider-fastly/internal/errors"
+	"github.com/fastly/terraform-provider-fastly/internal/importutil"
+	"github.com/fastly/terraform-provider-fastly/internal/resources/dynamicsnippet"
+	"github.com/fastly/terraform-provider-fastly/internal/service"
+	"github.com/fastly/terraform-provider-fastly/internal/validation"
+
+	fastly "github.com/fastly/go-fastly/v17/fastly"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+var _ resource.Resource = &Resource{}
+var _ resource.ResourceWithConfigure = &Resource{}
+var _ resource.ResourceWithImportState = &Resource{}
+
+type Resource struct {
+	providerData *fastlyclient.Data
+}
+
+func NewResource() resource.Resource {
+	return &Resource{}
+}
+
+type Model struct {
+	dynamicsnippet.NestedModel
+	ID      types.String `tfsdk:"id"`
+	Service types.String `tfsdk:"service_id"`
+	Version types.Int64  `tfsdk:"version"`
+}
+
+func (r *Resource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_service_dynamic_vcl_snippet"
+}
+
+func (r *Resource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Fastly dynamic VCL snippet metadata resource. Writes the versioned dynamic snippet container directly to the specified writable CDN service version.",
+		Attributes:  ResourceAttributes(),
+	}
+}
+
+func ResourceAttributes() map[string]schema.Attribute {
+	attrs := map[string]schema.Attribute{
+		"id": schema.StringAttribute{
+			Computed:    true,
+			Description: "Terraform resource identifier.",
+		},
+		"service_id": schema.StringAttribute{
+			Required:    true,
+			Description: "Fastly service ID.",
+			PlanModifiers: []planmodifier.String{
+				stringplanmodifier.RequiresReplace(),
+			},
+		},
+		"version": schema.Int64Attribute{
+			Required:    true,
+			Description: "Writable Fastly service version to modify.",
+			PlanModifiers: []planmodifier.Int64{
+				int64planmodifier.RequiresReplace(),
+			},
+		},
+	}
+	maps.Copy(attrs, dynamicsnippet.CopyCommonAttributes())
+
+	nameAttr := attrs["name"].(schema.StringAttribute)
+	nameAttr.PlanModifiers = []planmodifier.String{
+		stringplanmodifier.RequiresReplace(),
+	}
+	attrs["name"] = nameAttr
+
+	return attrs
+}
+
+func ID(serviceID string, version int, name string) string {
+	return fmt.Sprintf("%s-%d-%s", serviceID, version, name)
+}
+
+func (r *Resource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	data, diags := fastlyclient.FromProviderData(req.ProviderData)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() || data == nil {
+		return
+	}
+
+	r.providerData = data
+}
+
+func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan Model
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if err := validation.EnsureServiceTypeSupported(ctx, r.providerData.ServiceTypeChecker, plan.Service.ValueString(), "fastly_service_dynamic_vcl_snippet", service.TypeVCL); err != nil {
+		resp.Diagnostics.AddError("Unsupported Fastly service type", err.Error())
+		return
+	}
+
+	resp.Diagnostics.Append(r.providerData.VersionChecker.EnsureMutable(ctx, plan.Service.ValueString(), int(plan.Version.ValueInt64()))...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	tflog.Debug(ctx, "Creating Fastly dynamic VCL snippet metadata", map[string]any{
+		"service_id": plan.Service.ValueString(),
+		"version":    plan.Version.ValueInt64(),
+		"name":       service.StringValue(plan.Name),
+	})
+
+	s, err := r.providerData.Client.CreateSnippet(ctx, dynamicsnippet.BuildCreateInput(plan.Service.ValueString(), int(plan.Version.ValueInt64()), plan.NestedModel))
+	if err != nil {
+		resp.Diagnostics.AddError("Error creating dynamic VCL snippet", err.Error())
+		return
+	}
+
+	if err := flatten(ctx, s, &plan); err != nil {
+		resp.Diagnostics.AddError("Error reading dynamic VCL snippet after create", err.Error())
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+func (r *Resource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var state Model
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	tflog.Debug(ctx, "Reading Fastly dynamic VCL snippet metadata from API", map[string]any{
+		"service_id": state.Service.ValueString(),
+		"version":    state.Version.ValueInt64(),
+		"name":       state.Name.ValueString(),
+	})
+
+	s, err := r.providerData.Client.GetSnippet(ctx, &fastly.GetSnippetInput{
+		ServiceID:      state.Service.ValueString(),
+		ServiceVersion: int(state.Version.ValueInt64()),
+		Name:           state.Name.ValueString(),
+	})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			tflog.Warn(ctx, "Dynamic VCL snippet not found, removing from state", map[string]any{
+				"service_id": state.Service.ValueString(),
+				"version":    state.Version.ValueInt64(),
+				"name":       state.Name.ValueString(),
+			})
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.AddError("Error reading dynamic VCL snippet", err.Error())
+		return
+	}
+
+	if err := flatten(ctx, s, &state); err != nil {
+		resp.Diagnostics.AddError("Error reading dynamic VCL snippet", err.Error())
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var plan Model
+	var state Model
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if err := validation.EnsureServiceTypeSupported(ctx, r.providerData.ServiceTypeChecker, plan.Service.ValueString(), "fastly_service_dynamic_vcl_snippet", service.TypeVCL); err != nil {
+		resp.Diagnostics.AddError("Unsupported Fastly service type", err.Error())
+		return
+	}
+
+	resp.Diagnostics.Append(r.providerData.VersionChecker.EnsureMutable(ctx, plan.Service.ValueString(), int(plan.Version.ValueInt64()))...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	tflog.Debug(ctx, "Updating Fastly dynamic VCL snippet metadata", map[string]any{
+		"service_id": plan.Service.ValueString(),
+		"version":    plan.Version.ValueInt64(),
+		"name":       service.StringValue(plan.Name),
+	})
+
+	s, err := r.providerData.Client.UpdateSnippet(ctx, dynamicsnippet.BuildUpdateInput(plan.Service.ValueString(), int(plan.Version.ValueInt64()), plan.NestedModel))
+	if err != nil {
+		resp.Diagnostics.AddError("Error updating dynamic VCL snippet", err.Error())
+		return
+	}
+
+	if err := flatten(ctx, s, &plan); err != nil {
+		resp.Diagnostics.AddError("Error reading dynamic VCL snippet after update", err.Error())
+		return
+	}
+
+	plan.ID = state.ID
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+func (r *Resource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var state Model
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	tflog.Debug(ctx, "Deleting Fastly dynamic VCL snippet metadata", map[string]any{
+		"service_id": state.Service.ValueString(),
+		"version":    state.Version.ValueInt64(),
+		"name":       state.Name.ValueString(),
+	})
+
+	if err := validation.EnsureServiceTypeSupported(ctx, r.providerData.ServiceTypeChecker, state.Service.ValueString(), "fastly_service_dynamic_vcl_snippet", service.TypeVCL); err != nil {
+		if errors.IsNotFound(err) {
+			return
+		}
+		resp.Diagnostics.AddError("Unsupported Fastly service type", err.Error())
+		return
+	}
+
+	notFound, diags := r.providerData.VersionChecker.EnsureMutableForDelete(ctx, state.Service.ValueString(), int(state.Version.ValueInt64()))
+	resp.Diagnostics.Append(diags...)
+	if notFound || resp.Diagnostics.HasError() {
+		return
+	}
+
+	err := r.providerData.Client.DeleteSnippet(ctx, &fastly.DeleteSnippetInput{
+		ServiceID:      state.Service.ValueString(),
+		ServiceVersion: int(state.Version.ValueInt64()),
+		Name:           state.Name.ValueString(),
+	})
+	if err != nil && !errors.IsNotFound(err) {
+		resp.Diagnostics.AddError("Error deleting dynamic VCL snippet", err.Error())
+	}
+}
+
+func (r *Resource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	serviceID, version, name, err := importutil.ParseCompositeID(req.ID)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Invalid Import ID",
+			"Expected import ID in format: service_id/version/name\n"+
+				"For example: service123/3/block_scrapers\n\n"+
+				"Error: "+err.Error(),
+		)
+		return
+	}
+
+	tflog.Debug(ctx, "Importing dynamic VCL snippet", map[string]any{
+		"service_id": serviceID,
+		"version":    version,
+		"name":       name,
+	})
+
+	s, err := r.providerData.Client.GetSnippet(ctx, &fastly.GetSnippetInput{
+		ServiceID:      serviceID,
+		ServiceVersion: version,
+		Name:           name,
+	})
+	if err != nil {
+		resp.Diagnostics.AddError("Error importing dynamic VCL snippet", err.Error())
+		return
+	}
+
+	var state Model
+	state.Service = types.StringValue(serviceID)
+	state.Version = types.Int64Value(int64(version))
+	if err := flatten(ctx, s, &state); err != nil {
+		resp.Diagnostics.AddError("Error importing dynamic VCL snippet", err.Error())
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func flatten(ctx context.Context, s *fastly.Snippet, m *Model) error {
+	if s == nil {
+		tflog.Warn(ctx, "flatten called with nil dynamic VCL snippet")
+		return nil
+	}
+
+	nested, err := dynamicsnippet.FlattenToNestedModel(s)
+	if err != nil {
+		return err
+	}
+
+	m.ID = types.StringValue(ID(fastly.ToValue(s.ServiceID), fastly.ToValue(s.ServiceVersion), fastly.ToValue(s.Name)))
+	m.Service = types.StringValue(fastly.ToValue(s.ServiceID))
+	m.Version = types.Int64Value(int64(fastly.ToValue(s.ServiceVersion)))
+	m.NestedModel = nested
+
+	tflog.Debug(ctx, "Flattened dynamic VCL snippet state", map[string]any{
+		"id":         m.ID.ValueString(),
+		"service_id": m.Service.ValueString(),
+		"version":    m.Version.ValueInt64(),
+		"name":       m.Name.ValueString(),
+		"snippet_id": m.SnippetID.ValueString(),
+	})
+
+	return nil
+}

--- a/internal/resources/servicecdnauto/resource.go
+++ b/internal/resources/servicecdnauto/resource.go
@@ -10,6 +10,7 @@ import (
 	"github.com/fastly/terraform-provider-fastly/internal/resources/cdnacl"
 	"github.com/fastly/terraform-provider-fastly/internal/resources/condition"
 	"github.com/fastly/terraform-provider-fastly/internal/resources/domain"
+	"github.com/fastly/terraform-provider-fastly/internal/resources/dynamicsnippet"
 	"github.com/fastly/terraform-provider-fastly/internal/resources/gzip"
 	"github.com/fastly/terraform-provider-fastly/internal/resources/imageoptimizerdefaultsettings"
 	"github.com/fastly/terraform-provider-fastly/internal/resources/loggingdatadog"
@@ -68,6 +69,7 @@ type Model struct {
 	LoggingDatadog                []loggingdatadog.NestedModel                `tfsdk:"logging_datadog"`
 	ImageOptimizerDefaultSettings []imageoptimizerdefaultsettings.NestedModel `tfsdk:"image_optimizer_default_settings"`
 	Snippet                       []snippet.NestedModel                       `tfsdk:"snippet"`
+	DynamicSnippet                []dynamicsnippet.NestedModel                `tfsdk:"dynamic_snippet"`
 	VCL                           []vcl.NestedModel                           `tfsdk:"vcl"`
 }
 
@@ -128,6 +130,7 @@ func (r *Resource) Schema(_ context.Context, _ resource.SchemaRequest, resp *res
 			"logging_datadog":                  loggingdatadog.NestedBlockSchema(),
 			"image_optimizer_default_settings": imageoptimizerdefaultsettings.NestedBlockSchema(),
 			"snippet":                          snippet.NestedBlockSchema(),
+			"dynamic_snippet":                  dynamicsnippet.NestedBlockSchema(),
 			"vcl":                              vcl.NestedBlockSchema(),
 		},
 	}
@@ -158,6 +161,22 @@ func (r *Resource) ValidateConfig(ctx context.Context, req resource.ValidateConf
 		)
 	}
 
+	if err := dynamicsnippet.ValidateConfig(config.DynamicSnippet); err != nil {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("dynamic_snippet"),
+			"Invalid dynamic VCL snippet configuration",
+			err.Error(),
+		)
+	}
+
+	if err := dynamicsnippet.ValidateNoNameConflicts(config.DynamicSnippet, config.Snippet); err != nil {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("dynamic_snippet"),
+			"Invalid VCL snippet configuration",
+			err.Error(),
+		)
+	}
+
 	if err := vcl.ValidateConfig(config.VCL); err != nil {
 		resp.Diagnostics.AddAttributeError(
 			path.Root("vcl"),
@@ -177,6 +196,24 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 	if err := snippet.Validate(plan.Snippet); err != nil {
 		resp.Diagnostics.AddAttributeError(
 			path.Root("snippet"),
+			"Invalid VCL snippet configuration",
+			err.Error(),
+		)
+		return
+	}
+
+	if err := dynamicsnippet.Validate(plan.DynamicSnippet); err != nil {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("dynamic_snippet"),
+			"Invalid dynamic VCL snippet configuration",
+			err.Error(),
+		)
+		return
+	}
+
+	if err := dynamicsnippet.ValidateNoNameConflicts(plan.DynamicSnippet, plan.Snippet); err != nil {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("dynamic_snippet"),
 			"Invalid VCL snippet configuration",
 			err.Error(),
 		)
@@ -333,6 +370,18 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 	}
 	plan.Snippet = snippet.MatchOrderPreservePlanContent(snippets, plan.Snippet)
 
+	if err := dynamicsnippet.Reconcile(ctx, r.providerData.AutoClient(), serviceID, version, plan.DynamicSnippet); err != nil {
+		resp.Diagnostics.AddError("Error reconciling dynamic VCL snippets", err.Error())
+		return
+	}
+
+	dynamicSnippets, err := dynamicsnippet.ReadForVersion(ctx, r.providerData.AutoClient(), serviceID, version)
+	if err != nil {
+		resp.Diagnostics.AddError("Error reading dynamic VCL snippets", err.Error())
+		return
+	}
+	plan.DynamicSnippet = dynamicsnippet.MatchOrderPreservePlanFields(dynamicSnippets, plan.DynamicSnippet)
+
 	if err := vcl.Reconcile(ctx, r.providerData.AutoClient(), serviceID, version, plan.VCL); err != nil {
 		resp.Diagnostics.AddError("Error reconciling custom VCL files", err.Error())
 		return
@@ -469,6 +518,13 @@ func (r *Resource) Read(ctx context.Context, req resource.ReadRequest, resp *res
 	}
 	state.Snippet = snippet.MatchOrder(snippets, state.Snippet)
 
+	dynamicSnippets, err := dynamicsnippet.ReadForVersion(ctx, r.providerData.AutoClient(), state.ID.ValueString(), readVersion)
+	if err != nil {
+		resp.Diagnostics.AddError("Error reading dynamic VCL snippets", err.Error())
+		return
+	}
+	state.DynamicSnippet = dynamicsnippet.MatchOrder(dynamicSnippets, state.DynamicSnippet)
+
 	vcls, err := vcl.ReadForVersion(ctx, r.providerData.AutoClient(), state.ID.ValueString(), readVersion)
 	if err != nil {
 		resp.Diagnostics.AddError("Error reading custom VCL files", err.Error())
@@ -515,6 +571,24 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 		return
 	}
 
+	if err := dynamicsnippet.Validate(plan.DynamicSnippet); err != nil {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("dynamic_snippet"),
+			"Invalid dynamic VCL snippet configuration",
+			err.Error(),
+		)
+		return
+	}
+
+	if err := dynamicsnippet.ValidateNoNameConflicts(plan.DynamicSnippet, plan.Snippet); err != nil {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("dynamic_snippet"),
+			"Invalid VCL snippet configuration",
+			err.Error(),
+		)
+		return
+	}
+
 	if err := vcl.Validate(plan.VCL); err != nil {
 		resp.Diagnostics.AddAttributeError(
 			path.Root("vcl"),
@@ -549,6 +623,7 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 		!loggingdatadog.Equal(plan.LoggingDatadog, state.LoggingDatadog) ||
 		!imageoptimizerdefaultsettings.Equal(plan.ImageOptimizerDefaultSettings, state.ImageOptimizerDefaultSettings) ||
 		!snippet.Equal(plan.Snippet, state.Snippet) ||
+		!dynamicsnippet.Equal(plan.DynamicSnippet, state.DynamicSnippet) ||
 		!vcl.Equal(plan.VCL, state.VCL)
 	needsVersionChange := nestedChanged
 
@@ -706,6 +781,18 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 		}
 		plan.Snippet = snippet.MatchOrderPreservePlanContent(snippets, plan.Snippet)
 
+		if err := dynamicsnippet.Reconcile(ctx, r.providerData.AutoClient(), serviceID, targetVersion, plan.DynamicSnippet); err != nil {
+			resp.Diagnostics.AddError("Error reconciling dynamic VCL snippets", err.Error())
+			return
+		}
+
+		dynamicSnippets, err := dynamicsnippet.ReadForVersion(ctx, r.providerData.AutoClient(), serviceID, targetVersion)
+		if err != nil {
+			resp.Diagnostics.AddError("Error reading dynamic VCL snippets", err.Error())
+			return
+		}
+		plan.DynamicSnippet = dynamicsnippet.MatchOrderPreservePlanFields(dynamicSnippets, plan.DynamicSnippet)
+
 		if err := vcl.Reconcile(ctx, r.providerData.AutoClient(), serviceID, targetVersion, plan.VCL); err != nil {
 			resp.Diagnostics.AddError("Error reconciling custom VCL files", err.Error())
 			return
@@ -748,6 +835,7 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 		plan.LoggingDatadog = loggingdatadog.MatchOrder(state.LoggingDatadog, plan.LoggingDatadog)
 		plan.ImageOptimizerDefaultSettings = state.ImageOptimizerDefaultSettings
 		plan.Snippet = snippet.MatchOrderPreservePlanContent(state.Snippet, plan.Snippet)
+		plan.DynamicSnippet = dynamicsnippet.MatchOrderPreservePlanFields(state.DynamicSnippet, plan.DynamicSnippet)
 		plan.VCL = vcl.MatchOrderPreservePlanContent(state.VCL, plan.VCL)
 	}
 

--- a/templates/resources/service_dynamic_snippet_content.md.tmpl
+++ b/templates/resources/service_dynamic_snippet_content.md.tmpl
@@ -1,0 +1,115 @@
+---
+page_title: "fastly_service_dynamic_snippet_content Resource - fastly"
+subcategory: ""
+description: |-
+  Fastly dynamic VCL snippet content resource. Updates versionless dynamic snippet code directly by service ID and snippet ID.
+---
+
+# fastly_service_dynamic_snippet_content (Resource)
+
+Fastly dynamic VCL snippet content resource. Updates versionless dynamic snippet
+code directly by service ID and snippet ID.
+
+Dynamic VCL snippets have two lifecycle parts:
+
+- metadata such as `name`, `type`, and `priority`, which is versioned service
+  configuration
+- content, which is versionless and is managed by this resource
+
+In the automatic compatibility family, dynamic snippet metadata is managed by
+the `dynamic_snippet` block on `fastly_service_cdn_auto`.
+
+In the explicit/default first-class resource family, dynamic snippet metadata is
+managed by `fastly_service_dynamic_vcl_snippet`.
+
+Updating this resource's `content` does not clone, validate, stage, or activate a
+service version. Changes are applied immediately to the dynamic snippet.
+
+## Example Usage with automatic compatibility metadata
+
+```terraform
+resource "fastly_service_cdn_auto" "example" {
+  name = "example"
+
+  domain {
+    name = "www.example.com"
+  }
+
+  backend {
+    name    = "origin"
+    address = "origin.example.com"
+    port    = 443
+    use_ssl = true
+  }
+
+  dynamic_snippet {
+    name     = "block_scrapers"
+    type     = "recv"
+    priority = 100
+  }
+
+  force_destroy = true
+}
+
+resource "fastly_service_dynamic_snippet_content" "block_scrapers" {
+  service_id = fastly_service_cdn_auto.example.id
+  snippet_id = {
+    for s in fastly_service_cdn_auto.example.dynamic_snippet : s.name => s.snippet_id
+  }["block_scrapers"]
+
+  content = file("${path.module}/block_scrapers.vcl")
+}
+```
+
+## Example Usage with explicit/default metadata
+
+In the explicit/default workflow, dynamic snippet metadata is managed by
+`fastly_service_dynamic_vcl_snippet`. The content resource depends on the
+computed `snippet_id`, so Terraform creates the metadata container first and then
+applies versionless content.
+
+```terraform
+resource "fastly_service_cdn" "example" {
+  name = "example"
+
+  force_destroy = true
+}
+
+resource "fastly_service_dynamic_vcl_snippet" "block_scrapers" {
+  service_id = fastly_service_cdn.example.id
+  version    = 1
+
+  name     = "block_scrapers"
+  type     = "recv"
+  priority = 100
+}
+
+resource "fastly_service_dynamic_snippet_content" "block_scrapers" {
+  service_id = fastly_service_cdn.example.id
+  snippet_id = fastly_service_dynamic_vcl_snippet.block_scrapers.snippet_id
+
+  content = file("${path.module}/block_scrapers.vcl")
+}
+```
+
+{{ .SchemaMarkdown | trimspace }}
+
+## Import
+
+Import requires the service ID and dynamic snippet ID:
+
+```shell
+terraform import fastly_service_dynamic_snippet_content.block_scrapers SERVICE_ID/SNIPPET_ID
+```
+
+Example:
+
+```shell
+terraform import fastly_service_dynamic_snippet_content.block_scrapers SU1Z0isxPaozGVKXdv0eY/abc123
+```
+
+## Version lifecycle
+
+This resource does not clone, activate, or stage service versions. Dynamic
+snippet content is versionless and updates are applied directly to the dynamic
+snippet.

--- a/templates/resources/service_dynamic_vcl_snippet.md.tmpl
+++ b/templates/resources/service_dynamic_vcl_snippet.md.tmpl
@@ -1,0 +1,85 @@
+---
+page_title: "fastly_service_dynamic_vcl_snippet Resource - fastly"
+subcategory: ""
+description: |-
+  Fastly dynamic VCL snippet metadata resource. Writes the versioned dynamic snippet container directly to the specified writable CDN service version.
+---
+
+# fastly_service_dynamic_vcl_snippet (Resource)
+
+Fastly dynamic VCL snippet metadata resource. Writes the versioned dynamic
+snippet container directly to the specified writable CDN service version.
+
+This resource is part of the explicit/default first-class resource family. It
+manages the versioned metadata for a dynamic VCL snippet:
+
+- `name`
+- `type`
+- `priority`
+- computed `snippet_id`
+
+It does not manage dynamic snippet content. Dynamic snippet content is
+versionless and is managed separately with
+`fastly_service_dynamic_snippet_content`.
+
+Use this resource when you want to manage dynamic VCL snippet metadata explicitly
+against a known writable service version. For automatic service version cloning,
+validation, and activation, use the nested `dynamic_snippet` block on
+`fastly_service_cdn_auto`.
+
+## Example Usage
+
+```terraform
+resource "fastly_service_cdn" "example" {
+  name = "example"
+
+  force_destroy = true
+}
+
+resource "fastly_service_dynamic_vcl_snippet" "block_scrapers" {
+  service_id = fastly_service_cdn.example.id
+  version    = 1
+
+  name     = "block_scrapers"
+  type     = "recv"
+  priority = 100
+}
+
+resource "fastly_service_dynamic_snippet_content" "block_scrapers" {
+  service_id = fastly_service_cdn.example.id
+  snippet_id = fastly_service_dynamic_vcl_snippet.block_scrapers.snippet_id
+
+  content = file("${path.module}/block_scrapers.vcl")
+}
+```
+
+{{ .SchemaMarkdown | trimspace }}
+
+## Import
+
+Import requires the service ID, service version, and dynamic VCL snippet name:
+
+```shell
+terraform import fastly_service_dynamic_vcl_snippet.block_scrapers SERVICE_ID/VERSION/SNIPPET_NAME
+```
+
+Example:
+
+```shell
+terraform import fastly_service_dynamic_vcl_snippet.block_scrapers SU1Z0isxPaozGVKXdv0eY/3/block_scrapers
+```
+
+## Version lifecycle
+
+This resource does not clone, activate, or stage service versions. Use explicit
+service-version lifecycle actions to clone, validate, stage, or activate a
+service version.
+
+Only the dynamic snippet metadata is versioned. Dynamic snippet content is
+versionless and is managed separately with
+`fastly_service_dynamic_snippet_content`.
+
+Terraform can apply metadata and content in one run when the content resource
+references the computed `snippet_id`. The metadata resource still writes to the
+configured writable service version, while content updates are applied directly
+by snippet_id.


### PR DESCRIPTION
## Change summary

Adds dynamic VCL snippet support to the dual-model provider rewrite.

Dynamic snippet metadata/container configuration is managed through versioned
snippet endpoints, while dynamic snippet content is updated through the
non-versioned dynamic snippet endpoint by `service_id` and `snippet_id`. This PR
models that split across both dual-model resource families:

- `_auto`: `dynamic_snippet` nested block on `fastly_service_cdn_auto`
- explicit/default: `fastly_service_dynamic_vcl_snippet`
- versionless content: `fastly_service_dynamic_snippet_content`

The metadata surfaces manage `name`, `type`, `priority`, and the computed
`snippet_id`. They intentionally do not include `content`, because content
updates do not clone, validate, stage, or activate a service version.

This mirrors the regular VCL snippet PR #1381, which added both the `_auto`
`snippet` block and the explicit/default `fastly_service_vcl_snippet` resource.

## Implementation notes

Lifecycle behavior:

- `fastly_service_cdn_auto.dynamic_snippet` participates in the automatic
  clone/reconcile/validate/activate lifecycle
- `fastly_service_dynamic_vcl_snippet` writes directly to the caller-selected
  writable version and does not clone or activate
- `fastly_service_dynamic_snippet_content` updates versionless content directly
  by `service_id` and `snippet_id`

Additional behavior:

- dynamic metadata reads reject regular snippets, matching PR #1381 where
  regular snippet reads reject dynamic snippets
- regular and dynamic snippet names are validated as unique within a service
  version
- invalid non-empty priority values returned by the API are surfaced as errors

One intentional difference from the current SDK provider is `409 Conflict`
handling for `fastly_service_dynamic_snippet_content` create. The SDK provider
ignores `409` on create, but this PR surfaces the API error. Since create is
implemented as `UpdateDynamicSnippet`, treating a rejected update as successful
could write planned content into Terraform state even though Fastly rejected it.

The provider-level retry transport does not retry `409 Conflict` responses. If a
safe transient `409` race is later confirmed for this endpoint, it should be
handled with endpoint-specific retry logic rather than by treating the failed
write as successful.

## Relationship to regular snippet PR

This builds on #1381.

Regular snippets are fully versioned service configuration, including content.
Dynamic snippets split versioned metadata from versionless content, so content is
managed by a separate first-class resource.

### New Feature Submissions:

- [x] Does your submission pass tests?
- [x] Post the output of your test runs

```bash
=== RUN   TestAccFastlyServiceCDNAuto_withDynamicSnippet
=== PAUSE TestAccFastlyServiceCDNAuto_withDynamicSnippet
=== RUN   TestAccFastlyServiceCDNAuto_withDynamicSnippetMetadataUpdate
=== PAUSE TestAccFastlyServiceCDNAuto_withDynamicSnippetMetadataUpdate
=== RUN   TestAccFastlyServiceDynamicSnippetContent_create
=== PAUSE TestAccFastlyServiceDynamicSnippetContent_create
=== RUN   TestAccFastlyServiceDynamicSnippetContent_updateDoesNotCloneService
=== PAUSE TestAccFastlyServiceDynamicSnippetContent_updateDoesNotCloneService
=== RUN   TestAccFastlyServiceDynamicSnippetContent_import
=== PAUSE TestAccFastlyServiceDynamicSnippetContent_import
=== RUN   TestAccFastlyServiceDynamicSnippetContent_deleteManageSnippetsTrue
=== PAUSE TestAccFastlyServiceDynamicSnippetContent_deleteManageSnippetsTrue
=== RUN   TestAccFastlyServiceDynamicSnippetContent_deleteManageSnippetsFalse
=== PAUSE TestAccFastlyServiceDynamicSnippetContent_deleteManageSnippetsFalse
=== RUN   TestAccFastlyServiceCDNAuto_withRegularAndDynamicSnippetNameConflict
=== PAUSE TestAccFastlyServiceCDNAuto_withRegularAndDynamicSnippetNameConflict
=== RUN   TestAccFastlyServiceDynamicSnippetMetadataExplicit_basicAndUpdate
=== PAUSE TestAccFastlyServiceDynamicSnippetMetadataExplicit_basicAndUpdate
=== RUN   TestAccFastlyServiceDynamicSnippetMetadataExplicit_import
=== PAUSE TestAccFastlyServiceDynamicSnippetMetadataExplicit_import
=== RUN   TestAccFastlyServiceDynamicSnippetMetadataExplicit_rejectsRegularSnippetOnImport
=== PAUSE TestAccFastlyServiceDynamicSnippetMetadataExplicit_rejectsRegularSnippetOnImport
--- PASS: TestAccFastlyServiceCDNAuto_withRegularAndDynamicSnippetNameConflict (0.22s)
--- PASS: TestAccFastlyServiceDynamicSnippetMetadataExplicit_import (20.14s)
--- PASS: TestAccFastlyServiceDynamicSnippetMetadataExplicit_rejectsRegularSnippetOnImport (20.61s)
--- PASS: TestAccFastlyServiceDynamicSnippetMetadataExplicit_basicAndUpdate (24.96s)
--- PASS: TestAccFastlyServiceCDNAuto_withDynamicSnippet (43.05s)
--- PASS: TestAccFastlyServiceDynamicSnippetContent_import (45.75s)
--- PASS: TestAccFastlyServiceDynamicSnippetContent_create (46.35s)
--- PASS: TestAccFastlyServiceDynamicSnippetContent_updateDoesNotCloneService (52.13s)
--- PASS: TestAccFastlyServiceDynamicSnippetContent_deleteManageSnippetsFalse (52.94s)
--- PASS: TestAccFastlyServiceDynamicSnippetContent_deleteManageSnippetsTrue (53.41s)
--- PASS: TestAccFastlyServiceCDNAuto_withDynamicSnippetMetadataUpdate (56.06s)
PASS
```