### PR TITLE
[CDTOOL-1505] Add header support to fastly_service_cdn_auto

### DIFF
--- a/docs/resources/service_cdn_auto.md
+++ b/docs/resources/service_cdn_auto.md
@@ -242,7 +242,7 @@ Optional:
 - `priority` (Number) Lower priorities execute first. Default `100`.
 - `regex` (String) Regular expression to use. Only applies to the `regex` and `regex_repeat` actions.
 - `request_condition` (String) Name of already defined `condition` to apply. This `condition` must be of type `REQUEST`.
-- `response_condition` (String) Name of already defined `condition` to apply. This `condition` must be of type `RESPONSE`.
+- `response_condition` (String) Name of already defined `condition` to apply. This `condition` must be of type `RESPONSE`. For detailed information about Conditionals, see [Fastly's Documentation on Conditionals](https://docs.fastly.com/en/guides/using-conditions).
 - `source` (String) Variable to be used as a source for the header content. Does not apply to the `delete` action.
 - `substitution` (String) Value to substitute in place of regular expression. Only applies to the `regex` and `regex_repeat` actions.
 

--- a/docs/resources/service_cdn_auto.md
+++ b/docs/resources/service_cdn_auto.md
@@ -31,6 +31,7 @@ Automatic-lifecycle Fastly CDN service resource with nested versioned configurat
 - `dynamic_snippet` (Block List) Dynamic VCL snippet metadata attached to this service version. Dynamic snippet content is managed separately by `fastly_service_dynamic_snippet_content`. (see [below for nested schema](#nestedblock--dynamic_snippet))
 - `force_destroy` (Boolean) Deactivate the active version before deleting the service. Default `false`.
 - `gzip` (Block List) Gzip configurations attached to this service. (see [below for nested schema](#nestedblock--gzip))
+- `header` (Block List) Header manipulations attached to this service. (see [below for nested schema](#nestedblock--header))
 - `healthcheck` (Block List) Health checks attached to this service. (see [below for nested schema](#nestedblock--healthcheck))
 - `image_optimizer_default_settings` (Block List) Image Optimizer default settings for this service. At most one block is supported. The Image Optimizer product must already be enabled on the service (e.g. via `fastly_service_product_image_optimizer`) before these settings can be persisted; enabling the product and configuring this block cannot be done in the same initial `apply`, since this block is reconciled as part of this resource's own create step, before a separate product-enablement resource (which depends on this resource's `id`) can run. Enable the product in a prior `apply` first. (see [below for nested schema](#nestedblock--image_optimizer_default_settings))
 - `logging_bigquery` (Block List) BigQuery logging endpoints attached to this service. (see [below for nested schema](#nestedblock--logging_bigquery))
@@ -222,6 +223,28 @@ Optional:
 - `cache_condition` (String) Name of already defined `condition` controlling when this gzip configuration applies. This `condition` must be of type `CACHE`.
 - `content_types` (List of String) The content-type for each type of content you wish to have dynamically gzip'ed. Example: `["text/html", "text/css"]`.
 - `extensions` (List of String) File extensions for each file type to dynamically gzip. Example: `["css", "js"]`.
+
+
+<a id="nestedblock--header"></a>
+### Nested Schema for `header`
+
+Required:
+
+- `action` (String) The Header manipulation action to take; must be one of `set`, `append`, `delete`, `regex`, or `regex_repeat`.
+- `destination` (String) The name of the header that is going to be affected by the Action.
+- `name` (String) Unique name for this Header attribute. Changing this attribute will delete and recreate the resource.
+- `type` (String) The Request type on which to apply the selected Action; must be one of `request`, `fetch`, `cache`, or `response`.
+
+Optional:
+
+- `cache_condition` (String) Name of already defined `condition` to apply. This `condition` must be of type `CACHE`.
+- `ignore_if_set` (Boolean) Don't add the header if it is already present. Only applies to the `set` action. Default `false`.
+- `priority` (Number) Lower priorities execute first. Default `100`.
+- `regex` (String) Regular expression to use. Only applies to the `regex` and `regex_repeat` actions.
+- `request_condition` (String) Name of already defined `condition` to apply. This `condition` must be of type `REQUEST`.
+- `response_condition` (String) Name of already defined `condition` to apply. This `condition` must be of type `RESPONSE`.
+- `source` (String) Variable to be used as a source for the header content. Does not apply to the `delete` action.
+- `substitution` (String) Value to substitute in place of regular expression. Only applies to the `regex` and `regex_repeat` actions.
 
 
 <a id="nestedblock--healthcheck"></a>

--- a/internal/acceptance_tests/blocks/header_invalid_action.tf
+++ b/internal/acceptance_tests/blocks/header_invalid_action.tf
@@ -1,0 +1,6 @@
+  header {
+    name        = "{{.HEADER_NAME}}"
+    action      = "invalid"
+    type        = "request"
+    destination = "http.X-Custom"
+  }

--- a/internal/acceptance_tests/blocks/header_single.tf
+++ b/internal/acceptance_tests/blocks/header_single.tf
@@ -1,0 +1,6 @@
+  header {
+    name        = "{{.HEADER_NAME}}"
+    action      = "delete"
+    type        = "cache"
+    destination = "http.x-amz-request-id"
+  }

--- a/internal/acceptance_tests/blocks/header_updated.tf
+++ b/internal/acceptance_tests/blocks/header_updated.tf
@@ -1,0 +1,9 @@
+  header {
+    name          = "{{.HEADER_NAME}}"
+    action        = "set"
+    type          = "request"
+    destination   = "http.X-Custom"
+    source        = "req.http.Host"
+    priority      = 10
+    ignore_if_set = true
+  }

--- a/internal/acceptance_tests/blocks/header_with_request_condition.tf
+++ b/internal/acceptance_tests/blocks/header_with_request_condition.tf
@@ -1,0 +1,7 @@
+  header {
+    name              = "{{.HEADER_NAME}}"
+    action            = "delete"
+    type              = "request"
+    destination       = "http.x-amz-request-id"
+    request_condition = "{{.CONDITION_NAME}}"
+  }

--- a/internal/acceptance_tests/header_test.go
+++ b/internal/acceptance_tests/header_test.go
@@ -1,0 +1,189 @@
+package acceptancetests
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccFastlyServiceCDNAuto_withHeader(t *testing.T) {
+	t.Parallel()
+	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	domainName := fmt.Sprintf("%s.example.com", acctest.RandString(10))
+	headerName := fmt.Sprintf("header-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
+		CheckDestroy:             CheckServiceDestroy("fastly_service_cdn_auto"),
+		Steps: []resource.TestStep{
+			{
+				Config: ConfigCDNAutoBasic(serviceName, domainName),
+				Check: resource.ComposeTestCheckFunc(
+					CheckServiceExists("fastly_service_cdn_auto.test"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "header.#", "0"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "active_version", "1"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "managed_version", "1"),
+				),
+			},
+			{
+				Config: ConfigCDNAutoWithHeader(serviceName, domainName, headerName),
+				Check: resource.ComposeTestCheckFunc(
+					CheckServiceExists("fastly_service_cdn_auto.test"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "header.#", "1"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "header.0.name", headerName),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "header.0.action", "delete"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "header.0.type", "cache"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "header.0.destination", "http.x-amz-request-id"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "header.0.priority", "100"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "header.0.ignore_if_set", "false"),
+					// Adding a header should create and activate version 2
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "active_version", "2"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "managed_version", "2"),
+				),
+			},
+			{
+				Config: ConfigCDNAutoBasic(serviceName, domainName),
+				Check: resource.ComposeTestCheckFunc(
+					CheckServiceExists("fastly_service_cdn_auto.test"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "header.#", "0"),
+					// Removing the header should create and activate version 3
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "active_version", "3"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "managed_version", "3"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccFastlyServiceCDNAuto_withHeaderUpdate(t *testing.T) {
+	t.Parallel()
+	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	domainName := fmt.Sprintf("%s.example.com", acctest.RandString(10))
+	headerName := fmt.Sprintf("header-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
+		CheckDestroy:             CheckServiceDestroy("fastly_service_cdn_auto"),
+		Steps: []resource.TestStep{
+			{
+				Config: ConfigCDNAutoWithHeader(serviceName, domainName, headerName),
+				Check: resource.ComposeTestCheckFunc(
+					CheckServiceExists("fastly_service_cdn_auto.test"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "header.#", "1"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "header.0.action", "delete"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "header.0.type", "cache"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "active_version", "1"),
+				),
+			},
+			{
+				// Same name, in-place update of action/type/destination/source/priority/
+				// ignore_if_set - confirm update, not delete+recreate.
+				Config: ConfigCDNAutoWithHeaderUpdated(serviceName, domainName, headerName),
+				Check: resource.ComposeTestCheckFunc(
+					CheckServiceExists("fastly_service_cdn_auto.test"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "header.#", "1"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "header.0.name", headerName),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "header.0.action", "set"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "header.0.type", "request"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "header.0.destination", "http.X-Custom"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "header.0.source", "req.http.Host"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "header.0.priority", "10"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "header.0.ignore_if_set", "true"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "active_version", "2"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "managed_version", "2"),
+				),
+			},
+		},
+	})
+}
+
+// TestAccFastlyServiceCDNAuto_withHeaderRequestCondition confirms that a header's
+// request_condition can reference a real nested REQUEST-type condition block within the same
+// apply, verifying conditions are reconciled before header so the reference resolves within the
+// same service version (see servicecdnauto's Create/Update, which reconcile header after ACL and
+// after condition for this reason).
+func TestAccFastlyServiceCDNAuto_withHeaderRequestCondition(t *testing.T) {
+	t.Parallel()
+	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	domainName := fmt.Sprintf("%s.example.com", acctest.RandString(10))
+	headerName := fmt.Sprintf("header-%s", acctest.RandString(10))
+	conditionName := fmt.Sprintf("condition-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
+		CheckDestroy:             CheckServiceDestroy("fastly_service_cdn_auto"),
+		Steps: []resource.TestStep{
+			{
+				Config: ConfigCDNAutoWithHeaderRequestCondition(serviceName, domainName, headerName, conditionName),
+				Check: resource.ComposeTestCheckFunc(
+					CheckServiceExists("fastly_service_cdn_auto.test"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "condition.0.name", conditionName),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "header.0.name", headerName),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "header.0.request_condition", conditionName),
+				),
+			},
+			{
+				// Removing both the header and the condition it references in the same apply
+				// must not fail - see the analogous backendWithRequestCondition test's comment.
+				Config: ConfigCDNAutoBasic(serviceName, domainName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "condition.#", "0"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "header.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccFastlyServiceCDNAuto_headerInvalidAction(t *testing.T) {
+	t.Parallel()
+	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	domainName := fmt.Sprintf("%s.example.com", acctest.RandString(10))
+	headerName := fmt.Sprintf("header-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config:      ConfigCDNAutoWithHeaderInvalidAction(serviceName, domainName, headerName),
+				ExpectError: regexp.MustCompile(`Attribute header\[0\]\.action value must be one of`),
+			},
+		},
+	})
+}
+
+func TestAccFastlyServiceCDNAuto_importWithHeader(t *testing.T) {
+	t.Parallel()
+	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	domainName := fmt.Sprintf("%s.example.com", acctest.RandString(10))
+	headerName := fmt.Sprintf("header-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
+		CheckDestroy:             CheckServiceDestroy("fastly_service_cdn_auto"),
+		Steps: []resource.TestStep{
+			{
+				Config: ConfigCDNAutoWithHeader(serviceName, domainName, headerName),
+				Check: resource.ComposeTestCheckFunc(
+					CheckServiceExists("fastly_service_cdn_auto.test"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "header.#", "1"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "header.0.name", headerName),
+				),
+			},
+			{
+				ResourceName:            "fastly_service_cdn_auto.test",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"force_destroy", "reuse"},
+			},
+		},
+	})
+}

--- a/internal/acceptance_tests/test_helpers.go
+++ b/internal/acceptance_tests/test_helpers.go
@@ -708,6 +708,69 @@ func ConfigCDNAutoWithHealthCheckAndBackend(serviceName, domainName, healthCheck
 	)
 }
 
+// ConfigCDNAutoWithHeader returns a CDN auto service config with a domain and a header
+func ConfigCDNAutoWithHeader(serviceName, domainName, headerName string) string {
+	return BuildConfig(
+		ServiceCDNAuto,
+		map[string]string{
+			"SERVICE_NAME": serviceName,
+			"DOMAIN_NAME":  domainName,
+			"HEADER_NAME":  headerName,
+		},
+		"internal/acceptance_tests/blocks/domain_single.tf",
+		"internal/acceptance_tests/blocks/header_single.tf",
+	)
+}
+
+// ConfigCDNAutoWithHeaderUpdated returns a CDN auto service config with the same header name but
+// a different action, type, destination, source, priority, and ignore_if_set, for use as the
+// second step of an update test.
+func ConfigCDNAutoWithHeaderUpdated(serviceName, domainName, headerName string) string {
+	return BuildConfig(
+		ServiceCDNAuto,
+		map[string]string{
+			"SERVICE_NAME": serviceName,
+			"DOMAIN_NAME":  domainName,
+			"HEADER_NAME":  headerName,
+		},
+		"internal/acceptance_tests/blocks/domain_single.tf",
+		"internal/acceptance_tests/blocks/header_updated.tf",
+	)
+}
+
+// ConfigCDNAutoWithHeaderRequestCondition returns a CDN auto service config with a header whose
+// request_condition references a real nested REQUEST-type condition block.
+func ConfigCDNAutoWithHeaderRequestCondition(serviceName, domainName, headerName, conditionName string) string {
+	return BuildConfig(
+		ServiceCDNAuto,
+		map[string]string{
+			"SERVICE_NAME":   serviceName,
+			"DOMAIN_NAME":    domainName,
+			"HEADER_NAME":    headerName,
+			"CONDITION_NAME": conditionName,
+		},
+		"internal/acceptance_tests/blocks/domain_single.tf",
+		"internal/acceptance_tests/blocks/condition_single.tf",
+		"internal/acceptance_tests/blocks/header_with_request_condition.tf",
+	)
+}
+
+// ConfigCDNAutoWithHeaderInvalidAction returns a CDN auto service config with a header whose
+// action is not one of the accepted values, exercising the schema-level stringvalidator.OneOf
+// plan-time check.
+func ConfigCDNAutoWithHeaderInvalidAction(serviceName, domainName, headerName string) string {
+	return BuildConfig(
+		ServiceCDNAuto,
+		map[string]string{
+			"SERVICE_NAME": serviceName,
+			"DOMAIN_NAME":  domainName,
+			"HEADER_NAME":  headerName,
+		},
+		"internal/acceptance_tests/blocks/domain_single.tf",
+		"internal/acceptance_tests/blocks/header_invalid_action.tf",
+	)
+}
+
 // ConfigCDNAutoWithRateLimiter returns a CDN auto service config with a domain and a rate
 // limiter
 func ConfigCDNAutoWithRateLimiter(serviceName, domainName, rateLimiterName string) string {

--- a/internal/resources/header/header_test.go
+++ b/internal/resources/header/header_test.go
@@ -1,0 +1,170 @@
+package header
+
+import (
+	"testing"
+
+	fastly "github.com/fastly/go-fastly/v17/fastly"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func minimalNestedModel() NestedModel {
+	return NestedModel{
+		Name:              types.StringValue("header"),
+		Action:            types.StringValue("delete"),
+		Type:              types.StringValue("cache"),
+		Destination:       types.StringValue("http.aws-id"),
+		CacheCondition:    types.StringValue(""),
+		IgnoreIfSet:       types.BoolValue(false),
+		Priority:          types.Int64Value(100),
+		Regex:             types.StringValue(""),
+		RequestCondition:  types.StringValue(""),
+		ResponseCondition: types.StringValue(""),
+		Source:            types.StringValue(""),
+		Substitution:      types.StringValue(""),
+	}
+}
+
+func fullNestedModel() NestedModel {
+	return NestedModel{
+		Name:              types.StringValue("header"),
+		Action:            types.StringValue("regex"),
+		Type:              types.StringValue("request"),
+		Destination:       types.StringValue("http.X-Custom"),
+		CacheCondition:    types.StringValue("cache-condition"),
+		IgnoreIfSet:       types.BoolValue(true),
+		Priority:          types.Int64Value(10),
+		Regex:             types.StringValue("^foo"),
+		RequestCondition:  types.StringValue("request-condition"),
+		ResponseCondition: types.StringValue("response-condition"),
+		Source:            types.StringValue("http.server-name"),
+		Substitution:      types.StringValue("bar"),
+	}
+}
+
+func fullAPIHeader() *fastly.Header {
+	action := fastly.HeaderActionRegex
+	headerType := fastly.HeaderTypeRequest
+	return &fastly.Header{
+		Name:              new("header"),
+		Action:            &action,
+		Type:              &headerType,
+		Destination:       new("http.X-Custom"),
+		CacheCondition:    new("cache-condition"),
+		IgnoreIfSet:       new(true),
+		Priority:          new(10),
+		Regex:             new("^foo"),
+		RequestCondition:  new("request-condition"),
+		ResponseCondition: new("response-condition"),
+		Source:            new("http.server-name"),
+		Substitution:      new("bar"),
+	}
+}
+
+func TestToModel(t *testing.T) {
+	result := FlattenToNestedModel(fullAPIHeader())
+
+	assert.True(t, fullNestedModel().ModelsEqual(result))
+}
+
+func TestOpsEqual(t *testing.T) {
+	assert.True(t, ops{}.Equal(fullNestedModel(), fullAPIHeader()))
+}
+
+func TestOpsEqual_mismatch(t *testing.T) {
+	remote := fullAPIHeader()
+	remote.Priority = new(999)
+
+	assert.False(t, ops{}.Equal(fullNestedModel(), remote))
+}
+
+func TestBuildCreateInput(t *testing.T) {
+	input := BuildCreateInput("service-id", 3, fullNestedModel())
+
+	assert.Equal(t, "service-id", input.ServiceID)
+	assert.Equal(t, 3, input.ServiceVersion)
+	assert.Equal(t, "header", *input.Name)
+	assert.Equal(t, fastly.HeaderActionRegex, *input.Action)
+	assert.Equal(t, fastly.HeaderTypeRequest, *input.Type)
+	assert.Equal(t, "http.X-Custom", *input.Destination)
+	assert.Equal(t, "cache-condition", *input.CacheCondition)
+	assert.True(t, bool(*input.IgnoreIfSet))
+	assert.Equal(t, 10, *input.Priority)
+	assert.Equal(t, "^foo", *input.Regex)
+	assert.Equal(t, "request-condition", *input.RequestCondition)
+	assert.Equal(t, "response-condition", *input.ResponseCondition)
+	assert.Equal(t, "http.server-name", *input.Source)
+	assert.Equal(t, "bar", *input.Substitution)
+}
+
+func TestBuildUpdateInput(t *testing.T) {
+	input := BuildUpdateInput("service-id", 3, fullNestedModel())
+
+	assert.Equal(t, "service-id", input.ServiceID)
+	assert.Equal(t, 3, input.ServiceVersion)
+	assert.Equal(t, "header", input.Name)
+	assert.Equal(t, fastly.HeaderActionRegex, *input.Action)
+	assert.Equal(t, fastly.HeaderTypeRequest, *input.Type)
+	assert.Equal(t, "http.X-Custom", *input.Destination)
+	assert.Equal(t, "cache-condition", *input.CacheCondition)
+	assert.True(t, bool(*input.IgnoreIfSet))
+	assert.Equal(t, 10, *input.Priority)
+	assert.Equal(t, "^foo", *input.Regex)
+	assert.Equal(t, "request-condition", *input.RequestCondition)
+	assert.Equal(t, "response-condition", *input.ResponseCondition)
+	assert.Equal(t, "http.server-name", *input.Source)
+	assert.Equal(t, "bar", *input.Substitution)
+}
+
+func TestEqual(t *testing.T) {
+	tests := []struct {
+		name     string
+		a        []NestedModel
+		b        []NestedModel
+		expected bool
+	}{
+		{
+			name:     "both empty",
+			a:        []NestedModel{},
+			b:        []NestedModel{},
+			expected: true,
+		},
+		{
+			name:     "same content",
+			a:        []NestedModel{fullNestedModel()},
+			b:        []NestedModel{fullNestedModel()},
+			expected: true,
+		},
+		{
+			name: "different lengths",
+			a:    []NestedModel{minimalNestedModel()},
+			b: []NestedModel{
+				minimalNestedModel(),
+				fullNestedModel(),
+			},
+			expected: false,
+		},
+		{
+			name:     "different content",
+			a:        []NestedModel{minimalNestedModel()},
+			b:        []NestedModel{fullNestedModel()},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := Equal(tt.a, tt.b)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestMatchOrder(t *testing.T) {
+	a := NestedModel{Name: types.StringValue("a")}
+	b := NestedModel{Name: types.StringValue("b")}
+
+	result := MatchOrder([]NestedModel{b, a}, []NestedModel{a, b})
+
+	assert.Equal(t, []NestedModel{a, b}, result)
+}

--- a/internal/resources/header/schema.go
+++ b/internal/resources/header/schema.go
@@ -1,0 +1,295 @@
+package header
+
+import (
+	"context"
+
+	"github.com/fastly/terraform-provider-fastly/internal/reconcile"
+	"github.com/fastly/terraform-provider-fastly/internal/service"
+
+	fastly "github.com/fastly/go-fastly/v17/fastly"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+const (
+	DefaultCacheCondition    = ""
+	DefaultIgnoreIfSet       = false
+	DefaultPriority          = 100
+	DefaultRegex             = ""
+	DefaultRequestCondition  = ""
+	DefaultResponseCondition = ""
+	DefaultSource            = ""
+	DefaultSubstitution      = ""
+)
+
+type NestedModel struct {
+	Name              types.String `tfsdk:"name"`
+	Action            types.String `tfsdk:"action"`
+	Type              types.String `tfsdk:"type"`
+	Destination       types.String `tfsdk:"destination"`
+	CacheCondition    types.String `tfsdk:"cache_condition"`
+	IgnoreIfSet       types.Bool   `tfsdk:"ignore_if_set"`
+	Priority          types.Int64  `tfsdk:"priority"`
+	Regex             types.String `tfsdk:"regex"`
+	RequestCondition  types.String `tfsdk:"request_condition"`
+	ResponseCondition types.String `tfsdk:"response_condition"`
+	Source            types.String `tfsdk:"source"`
+	Substitution      types.String `tfsdk:"substitution"`
+}
+
+func (n NestedModel) ModelsEqual(other NestedModel) bool {
+	return service.StringValue(n.Name) == service.StringValue(other.Name) &&
+		service.StringValue(n.Action) == service.StringValue(other.Action) &&
+		service.StringValue(n.Type) == service.StringValue(other.Type) &&
+		service.StringValue(n.Destination) == service.StringValue(other.Destination) &&
+		service.StringValue(n.CacheCondition) == service.StringValue(other.CacheCondition) &&
+		service.BoolValue(n.IgnoreIfSet) == service.BoolValue(other.IgnoreIfSet) &&
+		service.Int64Value(n.Priority) == service.Int64Value(other.Priority) &&
+		service.StringValue(n.Regex) == service.StringValue(other.Regex) &&
+		service.StringValue(n.RequestCondition) == service.StringValue(other.RequestCondition) &&
+		service.StringValue(n.ResponseCondition) == service.StringValue(other.ResponseCondition) &&
+		service.StringValue(n.Source) == service.StringValue(other.Source) &&
+		service.StringValue(n.Substitution) == service.StringValue(other.Substitution)
+}
+
+func CommonAttributes() map[string]schema.Attribute {
+	return map[string]schema.Attribute{
+		"name": schema.StringAttribute{
+			Required:    true,
+			Description: "Unique name for this Header attribute. Changing this attribute will delete and recreate the resource.",
+		},
+		"action": schema.StringAttribute{
+			Required:    true,
+			Description: "The Header manipulation action to take; must be one of `set`, `append`, `delete`, `regex`, or `regex_repeat`.",
+			Validators: []validator.String{
+				stringvalidator.OneOf("set", "append", "delete", "regex", "regex_repeat"),
+			},
+		},
+		"type": schema.StringAttribute{
+			Required:    true,
+			Description: "The Request type on which to apply the selected Action; must be one of `request`, `fetch`, `cache`, or `response`.",
+			Validators: []validator.String{
+				stringvalidator.OneOf("request", "fetch", "cache", "response"),
+			},
+		},
+		"destination": schema.StringAttribute{
+			Required:    true,
+			Description: "The name of the header that is going to be affected by the Action.",
+		},
+		"cache_condition": schema.StringAttribute{
+			Optional:    true,
+			Computed:    true,
+			Default:     stringdefault.StaticString(DefaultCacheCondition),
+			Description: "Name of already defined `condition` to apply. This `condition` must be of type `CACHE`.",
+		},
+		"ignore_if_set": schema.BoolAttribute{
+			Optional:    true,
+			Computed:    true,
+			Default:     booldefault.StaticBool(DefaultIgnoreIfSet),
+			Description: "Don't add the header if it is already present. Only applies to the `set` action. Default `false`.",
+		},
+		"priority": schema.Int64Attribute{
+			Optional:    true,
+			Computed:    true,
+			Default:     int64default.StaticInt64(DefaultPriority),
+			Description: "Lower priorities execute first. Default `100`.",
+		},
+		"regex": schema.StringAttribute{
+			Optional:    true,
+			Computed:    true,
+			Default:     stringdefault.StaticString(DefaultRegex),
+			Description: "Regular expression to use. Only applies to the `regex` and `regex_repeat` actions.",
+		},
+		"request_condition": schema.StringAttribute{
+			Optional:    true,
+			Computed:    true,
+			Default:     stringdefault.StaticString(DefaultRequestCondition),
+			Description: "Name of already defined `condition` to apply. This `condition` must be of type `REQUEST`.",
+		},
+		"response_condition": schema.StringAttribute{
+			Optional:    true,
+			Computed:    true,
+			Default:     stringdefault.StaticString(DefaultResponseCondition),
+			Description: "Name of already defined `condition` to apply. This `condition` must be of type `RESPONSE`.",
+		},
+		"source": schema.StringAttribute{
+			Optional:    true,
+			Computed:    true,
+			Default:     stringdefault.StaticString(DefaultSource),
+			Description: "Variable to be used as a source for the header content. Does not apply to the `delete` action.",
+		},
+		"substitution": schema.StringAttribute{
+			Optional:    true,
+			Computed:    true,
+			Default:     stringdefault.StaticString(DefaultSubstitution),
+			Description: "Value to substitute in place of regular expression. Only applies to the `regex` and `regex_repeat` actions.",
+		},
+	}
+}
+
+func NestedBlockSchema() schema.ListNestedBlock {
+	return schema.ListNestedBlock{
+		Description: "Header manipulations attached to this service.",
+		NestedObject: schema.NestedBlockObject{
+			Attributes: CommonAttributes(),
+		},
+	}
+}
+
+type ops struct{}
+
+func (o ops) List(ctx context.Context, client *fastly.Client, serviceID string, version int) ([]*fastly.Header, error) {
+	return client.ListHeaders(ctx, &fastly.ListHeadersInput{
+		ServiceID:      serviceID,
+		ServiceVersion: version,
+	})
+}
+
+func (o ops) GetName(api *fastly.Header) string {
+	return fastly.ToValue(api.Name)
+}
+
+func (o ops) Delete(ctx context.Context, client *fastly.Client, serviceID string, version int, name string) error {
+	return client.DeleteHeader(ctx, &fastly.DeleteHeaderInput{
+		ServiceID:      serviceID,
+		ServiceVersion: version,
+		Name:           name,
+	})
+}
+
+func (o ops) Create(ctx context.Context, client *fastly.Client, serviceID string, version int, desired NestedModel) (*fastly.Header, error) {
+	return client.CreateHeader(ctx, BuildCreateInput(serviceID, version, desired))
+}
+
+func (o ops) Equal(desired NestedModel, remote *fastly.Header) bool {
+	return desired.ModelsEqual(o.ToModel(remote))
+}
+
+func (o ops) Update(ctx context.Context, client *fastly.Client, serviceID string, version int, desired NestedModel) (*fastly.Header, error) {
+	return client.UpdateHeader(ctx, BuildUpdateInput(serviceID, version, desired))
+}
+
+func (o ops) ToModel(api *fastly.Header) NestedModel {
+	return FlattenToNestedModel(api)
+}
+
+func BuildCreateInput(serviceID string, version int, desired NestedModel) *fastly.CreateHeaderInput {
+	name := service.StringValue(desired.Name)
+	destination := service.StringValue(desired.Destination)
+	cacheCondition := service.StringValue(desired.CacheCondition)
+	regex := service.StringValue(desired.Regex)
+	requestCondition := service.StringValue(desired.RequestCondition)
+	responseCondition := service.StringValue(desired.ResponseCondition)
+	source := service.StringValue(desired.Source)
+	substitution := service.StringValue(desired.Substitution)
+	priority := int(service.Int64Value(desired.Priority))
+	ignoreIfSet := fastly.Compatibool(service.BoolValue(desired.IgnoreIfSet))
+
+	return &fastly.CreateHeaderInput{
+		ServiceID:         serviceID,
+		ServiceVersion:    version,
+		Name:              &name,
+		Action:            headerActionPointer(desired.Action),
+		Type:              headerTypePointer(desired.Type),
+		Destination:       &destination,
+		CacheCondition:    &cacheCondition,
+		IgnoreIfSet:       &ignoreIfSet,
+		Priority:          &priority,
+		Regex:             &regex,
+		RequestCondition:  &requestCondition,
+		ResponseCondition: &responseCondition,
+		Source:            &source,
+		Substitution:      &substitution,
+	}
+}
+
+func BuildUpdateInput(serviceID string, version int, desired NestedModel) *fastly.UpdateHeaderInput {
+	destination := service.StringValue(desired.Destination)
+	cacheCondition := service.StringValue(desired.CacheCondition)
+	regex := service.StringValue(desired.Regex)
+	requestCondition := service.StringValue(desired.RequestCondition)
+	responseCondition := service.StringValue(desired.ResponseCondition)
+	source := service.StringValue(desired.Source)
+	substitution := service.StringValue(desired.Substitution)
+	priority := int(service.Int64Value(desired.Priority))
+	ignoreIfSet := fastly.Compatibool(service.BoolValue(desired.IgnoreIfSet))
+
+	return &fastly.UpdateHeaderInput{
+		ServiceID:         serviceID,
+		ServiceVersion:    version,
+		Name:              service.StringValue(desired.Name),
+		Action:            headerActionPointer(desired.Action),
+		Type:              headerTypePointer(desired.Type),
+		Destination:       &destination,
+		CacheCondition:    &cacheCondition,
+		IgnoreIfSet:       &ignoreIfSet,
+		Priority:          &priority,
+		Regex:             &regex,
+		RequestCondition:  &requestCondition,
+		ResponseCondition: &responseCondition,
+		Source:            &source,
+		Substitution:      &substitution,
+	}
+}
+
+func FlattenToNestedModel(api *fastly.Header) NestedModel {
+	return NestedModel{
+		Name:              types.StringValue(fastly.ToValue(api.Name)),
+		Action:            types.StringValue(string(fastly.ToValue(api.Action))),
+		Type:              types.StringValue(string(fastly.ToValue(api.Type))),
+		Destination:       types.StringValue(fastly.ToValue(api.Destination)),
+		CacheCondition:    types.StringValue(fastly.ToValue(api.CacheCondition)),
+		IgnoreIfSet:       types.BoolValue(fastly.ToValue(api.IgnoreIfSet)),
+		Priority:          types.Int64Value(int64(fastly.ToValue(api.Priority))),
+		Regex:             types.StringValue(fastly.ToValue(api.Regex)),
+		RequestCondition:  types.StringValue(fastly.ToValue(api.RequestCondition)),
+		ResponseCondition: types.StringValue(fastly.ToValue(api.ResponseCondition)),
+		Source:            types.StringValue(fastly.ToValue(api.Source)),
+		Substitution:      types.StringValue(fastly.ToValue(api.Substitution)),
+	}
+}
+
+// headerActionPointer looks up the API HeaderAction for a validated config value. desired.Action
+// is always one of the schema's stringvalidator.OneOf values by the time Create/Update run, so
+// this cast cannot produce an invalid enum value.
+func headerActionPointer(v types.String) *fastly.HeaderAction {
+	action := fastly.HeaderAction(service.StringValue(v))
+	return &action
+}
+
+// headerTypePointer looks up the API HeaderType for a validated config value. desired.Type is
+// always one of the schema's stringvalidator.OneOf values by the time Create/Update run, so this
+// cast cannot produce an invalid enum value.
+func headerTypePointer(v types.String) *fastly.HeaderType {
+	t := fastly.HeaderType(service.StringValue(v))
+	return &t
+}
+
+var reconciler = &reconcile.Resource[NestedModel, fastly.Header]{
+	Ops: ops{},
+	GetName: func(m NestedModel) string {
+		return service.StringValue(m.Name)
+	},
+	Sortable: true,
+}
+
+func ReadForVersion(ctx context.Context, client *fastly.Client, serviceID string, version int) ([]NestedModel, error) {
+	return reconciler.ReadForVersion(ctx, client, serviceID, version)
+}
+
+func Reconcile(ctx context.Context, client *fastly.Client, serviceID string, version int, desired []NestedModel) error {
+	return reconciler.Run(ctx, client, serviceID, version, desired)
+}
+
+func Equal(a, b []NestedModel) bool {
+	return reconcile.ModelsEqual(a, b, func(m NestedModel) string { return service.StringValue(m.Name) }, NestedModel.ModelsEqual, true)
+}
+
+func MatchOrder(items, order []NestedModel) []NestedModel {
+	return reconcile.MatchOrder(items, order, func(m NestedModel) string { return service.StringValue(m.Name) })
+}

--- a/internal/resources/header/schema.go
+++ b/internal/resources/header/schema.go
@@ -115,7 +115,7 @@ func CommonAttributes() map[string]schema.Attribute {
 			Optional:    true,
 			Computed:    true,
 			Default:     stringdefault.StaticString(DefaultResponseCondition),
-			Description: "Name of already defined `condition` to apply. This `condition` must be of type `RESPONSE`.",
+			Description: "Name of already defined `condition` to apply. This `condition` must be of type `RESPONSE`. For detailed information about Conditionals, see [Fastly's Documentation on Conditionals](https://docs.fastly.com/en/guides/using-conditions).",
 		},
 		"source": schema.StringAttribute{
 			Optional:    true,

--- a/internal/resources/servicecdnauto/resource.go
+++ b/internal/resources/servicecdnauto/resource.go
@@ -15,6 +15,7 @@ import (
 	"github.com/fastly/terraform-provider-fastly/internal/resources/domain"
 	"github.com/fastly/terraform-provider-fastly/internal/resources/dynamicsnippet"
 	"github.com/fastly/terraform-provider-fastly/internal/resources/gzip"
+	"github.com/fastly/terraform-provider-fastly/internal/resources/header"
 	"github.com/fastly/terraform-provider-fastly/internal/resources/healthcheck"
 	"github.com/fastly/terraform-provider-fastly/internal/resources/imageoptimizerdefaultsettings"
 	"github.com/fastly/terraform-provider-fastly/internal/resources/loggingbigquery"
@@ -77,6 +78,7 @@ type Model struct {
 	ACL                           []cdnacl.NestedModel                        `tfsdk:"acl"`
 	Condition                     []condition.NestedModel                     `tfsdk:"condition"`
 	HealthCheck                   []healthcheck.NestedModel                   `tfsdk:"healthcheck"`
+	Header                        []header.NestedModel                        `tfsdk:"header"`
 	Gzip                          []gzip.NestedModel                          `tfsdk:"gzip"`
 	CacheSetting                  []cachesetting.NestedModel                  `tfsdk:"cache_setting"`
 	Dictionary                    []dictionary.NestedModel                    `tfsdk:"dictionary"`
@@ -150,6 +152,7 @@ func (r *Resource) Schema(_ context.Context, _ resource.SchemaRequest, resp *res
 			"acl":                              cdnacl.NestedBlockSchema(),
 			"condition":                        condition.NestedBlockSchema(),
 			"healthcheck":                      healthcheck.NestedBlockSchema(),
+			"header":                           header.NestedBlockSchema(),
 			"gzip":                             gzip.NestedBlockSchema(),
 			"cache_setting":                    cachesetting.NestedBlockSchema(),
 			"dictionary":                       dictionary.NestedBlockSchema(),
@@ -327,9 +330,10 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 	}
 	plan.Domain = domain.MatchOrder(domains, plan.Domain)
 
-	// Conditions must be reconciled before backend/gzip/cache_setting: all three can reference
-	// a condition by name (request_condition, cache_condition), and the Fastly API rejects a
-	// create that names a condition which doesn't exist yet in this version.
+	// Conditions must be reconciled before backend/gzip/cache_setting/header: all four can
+	// reference a condition by name (request_condition, cache_condition, response_condition), and
+	// the Fastly API rejects a create that names a condition which doesn't exist yet in this
+	// version.
 	if err := condition.Reconcile(ctx, r.providerData.AutoClient(), serviceID, version, plan.Condition); err != nil {
 		resp.Diagnostics.AddError("Error reconciling conditions", err.Error())
 		return
@@ -395,6 +399,18 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 		return
 	}
 	plan.ACL = acls
+
+	if err := header.Reconcile(ctx, r.providerData.AutoClient(), serviceID, version, plan.Header); err != nil {
+		resp.Diagnostics.AddError("Error reconciling headers", err.Error())
+		return
+	}
+
+	headers, err := header.ReadForVersion(ctx, r.providerData.AutoClient(), serviceID, version)
+	if err != nil {
+		resp.Diagnostics.AddError("Error reading service headers", err.Error())
+		return
+	}
+	plan.Header = header.MatchOrder(headers, plan.Header)
 
 	if err := gzip.ReconcileWithPrevious(ctx, r.providerData.AutoClient(), serviceID, version, nil, plan.Gzip); err != nil {
 		resp.Diagnostics.AddError("Error reconciling gzip configurations", err.Error())
@@ -713,6 +729,11 @@ func (r *Resource) Read(ctx context.Context, req resource.ReadRequest, resp *res
 		resp.Diagnostics.AddError("Error reading service health checks", err.Error())
 		return
 	}
+	headers, err := header.ReadForVersion(ctx, r.providerData.AutoClient(), state.ID.ValueString(), readVersion)
+	if err != nil {
+		resp.Diagnostics.AddError("Error reading service headers", err.Error())
+		return
+	}
 	gzips, err := gzip.ReadForVersionWithPlan(ctx, r.providerData.AutoClient(), state.ID.ValueString(), readVersion, state.Gzip)
 	if err != nil {
 		resp.Diagnostics.AddError("Error reading service gzip configurations", err.Error())
@@ -789,6 +810,7 @@ func (r *Resource) Read(ctx context.Context, req resource.ReadRequest, resp *res
 	state.ACL = cdnacl.MatchOrder(acls, state.ACL)
 	state.Condition = condition.MatchOrder(conditions, state.Condition)
 	state.HealthCheck = healthcheck.MatchOrder(healthChecks, state.HealthCheck)
+	state.Header = header.MatchOrder(headers, state.Header)
 	state.Gzip = gzip.MatchOrder(gzips, state.Gzip)
 	state.CacheSetting = cachesetting.MatchOrder(cacheSettings, state.CacheSetting)
 	state.Dictionary = dictionary.MatchOrder(dictionaries, state.Dictionary)
@@ -912,6 +934,7 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 		!cdnacl.Equal(plan.ACL, state.ACL) ||
 		!condition.Equal(plan.Condition, state.Condition) ||
 		!healthcheck.Equal(plan.HealthCheck, state.HealthCheck) ||
+		!header.Equal(plan.Header, state.Header) ||
 		!gzip.Equal(plan.Gzip, state.Gzip) ||
 		!cachesetting.Equal(plan.CacheSetting, state.CacheSetting) ||
 		!dictionary.Equal(plan.Dictionary, state.Dictionary) ||
@@ -976,9 +999,10 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 		}
 		plan.Domain = domain.MatchOrder(domains, plan.Domain)
 
-		// Conditions must be reconciled before backend/gzip/cache_setting: all three can
-		// reference a condition by name (request_condition, cache_condition), and the Fastly
-		// API rejects a create that names a condition which doesn't exist yet in this version.
+		// Conditions must be reconciled before backend/gzip/cache_setting/header: all four can
+		// reference a condition by name (request_condition, cache_condition, response_condition),
+		// and the Fastly API rejects a create that names a condition which doesn't exist yet in
+		// this version.
 		if err := condition.Reconcile(ctx, r.providerData.AutoClient(), serviceID, targetVersion, plan.Condition); err != nil {
 			resp.Diagnostics.AddError("Error reconciling conditions", err.Error())
 			return
@@ -1077,6 +1101,18 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 			return
 		}
 		plan.ACL = acls
+
+		if err := header.Reconcile(ctx, r.providerData.AutoClient(), serviceID, targetVersion, plan.Header); err != nil {
+			resp.Diagnostics.AddError("Error reconciling headers", err.Error())
+			return
+		}
+
+		headers, err := header.ReadForVersion(ctx, r.providerData.AutoClient(), serviceID, targetVersion)
+		if err != nil {
+			resp.Diagnostics.AddError("Error reading service headers", err.Error())
+			return
+		}
+		plan.Header = header.MatchOrder(headers, plan.Header)
 
 		if err := gzip.ReconcileWithPrevious(ctx, r.providerData.AutoClient(), serviceID, targetVersion, state.Gzip, plan.Gzip); err != nil {
 			resp.Diagnostics.AddError("Error reconciling gzip configurations", err.Error())
@@ -1338,6 +1374,7 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 		plan.ACL = cdnacl.MatchOrder(state.ACL, plan.ACL)
 		plan.Condition = condition.MatchOrder(state.Condition, plan.Condition)
 		plan.HealthCheck = healthcheck.MatchOrder(state.HealthCheck, plan.HealthCheck)
+		plan.Header = header.MatchOrder(state.Header, plan.Header)
 		plan.Gzip = gzip.MatchOrder(state.Gzip, plan.Gzip)
 		plan.CacheSetting = cachesetting.MatchOrder(state.CacheSetting, plan.CacheSetting)
 		plan.Dictionary = dictionary.MatchOrder(state.Dictionary, plan.Dictionary)


### PR DESCRIPTION
### Change summary

Ports the legacy header block (fastly/block_fastly_service_header.go) as a nested config block on the automatic-lifecycle CDN service resource. Header is VCL-only in the legacy provider (registered only for vclAttributes, never for Compute), so it is wired into servicecdnauto only, not servicecomputeauto.

Reconciled after ACL/condition in Create and Update, since a header's cache_condition/request_condition/response_condition can reference a condition by name.

 All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/terraform-provider-fastly/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

* [x] Does your submission pass tests?
* [x] Post the output of your test runs
<img width="703" height="356" alt="Screenshot 2026-08-18 at 4 35 19 PM" src="https://github.com/user-attachments/assets/4f81122d-5e89-4f80-ba14-2118246dd5c1" />
