### PR TITLE
[Rewrite] Reset VCL only fields to default in logging `list` resources for Compute services

### DIFF
--- a/internal/resources/loggingbigquery/list.go
+++ b/internal/resources/loggingbigquery/list.go
@@ -105,7 +105,7 @@ func (l *ListResource) List(ctx context.Context, req list.ListRequest, stream *l
 				result.DisplayName = service.ToGeneratedResourceName(fastly.ToValue(svc.Name), serviceID, *bq.Name)
 
 				if req.IncludeResource {
-					result.Diagnostics.Append(setResourceAttrs(ctx, &result, bq, serviceID, version)...)
+					result.Diagnostics.Append(setResourceAttrs(ctx, &result, bq, serviceID, version, fastly.ToValue(svc.Type))...)
 				}
 
 				if !push(result) {
@@ -116,7 +116,14 @@ func (l *ListResource) List(ctx context.Context, req list.ListRequest, stream *l
 	}
 }
 
-func setResourceAttrs(ctx context.Context, result *list.ListResult, bq *fastly.BigQuery, serviceID string, version int) diag.Diagnostics {
+// setResourceAttrs sets the listed resource's attributes on result. serviceType
+// mirrors the Compute normalization applied by Create/Read/Import: the API
+// still returns its own values for the VCL-only fields on a Compute-attached
+// endpoint, but the standalone resource's schema rejects those fields being
+// configured on Compute, so they must be reset to their schema defaults here
+// too — otherwise this could emit resource data the resource itself can't
+// accept.
+func setResourceAttrs(ctx context.Context, result *list.ListResult, bq *fastly.BigQuery, serviceID string, version int, serviceType string) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	id := serviceID + "-" + fmt.Sprintf("%d", version) + "-" + fastly.ToValue(bq.Name)
@@ -126,6 +133,9 @@ func setResourceAttrs(ctx context.Context, result *list.ListResult, bq *fastly.B
 		ID:          types.StringValue(id),
 		Service:     types.StringValue(serviceID),
 		Version:     types.Int64Value(int64(version)),
+	}
+	if serviceType == service.TypeCompute {
+		ResetVCLOnlyToDefaults(&model.NestedModel)
 	}
 	diags.Append(result.Resource.Set(ctx, &model)...)
 	return diags

--- a/internal/resources/loggingbigquery/list_test.go
+++ b/internal/resources/loggingbigquery/list_test.go
@@ -1,0 +1,96 @@
+package loggingbigquery
+
+import (
+	"context"
+	"testing"
+
+	fastly "github.com/fastly/go-fastly/v17/fastly"
+	"github.com/hashicorp/terraform-plugin-framework/list"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/stretchr/testify/require"
+
+	"github.com/fastly/terraform-provider-fastly/internal/constants"
+	"github.com/fastly/terraform-provider-fastly/internal/service"
+)
+
+// TestSetResourceAttrs_computeResetsVCLOnlyFields covers the same Compute
+// normalization gap as TestResetVCLOnlyToDefaults (see loggingbigquery_test.go),
+// but for the list resource: the API still returns its own values for the
+// VCL-only fields on a Compute-attached endpoint, and those must be reset to
+// schema defaults here exactly as they are in Read/Import, or the list
+// resource emits data the standalone resource's own schema rejects.
+func TestSetResourceAttrs_computeResetsVCLOnlyFields(t *testing.T) {
+	ctx := context.Background()
+
+	bq := &fastly.BigQuery{
+		ServiceID:         new("service-id"),
+		ServiceVersion:    new(1),
+		Name:              new("logger"),
+		ProjectID:         new("project-id"),
+		Dataset:           new("dataset"),
+		Table:             new("table"),
+		Format:            new("api-assigned-compute-format"),
+		FormatVersion:     new(2),
+		Placement:         new("none"),
+		ResponseCondition: new("some-condition"),
+	}
+
+	tests := []struct {
+		name              string
+		serviceType       string
+		wantFormat        types.String
+		wantFormatVersion types.Int64
+		wantPlacement     types.String
+		wantRespCondition types.String
+	}{
+		{
+			name:              "vcl service keeps the API's values",
+			serviceType:       service.TypeVCL,
+			wantFormat:        types.StringValue("api-assigned-compute-format"),
+			wantFormatVersion: types.Int64Value(2),
+			wantPlacement:     types.StringValue("none"),
+			wantRespCondition: types.StringValue("some-condition"),
+		},
+		{
+			name:              "compute service resets VCL-only fields to schema defaults",
+			serviceType:       service.TypeCompute,
+			wantFormat:        types.StringValue(constants.LoggingBigQueryDefaultFormat),
+			wantFormatVersion: types.Int64Value(DefaultFormatVersion),
+			wantPlacement:     types.StringNull(),
+			wantRespCondition: types.StringValue(DefaultResponseCondition),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := buildTestListResult(ctx)
+
+			diags := setResourceAttrs(ctx, &result, bq, "service-id", 1, tt.serviceType)
+			require.False(t, diags.HasError(), diags)
+
+			var got Model
+			require.False(t, result.Resource.Get(ctx, &got).HasError())
+
+			require.Equal(t, tt.wantFormat, got.Format)
+			require.Equal(t, tt.wantFormatVersion, got.FormatVersion)
+			require.Equal(t, tt.wantPlacement, got.Placement)
+			require.Equal(t, tt.wantRespCondition, got.ResponseCondition)
+		})
+	}
+}
+
+// buildTestListResult builds a list.ListResult backed by the standalone
+// resource's own schema, mirroring how List() constructs one via
+// listidentity.NewResult but without requiring a full list.ListRequest.
+func buildTestListResult(ctx context.Context) list.ListResult {
+	s := schema.Schema{Attributes: ResourceAttributes()}
+	return list.ListResult{
+		Resource: &tfsdk.Resource{
+			Raw:    tftypes.NewValue(s.Type().TerraformType(ctx), nil),
+			Schema: s,
+		},
+	}
+}

--- a/internal/resources/loggingblobstorage/list.go
+++ b/internal/resources/loggingblobstorage/list.go
@@ -105,7 +105,7 @@ func (l *ListResource) List(ctx context.Context, req list.ListRequest, stream *l
 				result.DisplayName = service.ToGeneratedResourceName(fastly.ToValue(svc.Name), serviceID, *s.Name)
 
 				if req.IncludeResource {
-					result.Diagnostics.Append(setResourceAttrs(ctx, &result, s, serviceID, version)...)
+					result.Diagnostics.Append(setResourceAttrs(ctx, &result, s, serviceID, version, fastly.ToValue(svc.Type))...)
 				}
 
 				if !push(result) {
@@ -116,7 +116,14 @@ func (l *ListResource) List(ctx context.Context, req list.ListRequest, stream *l
 	}
 }
 
-func setResourceAttrs(ctx context.Context, result *list.ListResult, s *fastly.BlobStorage, serviceID string, version int) diag.Diagnostics {
+// setResourceAttrs sets the listed resource's attributes on result. serviceType
+// mirrors the Compute normalization applied by Create/Read/Import: the API
+// still returns its own values for the VCL-only fields on a Compute-attached
+// endpoint, but the standalone resource's schema rejects those fields being
+// configured on Compute, so they must be reset to their schema defaults here
+// too — otherwise this could emit resource data the resource itself can't
+// accept.
+func setResourceAttrs(ctx context.Context, result *list.ListResult, s *fastly.BlobStorage, serviceID string, version int, serviceType string) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	id := serviceID + "-" + fmt.Sprintf("%d", version) + "-" + fastly.ToValue(s.Name)
@@ -126,6 +133,9 @@ func setResourceAttrs(ctx context.Context, result *list.ListResult, s *fastly.Bl
 		ID:          types.StringValue(id),
 		Service:     types.StringValue(serviceID),
 		Version:     types.Int64Value(int64(version)),
+	}
+	if serviceType == service.TypeCompute {
+		ResetVCLOnlyToDefaults(&model.NestedModel)
 	}
 	diags.Append(result.Resource.Set(ctx, &model)...)
 	return diags

--- a/internal/resources/loggingblobstorage/list_test.go
+++ b/internal/resources/loggingblobstorage/list_test.go
@@ -1,0 +1,95 @@
+package loggingblobstorage
+
+import (
+	"context"
+	"testing"
+
+	fastly "github.com/fastly/go-fastly/v17/fastly"
+	"github.com/hashicorp/terraform-plugin-framework/list"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/stretchr/testify/require"
+
+	"github.com/fastly/terraform-provider-fastly/internal/constants"
+	"github.com/fastly/terraform-provider-fastly/internal/service"
+)
+
+// TestSetResourceAttrs_computeResetsVCLOnlyFields covers the same Compute
+// normalization gap as TestResetVCLOnlyToDefaults (see
+// loggingblobstorage_test.go), but for the list resource: the API still
+// returns its own values for the VCL-only fields on a Compute-attached
+// endpoint, and those must be reset to schema defaults here exactly as they
+// are in Read/Import, or the list resource emits data the standalone
+// resource's own schema rejects.
+func TestSetResourceAttrs_computeResetsVCLOnlyFields(t *testing.T) {
+	ctx := context.Background()
+
+	s := &fastly.BlobStorage{
+		ServiceID:         new("service-id"),
+		ServiceVersion:    new(1),
+		Name:              new("logger"),
+		Container:         new("container"),
+		Format:            new("api-assigned-compute-format"),
+		FormatVersion:     new(2),
+		Placement:         new("none"),
+		ResponseCondition: new("some-condition"),
+	}
+
+	tests := []struct {
+		name              string
+		serviceType       string
+		wantFormat        types.String
+		wantFormatVersion types.Int64
+		wantPlacement     types.String
+		wantRespCondition types.String
+	}{
+		{
+			name:              "vcl service keeps the API's values",
+			serviceType:       service.TypeVCL,
+			wantFormat:        types.StringValue("api-assigned-compute-format"),
+			wantFormatVersion: types.Int64Value(2),
+			wantPlacement:     types.StringValue("none"),
+			wantRespCondition: types.StringValue("some-condition"),
+		},
+		{
+			name:              "compute service resets VCL-only fields to schema defaults",
+			serviceType:       service.TypeCompute,
+			wantFormat:        types.StringValue(constants.LoggingBlobStorageDefaultFormat),
+			wantFormatVersion: types.Int64Value(DefaultFormatVersion),
+			wantPlacement:     types.StringNull(),
+			wantRespCondition: types.StringValue(DefaultResponseCondition),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := buildTestListResult(ctx)
+
+			diags := setResourceAttrs(ctx, &result, s, "service-id", 1, tt.serviceType)
+			require.False(t, diags.HasError(), diags)
+
+			var got Model
+			require.False(t, result.Resource.Get(ctx, &got).HasError())
+
+			require.Equal(t, tt.wantFormat, got.Format)
+			require.Equal(t, tt.wantFormatVersion, got.FormatVersion)
+			require.Equal(t, tt.wantPlacement, got.Placement)
+			require.Equal(t, tt.wantRespCondition, got.ResponseCondition)
+		})
+	}
+}
+
+// buildTestListResult builds a list.ListResult backed by the standalone
+// resource's own schema, mirroring how List() constructs one via
+// listidentity.NewResult but without requiring a full list.ListRequest.
+func buildTestListResult(ctx context.Context) list.ListResult {
+	s := schema.Schema{Attributes: ResourceAttributes()}
+	return list.ListResult{
+		Resource: &tfsdk.Resource{
+			Raw:    tftypes.NewValue(s.Type().TerraformType(ctx), nil),
+			Schema: s,
+		},
+	}
+}

--- a/internal/resources/loggingdatadog/list.go
+++ b/internal/resources/loggingdatadog/list.go
@@ -105,7 +105,7 @@ func (l *ListResource) List(ctx context.Context, req list.ListRequest, stream *l
 				result.DisplayName = service.ToGeneratedResourceName(fastly.ToValue(svc.Name), serviceID, *d.Name)
 
 				if req.IncludeResource {
-					result.Diagnostics.Append(setResourceAttrs(ctx, &result, d, serviceID, version)...)
+					result.Diagnostics.Append(setResourceAttrs(ctx, &result, d, serviceID, version, fastly.ToValue(svc.Type))...)
 				}
 
 				if !push(result) {
@@ -116,7 +116,14 @@ func (l *ListResource) List(ctx context.Context, req list.ListRequest, stream *l
 	}
 }
 
-func setResourceAttrs(ctx context.Context, result *list.ListResult, d *fastly.Datadog, serviceID string, version int) diag.Diagnostics {
+// setResourceAttrs sets the listed resource's attributes on result. serviceType
+// mirrors the Compute normalization applied by Create/Read/Import: the API
+// still returns its own values for the VCL-only fields on a Compute-attached
+// endpoint, but the standalone resource's schema rejects those fields being
+// configured on Compute, so they must be reset to their schema defaults here
+// too — otherwise this could emit resource data the resource itself can't
+// accept.
+func setResourceAttrs(ctx context.Context, result *list.ListResult, d *fastly.Datadog, serviceID string, version int, serviceType string) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	id := serviceID + "-" + fmt.Sprintf("%d", version) + "-" + fastly.ToValue(d.Name)
@@ -126,6 +133,9 @@ func setResourceAttrs(ctx context.Context, result *list.ListResult, d *fastly.Da
 		ID:          types.StringValue(id),
 		Service:     types.StringValue(serviceID),
 		Version:     types.Int64Value(int64(version)),
+	}
+	if serviceType == service.TypeCompute {
+		ResetVCLOnlyToDefaults(&model.NestedModel)
 	}
 	diags.Append(result.Resource.Set(ctx, &model)...)
 	return diags

--- a/internal/resources/loggingdatadog/list_test.go
+++ b/internal/resources/loggingdatadog/list_test.go
@@ -1,0 +1,95 @@
+package loggingdatadog
+
+import (
+	"context"
+	"testing"
+
+	fastly "github.com/fastly/go-fastly/v17/fastly"
+	"github.com/hashicorp/terraform-plugin-framework/list"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/stretchr/testify/require"
+
+	"github.com/fastly/terraform-provider-fastly/internal/constants"
+	"github.com/fastly/terraform-provider-fastly/internal/service"
+)
+
+// TestSetResourceAttrs_computeResetsVCLOnlyFields covers the same Compute
+// normalization gap as TestResetVCLOnlyToDefaults (see loggingdatadog_test.go),
+// but for the list resource: the API still returns its own values for the
+// VCL-only fields on a Compute-attached endpoint, and those must be reset to
+// schema defaults here exactly as they are in Read/Import, or the list
+// resource emits data the standalone resource's own schema rejects.
+func TestSetResourceAttrs_computeResetsVCLOnlyFields(t *testing.T) {
+	ctx := context.Background()
+
+	d := &fastly.Datadog{
+		ServiceID:         new("service-id"),
+		ServiceVersion:    new(1),
+		Name:              new("logger"),
+		Token:             new("token"),
+		Region:            new("US"),
+		Format:            new("api-assigned-compute-format"),
+		FormatVersion:     new(2),
+		Placement:         new("none"),
+		ResponseCondition: new("some-condition"),
+	}
+
+	tests := []struct {
+		name              string
+		serviceType       string
+		wantFormat        types.String
+		wantFormatVersion types.Int64
+		wantPlacement     types.String
+		wantRespCondition types.String
+	}{
+		{
+			name:              "vcl service keeps the API's values",
+			serviceType:       service.TypeVCL,
+			wantFormat:        types.StringValue("api-assigned-compute-format"),
+			wantFormatVersion: types.Int64Value(2),
+			wantPlacement:     types.StringValue("none"),
+			wantRespCondition: types.StringValue("some-condition"),
+		},
+		{
+			name:              "compute service resets VCL-only fields to schema defaults",
+			serviceType:       service.TypeCompute,
+			wantFormat:        types.StringValue(constants.LoggingDatadogDefaultFormat),
+			wantFormatVersion: types.Int64Value(DefaultFormatVersion),
+			wantPlacement:     types.StringNull(),
+			wantRespCondition: types.StringValue(DefaultResponseCondition),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := buildTestListResult(ctx)
+
+			diags := setResourceAttrs(ctx, &result, d, "service-id", 1, tt.serviceType)
+			require.False(t, diags.HasError(), diags)
+
+			var got Model
+			require.False(t, result.Resource.Get(ctx, &got).HasError())
+
+			require.Equal(t, tt.wantFormat, got.Format)
+			require.Equal(t, tt.wantFormatVersion, got.FormatVersion)
+			require.Equal(t, tt.wantPlacement, got.Placement)
+			require.Equal(t, tt.wantRespCondition, got.ResponseCondition)
+		})
+	}
+}
+
+// buildTestListResult builds a list.ListResult backed by the standalone
+// resource's own schema, mirroring how List() constructs one via
+// listidentity.NewResult but without requiring a full list.ListRequest.
+func buildTestListResult(ctx context.Context) list.ListResult {
+	s := schema.Schema{Attributes: ResourceAttributes()}
+	return list.ListResult{
+		Resource: &tfsdk.Resource{
+			Raw:    tftypes.NewValue(s.Type().TerraformType(ctx), nil),
+			Schema: s,
+		},
+	}
+}

--- a/internal/resources/loggingnewrelicotlp/list.go
+++ b/internal/resources/loggingnewrelicotlp/list.go
@@ -105,7 +105,7 @@ func (l *ListResource) List(ctx context.Context, req list.ListRequest, stream *l
 				result.DisplayName = service.ToGeneratedResourceName(fastly.ToValue(svc.Name), serviceID, *n.Name)
 
 				if req.IncludeResource {
-					result.Diagnostics.Append(setResourceAttrs(ctx, &result, n, serviceID, version)...)
+					result.Diagnostics.Append(setResourceAttrs(ctx, &result, n, serviceID, version, fastly.ToValue(svc.Type))...)
 				}
 
 				if !push(result) {
@@ -116,7 +116,14 @@ func (l *ListResource) List(ctx context.Context, req list.ListRequest, stream *l
 	}
 }
 
-func setResourceAttrs(ctx context.Context, result *list.ListResult, n *fastly.NewRelicOTLP, serviceID string, version int) diag.Diagnostics {
+// setResourceAttrs sets the listed resource's attributes on result. serviceType
+// mirrors the Compute normalization applied by Create/Read/Import: the API
+// still returns its own values for the VCL-only fields on a Compute-attached
+// endpoint, but the standalone resource's schema rejects those fields being
+// configured on Compute, so they must be reset to their schema defaults here
+// too — otherwise this could emit resource data the resource itself can't
+// accept.
+func setResourceAttrs(ctx context.Context, result *list.ListResult, n *fastly.NewRelicOTLP, serviceID string, version int, serviceType string) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	id := serviceID + "-" + fmt.Sprintf("%d", version) + "-" + fastly.ToValue(n.Name)
@@ -126,6 +133,9 @@ func setResourceAttrs(ctx context.Context, result *list.ListResult, n *fastly.Ne
 		ID:          types.StringValue(id),
 		Service:     types.StringValue(serviceID),
 		Version:     types.Int64Value(int64(version)),
+	}
+	if serviceType == service.TypeCompute {
+		ResetVCLOnlyToDefaults(&model.NestedModel)
 	}
 	diags.Append(result.Resource.Set(ctx, &model)...)
 	return diags

--- a/internal/resources/loggingnewrelicotlp/list_test.go
+++ b/internal/resources/loggingnewrelicotlp/list_test.go
@@ -1,0 +1,97 @@
+package loggingnewrelicotlp
+
+import (
+	"context"
+	"testing"
+
+	fastly "github.com/fastly/go-fastly/v17/fastly"
+	"github.com/hashicorp/terraform-plugin-framework/list"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/stretchr/testify/require"
+
+	"github.com/fastly/terraform-provider-fastly/internal/constants"
+	"github.com/fastly/terraform-provider-fastly/internal/service"
+)
+
+// TestSetResourceAttrs_computeResetsVCLOnlyFields covers the same Compute
+// normalization gap as TestResetVCLOnlyToDefaults (see
+// loggingnewrelicotlp_test.go), but for the list resource: the API still
+// returns its own values for the VCL-only fields on a Compute-attached
+// endpoint, and those must be reset to schema defaults here exactly as they
+// are in Read/Import, or the list resource emits data the standalone
+// resource's own schema rejects.
+func TestSetResourceAttrs_computeResetsVCLOnlyFields(t *testing.T) {
+	ctx := context.Background()
+
+	n := &fastly.NewRelicOTLP{
+		ServiceID:         new("service-id"),
+		ServiceVersion:    new(1),
+		Name:              new("logger"),
+		Token:             new("token"),
+		Region:            new("US"),
+		URL:               new("https://otlp.nr-data.net"),
+		Format:            new("api-assigned-compute-format"),
+		FormatVersion:     new(2),
+		Placement:         new("none"),
+		ResponseCondition: new("some-condition"),
+	}
+
+	tests := []struct {
+		name              string
+		serviceType       string
+		wantFormat        types.String
+		wantFormatVersion types.Int64
+		wantPlacement     types.String
+		wantRespCondition types.String
+	}{
+		{
+			name:              "vcl service keeps the API's values",
+			serviceType:       service.TypeVCL,
+			wantFormat:        types.StringValue("api-assigned-compute-format"),
+			wantFormatVersion: types.Int64Value(2),
+			wantPlacement:     types.StringValue("none"),
+			wantRespCondition: types.StringValue("some-condition"),
+		},
+		{
+			name:              "compute service resets VCL-only fields to schema defaults",
+			serviceType:       service.TypeCompute,
+			wantFormat:        types.StringValue(constants.LoggingNewRelicOTLPDefaultFormat),
+			wantFormatVersion: types.Int64Value(DefaultFormatVersion),
+			wantPlacement:     types.StringNull(),
+			wantRespCondition: types.StringValue(DefaultResponseCondition),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := buildTestListResult(ctx)
+
+			diags := setResourceAttrs(ctx, &result, n, "service-id", 1, tt.serviceType)
+			require.False(t, diags.HasError(), diags)
+
+			var got Model
+			require.False(t, result.Resource.Get(ctx, &got).HasError())
+
+			require.Equal(t, tt.wantFormat, got.Format)
+			require.Equal(t, tt.wantFormatVersion, got.FormatVersion)
+			require.Equal(t, tt.wantPlacement, got.Placement)
+			require.Equal(t, tt.wantRespCondition, got.ResponseCondition)
+		})
+	}
+}
+
+// buildTestListResult builds a list.ListResult backed by the standalone
+// resource's own schema, mirroring how List() constructs one via
+// listidentity.NewResult but without requiring a full list.ListRequest.
+func buildTestListResult(ctx context.Context) list.ListResult {
+	s := schema.Schema{Attributes: ResourceAttributes()}
+	return list.ListResult{
+		Resource: &tfsdk.Resource{
+			Raw:    tftypes.NewValue(s.Type().TerraformType(ctx), nil),
+			Schema: s,
+		},
+	}
+}

--- a/internal/resources/loggings3/list.go
+++ b/internal/resources/loggings3/list.go
@@ -105,7 +105,7 @@ func (l *ListResource) List(ctx context.Context, req list.ListRequest, stream *l
 				result.DisplayName = service.ToGeneratedResourceName(fastly.ToValue(svc.Name), serviceID, *s.Name)
 
 				if req.IncludeResource {
-					result.Diagnostics.Append(setResourceAttrs(ctx, &result, s, serviceID, version)...)
+					result.Diagnostics.Append(setResourceAttrs(ctx, &result, s, serviceID, version, fastly.ToValue(svc.Type))...)
 				}
 
 				if !push(result) {
@@ -116,7 +116,14 @@ func (l *ListResource) List(ctx context.Context, req list.ListRequest, stream *l
 	}
 }
 
-func setResourceAttrs(ctx context.Context, result *list.ListResult, s *fastly.S3, serviceID string, version int) diag.Diagnostics {
+// setResourceAttrs sets the listed resource's attributes on result. serviceType
+// mirrors the Compute normalization applied by Create/Read/Import: the API
+// still returns its own values for the VCL-only fields on a Compute-attached
+// endpoint, but the standalone resource's schema rejects those fields being
+// configured on Compute, so they must be reset to their schema defaults here
+// too — otherwise this could emit resource data the resource itself can't
+// accept.
+func setResourceAttrs(ctx context.Context, result *list.ListResult, s *fastly.S3, serviceID string, version int, serviceType string) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	id := serviceID + "-" + fmt.Sprintf("%d", version) + "-" + fastly.ToValue(s.Name)
@@ -126,6 +133,9 @@ func setResourceAttrs(ctx context.Context, result *list.ListResult, s *fastly.S3
 		ID:          types.StringValue(id),
 		Service:     types.StringValue(serviceID),
 		Version:     types.Int64Value(int64(version)),
+	}
+	if serviceType == service.TypeCompute {
+		ResetVCLOnlyToDefaults(&model.NestedModel)
 	}
 	diags.Append(result.Resource.Set(ctx, &model)...)
 	return diags

--- a/internal/resources/loggings3/list_test.go
+++ b/internal/resources/loggings3/list_test.go
@@ -1,0 +1,94 @@
+package loggings3
+
+import (
+	"context"
+	"testing"
+
+	fastly "github.com/fastly/go-fastly/v17/fastly"
+	"github.com/hashicorp/terraform-plugin-framework/list"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/stretchr/testify/require"
+
+	"github.com/fastly/terraform-provider-fastly/internal/constants"
+	"github.com/fastly/terraform-provider-fastly/internal/service"
+)
+
+// TestSetResourceAttrs_computeResetsVCLOnlyFields covers the same Compute
+// normalization gap as TestResetVCLOnlyToDefaults (see loggings3_test.go),
+// but for the list resource: the API still returns its own values for the
+// VCL-only fields on a Compute-attached endpoint, and those must be reset to
+// schema defaults here exactly as they are in Read/Import, or the list
+// resource emits data the standalone resource's own schema rejects.
+func TestSetResourceAttrs_computeResetsVCLOnlyFields(t *testing.T) {
+	ctx := context.Background()
+
+	s := &fastly.S3{
+		ServiceID:         new("service-id"),
+		ServiceVersion:    new(1),
+		Name:              new("logger"),
+		BucketName:        new("bucket"),
+		Format:            new("api-assigned-compute-format"),
+		FormatVersion:     new(2),
+		Placement:         new("none"),
+		ResponseCondition: new("some-condition"),
+	}
+
+	tests := []struct {
+		name              string
+		serviceType       string
+		wantFormat        types.String
+		wantFormatVersion types.Int64
+		wantPlacement     types.String
+		wantRespCondition types.String
+	}{
+		{
+			name:              "vcl service keeps the API's values",
+			serviceType:       service.TypeVCL,
+			wantFormat:        types.StringValue("api-assigned-compute-format"),
+			wantFormatVersion: types.Int64Value(2),
+			wantPlacement:     types.StringValue("none"),
+			wantRespCondition: types.StringValue("some-condition"),
+		},
+		{
+			name:              "compute service resets VCL-only fields to schema defaults",
+			serviceType:       service.TypeCompute,
+			wantFormat:        types.StringValue(constants.LoggingS3DefaultFormat),
+			wantFormatVersion: types.Int64Value(DefaultFormatVersion),
+			wantPlacement:     types.StringNull(),
+			wantRespCondition: types.StringValue(DefaultResponseCondition),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := buildTestListResult(ctx)
+
+			diags := setResourceAttrs(ctx, &result, s, "service-id", 1, tt.serviceType)
+			require.False(t, diags.HasError(), diags)
+
+			var got Model
+			require.False(t, result.Resource.Get(ctx, &got).HasError())
+
+			require.Equal(t, tt.wantFormat, got.Format)
+			require.Equal(t, tt.wantFormatVersion, got.FormatVersion)
+			require.Equal(t, tt.wantPlacement, got.Placement)
+			require.Equal(t, tt.wantRespCondition, got.ResponseCondition)
+		})
+	}
+}
+
+// buildTestListResult builds a list.ListResult backed by the standalone
+// resource's own schema, mirroring how List() constructs one via
+// listidentity.NewResult but without requiring a full list.ListRequest.
+func buildTestListResult(ctx context.Context) list.ListResult {
+	s := schema.Schema{Attributes: ResourceAttributes()}
+	return list.ListResult{
+		Resource: &tfsdk.Resource{
+			Raw:    tftypes.NewValue(s.Type().TerraformType(ctx), nil),
+			Schema: s,
+		},
+	}
+}


### PR DESCRIPTION
### Change summary

This PR is a follow up from https://github.com/fastly/terraform-provider-fastly/pull/1404#discussion_r3777543101. 

`BigQuery`, `Blob Storage`, `Datadog`, `New Relic OTLP`, and `S3` logging `list` resources could emit values for Compute-attached endpoints that the standalone resource's schema rejects. We are normalizing them the same way `Create` / `Read` / `Import` already do. 

 All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/terraform-provider-fastly/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

* [x] Does your submission pass tests?
* [x] Post the output of your test runs

```
=== RUN   TestSetResourceAttrs_computeResetsVCLOnlyFields
=== RUN   TestSetResourceAttrs_computeResetsVCLOnlyFields/vcl_service_keeps_the_API's_values
=== RUN   TestSetResourceAttrs_computeResetsVCLOnlyFields/compute_service_resets_VCL-only_fields_to_schema_defaults
--- PASS: TestSetResourceAttrs_computeResetsVCLOnlyFields (0.00s)
    --- PASS: TestSetResourceAttrs_computeResetsVCLOnlyFields/vcl_service_keeps_the_API's_values (0.00s)
    --- PASS: TestSetResourceAttrs_computeResetsVCLOnlyFields/compute_service_resets_VCL-only_fields_to_schema_defaults (0.00s)
PASS
ok      github.com/fastly/terraform-provider-fastly/internal/resources/loggingbigquery  (cached)
=== RUN   TestSetResourceAttrs_computeResetsVCLOnlyFields
=== RUN   TestSetResourceAttrs_computeResetsVCLOnlyFields/vcl_service_keeps_the_API's_values
=== RUN   TestSetResourceAttrs_computeResetsVCLOnlyFields/compute_service_resets_VCL-only_fields_to_schema_defaults
--- PASS: TestSetResourceAttrs_computeResetsVCLOnlyFields (0.00s)
    --- PASS: TestSetResourceAttrs_computeResetsVCLOnlyFields/vcl_service_keeps_the_API's_values (0.00s)
    --- PASS: TestSetResourceAttrs_computeResetsVCLOnlyFields/compute_service_resets_VCL-only_fields_to_schema_defaults (0.00s)
PASS
ok      github.com/fastly/terraform-provider-fastly/internal/resources/loggingblobstorage       (cached)
=== RUN   TestSetResourceAttrs_computeResetsVCLOnlyFields
=== RUN   TestSetResourceAttrs_computeResetsVCLOnlyFields/vcl_service_keeps_the_API's_values
=== RUN   TestSetResourceAttrs_computeResetsVCLOnlyFields/compute_service_resets_VCL-only_fields_to_schema_defaults
--- PASS: TestSetResourceAttrs_computeResetsVCLOnlyFields (0.00s)
    --- PASS: TestSetResourceAttrs_computeResetsVCLOnlyFields/vcl_service_keeps_the_API's_values (0.00s)
    --- PASS: TestSetResourceAttrs_computeResetsVCLOnlyFields/compute_service_resets_VCL-only_fields_to_schema_defaults (0.00s)
PASS
ok      github.com/fastly/terraform-provider-fastly/internal/resources/loggingdatadog   (cached)
=== RUN   TestSetResourceAttrs_computeResetsVCLOnlyFields
=== RUN   TestSetResourceAttrs_computeResetsVCLOnlyFields/vcl_service_keeps_the_API's_values
=== RUN   TestSetResourceAttrs_computeResetsVCLOnlyFields/compute_service_resets_VCL-only_fields_to_schema_defaults
--- PASS: TestSetResourceAttrs_computeResetsVCLOnlyFields (0.00s)
    --- PASS: TestSetResourceAttrs_computeResetsVCLOnlyFields/vcl_service_keeps_the_API's_values (0.00s)
    --- PASS: TestSetResourceAttrs_computeResetsVCLOnlyFields/compute_service_resets_VCL-only_fields_to_schema_defaults (0.00s)
PASS
ok      github.com/fastly/terraform-provider-fastly/internal/resources/loggingnewrelic  (cached)
=== RUN   TestSetResourceAttrs_computeResetsVCLOnlyFields
=== RUN   TestSetResourceAttrs_computeResetsVCLOnlyFields/vcl_service_keeps_the_API's_values
=== RUN   TestSetResourceAttrs_computeResetsVCLOnlyFields/compute_service_resets_VCL-only_fields_to_schema_defaults
--- PASS: TestSetResourceAttrs_computeResetsVCLOnlyFields (0.00s)
    --- PASS: TestSetResourceAttrs_computeResetsVCLOnlyFields/vcl_service_keeps_the_API's_values (0.00s)
    --- PASS: TestSetResourceAttrs_computeResetsVCLOnlyFields/compute_service_resets_VCL-only_fields_to_schema_defaults (0.00s)
PASS
ok      github.com/fastly/terraform-provider-fastly/internal/resources/loggingnewrelicotlp      (cached)
=== RUN   TestSetResourceAttrs_computeResetsVCLOnlyFields
=== RUN   TestSetResourceAttrs_computeResetsVCLOnlyFields/vcl_service_keeps_the_API's_values
=== RUN   TestSetResourceAttrs_computeResetsVCLOnlyFields/compute_service_resets_VCL-only_fields_to_schema_defaults
--- PASS: TestSetResourceAttrs_computeResetsVCLOnlyFields (0.00s)
    --- PASS: TestSetResourceAttrs_computeResetsVCLOnlyFields/vcl_service_keeps_the_API's_values (0.00s)
    --- PASS: TestSetResourceAttrs_computeResetsVCLOnlyFields/compute_service_resets_VCL-only_fields_to_schema_defaults (0.00s)
PASS
ok      github.com/fastly/terraform-provider-fastly/internal/resources/loggings3        (cached)
=== RUN   TestSetResourceAttrs_computeResetsVCLOnlyFields
=== RUN   TestSetResourceAttrs_computeResetsVCLOnlyFields/vcl_service_keeps_the_API's_values
=== RUN   TestSetResourceAttrs_computeResetsVCLOnlyFields/compute_service_resets_VCL-only_fields_to_schema_defaults
--- PASS: TestSetResourceAttrs_computeResetsVCLOnlyFields (0.00s)
    --- PASS: TestSetResourceAttrs_computeResetsVCLOnlyFields/vcl_service_keeps_the_API's_values (0.00s)
    --- PASS: TestSetResourceAttrs_computeResetsVCLOnlyFields/compute_service_resets_VCL-only_fields_to_schema_defaults (0.00s)
PASS
ok   
```

### Changes to Core Features:

* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
