### PR TITLE
Add int validation for `gzip_level` in S3 Logging

### DIFF
--- a/internal/acceptance_tests/blocks/logging_s3_gzip_level_invalid.tf
+++ b/internal/acceptance_tests/blocks/logging_s3_gzip_level_invalid.tf
@@ -1,0 +1,11 @@
+resource "fastly_service_logging_s3" "test" {
+  service_id  = fastly_service_cdn.test.id
+  version     = {{.SERVICE_VERSION}}
+  name        = "{{.LOGGING_S3_NAME}}"
+  bucket_name = "{{.BUCKET_NAME}}"
+  authentication = {
+    access_key = "AKIAIOSFODNN7EXAMPLE"
+    secret_key = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+  }
+  gzip_level = 15
+}

--- a/internal/acceptance_tests/blocks/logging_s3_gzip_level_sentinel.tf
+++ b/internal/acceptance_tests/blocks/logging_s3_gzip_level_sentinel.tf
@@ -1,0 +1,11 @@
+resource "fastly_service_logging_s3" "test" {
+  service_id  = fastly_service_cdn.test.id
+  version     = {{.SERVICE_VERSION}}
+  name        = "{{.LOGGING_S3_NAME}}"
+  bucket_name = "{{.BUCKET_NAME}}"
+  authentication = {
+    access_key = "AKIAIOSFODNN7EXAMPLE"
+    secret_key = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+  }
+  gzip_level = -1
+}

--- a/internal/acceptance_tests/logging_s3_test.go
+++ b/internal/acceptance_tests/logging_s3_test.go
@@ -462,6 +462,51 @@ func TestAccFastlyServiceLoggingS3_gzipCodec(t *testing.T) {
 // TestAccFastlyServiceLoggingS3_codecConflict verifies that configuring both
 // compression_codec and gzip_level fails at plan time with a clear validation
 // error, rather than producing an inconsistent-result error at apply time.
+// TestAccFastlyServiceLoggingS3_gzipLevelRange verifies that an explicitly
+// configured gzip_level outside 0-9 fails at plan time via int64validator.Between,
+// rather than at apply time.
+func TestAccFastlyServiceLoggingS3_gzipLevelRange(t *testing.T) {
+	t.Parallel()
+	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	domainName := fmt.Sprintf("%s.example.com", acctest.RandString(10))
+	loggerName := fmt.Sprintf("s3-logger-%s", acctest.RandString(10))
+	bucketName := fmt.Sprintf("tf-test-bucket-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config:      ConfigLoggingS3GzipLevelInvalid(serviceName, domainName, loggerName, bucketName),
+				ExpectError: regexp.MustCompile("value must be between 0 and 9"),
+			},
+		},
+	})
+}
+
+// TestAccFastlyServiceLoggingS3_gzipLevelSentinelRejected verifies that
+// explicitly configuring gzip_level = -1 (the internal "unset" sentinel) is
+// rejected at plan time, rather than being silently accepted and reinterpreted as
+// "unset" - a user should omit the attribute to get that behavior.
+func TestAccFastlyServiceLoggingS3_gzipLevelSentinelRejected(t *testing.T) {
+	t.Parallel()
+	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	domainName := fmt.Sprintf("%s.example.com", acctest.RandString(10))
+	loggerName := fmt.Sprintf("s3-logger-%s", acctest.RandString(10))
+	bucketName := fmt.Sprintf("tf-test-bucket-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config:      ConfigLoggingS3GzipLevelSentinel(serviceName, domainName, loggerName, bucketName),
+				ExpectError: regexp.MustCompile("value must be between 0 and 9"),
+			},
+		},
+	})
+}
+
 func TestAccFastlyServiceLoggingS3_codecConflict(t *testing.T) {
 	t.Parallel()
 	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))

--- a/internal/acceptance_tests/logging_s3_test.go
+++ b/internal/acceptance_tests/logging_s3_test.go
@@ -459,9 +459,6 @@ func TestAccFastlyServiceLoggingS3_gzipCodec(t *testing.T) {
 	})
 }
 
-// TestAccFastlyServiceLoggingS3_codecConflict verifies that configuring both
-// compression_codec and gzip_level fails at plan time with a clear validation
-// error, rather than producing an inconsistent-result error at apply time.
 // TestAccFastlyServiceLoggingS3_gzipLevelRange verifies that an explicitly
 // configured gzip_level outside 0-9 fails at plan time via int64validator.Between,
 // rather than at apply time.
@@ -507,6 +504,9 @@ func TestAccFastlyServiceLoggingS3_gzipLevelSentinelRejected(t *testing.T) {
 	})
 }
 
+// TestAccFastlyServiceLoggingS3_codecConflict verifies that configuring both
+// compression_codec and gzip_level fails at plan time with a clear validation
+// error, rather than producing an inconsistent-result error at apply time.
 func TestAccFastlyServiceLoggingS3_codecConflict(t *testing.T) {
 	t.Parallel()
 	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))

--- a/internal/acceptance_tests/test_helpers.go
+++ b/internal/acceptance_tests/test_helpers.go
@@ -1991,6 +1991,42 @@ func ConfigLoggingS3CodecConflict(serviceName, domainName, loggerName, bucketNam
 	)
 }
 
