### PR TITLE
[Rewrite] Optimize VCL/Compute logging input builders

### DIFF
--- a/internal/resources/loggingbigquery/expand.go
+++ b/internal/resources/loggingbigquery/expand.go
@@ -9,7 +9,10 @@ import (
 	"github.com/fastly/terraform-provider-fastly/internal/service"
 )
 
-func BuildCreateInput(serviceID string, version int, m NestedModel) *fastly.CreateBigQueryInput {
+// buildCommonCreateInput sets the Create fields shared by VCL and Compute
+// services. BuildCreateInput and BuildComputeCreateInput layer their
+// service-type-specific fields on top of this.
+func buildCommonCreateInput(serviceID string, version int, m commonModel) *fastly.CreateBigQueryInput {
 	input := &fastly.CreateBigQueryInput{
 		ServiceID:      serviceID,
 		ServiceVersion: version,
@@ -24,11 +27,16 @@ func BuildCreateInput(serviceID string, version int, m NestedModel) *fastly.Crea
 	input.SecretKey = fastly.NullString(service.StringValue(m.SecretKey()))
 	input.Template = fastly.NullString(service.StringValue(m.Template))
 	input.ProcessingRegion = fastly.NullString(service.StringValue(m.ProcessingRegion))
+
+	return input
+}
+
+func BuildCreateInput(serviceID string, version int, m NestedModel) *fastly.CreateBigQueryInput {
+	input := buildCommonCreateInput(serviceID, version, m.commonModel)
 	input.Format = fastly.NullString(service.StringValue(m.Format))
 	input.FormatVersion = fastly.NullInt(int(service.Int64Value(m.FormatVersion)))
 	input.Placement = fastly.NullString(service.StringValue(m.Placement))
 	input.ResponseCondition = fastly.NullString(service.StringValue(m.ResponseCondition))
-
 	return input
 }
 
@@ -36,25 +44,13 @@ func BuildCreateInput(serviceID string, version int, m NestedModel) *fastly.Crea
 // sets format, format_version, placement, or response_condition, since those
 // only affect generated VCL and Compute services don't have any.
 func BuildComputeCreateInput(serviceID string, version int, m ComputeNestedModel) *fastly.CreateBigQueryInput {
-	input := &fastly.CreateBigQueryInput{
-		ServiceID:      serviceID,
-		ServiceVersion: version,
-		Name:           new(service.StringValue(m.Name)),
-		ProjectID:      new(service.StringValue(m.ProjectID)),
-		Dataset:        new(service.StringValue(m.Dataset)),
-		Table:          new(service.StringValue(m.Table)),
-	}
-
-	input.AccountName = fastly.NullString(service.StringValue(m.AccountName()))
-	input.User = fastly.NullString(service.StringValue(m.Email()))
-	input.SecretKey = fastly.NullString(service.StringValue(m.SecretKey()))
-	input.Template = fastly.NullString(service.StringValue(m.Template))
-	input.ProcessingRegion = fastly.NullString(service.StringValue(m.ProcessingRegion))
-
-	return input
+	return buildCommonCreateInput(serviceID, version, m.commonModel)
 }
 
-func BuildUpdateInput(serviceID string, version int, m NestedModel) *fastly.UpdateBigQueryInput {
+// buildCommonUpdateInput sets the Update fields shared by VCL and Compute
+// services. BuildUpdateInput and BuildComputeUpdateInput layer their
+// service-type-specific fields on top of this.
+func buildCommonUpdateInput(serviceID string, version int, m commonModel) *fastly.UpdateBigQueryInput {
 	input := &fastly.UpdateBigQueryInput{
 		ServiceID:      serviceID,
 		ServiceVersion: version,
@@ -73,6 +69,19 @@ func BuildUpdateInput(serviceID string, version int, m NestedModel) *fastly.Upda
 	input.SecretKey = new(service.StringValue(m.SecretKey()))
 	input.Template = new(service.StringValue(m.Template))
 	input.ProcessingRegion = fastly.NullString(service.StringValue(m.ProcessingRegion))
+
+	return input
+}
+
+// BuildComputeUpdateInput is BuildUpdateInput for Compute services: it never
+// sets format, format_version, placement, or response_condition, since those
+// only affect generated VCL and Compute services don't have any.
+func BuildComputeUpdateInput(serviceID string, version int, m ComputeNestedModel) *fastly.UpdateBigQueryInput {
+	return buildCommonUpdateInput(serviceID, version, m.commonModel)
+}
+
+func BuildUpdateInput(serviceID string, version int, m NestedModel) *fastly.UpdateBigQueryInput {
+	input := buildCommonUpdateInput(serviceID, version, m.commonModel)
 	input.Format = fastly.NullString(service.StringValue(m.Format))
 	input.FormatVersion = fastly.NullInt(int(service.Int64Value(m.FormatVersion)))
 	// placement can be cleared back to unset / nil (distinct from "none" — see
@@ -87,32 +96,6 @@ func BuildUpdateInput(serviceID string, version int, m NestedModel) *fastly.Upda
 		input.Placement = fastly.NullValue[string]()
 	}
 	input.ResponseCondition = new(service.StringValue(m.ResponseCondition))
-
-	return input
-}
-
-// BuildComputeUpdateInput is BuildUpdateInput for Compute services: it never
-// sets format, format_version, placement, or response_condition, since those
-// only affect generated VCL and Compute services don't have any.
-func BuildComputeUpdateInput(serviceID string, version int, m ComputeNestedModel) *fastly.UpdateBigQueryInput {
-	input := &fastly.UpdateBigQueryInput{
-		ServiceID:      serviceID,
-		ServiceVersion: version,
-		Name:           service.StringValue(m.Name),
-		NewName:        new(service.StringValue(m.Name)),
-		ProjectID:      new(service.StringValue(m.ProjectID)),
-		Dataset:        new(service.StringValue(m.Dataset)),
-		Table:          new(service.StringValue(m.Table)),
-	}
-
-	// See BuildUpdateInput for why AccountName uses fastly.NullString here while
-	// User/SecretKey use new().
-	input.AccountName = fastly.NullString(service.StringValue(m.AccountName()))
-	input.User = new(service.StringValue(m.Email()))
-	input.SecretKey = new(service.StringValue(m.SecretKey()))
-	input.Template = new(service.StringValue(m.Template))
-	input.ProcessingRegion = fastly.NullString(service.StringValue(m.ProcessingRegion))
-
 	return input
 }
 

--- a/internal/resources/loggingdatadog/expand.go
+++ b/internal/resources/loggingdatadog/expand.go
@@ -6,7 +6,10 @@ import (
 	"github.com/fastly/terraform-provider-fastly/internal/service"
 )
 
-func BuildCreateInput(serviceID string, version int, m NestedModel) *fastly.CreateDatadogInput {
+// buildCommonCreateInput sets the Create fields shared by VCL and Compute
+// services. BuildCreateInput and BuildComputeCreateInput layer their
+// service-type-specific fields on top of this.
+func buildCommonCreateInput(serviceID string, version int, m commonModel) *fastly.CreateDatadogInput {
 	input := &fastly.CreateDatadogInput{
 		ServiceID:      serviceID,
 		ServiceVersion: version,
@@ -16,11 +19,16 @@ func BuildCreateInput(serviceID string, version int, m NestedModel) *fastly.Crea
 
 	input.Region = fastly.NullString(service.StringValue(m.Region))
 	input.ProcessingRegion = fastly.NullString(service.StringValue(m.ProcessingRegion))
+
+	return input
+}
+
+func BuildCreateInput(serviceID string, version int, m NestedModel) *fastly.CreateDatadogInput {
+	input := buildCommonCreateInput(serviceID, version, m.commonModel)
 	input.Format = fastly.NullString(service.StringValue(m.Format))
 	input.FormatVersion = fastly.NullInt(int(service.Int64Value(m.FormatVersion)))
 	input.Placement = fastly.NullString(service.StringValue(m.Placement))
 	input.ResponseCondition = fastly.NullString(service.StringValue(m.ResponseCondition))
-
 	return input
 }
 
@@ -28,20 +36,13 @@ func BuildCreateInput(serviceID string, version int, m NestedModel) *fastly.Crea
 // sets format, format_version, placement, or response_condition, since those
 // only affect generated VCL and Compute services don't have any.
 func BuildComputeCreateInput(serviceID string, version int, m ComputeNestedModel) *fastly.CreateDatadogInput {
-	input := &fastly.CreateDatadogInput{
-		ServiceID:      serviceID,
-		ServiceVersion: version,
-		Name:           new(service.StringValue(m.Name)),
-		Token:          new(service.StringValue(m.Token())),
-	}
-
-	input.Region = fastly.NullString(service.StringValue(m.Region))
-	input.ProcessingRegion = fastly.NullString(service.StringValue(m.ProcessingRegion))
-
-	return input
+	return buildCommonCreateInput(serviceID, version, m.commonModel)
 }
 
-func BuildUpdateInput(serviceID string, version int, m NestedModel) *fastly.UpdateDatadogInput {
+// buildCommonUpdateInput sets the Update fields shared by VCL and Compute
+// services. BuildUpdateInput and BuildComputeUpdateInput layer their
+// service-type-specific fields on top of this.
+func buildCommonUpdateInput(serviceID string, version int, m commonModel) *fastly.UpdateDatadogInput {
 	input := &fastly.UpdateDatadogInput{
 		ServiceID:      serviceID,
 		ServiceVersion: version,
@@ -52,6 +53,19 @@ func BuildUpdateInput(serviceID string, version int, m NestedModel) *fastly.Upda
 
 	input.Region = fastly.NullString(service.StringValue(m.Region))
 	input.ProcessingRegion = fastly.NullString(service.StringValue(m.ProcessingRegion))
+
+	return input
+}
+
+// BuildComputeUpdateInput is BuildUpdateInput for Compute services: it never
+// sets format, format_version, placement, or response_condition, since those
+// only affect generated VCL and Compute services don't have any.
+func BuildComputeUpdateInput(serviceID string, version int, m ComputeNestedModel) *fastly.UpdateDatadogInput {
+	return buildCommonUpdateInput(serviceID, version, m.commonModel)
+}
+
+func BuildUpdateInput(serviceID string, version int, m NestedModel) *fastly.UpdateDatadogInput {
+	input := buildCommonUpdateInput(serviceID, version, m.commonModel)
 	input.Format = fastly.NullString(service.StringValue(m.Format))
 	input.FormatVersion = fastly.NullInt(int(service.Int64Value(m.FormatVersion)))
 	// placement can be cleared back to unset / nil (distinct from "none" — see
@@ -71,25 +85,6 @@ func BuildUpdateInput(serviceID string, version int, m NestedModel) *fastly.Upda
 	// a previously-set value in place — producing an inconsistent-result error
 	// when the user clears the attribute.
 	input.ResponseCondition = new(service.StringValue(m.ResponseCondition))
-
-	return input
-}
-
-// BuildComputeUpdateInput is BuildUpdateInput for Compute services: it never
-// sets format, format_version, placement, or response_condition, since those
-// only affect generated VCL and Compute services don't have any.
-func BuildComputeUpdateInput(serviceID string, version int, m ComputeNestedModel) *fastly.UpdateDatadogInput {
-	input := &fastly.UpdateDatadogInput{
-		ServiceID:      serviceID,
-		ServiceVersion: version,
-		Name:           service.StringValue(m.Name),
-		NewName:        new(service.StringValue(m.Name)),
-		Token:          new(service.StringValue(m.Token())),
-	}
-
-	input.Region = fastly.NullString(service.StringValue(m.Region))
-	input.ProcessingRegion = fastly.NullString(service.StringValue(m.ProcessingRegion))
-
 	return input
 }
 

--- a/internal/resources/loggingnewrelicotlp/expand.go
+++ b/internal/resources/loggingnewrelicotlp/expand.go
@@ -6,7 +6,10 @@ import (
 	"github.com/fastly/terraform-provider-fastly/internal/service"
 )
 
-func BuildCreateInput(serviceID string, version int, m NestedModel) *fastly.CreateNewRelicOTLPInput {
+// buildCommonCreateInput sets the Create fields shared by VCL and Compute
+// services. BuildCreateInput and BuildComputeCreateInput layer their
+// service-type-specific fields on top of this.
+func buildCommonCreateInput(serviceID string, version int, m commonModel) *fastly.CreateNewRelicOTLPInput {
 	input := &fastly.CreateNewRelicOTLPInput{
 		ServiceID:      serviceID,
 		ServiceVersion: version,
@@ -17,11 +20,16 @@ func BuildCreateInput(serviceID string, version int, m NestedModel) *fastly.Crea
 	input.Region = fastly.NullString(service.StringValue(m.Region))
 	input.URL = fastly.NullString(service.StringValue(m.URL))
 	input.ProcessingRegion = fastly.NullString(service.StringValue(m.ProcessingRegion))
+
+	return input
+}
+
+func BuildCreateInput(serviceID string, version int, m NestedModel) *fastly.CreateNewRelicOTLPInput {
+	input := buildCommonCreateInput(serviceID, version, m.commonModel)
 	input.Format = fastly.NullString(service.StringValue(m.Format))
 	input.FormatVersion = fastly.NullInt(int(service.Int64Value(m.FormatVersion)))
 	input.Placement = fastly.NullString(service.StringValue(m.Placement))
 	input.ResponseCondition = fastly.NullString(service.StringValue(m.ResponseCondition))
-
 	return input
 }
 
@@ -29,21 +37,13 @@ func BuildCreateInput(serviceID string, version int, m NestedModel) *fastly.Crea
 // sets format, format_version, placement, or response_condition, since those
 // only affect generated VCL and Compute services don't have any.
 func BuildComputeCreateInput(serviceID string, version int, m ComputeNestedModel) *fastly.CreateNewRelicOTLPInput {
-	input := &fastly.CreateNewRelicOTLPInput{
-		ServiceID:      serviceID,
-		ServiceVersion: version,
-		Name:           new(service.StringValue(m.Name)),
-		Token:          new(service.StringValue(m.Token())),
-	}
-
-	input.Region = fastly.NullString(service.StringValue(m.Region))
-	input.URL = fastly.NullString(service.StringValue(m.URL))
-	input.ProcessingRegion = fastly.NullString(service.StringValue(m.ProcessingRegion))
-
-	return input
+	return buildCommonCreateInput(serviceID, version, m.commonModel)
 }
 
-func BuildUpdateInput(serviceID string, version int, m NestedModel) *fastly.UpdateNewRelicOTLPInput {
+// buildCommonUpdateInput sets the Update fields shared by VCL and Compute
+// services. BuildUpdateInput and BuildComputeUpdateInput layer their
+// service-type-specific fields on top of this.
+func buildCommonUpdateInput(serviceID string, version int, m commonModel) *fastly.UpdateNewRelicOTLPInput {
 	input := &fastly.UpdateNewRelicOTLPInput{
 		ServiceID:      serviceID,
 		ServiceVersion: version,
@@ -53,13 +53,26 @@ func BuildUpdateInput(serviceID string, version int, m NestedModel) *fastly.Upda
 	}
 
 	input.Region = fastly.NullString(service.StringValue(m.Region))
-	// url and response_condition default to "" and can be cleared, so always send
-	// them as a concrete value on update. fastly.NullString is not used because it
-	// maps "" to nil, which omits the field (url,omitempty) and leaves a
-	// previously-set value in place — producing an inconsistent-result error when
-	// the user clears the attribute.
+	// url defaults to "" and can be cleared, so always send it as a concrete
+	// value on update. fastly.NullString is not used because it maps "" to nil,
+	// which omits the field (url,omitempty) and leaves a previously-set value
+	// in place — producing an inconsistent-result error when the user clears
+	// the attribute.
 	input.URL = new(service.StringValue(m.URL))
 	input.ProcessingRegion = fastly.NullString(service.StringValue(m.ProcessingRegion))
+
+	return input
+}
+
+// BuildComputeUpdateInput is BuildUpdateInput for Compute services: it never
+// sets format, format_version, placement, or response_condition, since those
+// only affect generated VCL and Compute services don't have any.
+func BuildComputeUpdateInput(serviceID string, version int, m ComputeNestedModel) *fastly.UpdateNewRelicOTLPInput {
+	return buildCommonUpdateInput(serviceID, version, m.commonModel)
+}
+
+func BuildUpdateInput(serviceID string, version int, m NestedModel) *fastly.UpdateNewRelicOTLPInput {
+	input := buildCommonUpdateInput(serviceID, version, m.commonModel)
 	input.Format = fastly.NullString(service.StringValue(m.Format))
 	input.FormatVersion = fastly.NullInt(int(service.Int64Value(m.FormatVersion)))
 	// placement can be cleared back to unset / nil (distinct from "none" —
@@ -74,28 +87,6 @@ func BuildUpdateInput(serviceID string, version int, m NestedModel) *fastly.Upda
 		input.Placement = fastly.NullValue[string]()
 	}
 	input.ResponseCondition = new(service.StringValue(m.ResponseCondition))
-
-	return input
-}
-
-// BuildComputeUpdateInput is BuildUpdateInput for Compute services: it never
-// sets format, format_version, placement, or response_condition, since those
-// only affect generated VCL and Compute services don't have any.
-func BuildComputeUpdateInput(serviceID string, version int, m ComputeNestedModel) *fastly.UpdateNewRelicOTLPInput {
-	input := &fastly.UpdateNewRelicOTLPInput{
-		ServiceID:      serviceID,
-		ServiceVersion: version,
-		Name:           service.StringValue(m.Name),
-		NewName:        new(service.StringValue(m.Name)),
-		Token:          new(service.StringValue(m.Token())),
-	}
-
-	input.Region = fastly.NullString(service.StringValue(m.Region))
-	// url defaults to "" and can be cleared, so always send it as a concrete
-	// value on update — see BuildUpdateInput.
-	input.URL = new(service.StringValue(m.URL))
-	input.ProcessingRegion = fastly.NullString(service.StringValue(m.ProcessingRegion))
-
 	return input
 }
 

--- a/internal/resources/loggings3/expand.go
+++ b/internal/resources/loggings3/expand.go
@@ -6,7 +6,10 @@ import (
 	"github.com/fastly/terraform-provider-fastly/internal/service"
 )
 
-func BuildCreateInput(serviceID string, version int, m NestedModel) *fastly.CreateS3Input {
+// buildCommonCreateInput sets the Create fields shared by VCL and Compute
+// services. BuildCreateInput and BuildComputeCreateInput layer their
+// service-type-specific fields on top of this.
+func buildCommonCreateInput(serviceID string, version int, m commonModel) *fastly.CreateS3Input {
 	input := &fastly.CreateS3Input{
 		ServiceID:      serviceID,
 		ServiceVersion: version,
@@ -29,12 +32,8 @@ func BuildCreateInput(serviceID string, version int, m NestedModel) *fastly.Crea
 	if gl := service.Int64Value(m.GzipLevel); gl != DefaultGzipLevel {
 		input.GzipLevel = new(int(gl))
 	}
-	input.Format = fastly.NullString(service.StringValue(m.Format))
-	input.FormatVersion = fastly.NullInt(int(service.Int64Value(m.FormatVersion)))
 	input.MessageType = fastly.NullString(service.StringValue(m.MessageType))
 	input.TimestampFormat = fastly.NullString(service.StringValue(m.TimestampFormat))
-	input.Placement = fastly.NullString(service.StringValue(m.Placement))
-	input.ResponseCondition = fastly.NullString(service.StringValue(m.ResponseCondition))
 	input.PublicKey = fastly.NullString(service.StringValue(m.PublicKey))
 	input.ProcessingRegion = fastly.NullString(service.StringValue(m.ProcessingRegion))
 
@@ -57,6 +56,15 @@ func BuildCreateInput(serviceID string, version int, m NestedModel) *fastly.Crea
 		input.FileMaxBytes = &v
 	}
 
+	return input
+}
+
+func BuildCreateInput(serviceID string, version int, m NestedModel) *fastly.CreateS3Input {
+	input := buildCommonCreateInput(serviceID, version, m.commonModel)
+	input.Format = fastly.NullString(service.StringValue(m.Format))
+	input.FormatVersion = fastly.NullInt(int(service.Int64Value(m.FormatVersion)))
+	input.Placement = fastly.NullString(service.StringValue(m.Placement))
+	input.ResponseCondition = fastly.NullString(service.StringValue(m.ResponseCondition))
 	return input
 }
 
@@ -84,59 +92,13 @@ func ClearVCLOnlyUpdateFields(input *fastly.UpdateS3Input) {
 // sets format, format_version, placement, or response_condition, since those
 // only affect generated VCL and Compute services don't have any.
 func BuildComputeCreateInput(serviceID string, version int, m ComputeNestedModel) *fastly.CreateS3Input {
-	input := &fastly.CreateS3Input{
-		ServiceID:      serviceID,
-		ServiceVersion: version,
-		Name:           new(service.StringValue(m.Name)),
-		BucketName:     new(service.StringValue(m.BucketName)),
-	}
-
-	input.AccessKey = fastly.NullString(service.StringValue(m.AccessKey()))
-	input.SecretKey = fastly.NullString(service.StringValue(m.SecretKey()))
-	input.IAMRole = fastly.NullString(service.StringValue(m.IAMRole()))
-	input.Domain = fastly.NullString(service.StringValue(m.Domain))
-	input.Path = new(service.StringValue(m.Path))
-	input.Period = fastly.NullInt(int(service.Int64Value(m.Period)))
-	input.CompressionCodec = fastly.NullString(service.StringValue(m.CompressionCodec))
-	// Only send an explicitly configured gzip_level. DefaultGzipLevel (-1) means
-	// unset: the API rejects requests that set both compression_codec and
-	// gzip_level, and it auto-manages the level when omitted. fastly.NullInt is
-	// not used here because it treats 0 as unset too, which would silently drop
-	// an explicit "no compression" (gzip_level = 0).
-	if gl := service.Int64Value(m.GzipLevel); gl != DefaultGzipLevel {
-		input.GzipLevel = new(int(gl))
-	}
-	input.MessageType = fastly.NullString(service.StringValue(m.MessageType))
-	input.TimestampFormat = fastly.NullString(service.StringValue(m.TimestampFormat))
-	input.PublicKey = fastly.NullString(service.StringValue(m.PublicKey))
-	input.ProcessingRegion = fastly.NullString(service.StringValue(m.ProcessingRegion))
-
-	if acl := service.StringValue(m.ACL); acl != "" {
-		v := fastly.S3AccessControlList(acl)
-		input.ACL = &v
-	}
-	if red := service.StringValue(m.Redundancy); red != "" {
-		v := fastly.S3Redundancy(red)
-		input.Redundancy = &v
-	}
-	if enc := service.StringValue(m.ServerSideEncryption); enc != "" {
-		v := fastly.S3ServerSideEncryption(enc)
-		input.ServerSideEncryption = &v
-	}
-	input.ServerSideEncryptionKMSKeyID = fastly.NullString(service.StringValue(m.ServerSideEncryptionKMSKeyID))
-
-	if fmb := service.Int64Value(m.FileMaxBytes); fmb != 0 {
-		v := int(fmb)
-		input.FileMaxBytes = &v
-	}
-
-	return input
+	return buildCommonCreateInput(serviceID, version, m.commonModel)
 }
 
-// BuildComputeUpdateInput is BuildUpdateInput for Compute services: it never
-// sets format, format_version, placement, or response_condition, since those
-// only affect generated VCL and Compute services don't have any.
-func BuildComputeUpdateInput(serviceID string, version int, m ComputeNestedModel) *fastly.UpdateS3Input {
+// buildCommonUpdateInput sets the Update fields shared by VCL and Compute
+// services. BuildUpdateInput and BuildComputeUpdateInput layer their
+// service-type-specific fields on top of this.
+func buildCommonUpdateInput(serviceID string, version int, m commonModel) *fastly.UpdateS3Input {
 	input := &fastly.UpdateS3Input{
 		ServiceID:      serviceID,
 		ServiceVersion: version,
@@ -185,38 +147,19 @@ func BuildComputeUpdateInput(serviceID string, version int, m ComputeNestedModel
 	return input
 }
 
-func BuildUpdateInput(serviceID string, version int, m NestedModel) *fastly.UpdateS3Input {
-	input := &fastly.UpdateS3Input{
-		ServiceID:      serviceID,
-		ServiceVersion: version,
-		Name:           service.StringValue(m.Name),
-		NewName:        new(service.StringValue(m.Name)),
-		BucketName:     new(service.StringValue(m.BucketName)),
-	}
+// BuildComputeUpdateInput is BuildUpdateInput for Compute services: it never
+// sets format, format_version, placement, or response_condition, since those
+// only affect generated VCL and Compute services don't have any.
+func BuildComputeUpdateInput(serviceID string, version int, m ComputeNestedModel) *fastly.UpdateS3Input {
+	return buildCommonUpdateInput(serviceID, version, m.commonModel)
+}
 
-	// Credentials default to "" and can be cleared — e.g. switching from
-	// access_key/secret_key to iam_role auth. Always send a concrete value via
-	// new() rather than fastly.NullString, which maps "" to nil, omits the field
-	// (access_key,omitempty), and leaves the previously-set credential in place.
-	input.AccessKey = new(service.StringValue(m.AccessKey()))
-	input.SecretKey = new(service.StringValue(m.SecretKey()))
-	input.IAMRole = new(service.StringValue(m.IAMRole()))
-	input.Domain = fastly.NullString(service.StringValue(m.Domain))
-	input.Path = new(service.StringValue(m.Path))
-	input.Period = fastly.NullInt(int(service.Int64Value(m.Period)))
-	input.CompressionCodec = new(service.StringValue(m.CompressionCodec))
-	// Only send an explicitly configured gzip_level. DefaultGzipLevel (-1) means
-	// unset: the API rejects requests that set both compression_codec and
-	// gzip_level, and it auto-manages the level when omitted.
-	if gl := service.Int64Value(m.GzipLevel); gl != DefaultGzipLevel {
-		input.GzipLevel = new(int(gl))
-	}
+func BuildUpdateInput(serviceID string, version int, m NestedModel) *fastly.UpdateS3Input {
+	input := buildCommonUpdateInput(serviceID, version, m.commonModel)
 	input.Format = fastly.NullString(service.StringValue(m.Format))
 	input.FormatVersion = fastly.NullInt(int(service.Int64Value(m.FormatVersion)))
-	input.MessageType = fastly.NullString(service.StringValue(m.MessageType))
-	input.TimestampFormat = fastly.NullString(service.StringValue(m.TimestampFormat))
-	// placement can be cleared back to unset / nil (distinct from "none" —
-	// see schema.go). UpdateS3Input.Placement is a *Nullable[string]
+	// placement can be cleared back to unset / nil (distinct from "none" — see
+	// schema.go). UpdateS3Input.Placement is a *Nullable[string]
 	// specifically so this can be sent as a real JSON null: omitting the field
 	// leaves the previous value in place, and sending a literal empty string
 	// gets stored as "" rather than reverting to null/auto-placement — neither
@@ -227,23 +170,5 @@ func BuildUpdateInput(serviceID string, version int, m NestedModel) *fastly.Upda
 		input.Placement = fastly.NullValue[string]()
 	}
 	input.ResponseCondition = new(service.StringValue(m.ResponseCondition))
-	input.PublicKey = new(service.StringValue(m.PublicKey))
-	input.ProcessingRegion = fastly.NullString(service.StringValue(m.ProcessingRegion))
-
-	aclVal := fastly.S3AccessControlList(service.StringValue(m.ACL))
-	input.ACL = &aclVal
-
-	redVal := fastly.S3Redundancy(service.StringValue(m.Redundancy))
-	input.Redundancy = &redVal
-
-	if enc := service.StringValue(m.ServerSideEncryption); enc != "" {
-		v := fastly.S3ServerSideEncryption(enc)
-		input.ServerSideEncryption = &v
-	}
-	input.ServerSideEncryptionKMSKeyID = new(service.StringValue(m.ServerSideEncryptionKMSKeyID))
-
-	fmb := int(service.Int64Value(m.FileMaxBytes))
-	input.FileMaxBytes = &fmb
-
 	return input
 }


### PR DESCRIPTION
### Change summary

This PR is a follow up to https://github.com/fastly/terraform-provider-fastly/pull/1400#discussion_r3769460785. 

We are reducing duplicated field-setters across VCL and Compute builders through a shared `buildCommonCreateInput` /
`buildCommonUpdateInput(commonModel)` helpers. 

 All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/terraform-provider-fastly/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

* [x] Does your submission pass tests?
* [x] Post the output of your test runs

```
--- PASS: TestAccFastlyServiceLoggingDatadog_importBasic (41.14s)
=== CONT  TestAccFastlyServiceCDNAuto_withLoggingS3
--- PASS: TestAccFastlyServiceLoggingDatadog_formatDefault (55.07s)
=== CONT  TestAccFastlyServiceLoggingNewRelicOTLP_computeConsistentAfterApply
--- PASS: TestAccFastlyServiceLoggingDatadog_computeConsistentAfterApply (57.92s)
=== CONT  TestAccFastlyServiceLoggingNewRelicOTLP_formatDefault
--- PASS: TestAccFastlyServiceLoggingS3_compressionCodec (84.76s)
=== CONT  TestAccFastlyServiceLoggingNewRelicOTLP_computeRejectsVCLOnlyFields
--- PASS: TestAccFastlyServiceLoggingDatadog_update (99.73s)
=== CONT  TestAccFastlyServiceComputeAuto_loggingDatadogRejectsVCLOnlyFields
--- PASS: TestAccFastlyServiceComputeAuto_loggingDatadogRejectsVCLOnlyFields (0.14s)
=== CONT  TestAccFastlyServiceLoggingDatadog_basic
--- PASS: TestAccFastlyServiceLoggingDatadog_versionUpdateInPlace (107.65s)
=== CONT  TestAccFastlyServiceLoggingDatadog_computeRejectsVCLOnlyFields
--- PASS: TestAccFastlyServiceLoggingNewRelicOTLP_versionUpdateInPlace (109.42s)
=== CONT  TestAccFastlyServiceCDNAuto_withMultipleLoggingDatadog
--- PASS: TestAccFastlyServiceLoggingNewRelicOTLP_computeRejectsVCLOnlyFields (27.62s)
=== CONT  TestAccFastlyServiceLoggingS3_credentialSwitchClearsKeys
--- PASS: TestAccFastlyServiceLoggingDatadog_computeRejectsVCLOnlyFields (19.10s)
=== CONT  TestAccFastlyServiceLoggingS3_importBasic
--- PASS: TestAccFastlyServiceLoggingNewRelicOTLP_computeConsistentAfterApply (74.82s)
=== CONT  TestAccFastlyServiceLoggingS3_placementUnsetVsNone
--- PASS: TestAccFastlyServiceComputeAuto_withLoggingS3 (132.14s)
=== CONT  TestAccFastlyServiceLoggingS3_clearToDefaults
--- PASS: TestAccFastlyServiceLoggingNewRelicOTLP_formatDefault (74.85s)
=== CONT  TestAccFastlyServiceLoggingS3_allAttr
--- PASS: TestAccFastlyServiceCDNAuto_withBackendAndLoggingDatadog (139.91s)
=== CONT  TestAccFastlyServiceLoggingS3_update
--- PASS: TestAccFastlyServiceLoggingDatadog_basic (51.79s)
=== CONT  TestAccFastlyServiceLoggingS3_iamRole
--- PASS: TestAccFastlyServiceCDNAuto_withLoggingNewRelicOTLP (161.82s)
=== CONT  TestAccFastlyServiceCDNAuto_withMultipleLoggingS3
--- PASS: TestAccFastlyServiceCDNAuto_withLoggingBigQuery (171.91s)
=== CONT  TestAccFastlyServiceCDNAuto_withBackendAndLoggingS3
--- PASS: TestAccFastlyServiceCDNAuto_withLoggingDatadog (174.04s)
=== CONT  TestAccFastlyServiceCDNAuto_withLoggingS3GzipCodec
--- PASS: TestAccFastlyServiceLoggingS3_importBasic (51.32s)
=== CONT  TestAccFastlyServiceCDNAuto_withLoggingDatadogRemoved
--- PASS: TestAccFastlyServiceLoggingS3_credentialSwitchClearsKeys (69.29s)
=== CONT  TestAccFastlyServiceLoggingNewRelicOTLP_basic
--- PASS: TestAccFastlyServiceCDNAuto_withLoggingS3Update (183.77s)
=== CONT  TestAccFastlyServiceLoggingNewRelicOTLP_placementUnsetVsNone
--- PASS: TestAccFastlyServiceLoggingS3_allAttr (59.20s)
=== CONT  TestAccFastlyServiceLoggingNewRelicOTLP_clearToDefaults
--- PASS: TestAccFastlyServiceCDNAuto_withLoggingNewRelicOTLPUpdate (208.53s)
=== CONT  TestAccFastlyServiceLoggingNewRelicOTLP_importBasic
--- PASS: TestAccFastlyServiceLoggingS3_clearToDefaults (95.80s)
=== CONT  TestAccFastlyServiceLoggingNewRelicOTLP_update
--- PASS: TestAccFastlyServiceLoggingS3_iamRole (83.11s)
=== CONT  TestAccFastlyServiceLoggingDatadog_placementUnsetVsNone
--- PASS: TestAccFastlyServiceCDNAuto_withLoggingS3 (199.18s)
=== CONT  TestAccFastlyServiceLoggingDatadog_clearToDefaults
--- PASS: TestAccFastlyServiceLoggingS3_update (106.71s)
=== CONT  TestAccFastlyServiceComputeAuto_withLoggingNewRelicOTLP
--- PASS: TestAccFastlyServiceLoggingS3_placementUnsetVsNone (119.07s)
=== CONT  TestAccFastlyServiceComputeAuto_loggingNewRelicOTLPRejectsVCLOnlyFields
--- PASS: TestAccFastlyServiceComputeAuto_loggingNewRelicOTLPRejectsVCLOnlyFields (0.14s)
=== CONT  TestAccFastlyServiceLoggingS3_computeRejectsVCLOnlyFields
--- PASS: TestAccFastlyServiceCDNAuto_withMultipleLoggingDatadog (145.04s)
=== CONT  TestAccFastlyServiceLoggingS3_versionUpdateInPlace
--- PASS: TestAccFastlyServiceLoggingNewRelicOTLP_basic (87.19s)
=== CONT  TestAccFastlyServiceLoggingS3_computeConsistentAfterApply
--- PASS: TestAccFastlyServiceLoggingS3_computeRejectsVCLOnlyFields (28.25s)
=== CONT  TestAccFastlyServiceLoggingS3_formatDefault
--- PASS: TestAccFastlyServiceCDNAuto_loggingDatadogPlacementUnsetVsNone (279.27s)
=== CONT  TestAccFastlyServiceLoggingS3_basic
--- PASS: TestAccFastlyServiceLoggingNewRelicOTLP_importBasic (71.34s)
=== CONT  TestAccFastlyServiceCDNAuto_withLoggingDatadogUpdate
--- PASS: TestAccFastlyServiceCDNAuto_loggingNewRelicOTLPPlacementUnsetVsNone (286.91s)
=== CONT  TestAccFastlyServiceComputeAuto_withLoggingDatadog
--- PASS: TestAccFastlyServiceLoggingNewRelicOTLP_clearToDefaults (99.65s)
=== CONT  TestAccFastlyServiceLoggingS3_gzipLevelSentinelRejected
--- PASS: TestAccFastlyServiceLoggingS3_gzipLevelSentinelRejected (0.15s)
=== CONT  TestAccFastlyServiceLoggingS3_codecConflict
--- PASS: TestAccFastlyServiceLoggingS3_codecConflict (0.14s)
=== CONT  TestAccFastlyServiceComputeAuto_loggingS3RejectsVCLOnlyFields
--- PASS: TestAccFastlyServiceComputeAuto_loggingS3RejectsVCLOnlyFields (0.15s)
=== CONT  TestAccFastlyServiceLoggingBigQuery_update
--- PASS: TestAccFastlyServiceLoggingNewRelicOTLP_placementUnsetVsNone (117.79s)
=== CONT  TestAccFastlyServiceLoggingBigQuery_computeConsistentAfterApply
--- PASS: TestAccFastlyServiceLoggingNewRelicOTLP_update (80.68s)
=== CONT  TestAccFastlyServiceLoggingBigQuery_formatDefault
--- PASS: TestAccFastlyServiceCDNAuto_withMultipleLoggingS3 (149.40s)
=== CONT  TestAccFastlyServiceLoggingBigQuery_computeRejectsVCLOnlyFields
--- PASS: TestAccFastlyServiceCDNAuto_withLoggingS3GzipCodec (137.75s)
=== CONT  TestAccFastlyServiceLoggingBigQuery_versionUpdateInPlace
--- PASS: TestAccFastlyServiceLoggingDatadog_clearToDefaults (75.65s)
=== CONT  TestAccFastlyServiceLoggingBigQuery_placementUnsetVsNone
--- PASS: TestAccFastlyServiceCDNAuto_withBackendAndLoggingS3 (144.61s)
=== CONT  TestAccFastlyServiceLoggingBigQuery_clearToDefaults
--- PASS: TestAccFastlyServiceLoggingS3_computeConsistentAfterApply (57.20s)
=== CONT  TestAccFastlyServiceLoggingBigQuery_importBasic
--- PASS: TestAccFastlyServiceLoggingS3_formatDefault (51.88s)
=== CONT  TestAccFastlyServiceLoggingBigQuery_accountNameToEmailSecretKey
--- PASS: TestAccFastlyServiceLoggingDatadog_placementUnsetVsNone (94.99s)
=== CONT  TestAccFastlyServiceCDNAuto_withMultipleLoggingBigQuery
--- PASS: TestAccFastlyServiceLoggingBigQuery_computeRejectsVCLOnlyFields (22.40s)
=== CONT  TestAccFastlyServiceLoggingBigQuery_basic
--- PASS: TestAccFastlyServiceLoggingS3_basic (56.33s)
=== CONT  TestAccFastlyServiceComputeAuto_loggingBigQueryRejectsVCLOnlyFields
--- PASS: TestAccFastlyServiceComputeAuto_loggingBigQueryRejectsVCLOnlyFields (0.14s)
=== CONT  TestAccFastlyServiceComputeAuto_withLoggingBigQuery
--- PASS: TestAccFastlyServiceLoggingS3_versionUpdateInPlace (81.86s)
=== CONT  TestAccFastlyServiceCDNAuto_withBackendAndLoggingBigQuery
--- PASS: TestAccFastlyServiceLoggingBigQuery_computeConsistentAfterApply (52.62s)
=== CONT  TestAccFastlyServiceLoggingS3_gzipLevelRange
--- PASS: TestAccFastlyServiceLoggingS3_gzipLevelRange (0.15s)
=== CONT  TestAccFastlyServiceLoggingS3_gzipCodec
--- PASS: TestAccFastlyServiceLoggingBigQuery_update (75.27s)
=== CONT  TestAccFastlyServiceCDNAuto_withBackendAndLoggingNewRelicOTLP
--- PASS: TestAccFastlyServiceLoggingBigQuery_formatDefault (59.34s)
=== CONT  TestAccFastlyServiceCDNAuto_withLoggingBigQueryRemoved
--- PASS: TestAccFastlyServiceCDNAuto_withLoggingDatadogRemoved (191.61s)
=== CONT  TestAccFastlyServiceCDNAuto_loggingBigQueryPlacementUnsetVsNone
--- PASS: TestAccFastlyServiceLoggingBigQuery_importBasic (65.02s)
=== CONT  TestAccFastlyServiceCDNAuto_loggingBigQueryAccountNameToEmailSecretKey
--- PASS: TestAccFastlyServiceLoggingBigQuery_clearToDefaults (76.46s)
=== CONT  TestAccFastlyServiceCDNAuto_withLoggingBigQueryUpdate
--- PASS: TestAccFastlyServiceComputeAuto_withLoggingNewRelicOTLP (146.48s)
=== CONT  TestAccFastlyServiceCDNAuto_withMultipleLoggingNewRelicOTLP
--- PASS: TestAccFastlyServiceLoggingBigQuery_basic (64.83s)
--- PASS: TestAccFastlyServiceLoggingBigQuery_versionUpdateInPlace (90.71s)
--- PASS: TestAccFastlyServiceComputeAuto_withLoggingDatadog (116.13s)
--- PASS: TestAccFastlyServiceLoggingBigQuery_placementUnsetVsNone (98.36s)
--- PASS: TestAccFastlyServiceLoggingS3_gzipCodec (65.58s)
--- PASS: TestAccFastlyServiceLoggingBigQuery_accountNameToEmailSecretKey (98.96s)
--- PASS: TestAccFastlyServiceCDNAuto_withMultipleLoggingBigQuery (105.50s)
--- PASS: TestAccFastlyServiceCDNAuto_withLoggingDatadogUpdate (160.17s)
--- PASS: TestAccFastlyServiceCDNAuto_withBackendAndLoggingBigQuery (109.16s)
--- PASS: TestAccFastlyServiceComputeAuto_withLoggingBigQuery (110.40s)
--- PASS: TestAccFastlyServiceCDNAuto_withBackendAndLoggingNewRelicOTLP (82.39s)
--- PASS: TestAccFastlyServiceCDNAuto_withMultipleLoggingNewRelicOTLP (68.11s)
--- PASS: TestAccFastlyServiceCDNAuto_withLoggingBigQueryRemoved (109.08s)
--- PASS: TestAccFastlyServiceCDNAuto_withLoggingBigQueryUpdate (93.37s)
--- PASS: TestAccFastlyServiceCDNAuto_loggingBigQueryAccountNameToEmailSecretKey (107.15s)
--- PASS: TestAccFastlyServiceCDNAuto_loggingBigQueryPlacementUnsetVsNone (139.64s)
PASS
ok    
```

### Changes to Core Features:

* [ ] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?