### PR TITLE
[CDTOOL-1599] Add VCL snippets data source

### DIFF
--- a/docs/data-sources/vcl_snippets.md
+++ b/docs/data-sources/vcl_snippets.md
@@ -1,0 +1,57 @@
+---
+page_title: "fastly_vcl_snippets Data Source - fastly"
+subcategory: ""
+description: |-
+  Use this data source to retrieve VCL snippets for a Fastly service version.
+---
+
+# fastly_vcl_snippets (Data Source)
+
+Use this data source to retrieve regular and dynamic VCL snippet metadata for a Fastly service version.
+
+This data source reads snippets through the versioned snippet list endpoint. It is useful with both VCL snippet resource families added in:
+
+- regular VCL snippets: [#1381](https://github.com/fastly/terraform-provider-fastly/pull/1381)
+- dynamic VCL snippets: [#1397](https://github.com/fastly/terraform-provider-fastly/pull/1397)
+
+Dynamic snippet content is versionless and is managed separately with `fastly_service_dynamic_snippet_content`.
+
+## Example Usage
+
+```terraform
+data "fastly_vcl_snippets" "example" {
+  service_id      = fastly_service_cdn_auto.example.id
+  service_version = fastly_service_cdn_auto.example.active_version
+}
+
+output "recv_snippet_names" {
+  value = [
+    for snippet in data.fastly_vcl_snippets.example.vcl_snippets :
+    snippet.name if snippet.type == "recv"
+  ]
+}
+```
+
+## Schema
+
+### Required
+
+- `service_id` (String) Fastly service ID.
+- `service_version` (Number) Fastly service version to read snippets from.
+
+### Read-Only
+
+- `id` (String) Terraform data source identifier.
+- `vcl_snippets` (Attributes Set) List of all VCL snippets for the configured service version. (see [below for nested schema](#nestedatt--vcl_snippets))
+
+<a id="nestedatt--vcl_snippets"></a>
+### Nested Schema for `vcl_snippets`
+
+Read-Only:
+
+- `content` (String) The VCL code that specifies exactly what the snippet does.
+- `dynamic` (Boolean) Whether this is a dynamic VCL snippet.
+- `id` (String) Fastly-generated VCL snippet identifier.
+- `name` (String) The name for the snippet.
+- `priority` (Number) Priority determines execution order. Lower numbers execute first.
+- `type` (String) The location in generated VCL where the snippet should be placed.

--- a/internal/acceptance_tests/test_helpers.go
+++ b/internal/acceptance_tests/test_helpers.go
@@ -2956,6 +2956,40 @@ func ConfigServiceDynamicVCLSnippetContent(serviceName, snippetName, snippetType
 	return joinBlocks(serviceConfig, contentResource)
 }
 
+// ConfigDataSourceVCLSnippets returns a CDN auto service with regular and dynamic
+// VCL snippets plus a fastly_vcl_snippets data source that reads the active version.
+func ConfigDataSourceVCLSnippets(serviceName, domainName, backendName, regularNameOne, regularNameTwo, dynamicName, snippetFilePathOne, snippetFilePathTwo string) string {
+	serviceConfig := BuildConfig(
+		ServiceCDNAuto,
+		map[string]string{
+			"SERVICE_NAME":             serviceName,
+			"DOMAIN_NAME":              domainName,
+			"BACKEND_NAME":             backendName,
+			"SNIPPET_NAME_ONE":         regularNameOne,
+			"SNIPPET_NAME_TWO":         regularNameTwo,
+			"SNIPPET_FILE_PATH_ONE":    filepath.ToSlash(snippetFilePathOne),
+			"SNIPPET_FILE_PATH_TWO":    filepath.ToSlash(snippetFilePathTwo),
+			"DYNAMIC_SNIPPET_NAME":     dynamicName,
+			"DYNAMIC_SNIPPET_TYPE":     "recv",
+			"DYNAMIC_SNIPPET_PRIORITY": "25",
+		},
+		"internal/acceptance_tests/blocks/domain_single.tf",
+		"internal/acceptance_tests/blocks/backend_single.tf",
+		"internal/acceptance_tests/blocks/snippet_nested_multiple.tf",
+		"internal/acceptance_tests/blocks/dynamic_snippet_nested.tf",
+	)
+
+	dataSource := `
+data "fastly_vcl_snippets" "example" {
+  depends_on      = [fastly_service_cdn_auto.test]
+  service_id      = fastly_service_cdn_auto.test.id
+  service_version = fastly_service_cdn_auto.test.active_version
+}
+`
+
+	return joinBlocks(serviceConfig, dataSource)
+}
+
 func renderFixtureBlock(path string, values map[string]string) string {
 	data, err := os.ReadFile(path)
 	if err != nil {

--- a/internal/acceptance_tests/vcl_snippets_data_source_test.go
+++ b/internal/acceptance_tests/vcl_snippets_data_source_test.go
@@ -58,35 +58,3 @@ func TestAccFastlyDataSourceVCLSnippets_Config(t *testing.T) {
 		},
 	})
 }
-
-func ConfigDataSourceVCLSnippets(serviceName, domainName, backendName, regularNameOne, regularNameTwo, dynamicName, snippetFilePathOne, snippetFilePathTwo string) string {
-	serviceConfig := BuildConfig(
-		ServiceCDNAuto,
-		map[string]string{
-			"SERVICE_NAME":             serviceName,
-			"DOMAIN_NAME":              domainName,
-			"BACKEND_NAME":             backendName,
-			"SNIPPET_NAME_ONE":         regularNameOne,
-			"SNIPPET_NAME_TWO":         regularNameTwo,
-			"SNIPPET_FILE_PATH_ONE":    snippetFilePathOne,
-			"SNIPPET_FILE_PATH_TWO":    snippetFilePathTwo,
-			"DYNAMIC_SNIPPET_NAME":     dynamicName,
-			"DYNAMIC_SNIPPET_TYPE":     "recv",
-			"DYNAMIC_SNIPPET_PRIORITY": "25",
-		},
-		"internal/acceptance_tests/blocks/domain_single.tf",
-		"internal/acceptance_tests/blocks/backend_single.tf",
-		"internal/acceptance_tests/blocks/snippet_nested_multiple.tf",
-		"internal/acceptance_tests/blocks/dynamic_snippet_nested.tf",
-	)
-
-	dataSource := `
-data "fastly_vcl_snippets" "example" {
-  depends_on      = [fastly_service_cdn_auto.test]
-  service_id      = fastly_service_cdn_auto.test.id
-  service_version = fastly_service_cdn_auto.test.active_version
-}
-`
-
-	return joinBlocks(serviceConfig, dataSource)
-}

--- a/internal/acceptance_tests/vcl_snippets_data_source_test.go
+++ b/internal/acceptance_tests/vcl_snippets_data_source_test.go
@@ -1,0 +1,92 @@
+package acceptancetests
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccFastlyDataSourceVCLSnippets_Config(t *testing.T) {
+	t.Parallel()
+
+	serviceName := fmt.Sprintf("tf-test-vcl-snippets-ds-%s", acctest.RandString(10))
+	domainName := fmt.Sprintf("%s.example.com", acctest.RandString(10))
+	backendName := fmt.Sprintf("backend-%s", acctest.RandString(10))
+	regularNameOne := fmt.Sprintf("regular_recv_%s", acctest.RandString(10))
+	regularNameTwo := fmt.Sprintf("regular_deliver_%s", acctest.RandString(10))
+	dynamicName := fmt.Sprintf("dynamic_recv_%s", acctest.RandString(10))
+	contentOne := `set req.http.X-Terraform-Snippet-Data-Source = "one";`
+	contentTwo := `set resp.http.X-Terraform-Snippet-Data-Source = "two";`
+	snippetFileOne := writeSnippetFile(t, "data-source-one.vcl", contentOne)
+	snippetFileTwo := writeSnippetFile(t, "data-source-two.vcl", contentTwo)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
+		CheckDestroy:             CheckServiceDestroy("fastly_service_cdn_auto"),
+		Steps: []resource.TestStep{
+			{
+				Config: ConfigDataSourceVCLSnippets(serviceName, domainName, backendName, regularNameOne, regularNameTwo, dynamicName, snippetFileOne, snippetFileTwo),
+				Check: resource.ComposeTestCheckFunc(
+					CheckServiceExists("fastly_service_cdn_auto.test"),
+					resource.TestCheckResourceAttr("data.fastly_vcl_snippets.example", "vcl_snippets.#", "3"),
+					resource.TestCheckResourceAttrSet("data.fastly_vcl_snippets.example", "id"),
+					resource.TestCheckTypeSetElemNestedAttrs("data.fastly_vcl_snippets.example", "vcl_snippets.*", map[string]string{
+						"name":     regularNameOne,
+						"type":     "recv",
+						"priority": "100",
+						"dynamic":  "false",
+						"content":  contentOne,
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs("data.fastly_vcl_snippets.example", "vcl_snippets.*", map[string]string{
+						"name":     regularNameTwo,
+						"type":     "deliver",
+						"priority": "50",
+						"dynamic":  "false",
+						"content":  contentTwo,
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs("data.fastly_vcl_snippets.example", "vcl_snippets.*", map[string]string{
+						"name":     dynamicName,
+						"type":     "recv",
+						"priority": "25",
+						"dynamic":  "true",
+					}),
+				),
+			},
+		},
+	})
+}
+
+func ConfigDataSourceVCLSnippets(serviceName, domainName, backendName, regularNameOne, regularNameTwo, dynamicName, snippetFilePathOne, snippetFilePathTwo string) string {
+	serviceConfig := BuildConfig(
+		ServiceCDNAuto,
+		map[string]string{
+			"SERVICE_NAME":             serviceName,
+			"DOMAIN_NAME":              domainName,
+			"BACKEND_NAME":             backendName,
+			"SNIPPET_NAME_ONE":         regularNameOne,
+			"SNIPPET_NAME_TWO":         regularNameTwo,
+			"SNIPPET_FILE_PATH_ONE":    snippetFilePathOne,
+			"SNIPPET_FILE_PATH_TWO":    snippetFilePathTwo,
+			"DYNAMIC_SNIPPET_NAME":     dynamicName,
+			"DYNAMIC_SNIPPET_TYPE":     "recv",
+			"DYNAMIC_SNIPPET_PRIORITY": "25",
+		},
+		"internal/acceptance_tests/blocks/domain_single.tf",
+		"internal/acceptance_tests/blocks/backend_single.tf",
+		"internal/acceptance_tests/blocks/snippet_nested_multiple.tf",
+		"internal/acceptance_tests/blocks/dynamic_snippet_nested.tf",
+	)
+
+	dataSource := `
+data "fastly_vcl_snippets" "example" {
+  depends_on      = [fastly_service_cdn_auto.test]
+  service_id      = fastly_service_cdn_auto.test.id
+  service_version = fastly_service_cdn_auto.test.active_version
+}
+`
+
+	return joinBlocks(serviceConfig, dataSource)
+}

--- a/internal/datasources/vclsnippets/data_source.go
+++ b/internal/datasources/vclsnippets/data_source.go
@@ -21,6 +21,8 @@ import (
 
 var _ datasource.DataSource = &DataSource{}
 
+const defaultPriority int64 = 100
+
 type DataSource struct {
 	providerData *fastlyclient.Data
 }
@@ -201,7 +203,7 @@ func flattenVCLSnippets(snippets []*fastly.Snippet) (types.Set, []string, diag.D
 
 func parsePriority(value *string) (int64, error) {
 	if value == nil || *value == "" {
-		return 0, nil
+		return defaultPriority, nil
 	}
 
 	priority, err := strconv.ParseInt(*value, 10, 64)

--- a/internal/datasources/vclsnippets/data_source.go
+++ b/internal/datasources/vclsnippets/data_source.go
@@ -1,0 +1,213 @@
+package vclsnippets
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	fastlyclient "github.com/fastly/terraform-provider-fastly/internal/client"
+	"github.com/fastly/terraform-provider-fastly/internal/datasources/idhash"
+	"github.com/fastly/terraform-provider-fastly/internal/service"
+	"github.com/fastly/terraform-provider-fastly/internal/validation"
+
+	"github.com/fastly/go-fastly/v17/fastly"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+var _ datasource.DataSource = &DataSource{}
+
+type DataSource struct {
+	providerData *fastlyclient.Data
+}
+
+type DataSourceModel struct {
+	ID             types.String `tfsdk:"id"`
+	ServiceID      types.String `tfsdk:"service_id"`
+	ServiceVersion types.Int64  `tfsdk:"service_version"`
+	VCLSnippets    types.Set    `tfsdk:"vcl_snippets"`
+}
+
+var snippetAttrTypes = map[string]attr.Type{
+	"content":  types.StringType,
+	"dynamic":  types.BoolType,
+	"id":       types.StringType,
+	"name":     types.StringType,
+	"priority": types.Int64Type,
+	"type":     types.StringType,
+}
+
+func NewDataSource() datasource.DataSource {
+	return &DataSource{}
+}
+
+func (d *DataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_vcl_snippets"
+}
+
+func (d *DataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Use this data source to retrieve VCL snippets for a Fastly service version.",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed:    true,
+				Description: "Terraform data source identifier.",
+			},
+			"service_id": schema.StringAttribute{
+				Required:    true,
+				Description: "Fastly service ID.",
+			},
+			"service_version": schema.Int64Attribute{
+				Required:    true,
+				Description: "Fastly service version to read snippets from.",
+			},
+			"vcl_snippets": schema.SetNestedAttribute{
+				Computed:    true,
+				Description: "List of all VCL snippets for the configured service version.",
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"content": schema.StringAttribute{
+							Computed:    true,
+							Description: "The VCL code that specifies exactly what the snippet does.",
+						},
+						"dynamic": schema.BoolAttribute{
+							Computed:    true,
+							Description: "Whether this is a dynamic VCL snippet.",
+						},
+						"id": schema.StringAttribute{
+							Computed:    true,
+							Description: "Fastly-generated VCL snippet identifier.",
+						},
+						"name": schema.StringAttribute{
+							Computed:    true,
+							Description: "The name for the snippet.",
+						},
+						"priority": schema.Int64Attribute{
+							Computed:    true,
+							Description: "Priority determines execution order. Lower numbers execute first.",
+						},
+						"type": schema.StringAttribute{
+							Computed:    true,
+							Description: "The location in generated VCL where the snippet should be placed.",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (d *DataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	data, diags := fastlyclient.FromProviderData(req.ProviderData)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() || data == nil {
+		return
+	}
+
+	d.providerData = data
+}
+
+func (d *DataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var state DataSourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	serviceID := state.ServiceID.ValueString()
+	version := int(state.ServiceVersion.ValueInt64())
+
+	if err := validation.EnsureServiceTypeSupported(ctx, d.providerData.ServiceTypeChecker, serviceID, "fastly_vcl_snippets", service.TypeVCL); err != nil {
+		resp.Diagnostics.AddError("Unsupported Fastly service type", err.Error())
+		return
+	}
+
+	tflog.Debug(ctx, "Reading Fastly VCL snippets", map[string]any{
+		"service_id":      serviceID,
+		"service_version": version,
+	})
+
+	snippets, err := d.providerData.Client.ListSnippets(ctx, &fastly.ListSnippetsInput{
+		ServiceID:      serviceID,
+		ServiceVersion: version,
+	})
+	if err != nil {
+		resp.Diagnostics.AddError("Error reading VCL snippets", err.Error())
+		return
+	}
+
+	setVal, ids, diags := flattenVCLSnippets(snippets)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	state.VCLSnippets = setVal
+	state.ID = types.StringValue(idhash.HashIDs(ids))
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func flattenVCLSnippets(snippets []*fastly.Snippet) (types.Set, []string, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	ids := make([]string, 0, len(snippets))
+	elements := make([]attr.Value, 0, len(snippets))
+
+	for _, snippet := range snippets {
+		if snippet == nil {
+			continue
+		}
+
+		priority, err := parsePriority(snippet.Priority)
+		if err != nil {
+			diags.AddError("Error parsing VCL snippet priority", err.Error())
+			return types.SetNull(types.ObjectType{AttrTypes: snippetAttrTypes}), nil, diags
+		}
+
+		id := fastly.ToValue(snippet.SnippetID)
+		name := fastly.ToValue(snippet.Name)
+		content := fastly.ToValue(snippet.Content)
+		snippetType := string(fastly.ToValue(snippet.Type))
+		dynamic := fastly.ToValue(snippet.Dynamic) == 1
+
+		ids = append(ids, fmt.Sprintf("%s/%s/%s/%d/%t/%s", id, name, snippetType, priority, dynamic, content))
+
+		obj, objDiags := types.ObjectValue(snippetAttrTypes, map[string]attr.Value{
+			"content":  types.StringValue(content),
+			"dynamic":  types.BoolValue(dynamic),
+			"id":       types.StringValue(id),
+			"name":     types.StringValue(name),
+			"priority": types.Int64Value(priority),
+			"type":     types.StringValue(snippetType),
+		})
+		diags.Append(objDiags...)
+		elements = append(elements, obj)
+	}
+
+	if diags.HasError() {
+		return types.SetNull(types.ObjectType{AttrTypes: snippetAttrTypes}), nil, diags
+	}
+
+	setVal, setDiags := types.SetValue(types.ObjectType{AttrTypes: snippetAttrTypes}, elements)
+	diags.Append(setDiags...)
+
+	return setVal, ids, diags
+}
+
+func parsePriority(value *string) (int64, error) {
+	if value == nil || *value == "" {
+		return 0, nil
+	}
+
+	priority, err := strconv.ParseInt(*value, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("error parsing VCL snippet priority %q: %w", *value, err)
+	}
+
+	return priority, nil
+}

--- a/internal/datasources/vclsnippets/data_source_test.go
+++ b/internal/datasources/vclsnippets/data_source_test.go
@@ -64,7 +64,7 @@ func TestParsePriority(t *testing.T) {
 	}
 
 	value := "25"
-	got, err := parsePriority(&value)
+	got, err = parsePriority(&value)
 	if err != nil {
 		t.Fatalf("parsePriority returned error: %s", err)
 	}

--- a/internal/datasources/vclsnippets/data_source_test.go
+++ b/internal/datasources/vclsnippets/data_source_test.go
@@ -55,6 +55,14 @@ func TestFlattenVCLSnippetsInvalidPriority(t *testing.T) {
 }
 
 func TestParsePriority(t *testing.T) {
+	got, err := parsePriority(nil)
+	if err != nil {
+		t.Fatalf("parsePriority nil returned error: %s", err)
+	}
+	if got != defaultPriority {
+		t.Fatalf("parsePriority nil = %d, want %d", got, defaultPriority)
+	}
+
 	value := "25"
 	got, err := parsePriority(&value)
 	if err != nil {
@@ -69,7 +77,7 @@ func TestParsePriority(t *testing.T) {
 	if err != nil {
 		t.Fatalf("parsePriority empty returned error: %s", err)
 	}
-	if got != 0 {
-		t.Fatalf("parsePriority empty = %d, want 0", got)
+	if got != defaultPriority {
+		t.Fatalf("parsePriority empty = %d, want %d", got, defaultPriority)
 	}
 }

--- a/internal/datasources/vclsnippets/data_source_test.go
+++ b/internal/datasources/vclsnippets/data_source_test.go
@@ -1,0 +1,75 @@
+package vclsnippets
+
+import (
+	"testing"
+
+	"github.com/fastly/go-fastly/v17/fastly"
+)
+
+func TestFlattenVCLSnippets(t *testing.T) {
+	name := "recv_snippet"
+	content := "set req.http.X-Test = \"regular\";"
+	priority := "10"
+	snippetType := fastly.SnippetType("recv")
+	snippetID := "snippet-id"
+	dynamic := 0
+
+	setVal, ids, diags := flattenVCLSnippets([]*fastly.Snippet{
+		{
+			Name:      &name,
+			Content:   &content,
+			Priority:  &priority,
+			Type:      &snippetType,
+			SnippetID: &snippetID,
+			Dynamic:   &dynamic,
+		},
+	})
+	if diags.HasError() {
+		t.Fatalf("flattenVCLSnippets returned diagnostics: %v", diags)
+	}
+
+	if len(ids) != 1 {
+		t.Fatalf("ids length = %d, want 1", len(ids))
+	}
+
+	if setVal.IsNull() || setVal.IsUnknown() {
+		t.Fatal("expected non-null, known set")
+	}
+
+	if len(setVal.Elements()) != 1 {
+		t.Fatalf("set elements length = %d, want 1", len(setVal.Elements()))
+	}
+}
+
+func TestFlattenVCLSnippetsInvalidPriority(t *testing.T) {
+	priority := "invalid"
+
+	_, _, diags := flattenVCLSnippets([]*fastly.Snippet{
+		{
+			Priority: &priority,
+		},
+	})
+	if !diags.HasError() {
+		t.Fatal("expected invalid priority to return diagnostics")
+	}
+}
+
+func TestParsePriority(t *testing.T) {
+	value := "25"
+	got, err := parsePriority(&value)
+	if err != nil {
+		t.Fatalf("parsePriority returned error: %s", err)
+	}
+	if got != 25 {
+		t.Fatalf("parsePriority = %d, want 25", got)
+	}
+
+	empty := ""
+	got, err = parsePriority(&empty)
+	if err != nil {
+		t.Fatalf("parsePriority empty returned error: %s", err)
+	}
+	if got != 0 {
+		t.Fatalf("parsePriority empty = %d, want 0", got)
+	}
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -22,6 +22,7 @@ import (
 	"github.com/fastly/terraform-provider-fastly/internal/datasources/acls"
 	"github.com/fastly/terraform-provider-fastly/internal/datasources/kvstores"
 	"github.com/fastly/terraform-provider-fastly/internal/datasources/serviceversion"
+	"github.com/fastly/terraform-provider-fastly/internal/datasources/vclsnippets"
 	"github.com/fastly/terraform-provider-fastly/internal/resources/acl"
 	"github.com/fastly/terraform-provider-fastly/internal/resources/aclentries"
 	"github.com/fastly/terraform-provider-fastly/internal/resources/backend"
@@ -148,6 +149,7 @@ func (p *fastlyProvider) DataSources(_ context.Context) []func() datasource.Data
 		acls.NewDataSource,
 		kvstores.NewDataSource,
 		serviceversion.NewDataSource,
+		vclsnippets.NewDataSource,
 	}
 }
 

--- a/templates/data-sources/vcl_snippets.md.tmpl
+++ b/templates/data-sources/vcl_snippets.md.tmpl
@@ -1,0 +1,35 @@
+---
+page_title: "fastly_vcl_snippets Data Source - fastly"
+subcategory: ""
+description: |-
+  Use this data source to retrieve VCL snippets for a Fastly service version.
+---
+
+# fastly_vcl_snippets (Data Source)
+
+Use this data source to retrieve regular and dynamic VCL snippet metadata for a Fastly service version.
+
+This data source reads snippets through the versioned snippet list endpoint. It is useful with both VCL snippet resource families added in:
+
+- regular VCL snippets: [#1381](https://github.com/fastly/terraform-provider-fastly/pull/1381)
+- dynamic VCL snippets: [#1397](https://github.com/fastly/terraform-provider-fastly/pull/1397)
+
+Dynamic snippet content is versionless and is managed separately with `fastly_service_dynamic_snippet_content`.
+
+## Example Usage
+
+```terraform
+data "fastly_vcl_snippets" "example" {
+  service_id      = fastly_service_cdn_auto.example.id
+  service_version = fastly_service_cdn_auto.example.active_version
+}
+
+output "recv_snippet_names" {
+  value = [
+    for snippet in data.fastly_vcl_snippets.example.vcl_snippets :
+    snippet.name if snippet.type == "recv"
+  ]
+}
+```
+
+{{ .SchemaMarkdown | trimspace }}


### PR DESCRIPTION
## Change summary

Adds the `fastly_vcl_snippets` data source to the dual-model provider rewrite.

The data source reads all VCL snippets for a service version using the versioned
snippets list endpoint:

`GET /service/{service_id}/version/{version_id}/snippet`

It can return regular VCL snippets added in PR #1381 and dynamic snippet
metadata/containers added in PR #1397.

This brings forward the current SDK provider data source behavior into the
dual-model provider.

## New Feature Submissions

- [x] Does your submission pass tests?
- [x] Post the output of your test runs

```bash
=== RUN   TestAccFastlyDataSourceVCLSnippets_Config
=== PAUSE TestAccFastlyDataSourceVCLSnippets_Config
=== CONT  TestAccFastlyDataSourceVCLSnippets_Config
--- PASS: TestAccFastlyDataSourceVCLSnippets_Config (20.63s)
PASS
```