### PR TITLE
[CDTOOL-1499] Add cache setting support to auto service resources

### DIFF
--- a/docs/resources/service_cdn_auto.md
+++ b/docs/resources/service_cdn_auto.md
@@ -22,6 +22,7 @@ Automatic-lifecycle Fastly CDN service resource with nested versioned configurat
 
 - `acl` (Block List) ACLs attached to this service. (see [below for nested schema](#nestedblock--acl))
 - `backend` (Block List) Backends attached to this service. (see [below for nested schema](#nestedblock--backend))
+- `cache_setting` (Block List) Cache settings attached to this service. (see [below for nested schema](#nestedblock--cache_setting))
 - `comment` (String) Optional service comment.
 - `condition` (Block List) Conditions attached to this service. (see [below for nested schema](#nestedblock--condition))
 - `dictionary` (Block List) Edge dictionaries attached to this service. (see [below for nested schema](#nestedblock--dictionary))
@@ -107,6 +108,21 @@ Optional:
 - `ssl_client_cert` (String, Sensitive) Client certificate used when connecting to the backend.
 - `ssl_client_key` (String, Sensitive) Client key used when connecting to the backend.
 
+
+
+<a id="nestedblock--cache_setting"></a>
+### Nested Schema for `cache_setting`
+
+Required:
+
+- `name` (String) Unique name for this Cache Setting. Changing this attribute will delete and recreate the resource.
+
+Optional:
+
+- `action` (String) One of `cache`, `pass`, or `restart`, as defined on Fastly's documentation under ["Caching action descriptions"](https://docs.fastly.com/en/guides/controlling-caching#caching-action-descriptions).
+- `cache_condition` (String) Name of already defined `condition` used to test whether this settings object should be used. This `condition` must be of type `CACHE`.
+- `stale_ttl` (Number) Max "Time To Live" (in seconds) for stale (unreachable) objects. Default `0`.
+- `ttl` (Number) The Time-To-Live (TTL, in seconds) for the object. Default `0`.
 
 
 <a id="nestedblock--condition"></a>

--- a/examples/orchestration-cdn-auto/README.md
+++ b/examples/orchestration-cdn-auto/README.md
@@ -11,8 +11,10 @@ The example provisions and manages:
 - one service-specific backend on only service 1
 - one domain per service
 - one ACL per service (service 1 has an IP allowlist, service 2 has a temporary blocklist)
-- one condition on service 1, referenced by its gzip configuration's `cache_condition`
+- one condition on service 1, referenced by its gzip and cache setting
+  configurations' `cache_condition`
 - one gzip configuration on service 1
+- one cache setting on service 1
 - one edge dictionary on service 1
 - Image Optimizer enabled on service 1 (default settings added in a follow-up apply - see below)
 
@@ -52,10 +54,10 @@ Expected bootstrap behavior:
 1. Terraform creates both `fastly_service_cdn_auto` services.
 2. Fastly creates editable version `1` for each new service.
 3. The provider reconciles the nested `domain`, `backend`, `acl`, `condition`,
-   and `gzip` blocks to version `1`. `condition` is reconciled before `backend`
-   and `gzip` since both can reference a condition by name, and the Fastly API
-   rejects a backend or gzip config that names a condition which doesn't exist
-   yet in that version.
+   `gzip`, and `cache_setting` blocks to version `1`. `condition` is
+   reconciled before `backend`, `gzip`, and `cache_setting` since all three
+   can reference a condition by name, and the Fastly API rejects a config
+   that names a condition which doesn't exist yet in that version.
 4. The provider validates and activates version `1`.
 5. `fastly_service_product_image_optimizer.service_1` enables the Image
    Optimizer product on `service_1`.
@@ -183,6 +185,32 @@ You should see:
 - `service_1_managed_version` increase
 - `service_1_active_version` move to the new version
 - the updated `content_types` reflected in the service configuration
+- `service_2_*` outputs remain unchanged
+
+### Add or modify a cache setting
+
+For example, change service 1's cache setting `action` from `cache` to `pass`:
+
+```hcl
+  cache_setting {
+    name            = "text_assets_ttl"
+    action          = "pass"
+    ttl             = 3600
+    cache_condition = "text_assets_only"
+  }
+```
+
+Then run:
+
+```bash
+terraform apply
+```
+
+You should see:
+
+- `service_1_managed_version` increase
+- `service_1_active_version` move to the new version
+- the updated `action` reflected in the service configuration
 - `service_2_*` outputs remain unchanged
 
 ### Add or modify a condition

--- a/examples/orchestration-cdn-auto/main.tf
+++ b/examples/orchestration-cdn-auto/main.tf
@@ -58,6 +58,13 @@ resource "fastly_service_cdn_auto" "service_1" {
     cache_condition = "text_assets_only"
   }
 
+  cache_setting {
+    name            = "text_assets_ttl"
+    action          = "cache"
+    ttl             = 3600
+    cache_condition = "text_assets_only"
+  }
+
   dictionary {
     name = "feature_flags"
   }

--- a/internal/acceptance_tests/blocks/cache_setting_minimal.tf
+++ b/internal/acceptance_tests/blocks/cache_setting_minimal.tf
@@ -1,0 +1,3 @@
+  cache_setting {
+    name = "{{.CACHE_SETTING_NAME}}"
+  }

--- a/internal/acceptance_tests/blocks/cache_setting_multi.tf
+++ b/internal/acceptance_tests/blocks/cache_setting_multi.tf
@@ -1,0 +1,9 @@
+  cache_setting {
+    name = "{{.CACHE_SETTING_NAME_1}}"
+    ttl  = 3600
+  }
+
+  cache_setting {
+    name   = "{{.CACHE_SETTING_NAME_2}}"
+    action = "pass"
+  }

--- a/internal/acceptance_tests/blocks/cache_setting_single.tf
+++ b/internal/acceptance_tests/blocks/cache_setting_single.tf
@@ -1,0 +1,6 @@
+  cache_setting {
+    name      = "{{.CACHE_SETTING_NAME}}"
+    action    = "cache"
+    ttl       = 3600
+    stale_ttl = 120
+  }

--- a/internal/acceptance_tests/blocks/cache_setting_updated.tf
+++ b/internal/acceptance_tests/blocks/cache_setting_updated.tf
@@ -1,0 +1,6 @@
+  cache_setting {
+    name      = "{{.CACHE_SETTING_NAME}}"
+    action    = "pass"
+    ttl       = 7200
+    stale_ttl = 300
+  }

--- a/internal/acceptance_tests/blocks/cache_setting_with_cache_condition.tf
+++ b/internal/acceptance_tests/blocks/cache_setting_with_cache_condition.tf
@@ -1,0 +1,6 @@
+  cache_setting {
+    name            = "{{.CACHE_SETTING_NAME}}"
+    action          = "cache"
+    ttl             = 3600
+    cache_condition = "{{.CONDITION_NAME}}"
+  }

--- a/internal/acceptance_tests/service_cdn_auto_test.go
+++ b/internal/acceptance_tests/service_cdn_auto_test.go
@@ -585,6 +585,226 @@ func TestAccFastlyServiceCDNAuto_gzipWithCacheCondition(t *testing.T) {
 	})
 }
 
+func TestAccFastlyServiceCDNAuto_withCacheSetting(t *testing.T) {
+	t.Parallel()
+	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	domainName := fmt.Sprintf("%s.example.com", acctest.RandString(10))
+	cacheSettingName := fmt.Sprintf("cache-setting-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
+		CheckDestroy:             CheckServiceDestroy("fastly_service_cdn_auto"),
+		Steps: []resource.TestStep{
+			{
+				Config: ConfigCDNAutoBasic(serviceName, domainName),
+				Check: resource.ComposeTestCheckFunc(
+					CheckServiceExists("fastly_service_cdn_auto.test"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "cache_setting.#", "0"),
+					// Initial version should be 1
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "active_version", "1"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "managed_version", "1"),
+				),
+			},
+			{
+				Config: ConfigCDNAutoWithCacheSetting(serviceName, domainName, cacheSettingName),
+				Check: resource.ComposeTestCheckFunc(
+					CheckServiceExists("fastly_service_cdn_auto.test"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "cache_setting.#", "1"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "cache_setting.0.name", cacheSettingName),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "cache_setting.0.action", "cache"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "cache_setting.0.ttl", "3600"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "cache_setting.0.stale_ttl", "120"),
+					// Adding a cache setting should create and activate version 2
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "active_version", "2"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "managed_version", "2"),
+				),
+			},
+			{
+				Config: ConfigCDNAutoBasic(serviceName, domainName),
+				Check: resource.ComposeTestCheckFunc(
+					CheckServiceExists("fastly_service_cdn_auto.test"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "cache_setting.#", "0"),
+					// Removing the cache setting should create and activate version 3
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "active_version", "3"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "managed_version", "3"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccFastlyServiceCDNAuto_cacheSettingMinimal(t *testing.T) {
+	t.Parallel()
+	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	domainName := fmt.Sprintf("%s.example.com", acctest.RandString(10))
+	cacheSettingName := fmt.Sprintf("cache-setting-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
+		CheckDestroy:             CheckServiceDestroy("fastly_service_cdn_auto"),
+		Steps: []resource.TestStep{
+			{
+				// action/ttl/stale_ttl left unset must default to null/0 rather than
+				// drifting on every plan.
+				Config: ConfigCDNAutoWithCacheSettingMinimal(serviceName, domainName, cacheSettingName),
+				Check: resource.ComposeTestCheckFunc(
+					CheckServiceExists("fastly_service_cdn_auto.test"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "cache_setting.#", "1"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "cache_setting.0.name", cacheSettingName),
+					resource.TestCheckNoResourceAttr("fastly_service_cdn_auto.test", "cache_setting.0.action"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "cache_setting.0.ttl", "0"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "cache_setting.0.stale_ttl", "0"),
+				),
+			},
+			{
+				Config:   ConfigCDNAutoWithCacheSettingMinimal(serviceName, domainName, cacheSettingName),
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+func TestAccFastlyServiceCDNAuto_cacheSettingUpdated(t *testing.T) {
+	t.Parallel()
+	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	domainName := fmt.Sprintf("%s.example.com", acctest.RandString(10))
+	cacheSettingName := fmt.Sprintf("cache-setting-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
+		CheckDestroy:             CheckServiceDestroy("fastly_service_cdn_auto"),
+		Steps: []resource.TestStep{
+			{
+				Config: ConfigCDNAutoWithCacheSetting(serviceName, domainName, cacheSettingName),
+				Check: resource.ComposeTestCheckFunc(
+					CheckServiceExists("fastly_service_cdn_auto.test"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "cache_setting.0.action", "cache"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "cache_setting.0.ttl", "3600"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "cache_setting.0.stale_ttl", "120"),
+				),
+			},
+			{
+				// Same name, different action/ttl/stale_ttl - this is an in-place update,
+				// not a delete+recreate, since the name (the reconciler's identity key)
+				// hasn't changed.
+				Config: ConfigCDNAutoWithCacheSettingUpdated(serviceName, domainName, cacheSettingName),
+				Check: resource.ComposeTestCheckFunc(
+					CheckServiceExists("fastly_service_cdn_auto.test"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "cache_setting.#", "1"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "cache_setting.0.name", cacheSettingName),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "cache_setting.0.action", "pass"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "cache_setting.0.ttl", "7200"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "cache_setting.0.stale_ttl", "300"),
+				),
+			},
+			{
+				// Removing action/ttl/stale_ttl from config must clear them back to
+				// null/0 remotely, not just hide the drift in state.
+				Config: ConfigCDNAutoWithCacheSettingMinimal(serviceName, domainName, cacheSettingName),
+				Check: resource.ComposeTestCheckFunc(
+					CheckServiceExists("fastly_service_cdn_auto.test"),
+					resource.TestCheckNoResourceAttr("fastly_service_cdn_auto.test", "cache_setting.0.action"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "cache_setting.0.ttl", "0"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "cache_setting.0.stale_ttl", "0"),
+				),
+			},
+			{
+				Config:   ConfigCDNAutoWithCacheSettingMinimal(serviceName, domainName, cacheSettingName),
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+func TestAccFastlyServiceCDNAuto_multipleCacheSettings(t *testing.T) {
+	t.Parallel()
+	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	domainName := fmt.Sprintf("%s.example.com", acctest.RandString(10))
+	cacheSettingName1 := fmt.Sprintf("cache-setting-a-%s", acctest.RandString(10))
+	cacheSettingName2 := fmt.Sprintf("cache-setting-b-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
+		CheckDestroy:             CheckServiceDestroy("fastly_service_cdn_auto"),
+		Steps: []resource.TestStep{
+			{
+				Config: ConfigCDNAutoWithMultipleCacheSettings(serviceName, domainName, cacheSettingName1, cacheSettingName2),
+				Check: resource.ComposeTestCheckFunc(
+					CheckServiceExists("fastly_service_cdn_auto.test"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "cache_setting.#", "2"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "cache_setting.0.name", cacheSettingName1),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "cache_setting.0.ttl", "3600"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "cache_setting.1.name", cacheSettingName2),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "cache_setting.1.action", "pass"),
+				),
+			},
+			{
+				Config:   ConfigCDNAutoWithMultipleCacheSettings(serviceName, domainName, cacheSettingName1, cacheSettingName2),
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+func TestAccFastlyServiceCDNAuto_cacheSettingWithCacheCondition(t *testing.T) {
+	t.Parallel()
+	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	domainName := fmt.Sprintf("%s.example.com", acctest.RandString(10))
+	cacheSettingName := fmt.Sprintf("cache-setting-%s", acctest.RandString(10))
+	conditionName := fmt.Sprintf("condition-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
+		CheckDestroy:             CheckServiceDestroy("fastly_service_cdn_auto"),
+		Steps: []resource.TestStep{
+			{
+				Config: ConfigCDNAutoWithCacheSettingCacheCondition(serviceName, domainName, cacheSettingName, conditionName),
+				Check: resource.ComposeTestCheckFunc(
+					CheckServiceExists("fastly_service_cdn_auto.test"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "condition.0.name", conditionName),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "condition.0.type", "CACHE"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "cache_setting.0.name", cacheSettingName),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "cache_setting.0.cache_condition", conditionName),
+				),
+			},
+		},
+	})
+}
+
+func TestAccFastlyServiceCDNAuto_importWithCacheSetting(t *testing.T) {
+	t.Parallel()
+	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	domainName := fmt.Sprintf("%s.example.com", acctest.RandString(10))
+	cacheSettingName := fmt.Sprintf("cache-setting-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
+		CheckDestroy:             CheckServiceDestroy("fastly_service_cdn_auto"),
+		Steps: []resource.TestStep{
+			{
+				Config: ConfigCDNAutoWithCacheSetting(serviceName, domainName, cacheSettingName),
+				Check: resource.ComposeTestCheckFunc(
+					CheckServiceExists("fastly_service_cdn_auto.test"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "cache_setting.#", "1"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "cache_setting.0.name", cacheSettingName),
+				),
+			},
+			{
+				ResourceName:            "fastly_service_cdn_auto.test",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"force_destroy", "reuse"},
+			},
+		},
+	})
+}
+
 func TestAccFastlyServiceCDNAuto_import(t *testing.T) {
 	t.Parallel()
 	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))

--- a/internal/acceptance_tests/test_helpers.go
+++ b/internal/acceptance_tests/test_helpers.go
@@ -813,6 +813,83 @@ func ConfigCDNAutoWithGzipCacheCondition(serviceName, domainName, gzipName, cond
 	)
 }
 
+// ConfigCDNAutoWithCacheSetting returns a CDN auto service config with a domain and a cache
+// setting
+func ConfigCDNAutoWithCacheSetting(serviceName, domainName, cacheSettingName string) string {
+	return BuildConfig(
+		ServiceCDNAuto,
+		map[string]string{
+			"SERVICE_NAME":       serviceName,
+			"DOMAIN_NAME":        domainName,
+			"CACHE_SETTING_NAME": cacheSettingName,
+		},
+		"internal/acceptance_tests/blocks/domain_single.tf",
+		"internal/acceptance_tests/blocks/cache_setting_single.tf",
+	)
+}
+
+// ConfigCDNAutoWithCacheSettingMinimal returns a CDN auto service config with a cache setting
+// that leaves action, ttl, and stale_ttl unset
+func ConfigCDNAutoWithCacheSettingMinimal(serviceName, domainName, cacheSettingName string) string {
+	return BuildConfig(
+		ServiceCDNAuto,
+		map[string]string{
+			"SERVICE_NAME":       serviceName,
+			"DOMAIN_NAME":        domainName,
+			"CACHE_SETTING_NAME": cacheSettingName,
+		},
+		"internal/acceptance_tests/blocks/domain_single.tf",
+		"internal/acceptance_tests/blocks/cache_setting_minimal.tf",
+	)
+}
+
+// ConfigCDNAutoWithCacheSettingUpdated returns a CDN auto service config with the same cache
+// setting name but different action, ttl, and stale_ttl values
+func ConfigCDNAutoWithCacheSettingUpdated(serviceName, domainName, cacheSettingName string) string {
+	return BuildConfig(
+		ServiceCDNAuto,
+		map[string]string{
+			"SERVICE_NAME":       serviceName,
+			"DOMAIN_NAME":        domainName,
+			"CACHE_SETTING_NAME": cacheSettingName,
+		},
+		"internal/acceptance_tests/blocks/domain_single.tf",
+		"internal/acceptance_tests/blocks/cache_setting_updated.tf",
+	)
+}
+
+// ConfigCDNAutoWithMultipleCacheSettings returns a CDN auto service config with two cache settings
+func ConfigCDNAutoWithMultipleCacheSettings(serviceName, domainName, cacheSettingName1, cacheSettingName2 string) string {
+	return BuildConfig(
+		ServiceCDNAuto,
+		map[string]string{
+			"SERVICE_NAME":         serviceName,
+			"DOMAIN_NAME":          domainName,
+			"CACHE_SETTING_NAME_1": cacheSettingName1,
+			"CACHE_SETTING_NAME_2": cacheSettingName2,
+		},
+		"internal/acceptance_tests/blocks/domain_single.tf",
+		"internal/acceptance_tests/blocks/cache_setting_multi.tf",
+	)
+}
+
+// ConfigCDNAutoWithCacheSettingCacheCondition returns a CDN auto service config with a cache
+// setting whose cache_condition references a real nested CACHE-type condition block.
+func ConfigCDNAutoWithCacheSettingCacheCondition(serviceName, domainName, cacheSettingName, conditionName string) string {
+	return BuildConfig(
+		ServiceCDNAuto,
+		map[string]string{
+			"SERVICE_NAME":       serviceName,
+			"DOMAIN_NAME":        domainName,
+			"CACHE_SETTING_NAME": cacheSettingName,
+			"CONDITION_NAME":     conditionName,
+		},
+		"internal/acceptance_tests/blocks/domain_single.tf",
+		"internal/acceptance_tests/blocks/condition_cache.tf",
+		"internal/acceptance_tests/blocks/cache_setting_with_cache_condition.tf",
+	)
+}
+
 // ConfigACLForImport returns a test configuration for importing an ACL
 func ConfigACLForImport(serviceName, domainName, aclName string) string {
 	return BuildConfig(

--- a/internal/resources/cachesetting/cachesetting_test.go
+++ b/internal/resources/cachesetting/cachesetting_test.go
@@ -108,6 +108,7 @@ func TestActionPointer(t *testing.T) {
 		{name: "unknown", value: types.StringUnknown(), expected: nil},
 		{name: "empty", value: types.StringValue(""), expected: nil},
 		{name: "cache", value: types.StringValue("cache"), expected: new(fastly.CacheSettingActionCache)},
+		{name: "uppercase", value: types.StringValue("PASS"), expected: new(fastly.CacheSettingActionPass)},
 	}
 
 	for _, tt := range tests {

--- a/internal/resources/cachesetting/cachesetting_test.go
+++ b/internal/resources/cachesetting/cachesetting_test.go
@@ -1,0 +1,176 @@
+package cachesetting
+
+import (
+	"testing"
+
+	fastly "github.com/fastly/go-fastly/v17/fastly"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func minimalNestedModel() NestedModel {
+	return NestedModel{
+		Name:           types.StringValue("cache-setting"),
+		Action:         types.StringNull(),
+		CacheCondition: types.StringNull(),
+		StaleTTL:       types.Int64Value(0),
+		TTL:            types.Int64Value(0),
+	}
+}
+
+func fullNestedModel() NestedModel {
+	return NestedModel{
+		Name:           types.StringValue("cache-setting"),
+		Action:         types.StringValue("cache"),
+		CacheCondition: types.StringValue("cache-condition"),
+		StaleTTL:       types.Int64Value(120),
+		TTL:            types.Int64Value(3600),
+	}
+}
+
+func TestToModel(t *testing.T) {
+	action := fastly.CacheSettingActionCache
+	api := &fastly.CacheSetting{
+		Name:           new("cache-setting"),
+		Action:         &action,
+		CacheCondition: new("cache-condition"),
+		StaleTTL:       new(120),
+		TTL:            new(3600),
+	}
+
+	result := ops{}.ToModel(api)
+
+	assert.True(t, fullNestedModel().ModelsEqual(result))
+}
+
+func TestToModel_emptyOptionalFields(t *testing.T) {
+	emptyAction := fastly.CacheSettingAction("")
+	api := &fastly.CacheSetting{
+		Name:           new("cache-setting"),
+		Action:         &emptyAction,
+		CacheCondition: new(""),
+		StaleTTL:       new(0),
+		TTL:            new(0),
+	}
+
+	result := ops{}.ToModel(api)
+
+	assert.Equal(t, "cache-setting", result.Name.ValueString())
+	assert.True(t, result.Action.IsNull())
+	assert.True(t, result.CacheCondition.IsNull())
+	assert.Equal(t, int64(0), result.StaleTTL.ValueInt64())
+	assert.Equal(t, int64(0), result.TTL.ValueInt64())
+}
+
+func TestToModel_nilOptionalFields(t *testing.T) {
+	api := &fastly.CacheSetting{
+		Name:     new("cache-setting"),
+		StaleTTL: new(0),
+		TTL:      new(0),
+	}
+
+	result := ops{}.ToModel(api)
+
+	assert.True(t, result.Action.IsNull())
+	assert.True(t, result.CacheCondition.IsNull())
+}
+
+func TestOpsEqual(t *testing.T) {
+	action := fastly.CacheSettingActionCache
+	remote := &fastly.CacheSetting{
+		Name:           new("cache-setting"),
+		Action:         &action,
+		CacheCondition: new("cache-condition"),
+		StaleTTL:       new(120),
+		TTL:            new(3600),
+	}
+
+	assert.True(t, ops{}.Equal(fullNestedModel(), remote))
+}
+
+func TestOpsEqual_mismatch(t *testing.T) {
+	remote := &fastly.CacheSetting{
+		Name:     new("cache-setting"),
+		StaleTTL: new(0),
+		TTL:      new(0),
+	}
+
+	assert.False(t, ops{}.Equal(fullNestedModel(), remote))
+}
+
+func TestActionPointer(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    types.String
+		expected *fastly.CacheSettingAction
+	}{
+		{name: "null", value: types.StringNull(), expected: nil},
+		{name: "unknown", value: types.StringUnknown(), expected: nil},
+		{name: "empty", value: types.StringValue(""), expected: nil},
+		{name: "cache", value: types.StringValue("cache"), expected: new(fastly.CacheSettingActionCache)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := actionPointer(tt.value)
+			if tt.expected == nil {
+				assert.Nil(t, result)
+			} else if assert.NotNil(t, result) {
+				assert.Equal(t, *tt.expected, *result)
+			}
+		})
+	}
+}
+
+func TestEqual(t *testing.T) {
+	tests := []struct {
+		name     string
+		a        []NestedModel
+		b        []NestedModel
+		expected bool
+	}{
+		{
+			name:     "both empty",
+			a:        []NestedModel{},
+			b:        []NestedModel{},
+			expected: true,
+		},
+		{
+			name:     "same content",
+			a:        []NestedModel{fullNestedModel()},
+			b:        []NestedModel{fullNestedModel()},
+			expected: true,
+		},
+		{
+			name: "different lengths",
+			a:    []NestedModel{minimalNestedModel()},
+			b: []NestedModel{
+				minimalNestedModel(),
+				fullNestedModel(),
+			},
+			expected: false,
+		},
+		{
+			name:     "different content",
+			a:        []NestedModel{minimalNestedModel()},
+			b:        []NestedModel{fullNestedModel()},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := Equal(tt.a, tt.b)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestMatchOrder(t *testing.T) {
+	a := NestedModel{Name: types.StringValue("a")}
+	b := NestedModel{Name: types.StringValue("b")}
+
+	result := MatchOrder([]NestedModel{b, a}, []NestedModel{a, b})
+
+	assert.Equal(t, []NestedModel{a, b}, result)
+}

--- a/internal/resources/cachesetting/schema.go
+++ b/internal/resources/cachesetting/schema.go
@@ -2,6 +2,7 @@ package cachesetting
 
 import (
 	"context"
+	"strings"
 
 	"github.com/fastly/terraform-provider-fastly/internal/reconcile"
 	"github.com/fastly/terraform-provider-fastly/internal/service"
@@ -40,7 +41,7 @@ func CommonAttributes() map[string]schema.Attribute {
 			Optional:    true,
 			Description: "One of `cache`, `pass`, or `restart`, as defined on Fastly's documentation under [\"Caching action descriptions\"](https://docs.fastly.com/en/guides/controlling-caching#caching-action-descriptions).",
 			Validators: []validator.String{
-				stringvalidator.OneOf("cache", "pass", "restart"),
+				stringvalidator.OneOfCaseInsensitive("cache", "pass", "restart"),
 			},
 		},
 		"cache_condition": schema.StringAttribute{
@@ -114,12 +115,14 @@ func (o ops) Create(ctx context.Context, client *fastly.Client, serviceID string
 }
 
 // actionPointer returns nil for a null/unknown/empty action, so Create omits the field
-// rather than sending an invalid empty string for an enum the Fastly API validates.
+// rather than sending an invalid empty string for an enum the Fastly API validates. The
+// value is lowercased since the validator accepts any case (e.g. PASS) but the API expects
+// the lowercase enum value.
 func actionPointer(v types.String) *fastly.CacheSettingAction {
 	if v.IsNull() || v.IsUnknown() || v.ValueString() == "" {
 		return nil
 	}
-	action := fastly.CacheSettingAction(v.ValueString())
+	action := fastly.CacheSettingAction(strings.ToLower(v.ValueString()))
 	return &action
 }
 
@@ -128,7 +131,7 @@ func (o ops) Equal(desired NestedModel, remote *fastly.CacheSetting) bool {
 }
 
 func (o ops) Update(ctx context.Context, client *fastly.Client, serviceID string, version int, desired NestedModel) (*fastly.CacheSetting, error) {
-	action := fastly.CacheSettingAction(service.StringValue(desired.Action))
+	action := fastly.CacheSettingAction(strings.ToLower(service.StringValue(desired.Action)))
 	cacheCondition := service.StringValue(desired.CacheCondition)
 	ttl := int(service.Int64Value(desired.TTL))
 	staleTTL := int(service.Int64Value(desired.StaleTTL))

--- a/internal/resources/cachesetting/schema.go
+++ b/internal/resources/cachesetting/schema.go
@@ -1,0 +1,188 @@
+package cachesetting
+
+import (
+	"context"
+
+	"github.com/fastly/terraform-provider-fastly/internal/reconcile"
+	"github.com/fastly/terraform-provider-fastly/internal/service"
+
+	fastly "github.com/fastly/go-fastly/v17/fastly"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+type NestedModel struct {
+	Name           types.String `tfsdk:"name"`
+	Action         types.String `tfsdk:"action"`
+	CacheCondition types.String `tfsdk:"cache_condition"`
+	StaleTTL       types.Int64  `tfsdk:"stale_ttl"`
+	TTL            types.Int64  `tfsdk:"ttl"`
+}
+
+func (n NestedModel) ModelsEqual(other NestedModel) bool {
+	return service.StringValue(n.Name) == service.StringValue(other.Name) &&
+		service.StringValue(n.Action) == service.StringValue(other.Action) &&
+		service.StringValue(n.CacheCondition) == service.StringValue(other.CacheCondition) &&
+		service.Int64Value(n.StaleTTL) == service.Int64Value(other.StaleTTL) &&
+		service.Int64Value(n.TTL) == service.Int64Value(other.TTL)
+}
+
+func CommonAttributes() map[string]schema.Attribute {
+	return map[string]schema.Attribute{
+		"name": schema.StringAttribute{
+			Required:    true,
+			Description: "Unique name for this Cache Setting. Changing this attribute will delete and recreate the resource.",
+		},
+		"action": schema.StringAttribute{
+			Optional:    true,
+			Description: "One of `cache`, `pass`, or `restart`, as defined on Fastly's documentation under [\"Caching action descriptions\"](https://docs.fastly.com/en/guides/controlling-caching#caching-action-descriptions).",
+			Validators: []validator.String{
+				stringvalidator.OneOf("cache", "pass", "restart"),
+			},
+		},
+		"cache_condition": schema.StringAttribute{
+			Optional:    true,
+			Description: "Name of already defined `condition` used to test whether this settings object should be used. This `condition` must be of type `CACHE`.",
+		},
+		"stale_ttl": schema.Int64Attribute{
+			Optional:    true,
+			Computed:    true,
+			Default:     int64default.StaticInt64(0),
+			Description: "Max \"Time To Live\" (in seconds) for stale (unreachable) objects. Default `0`.",
+		},
+		"ttl": schema.Int64Attribute{
+			Optional:    true,
+			Computed:    true,
+			Default:     int64default.StaticInt64(0),
+			Description: "The Time-To-Live (TTL, in seconds) for the object. Default `0`.",
+		},
+	}
+}
+
+func NestedBlockSchema() schema.ListNestedBlock {
+	return schema.ListNestedBlock{
+		Description: "Cache settings attached to this service.",
+		NestedObject: schema.NestedBlockObject{
+			Attributes: CommonAttributes(),
+		},
+	}
+}
+
+type ops struct{}
+
+func (o ops) List(ctx context.Context, client *fastly.Client, serviceID string, version int) ([]*fastly.CacheSetting, error) {
+	return client.ListCacheSettings(ctx, &fastly.ListCacheSettingsInput{
+		ServiceID:      serviceID,
+		ServiceVersion: version,
+	})
+}
+
+func (o ops) GetName(api *fastly.CacheSetting) string {
+	return fastly.ToValue(api.Name)
+}
+
+func (o ops) Delete(ctx context.Context, client *fastly.Client, serviceID string, version int, name string) error {
+	return client.DeleteCacheSetting(ctx, &fastly.DeleteCacheSettingInput{
+		ServiceID:      serviceID,
+		ServiceVersion: version,
+		Name:           name,
+	})
+}
+
+// Create omits Action entirely when unset, rather than sending an empty string, since the
+// Fastly API validates Action as one of cache/pass/restart and may reject a blank value on
+// creation. Update (below) always sends Action, since that's the only way to clear a
+// previously configured value back to unset.
+func (o ops) Create(ctx context.Context, client *fastly.Client, serviceID string, version int, desired NestedModel) (*fastly.CacheSetting, error) {
+	name := service.StringValue(desired.Name)
+	cacheCondition := service.StringValue(desired.CacheCondition)
+	ttl := int(service.Int64Value(desired.TTL))
+	staleTTL := int(service.Int64Value(desired.StaleTTL))
+
+	return client.CreateCacheSetting(ctx, &fastly.CreateCacheSettingInput{
+		ServiceID:      serviceID,
+		ServiceVersion: version,
+		Name:           &name,
+		Action:         actionPointer(desired.Action),
+		CacheCondition: &cacheCondition,
+		TTL:            &ttl,
+		StaleTTL:       &staleTTL,
+	})
+}
+
+// actionPointer returns nil for a null/unknown/empty action, so Create omits the field
+// rather than sending an invalid empty string for an enum the Fastly API validates.
+func actionPointer(v types.String) *fastly.CacheSettingAction {
+	if v.IsNull() || v.IsUnknown() || v.ValueString() == "" {
+		return nil
+	}
+	action := fastly.CacheSettingAction(v.ValueString())
+	return &action
+}
+
+func (o ops) Equal(desired NestedModel, remote *fastly.CacheSetting) bool {
+	return desired.ModelsEqual(o.ToModel(remote))
+}
+
+func (o ops) Update(ctx context.Context, client *fastly.Client, serviceID string, version int, desired NestedModel) (*fastly.CacheSetting, error) {
+	action := fastly.CacheSettingAction(service.StringValue(desired.Action))
+	cacheCondition := service.StringValue(desired.CacheCondition)
+	ttl := int(service.Int64Value(desired.TTL))
+	staleTTL := int(service.Int64Value(desired.StaleTTL))
+
+	return client.UpdateCacheSetting(ctx, &fastly.UpdateCacheSettingInput{
+		ServiceID:      serviceID,
+		ServiceVersion: version,
+		Name:           service.StringValue(desired.Name),
+		Action:         &action,
+		CacheCondition: &cacheCondition,
+		TTL:            &ttl,
+		StaleTTL:       &staleTTL,
+	})
+}
+
+func (o ops) ToModel(api *fastly.CacheSetting) NestedModel {
+	model := NestedModel{
+		Name:     types.StringValue(fastly.ToValue(api.Name)),
+		TTL:      types.Int64Value(int64(fastly.ToValue(api.TTL))),
+		StaleTTL: types.Int64Value(int64(fastly.ToValue(api.StaleTTL))),
+	}
+	if api.Action != nil && *api.Action != "" {
+		model.Action = types.StringValue(string(*api.Action))
+	} else {
+		model.Action = types.StringNull()
+	}
+	if api.CacheCondition != nil && *api.CacheCondition != "" {
+		model.CacheCondition = types.StringValue(*api.CacheCondition)
+	} else {
+		model.CacheCondition = types.StringNull()
+	}
+	return model
+}
+
+var reconciler = &reconcile.Resource[NestedModel, fastly.CacheSetting]{
+	Ops: ops{},
+	GetName: func(m NestedModel) string {
+		return service.StringValue(m.Name)
+	},
+	Sortable: true,
+}
+
+func ReadForVersion(ctx context.Context, client *fastly.Client, serviceID string, version int) ([]NestedModel, error) {
+	return reconciler.ReadForVersion(ctx, client, serviceID, version)
+}
+
+func Reconcile(ctx context.Context, client *fastly.Client, serviceID string, version int, desired []NestedModel) error {
+	return reconciler.Run(ctx, client, serviceID, version, desired)
+}
+
+func Equal(a, b []NestedModel) bool {
+	return reconcile.ModelsEqual(a, b, func(m NestedModel) string { return service.StringValue(m.Name) }, NestedModel.ModelsEqual, true)
+}
+
+func MatchOrder(items, order []NestedModel) []NestedModel {
+	return reconcile.MatchOrder(items, order, func(m NestedModel) string { return service.StringValue(m.Name) })
+}

--- a/internal/resources/servicecdnauto/resource.go
+++ b/internal/resources/servicecdnauto/resource.go
@@ -7,6 +7,7 @@ import (
 	fastlyclient "github.com/fastly/terraform-provider-fastly/internal/client"
 	"github.com/fastly/terraform-provider-fastly/internal/errors"
 	"github.com/fastly/terraform-provider-fastly/internal/resources/backend"
+	"github.com/fastly/terraform-provider-fastly/internal/resources/cachesetting"
 	"github.com/fastly/terraform-provider-fastly/internal/resources/cdnacl"
 	"github.com/fastly/terraform-provider-fastly/internal/resources/condition"
 	"github.com/fastly/terraform-provider-fastly/internal/resources/dictionary"
@@ -67,6 +68,7 @@ type Model struct {
 	ACL                           []cdnacl.NestedModel                        `tfsdk:"acl"`
 	Condition                     []condition.NestedModel                     `tfsdk:"condition"`
 	Gzip                          []gzip.NestedModel                          `tfsdk:"gzip"`
+	CacheSetting                  []cachesetting.NestedModel                  `tfsdk:"cache_setting"`
 	Dictionary                    []dictionary.NestedModel                    `tfsdk:"dictionary"`
 	LoggingBlobStorage            []loggingblobstorage.NestedModel            `tfsdk:"logging_blobstorage"`
 	LoggingS3                     []loggings3.NestedModel                     `tfsdk:"logging_s3"`
@@ -131,6 +133,7 @@ func (r *Resource) Schema(_ context.Context, _ resource.SchemaRequest, resp *res
 			"acl":                              cdnacl.NestedBlockSchema(),
 			"condition":                        condition.NestedBlockSchema(),
 			"gzip":                             gzip.NestedBlockSchema(),
+			"cache_setting":                    cachesetting.NestedBlockSchema(),
 			"dictionary":                       dictionary.NestedBlockSchema(),
 			"logging_blobstorage":              loggingblobstorage.NestedBlockSchema(),
 			"logging_s3":                       loggings3.NestedBlockSchema(),
@@ -268,8 +271,8 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 	}
 	plan.Domain = domain.MatchOrder(domains, plan.Domain)
 
-	// Conditions must be reconciled before backend/gzip: both can reference a condition by
-	// name (request_condition, cache_condition), and the Fastly API rejects a backend/gzip
+	// Conditions must be reconciled before backend/gzip/cache_setting: all three can reference
+	// a condition by name (request_condition, cache_condition), and the Fastly API rejects a
 	// create that names a condition which doesn't exist yet in this version.
 	if err := condition.Reconcile(ctx, r.providerData.AutoClient(), serviceID, version, plan.Condition); err != nil {
 		resp.Diagnostics.AddError("Error reconciling conditions", err.Error())
@@ -318,6 +321,18 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 		return
 	}
 	plan.Gzip = gzip.MatchOrder(gzips, plan.Gzip)
+
+	if err := cachesetting.Reconcile(ctx, r.providerData.AutoClient(), serviceID, version, plan.CacheSetting); err != nil {
+		resp.Diagnostics.AddError("Error reconciling cache settings", err.Error())
+		return
+	}
+
+	cacheSettings, err := cachesetting.ReadForVersion(ctx, r.providerData.AutoClient(), serviceID, version)
+	if err != nil {
+		resp.Diagnostics.AddError("Error reading service cache settings", err.Error())
+		return
+	}
+	plan.CacheSetting = cachesetting.MatchOrder(cacheSettings, plan.CacheSetting)
 
 	if err := dictionary.ReconcileWithPrevious(ctx, r.providerData.AutoClient(), serviceID, version, nil, plan.Dictionary); err != nil {
 		resp.Diagnostics.AddError("Error reconciling dictionaries", err.Error())
@@ -532,6 +547,11 @@ func (r *Resource) Read(ctx context.Context, req resource.ReadRequest, resp *res
 		resp.Diagnostics.AddError("Error reading service gzip configurations", err.Error())
 		return
 	}
+	cacheSettings, err := cachesetting.ReadForVersion(ctx, r.providerData.AutoClient(), state.ID.ValueString(), readVersion)
+	if err != nil {
+		resp.Diagnostics.AddError("Error reading service cache settings", err.Error())
+		return
+	}
 	dictionaries, err := dictionary.ReadForVersionWithPlan(ctx, r.providerData.AutoClient(), state.ID.ValueString(), readVersion, state.Dictionary)
 	if err != nil {
 		resp.Diagnostics.AddError("Error reading service dictionaries", err.Error())
@@ -567,6 +587,7 @@ func (r *Resource) Read(ctx context.Context, req resource.ReadRequest, resp *res
 	state.ACL = cdnacl.MatchOrder(acls, state.ACL)
 	state.Condition = condition.MatchOrder(conditions, state.Condition)
 	state.Gzip = gzip.MatchOrder(gzips, state.Gzip)
+	state.CacheSetting = cachesetting.MatchOrder(cacheSettings, state.CacheSetting)
 	state.Dictionary = dictionary.MatchOrder(dictionaries, state.Dictionary)
 	state.LoggingBlobStorage = loggingblobstorage.MatchOrder(loggingBlobStorages, state.LoggingBlobStorage)
 	state.LoggingS3 = loggings3.MatchOrder(loggingS3s, state.LoggingS3)
@@ -681,6 +702,7 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 		!cdnacl.Equal(plan.ACL, state.ACL) ||
 		!condition.Equal(plan.Condition, state.Condition) ||
 		!gzip.Equal(plan.Gzip, state.Gzip) ||
+		!cachesetting.Equal(plan.CacheSetting, state.CacheSetting) ||
 		!dictionary.Equal(plan.Dictionary, state.Dictionary) ||
 		!loggingblobstorage.Equal(plan.LoggingBlobStorage, state.LoggingBlobStorage) ||
 		!loggings3.Equal(plan.LoggingS3, state.LoggingS3) ||
@@ -736,9 +758,9 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 		}
 		plan.Domain = domain.MatchOrder(domains, plan.Domain)
 
-		// Conditions must be reconciled before backend/gzip: both can reference a condition by
-		// name (request_condition, cache_condition), and the Fastly API rejects a backend/gzip
-		// create that names a condition which doesn't exist yet in this version.
+		// Conditions must be reconciled before backend/gzip/cache_setting: all three can
+		// reference a condition by name (request_condition, cache_condition), and the Fastly
+		// API rejects a create that names a condition which doesn't exist yet in this version.
 		if err := condition.Reconcile(ctx, r.providerData.AutoClient(), serviceID, targetVersion, plan.Condition); err != nil {
 			resp.Diagnostics.AddError("Error reconciling conditions", err.Error())
 			return
@@ -786,6 +808,18 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 			return
 		}
 		plan.Gzip = gzip.MatchOrder(gzips, plan.Gzip)
+
+		if err := cachesetting.Reconcile(ctx, r.providerData.AutoClient(), serviceID, targetVersion, plan.CacheSetting); err != nil {
+			resp.Diagnostics.AddError("Error reconciling cache settings", err.Error())
+			return
+		}
+
+		cacheSettings, err := cachesetting.ReadForVersion(ctx, r.providerData.AutoClient(), serviceID, targetVersion)
+		if err != nil {
+			resp.Diagnostics.AddError("Error reading service cache settings", err.Error())
+			return
+		}
+		plan.CacheSetting = cachesetting.MatchOrder(cacheSettings, plan.CacheSetting)
 
 		if err := dictionary.ReconcileWithPrevious(ctx, r.providerData.AutoClient(), serviceID, targetVersion, state.Dictionary, plan.Dictionary); err != nil {
 			resp.Diagnostics.AddError("Error reconciling dictionaries", err.Error())
@@ -932,6 +966,7 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 		plan.ACL = cdnacl.MatchOrder(state.ACL, plan.ACL)
 		plan.Condition = condition.MatchOrder(state.Condition, plan.Condition)
 		plan.Gzip = gzip.MatchOrder(state.Gzip, plan.Gzip)
+		plan.CacheSetting = cachesetting.MatchOrder(state.CacheSetting, plan.CacheSetting)
 		plan.Dictionary = dictionary.MatchOrder(state.Dictionary, plan.Dictionary)
 		plan.LoggingBlobStorage = loggingblobstorage.MatchOrder(state.LoggingBlobStorage, plan.LoggingBlobStorage)
 		plan.LoggingS3 = loggings3.MatchOrder(state.LoggingS3, plan.LoggingS3)


### PR DESCRIPTION
### Change summary

Ports Cache Setting nested configuration to fastly_service_cdn_auto (CDTOOL-1499). ttl/stale_ttl default to 0 (Computed) so removing them from config reliably clears the remote value via an explicit Update, avoiding gzip's previous-state tracking for this simpler case.

 All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/terraform-provider-fastly/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

* [x] Does your submission pass tests?
* [x] Post the output of your test runs
<img width="710" height="409" alt="Screenshot 2026-08-13 at 3 45 01 PM" src="https://github.com/user-attachments/assets/32bd47d8-2449-4fc8-b8c0-525f23782b00" />