+func ConfigLoggingS3GzipLevelInvalid(serviceName, domainName, loggerName, bucketName string) string {
+	return BuildConfig(
+		ServiceCDN,
+		map[string]string{
+			"SERVICE_NAME":    serviceName,
+			"SERVICE_COMMENT": "",
+			"DOMAIN_NAME":     domainName,
+			"SERVICE_VERSION": "1",
+			"LOGGING_S3_NAME": loggerName,
+			"BUCKET_NAME":     bucketName,
+		},
+		"internal/acceptance_tests/blocks/service_cdn_domain.tf",
+		"internal/acceptance_tests/blocks/logging_s3_gzip_level_invalid.tf",
+	)
+}
+
+// ConfigLoggingS3GzipLevelSentinel returns a config that explicitly sets
+// gzip_level = -1, the internal "unset" sentinel. This should fail plan-time
+// validation via int64validator.Between(0, 9) rather than being silently accepted
+// and reinterpreted as "unset" - a user should omit the attribute for that.
+func ConfigLoggingS3GzipLevelSentinel(serviceName, domainName, loggerName, bucketName string) string {
+	return BuildConfig(
+		ServiceCDN,
+		map[string]string{
+			"SERVICE_NAME":    serviceName,
+			"SERVICE_COMMENT": "",
+			"DOMAIN_NAME":     domainName,
+			"SERVICE_VERSION": "1",
+			"LOGGING_S3_NAME": loggerName,
+			"BUCKET_NAME":     bucketName,
+		},
+		"internal/acceptance_tests/blocks/service_cdn_domain.tf",
+		"internal/acceptance_tests/blocks/logging_s3_gzip_level_sentinel.tf",
+	)
+}
+
 func ConfigLoggingS3ForImport(serviceName, domainName, loggerName, bucketName string) string {
 	return BuildConfig(
 		ServiceCDN,

--- a/internal/resources/loggings3/schema.go
+++ b/internal/resources/loggings3/schema.go
@@ -310,9 +310,14 @@ func sharedAttributes() map[string]schema.Attribute {
 			// compression_codec and gzip_level are mutually exclusive; the API
 			// rejects a request that sets both. Validation runs against config,
 			// where an unset gzip_level is null rather than the -1 default, so
-			// this correctly fires only when both are set.
+			// this correctly fires only when both are set. int64validator.Between
+			// likewise skips a null (omitted) config value, so it only rejects an
+			// explicitly configured value outside 0-9 — including the internal -1
+			// sentinel itself, which a user should never configure directly (omit
+			// the attribute instead to get the same "unset" behavior).
 			Validators: []validator.Int64{
 				gzipLevelCodecConflict{},
+				int64validator.Between(0, 9),
 			},
 			Description: "The level of gzip encoding when sending logs. Valid values are `0` (no compression) through `9`. To compress at a specific gzip level, leave `compression_codec` unset and set this. Conflicts with `compression_codec`: setting both in the same request will result in an error.",
 		},


### PR DESCRIPTION
### Change summary

This PR is a follow up to the discussion in  https://github.com/fastly/terraform-provider-fastly/pull/1400#discussion_r3771639842 - where we agreed to add additional validation around the values of the `gzip_level` attribute across logging endpoints that used it. 

 All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/terraform-provider-fastly/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

* [x] Does your submission pass tests?
* [x] Post the output of your test runs

```
=== RUN   TestAccFastlyServiceLoggingBlobStorage_gzipLevelRange
=== PAUSE TestAccFastlyServiceLoggingBlobStorage_gzipLevelRange
=== RUN   TestAccFastlyServiceLoggingBlobStorage_gzipLevelSentinelRejected
=== PAUSE TestAccFastlyServiceLoggingBlobStorage_gzipLevelSentinelRejected
=== RUN   TestAccFastlyServiceLoggingS3_gzipLevelRange
=== PAUSE TestAccFastlyServiceLoggingS3_gzipLevelRange
=== RUN   TestAccFastlyServiceLoggingS3_gzipLevelSentinelRejected
=== PAUSE TestAccFastlyServiceLoggingS3_gzipLevelSentinelRejected
=== CONT  TestAccFastlyServiceLoggingBlobStorage_gzipLevelRange
=== CONT  TestAccFastlyServiceLoggingS3_gzipLevelRange
=== CONT  TestAccFastlyServiceLoggingS3_gzipLevelSentinelRejected
=== CONT  TestAccFastlyServiceLoggingBlobStorage_gzipLevelSentinelRejected
--- PASS: TestAccFastlyServiceLoggingS3_gzipLevelSentinelRejected (0.18s)
--- PASS: TestAccFastlyServiceLoggingS3_gzipLevelRange (0.18s)
--- PASS: TestAccFastlyServiceLoggingBlobStorage_gzipLevelSentinelRejected (0.18s)
--- PASS: TestAccFastlyServiceLoggingBlobStorage_gzipLevelRange (0.18s)
PASS
ok 
```

### Changes to Core Features:

* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
