### PR TITLE
[CDTOOL-1537] Add Request Setting support to fastly_service_cdn_auto

### DIFF
--- a/docs/resources/service_cdn_auto.md
+++ b/docs/resources/service_cdn_auto.md
@@ -45,6 +45,7 @@ Automatic-lifecycle Fastly CDN service resource with nested versioned configurat
 - `logging_splunk` (Block List) Splunk logging endpoints attached to this service. (see [below for nested schema](#nestedblock--logging_splunk))
 - `logging_sumologic` (Block List) Sumo Logic logging endpoints attached to this service. (see [below for nested schema](#nestedblock--logging_sumologic))
 - `rate_limiter` (Block List) Rate limiters attached to this service. (see [below for nested schema](#nestedblock--rate_limiter))
+- `request_setting` (Block List) Request settings attached to this service. (see [below for nested schema](#nestedblock--request_setting))
 - `reuse` (Boolean) Deactivate the active version but do not delete the service, allowing it to be reused/imported elsewhere. Default `false`.
 - `snippet` (Block List) Regular VCL snippets attached to this service version. (see [below for nested schema](#nestedblock--snippet))
 - `vcl` (Block List) Custom VCL files attached to this service. (see [below for nested schema](#nestedblock--vcl))
@@ -637,6 +638,27 @@ Required:
 - `content_type` (String) HTTP Content-Type (e.g. `application/json`).
 - `status` (Number) HTTP response status code (e.g. `429`).
 
+
+
+<a id="nestedblock--request_setting"></a>
+### Nested Schema for `request_setting`
+
+Required:
+
+- `name` (String) Unique name to refer to this Request Setting. Changing this attribute will delete and recreate the resource.
+
+Optional:
+
+- `action` (String) Allows you to terminate request handling and immediately perform an action. When set it can be `lookup` or `pass` (ignore the cache completely).
+- `bypass_busy_wait` (Boolean) Disable collapsed forwarding, so you don't wait for other objects to origin. Default `false`.
+- `default_host` (String) Sets the host header.
+- `force_miss` (Boolean) Force a cache miss for the request. Default `false`.
+- `force_ssl` (Boolean) Forces the request to use SSL (redirects a non-SSL request to SSL). Default `false`.
+- `hash_keys` (String) Comma separated list of varnish request object fields that should be in the hash key.
+- `max_stale_age` (Number) How old an object is allowed to be to serve `stale-if-error` or `stale-while-revalidate`, in seconds. Default `0`.
+- `request_condition` (String) Name of already defined `condition` to determine if this request setting should be applied. Should be unique across multiple instances of `request_setting`, including any left unset (Fastly rejects more than one request setting sharing the same, or unset, `request_condition`).
+- `timer_support` (Boolean) Injects the X-Timer info into the request for viewing origin fetch durations. Default `false`.
+- `xff` (String) X-Forwarded-For, should be `clear`, `leave`, `append`, `append_all`, or `overwrite`.
 
 
 <a id="nestedblock--snippet"></a>

--- a/internal/acceptance_tests/blocks/request_setting_invalid_action.tf
+++ b/internal/acceptance_tests/blocks/request_setting_invalid_action.tf
@@ -1,0 +1,4 @@
+  request_setting {
+    name   = "{{.REQUEST_SETTING_NAME}}"
+    action = "invalid"
+  }

--- a/internal/acceptance_tests/blocks/request_setting_minimal.tf
+++ b/internal/acceptance_tests/blocks/request_setting_minimal.tf
@@ -1,0 +1,3 @@
+  request_setting {
+    name = "{{.REQUEST_SETTING_NAME}}"
+  }

--- a/internal/acceptance_tests/blocks/request_setting_multi.tf
+++ b/internal/acceptance_tests/blocks/request_setting_multi.tf
@@ -1,0 +1,23 @@
+  condition {
+    name      = "{{.CONDITION_NAME_1}}"
+    type      = "REQUEST"
+    statement = "req.url ~ \"^/admin\""
+  }
+
+  condition {
+    name      = "{{.CONDITION_NAME_2}}"
+    type      = "REQUEST"
+    statement = "req.url ~ \"^/api\""
+  }
+
+  request_setting {
+    name              = "{{.REQUEST_SETTING_NAME_1}}"
+    request_condition = "{{.CONDITION_NAME_1}}"
+    max_stale_age     = 120
+  }
+
+  request_setting {
+    name              = "{{.REQUEST_SETTING_NAME_2}}"
+    request_condition = "{{.CONDITION_NAME_2}}"
+    action            = "pass"
+  }

--- a/internal/acceptance_tests/blocks/request_setting_single.tf
+++ b/internal/acceptance_tests/blocks/request_setting_single.tf
@@ -1,0 +1,12 @@
+  request_setting {
+    name             = "{{.REQUEST_SETTING_NAME}}"
+    action           = "lookup"
+    bypass_busy_wait = true
+    default_host     = "host.example.com"
+    force_miss       = true
+    force_ssl        = true
+    hash_keys        = "req.url,req.http.host"
+    max_stale_age    = 120
+    timer_support    = true
+    xff              = "append"
+  }

--- a/internal/acceptance_tests/blocks/request_setting_updated.tf
+++ b/internal/acceptance_tests/blocks/request_setting_updated.tf
@@ -1,0 +1,12 @@
+  request_setting {
+    name             = "{{.REQUEST_SETTING_NAME}}"
+    action           = "pass"
+    bypass_busy_wait = false
+    default_host     = "other.example.com"
+    force_miss       = false
+    force_ssl        = false
+    hash_keys        = "req.http.host"
+    max_stale_age    = 300
+    timer_support    = false
+    xff              = "clear"
+  }

--- a/internal/acceptance_tests/blocks/request_setting_with_request_condition.tf
+++ b/internal/acceptance_tests/blocks/request_setting_with_request_condition.tf
@@ -1,0 +1,5 @@
+  request_setting {
+    name              = "{{.REQUEST_SETTING_NAME}}"
+    action            = "lookup"
+    request_condition = "{{.CONDITION_NAME}}"
+  }

--- a/internal/acceptance_tests/service_cdn_auto_test.go
+++ b/internal/acceptance_tests/service_cdn_auto_test.go
@@ -777,6 +777,233 @@ func TestAccFastlyServiceCDNAuto_cacheSettingWithCacheCondition(t *testing.T) {
 	})
 }
 
+func TestAccFastlyServiceCDNAuto_withRequestSetting(t *testing.T) {
+	t.Parallel()
+	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	domainName := fmt.Sprintf("%s.example.com", acctest.RandString(10))
+	requestSettingName := fmt.Sprintf("request-setting-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
+		CheckDestroy:             CheckServiceDestroy("fastly_service_cdn_auto"),
+		Steps: []resource.TestStep{
+			{
+				Config: ConfigCDNAutoBasic(serviceName, domainName),
+				Check: resource.ComposeTestCheckFunc(
+					CheckServiceExists("fastly_service_cdn_auto.test"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "request_setting.#", "0"),
+					// Initial version should be 1
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "active_version", "1"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "managed_version", "1"),
+				),
+			},
+			{
+				Config: ConfigCDNAutoWithRequestSetting(serviceName, domainName, requestSettingName),
+				Check: resource.ComposeTestCheckFunc(
+					CheckServiceExists("fastly_service_cdn_auto.test"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "request_setting.#", "1"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "request_setting.0.name", requestSettingName),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "request_setting.0.action", "lookup"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "request_setting.0.bypass_busy_wait", "true"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "request_setting.0.default_host", "host.example.com"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "request_setting.0.force_miss", "true"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "request_setting.0.force_ssl", "true"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "request_setting.0.hash_keys", "req.url,req.http.host"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "request_setting.0.max_stale_age", "120"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "request_setting.0.timer_support", "true"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "request_setting.0.xff", "append"),
+					// Adding a request setting should create and activate version 2
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "active_version", "2"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "managed_version", "2"),
+				),
+			},
+			{
+				Config: ConfigCDNAutoBasic(serviceName, domainName),
+				Check: resource.ComposeTestCheckFunc(
+					CheckServiceExists("fastly_service_cdn_auto.test"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "request_setting.#", "0"),
+					// Removing the request setting should create and activate version 3
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "active_version", "3"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "managed_version", "3"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccFastlyServiceCDNAuto_requestSettingMinimal(t *testing.T) {
+	t.Parallel()
+	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	domainName := fmt.Sprintf("%s.example.com", acctest.RandString(10))
+	requestSettingName := fmt.Sprintf("request-setting-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
+		CheckDestroy:             CheckServiceDestroy("fastly_service_cdn_auto"),
+		Steps: []resource.TestStep{
+			{
+				// Every optional attribute left unset must default to null/false/0 rather
+				// than drifting on every plan.
+				Config: ConfigCDNAutoWithRequestSettingMinimal(serviceName, domainName, requestSettingName),
+				Check: resource.ComposeTestCheckFunc(
+					CheckServiceExists("fastly_service_cdn_auto.test"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "request_setting.#", "1"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "request_setting.0.name", requestSettingName),
+					resource.TestCheckNoResourceAttr("fastly_service_cdn_auto.test", "request_setting.0.action"),
+					resource.TestCheckNoResourceAttr("fastly_service_cdn_auto.test", "request_setting.0.xff"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "request_setting.0.bypass_busy_wait", "false"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "request_setting.0.default_host", ""),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "request_setting.0.force_miss", "false"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "request_setting.0.force_ssl", "false"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "request_setting.0.hash_keys", ""),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "request_setting.0.max_stale_age", "0"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "request_setting.0.timer_support", "false"),
+				),
+			},
+			{
+				Config:   ConfigCDNAutoWithRequestSettingMinimal(serviceName, domainName, requestSettingName),
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+func TestAccFastlyServiceCDNAuto_requestSettingUpdated(t *testing.T) {
+	t.Parallel()
+	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	domainName := fmt.Sprintf("%s.example.com", acctest.RandString(10))
+	requestSettingName := fmt.Sprintf("request-setting-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
+		CheckDestroy:             CheckServiceDestroy("fastly_service_cdn_auto"),
+		Steps: []resource.TestStep{
+			{
+				Config: ConfigCDNAutoWithRequestSetting(serviceName, domainName, requestSettingName),
+				Check: resource.ComposeTestCheckFunc(
+					CheckServiceExists("fastly_service_cdn_auto.test"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "request_setting.0.action", "lookup"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "request_setting.0.max_stale_age", "120"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "request_setting.0.xff", "append"),
+				),
+			},
+			{
+				// Same name, different attribute values - this is an in-place update, not a
+				// delete+recreate, since the name (the reconciler's identity key) hasn't
+				// changed.
+				Config: ConfigCDNAutoWithRequestSettingUpdated(serviceName, domainName, requestSettingName),
+				Check: resource.ComposeTestCheckFunc(
+					CheckServiceExists("fastly_service_cdn_auto.test"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "request_setting.#", "1"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "request_setting.0.name", requestSettingName),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "request_setting.0.action", "pass"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "request_setting.0.default_host", "other.example.com"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "request_setting.0.hash_keys", "req.http.host"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "request_setting.0.max_stale_age", "300"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "request_setting.0.xff", "clear"),
+				),
+			},
+			{
+				// Removing every optional attribute from config must clear them back to
+				// null/false/0 remotely, not just hide the drift in state.
+				Config: ConfigCDNAutoWithRequestSettingMinimal(serviceName, domainName, requestSettingName),
+				Check: resource.ComposeTestCheckFunc(
+					CheckServiceExists("fastly_service_cdn_auto.test"),
+					resource.TestCheckNoResourceAttr("fastly_service_cdn_auto.test", "request_setting.0.action"),
+					resource.TestCheckNoResourceAttr("fastly_service_cdn_auto.test", "request_setting.0.xff"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "request_setting.0.default_host", ""),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "request_setting.0.hash_keys", ""),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "request_setting.0.max_stale_age", "0"),
+				),
+			},
+			{
+				Config:   ConfigCDNAutoWithRequestSettingMinimal(serviceName, domainName, requestSettingName),
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+func TestAccFastlyServiceCDNAuto_multipleRequestSettings(t *testing.T) {
+	t.Parallel()
+	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	domainName := fmt.Sprintf("%s.example.com", acctest.RandString(10))
+	requestSettingName1 := fmt.Sprintf("request-setting-a-%s", acctest.RandString(10))
+	requestSettingName2 := fmt.Sprintf("request-setting-b-%s", acctest.RandString(10))
+	conditionName1 := fmt.Sprintf("condition-a-%s", acctest.RandString(10))
+	conditionName2 := fmt.Sprintf("condition-b-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
+		CheckDestroy:             CheckServiceDestroy("fastly_service_cdn_auto"),
+		Steps: []resource.TestStep{
+			{
+				Config: ConfigCDNAutoWithMultipleRequestSettings(serviceName, domainName, requestSettingName1, requestSettingName2, conditionName1, conditionName2),
+				Check: resource.ComposeTestCheckFunc(
+					CheckServiceExists("fastly_service_cdn_auto.test"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "request_setting.#", "2"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "request_setting.0.name", requestSettingName1),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "request_setting.0.max_stale_age", "120"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "request_setting.1.name", requestSettingName2),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "request_setting.1.action", "pass"),
+				),
+			},
+			{
+				Config:   ConfigCDNAutoWithMultipleRequestSettings(serviceName, domainName, requestSettingName1, requestSettingName2, conditionName1, conditionName2),
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+func TestAccFastlyServiceCDNAuto_requestSettingInvalidAction(t *testing.T) {
+	t.Parallel()
+	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	domainName := fmt.Sprintf("%s.example.com", acctest.RandString(10))
+	requestSettingName := fmt.Sprintf("request-setting-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config:      ConfigCDNAutoWithRequestSettingInvalidAction(serviceName, domainName, requestSettingName),
+				ExpectError: regexp.MustCompile(`Attribute request_setting\[0\]\.action value must be one of`),
+			},
+		},
+	})
+}
+
+func TestAccFastlyServiceCDNAuto_requestSettingWithRequestCondition(t *testing.T) {
+	t.Parallel()
+	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	domainName := fmt.Sprintf("%s.example.com", acctest.RandString(10))
+	requestSettingName := fmt.Sprintf("request-setting-%s", acctest.RandString(10))
+	conditionName := fmt.Sprintf("condition-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
+		CheckDestroy:             CheckServiceDestroy("fastly_service_cdn_auto"),
+		Steps: []resource.TestStep{
+			{
+				Config: ConfigCDNAutoWithRequestSettingRequestCondition(serviceName, domainName, requestSettingName, conditionName),
+				Check: resource.ComposeTestCheckFunc(
+					CheckServiceExists("fastly_service_cdn_auto.test"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "condition.0.name", conditionName),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "condition.0.type", "REQUEST"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "request_setting.0.name", requestSettingName),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "request_setting.0.request_condition", conditionName),
+				),
+			},
+		},
+	})
+}
+
 func TestAccFastlyServiceCDNAuto_withRateLimiter(t *testing.T) {
 	t.Parallel()
 	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
@@ -1368,6 +1595,35 @@ func TestAccFastlyServiceCDNAuto_importWithCacheSetting(t *testing.T) {
 					CheckServiceExists("fastly_service_cdn_auto.test"),
 					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "cache_setting.#", "1"),
 					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "cache_setting.0.name", cacheSettingName),
+				),
+			},
+			{
+				ResourceName:            "fastly_service_cdn_auto.test",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"force_destroy", "reuse"},
+			},
+		},
+	})
+}
+
+func TestAccFastlyServiceCDNAuto_importWithRequestSetting(t *testing.T) {
+	t.Parallel()
+	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	domainName := fmt.Sprintf("%s.example.com", acctest.RandString(10))
+	requestSettingName := fmt.Sprintf("request-setting-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { PreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
+		CheckDestroy:             CheckServiceDestroy("fastly_service_cdn_auto"),
+		Steps: []resource.TestStep{
+			{
+				Config: ConfigCDNAutoWithRequestSetting(serviceName, domainName, requestSettingName),
+				Check: resource.ComposeTestCheckFunc(
+					CheckServiceExists("fastly_service_cdn_auto.test"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "request_setting.#", "1"),
+					resource.TestCheckResourceAttr("fastly_service_cdn_auto.test", "request_setting.0.name", requestSettingName),
 				),
 			},
 			{

--- a/internal/acceptance_tests/test_helpers.go
+++ b/internal/acceptance_tests/test_helpers.go
@@ -1254,6 +1254,101 @@ func ConfigCDNAutoWithCacheSettingCacheCondition(serviceName, domainName, cacheS
 	)
 }
 
+func ConfigCDNAutoWithRequestSetting(serviceName, domainName, requestSettingName string) string {
+	return BuildConfig(
+		ServiceCDNAuto,
+		map[string]string{
+			"SERVICE_NAME":         serviceName,
+			"DOMAIN_NAME":          domainName,
+			"REQUEST_SETTING_NAME": requestSettingName,
+		},
+		"internal/acceptance_tests/blocks/domain_single.tf",
+		"internal/acceptance_tests/blocks/request_setting_single.tf",
+	)
+}
+
+// ConfigCDNAutoWithRequestSettingMinimal returns a CDN auto service config with a request
+// setting that leaves every optional attribute unset.
+func ConfigCDNAutoWithRequestSettingMinimal(serviceName, domainName, requestSettingName string) string {
+	return BuildConfig(
+		ServiceCDNAuto,
+		map[string]string{
+			"SERVICE_NAME":         serviceName,
+			"DOMAIN_NAME":          domainName,
+			"REQUEST_SETTING_NAME": requestSettingName,
+		},
+		"internal/acceptance_tests/blocks/domain_single.tf",
+		"internal/acceptance_tests/blocks/request_setting_minimal.tf",
+	)
+}
+
+// ConfigCDNAutoWithRequestSettingUpdated returns a CDN auto service config with the same
+// request setting name but different attribute values.
+func ConfigCDNAutoWithRequestSettingUpdated(serviceName, domainName, requestSettingName string) string {
+	return BuildConfig(
+		ServiceCDNAuto,
+		map[string]string{
+			"SERVICE_NAME":         serviceName,
+			"DOMAIN_NAME":          domainName,
+			"REQUEST_SETTING_NAME": requestSettingName,
+		},
+		"internal/acceptance_tests/blocks/domain_single.tf",
+		"internal/acceptance_tests/blocks/request_setting_updated.tf",
+	)
+}
+
+// ConfigCDNAutoWithMultipleRequestSettings returns a CDN auto service config with two request
+// settings, each scoped to its own request_condition - Fastly rejects more than one request
+// setting sharing the same request_condition value (including the unset/blank default).
+func ConfigCDNAutoWithMultipleRequestSettings(serviceName, domainName, requestSettingName1, requestSettingName2, conditionName1, conditionName2 string) string {
+	return BuildConfig(
+		ServiceCDNAuto,
+		map[string]string{
+			"SERVICE_NAME":           serviceName,
+			"DOMAIN_NAME":            domainName,
+			"REQUEST_SETTING_NAME_1": requestSettingName1,
+			"REQUEST_SETTING_NAME_2": requestSettingName2,
+			"CONDITION_NAME_1":       conditionName1,
+			"CONDITION_NAME_2":       conditionName2,
+		},
+		"internal/acceptance_tests/blocks/domain_single.tf",
+		"internal/acceptance_tests/blocks/request_setting_multi.tf",
+	)
+}
+
+// ConfigCDNAutoWithRequestSettingInvalidAction returns a CDN auto service config with a request
+// setting whose action is not one of the accepted values, exercising the schema-level
+// stringvalidator.OneOfCaseInsensitive plan-time check.
+func ConfigCDNAutoWithRequestSettingInvalidAction(serviceName, domainName, requestSettingName string) string {
+	return BuildConfig(
+		ServiceCDNAuto,
+		map[string]string{
+			"SERVICE_NAME":         serviceName,
+			"DOMAIN_NAME":          domainName,
+			"REQUEST_SETTING_NAME": requestSettingName,
+		},
+		"internal/acceptance_tests/blocks/domain_single.tf",
+		"internal/acceptance_tests/blocks/request_setting_invalid_action.tf",
+	)
+}
+
+// ConfigCDNAutoWithRequestSettingRequestCondition returns a CDN auto service config with a
+// request setting whose request_condition references a real nested REQUEST-type condition block.
+func ConfigCDNAutoWithRequestSettingRequestCondition(serviceName, domainName, requestSettingName, conditionName string) string {
+	return BuildConfig(
+		ServiceCDNAuto,
+		map[string]string{
+			"SERVICE_NAME":         serviceName,
+			"DOMAIN_NAME":          domainName,
+			"REQUEST_SETTING_NAME": requestSettingName,
+			"CONDITION_NAME":       conditionName,
+		},
+		"internal/acceptance_tests/blocks/domain_single.tf",
+		"internal/acceptance_tests/blocks/condition_single.tf",
+		"internal/acceptance_tests/blocks/request_setting_with_request_condition.tf",
+	)
+}
+
 // ConfigACLForImport returns a test configuration for importing an ACL
 func ConfigACLForImport(serviceName, domainName, aclName string) string {
 	return BuildConfig(

--- a/internal/resources/requestsetting/requestsetting_test.go
+++ b/internal/resources/requestsetting/requestsetting_test.go
@@ -1,0 +1,238 @@
+package requestsetting
+
+import (
+	"testing"
+
+	fastly "github.com/fastly/go-fastly/v17/fastly"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func minimalNestedModel() NestedModel {
+	return NestedModel{
+		Name:             types.StringValue("request-setting"),
+		Action:           types.StringNull(),
+		BypassBusyWait:   types.BoolValue(false),
+		DefaultHost:      types.StringValue(""),
+		ForceMiss:        types.BoolValue(false),
+		ForceSSL:         types.BoolValue(false),
+		HashKeys:         types.StringValue(""),
+		MaxStaleAge:      types.Int64Value(0),
+		RequestCondition: types.StringValue(""),
+		TimerSupport:     types.BoolValue(false),
+		XFF:              types.StringNull(),
+	}
+}
+
+func fullNestedModel() NestedModel {
+	return NestedModel{
+		Name:             types.StringValue("request-setting"),
+		Action:           types.StringValue("lookup"),
+		BypassBusyWait:   types.BoolValue(true),
+		DefaultHost:      types.StringValue("host.example.com"),
+		ForceMiss:        types.BoolValue(true),
+		ForceSSL:         types.BoolValue(true),
+		HashKeys:         types.StringValue("field1,field2"),
+		MaxStaleAge:      types.Int64Value(120),
+		RequestCondition: types.StringValue("request-condition"),
+		TimerSupport:     types.BoolValue(true),
+		XFF:              types.StringValue("append"),
+	}
+}
+
+func TestToModel(t *testing.T) {
+	action := fastly.RequestSettingActionLookup
+	xff := fastly.RequestSettingXFFAppend
+	api := &fastly.RequestSetting{
+		Name:             new("request-setting"),
+		Action:           &action,
+		BypassBusyWait:   new(true),
+		DefaultHost:      new("host.example.com"),
+		ForceMiss:        new(true),
+		ForceSSL:         new(true),
+		HashKeys:         new("field1,field2"),
+		MaxStaleAge:      new(120),
+		RequestCondition: new("request-condition"),
+		TimerSupport:     new(true),
+		XForwardedFor:    &xff,
+	}
+
+	result := ops{}.ToModel(api)
+
+	assert.True(t, fullNestedModel().ModelsEqual(result))
+}
+
+func TestToModel_emptyOptionalFields(t *testing.T) {
+	emptyAction := fastly.RequestSettingAction("")
+	emptyXFF := fastly.RequestSettingXFF("")
+	api := &fastly.RequestSetting{
+		Name:             new("request-setting"),
+		Action:           &emptyAction,
+		BypassBusyWait:   new(false),
+		DefaultHost:      new(""),
+		ForceMiss:        new(false),
+		ForceSSL:         new(false),
+		HashKeys:         new(""),
+		MaxStaleAge:      new(0),
+		RequestCondition: new(""),
+		TimerSupport:     new(false),
+		XForwardedFor:    &emptyXFF,
+	}
+
+	result := ops{}.ToModel(api)
+
+	assert.Equal(t, "request-setting", result.Name.ValueString())
+	assert.True(t, result.Action.IsNull())
+	assert.True(t, result.XFF.IsNull())
+	assert.Equal(t, "", result.DefaultHost.ValueString())
+	assert.Equal(t, "", result.HashKeys.ValueString())
+	assert.Equal(t, "", result.RequestCondition.ValueString())
+	assert.Equal(t, int64(0), result.MaxStaleAge.ValueInt64())
+}
+
+func TestToModel_nilOptionalFields(t *testing.T) {
+	api := &fastly.RequestSetting{
+		Name:        new("request-setting"),
+		MaxStaleAge: new(0),
+	}
+
+	result := ops{}.ToModel(api)
+
+	assert.True(t, result.Action.IsNull())
+	assert.True(t, result.XFF.IsNull())
+	assert.Equal(t, "", result.DefaultHost.ValueString())
+	assert.Equal(t, "", result.HashKeys.ValueString())
+	assert.Equal(t, "", result.RequestCondition.ValueString())
+}
+
+func TestOpsEqual(t *testing.T) {
+	action := fastly.RequestSettingActionLookup
+	xff := fastly.RequestSettingXFFAppend
+	remote := &fastly.RequestSetting{
+		Name:             new("request-setting"),
+		Action:           &action,
+		BypassBusyWait:   new(true),
+		DefaultHost:      new("host.example.com"),
+		ForceMiss:        new(true),
+		ForceSSL:         new(true),
+		HashKeys:         new("field1,field2"),
+		MaxStaleAge:      new(120),
+		RequestCondition: new("request-condition"),
+		TimerSupport:     new(true),
+		XForwardedFor:    &xff,
+	}
+
+	assert.True(t, ops{}.Equal(fullNestedModel(), remote))
+}
+
+func TestOpsEqual_mismatch(t *testing.T) {
+	remote := &fastly.RequestSetting{
+		Name:        new("request-setting"),
+		MaxStaleAge: new(0),
+	}
+
+	assert.False(t, ops{}.Equal(fullNestedModel(), remote))
+}
+
+func TestActionPointer(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    types.String
+		expected *fastly.RequestSettingAction
+	}{
+		{name: "null", value: types.StringNull(), expected: nil},
+		{name: "unknown", value: types.StringUnknown(), expected: nil},
+		{name: "empty", value: types.StringValue(""), expected: nil},
+		{name: "lookup", value: types.StringValue("lookup"), expected: new(fastly.RequestSettingActionLookup)},
+		{name: "uppercase", value: types.StringValue("PASS"), expected: new(fastly.RequestSettingActionPass)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := actionPointer(tt.value)
+			if tt.expected == nil {
+				assert.Nil(t, result)
+			} else if assert.NotNil(t, result) {
+				assert.Equal(t, *tt.expected, *result)
+			}
+		})
+	}
+}
+
+func TestXFFPointer(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    types.String
+		expected *fastly.RequestSettingXFF
+	}{
+		{name: "null", value: types.StringNull(), expected: nil},
+		{name: "unknown", value: types.StringUnknown(), expected: nil},
+		{name: "empty", value: types.StringValue(""), expected: nil},
+		{name: "append", value: types.StringValue("append"), expected: new(fastly.RequestSettingXFFAppend)},
+		{name: "uppercase", value: types.StringValue("CLEAR"), expected: new(fastly.RequestSettingXFFClear)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := xffPointer(tt.value)
+			if tt.expected == nil {
+				assert.Nil(t, result)
+			} else if assert.NotNil(t, result) {
+				assert.Equal(t, *tt.expected, *result)
+			}
+		})
+	}
+}
+
+func TestEqual(t *testing.T) {
+	tests := []struct {
+		name     string
+		a        []NestedModel
+		b        []NestedModel
+		expected bool
+	}{
+		{
+			name:     "both empty",
+			a:        []NestedModel{},
+			b:        []NestedModel{},
+			expected: true,
+		},
+		{
+			name:     "same content",
+			a:        []NestedModel{fullNestedModel()},
+			b:        []NestedModel{fullNestedModel()},
+			expected: true,
+		},
+		{
+			name: "different lengths",
+			a:    []NestedModel{minimalNestedModel()},
+			b: []NestedModel{
+				minimalNestedModel(),
+				fullNestedModel(),
+			},
+			expected: false,
+		},
+		{
+			name:     "different content",
+			a:        []NestedModel{minimalNestedModel()},
+			b:        []NestedModel{fullNestedModel()},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := Equal(tt.a, tt.b)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestMatchOrder(t *testing.T) {
+	a := NestedModel{Name: types.StringValue("a")}
+	b := NestedModel{Name: types.StringValue("b")}
+
+	result := MatchOrder([]NestedModel{b, a}, []NestedModel{a, b})
+
+	assert.Equal(t, []NestedModel{a, b}, result)
+}

--- a/internal/resources/requestsetting/schema.go
+++ b/internal/resources/requestsetting/schema.go
@@ -1,0 +1,283 @@
+package requestsetting
+
+import (
+	"context"
+	"strings"
+
+	"github.com/fastly/terraform-provider-fastly/internal/reconcile"
+	"github.com/fastly/terraform-provider-fastly/internal/service"
+
+	fastly "github.com/fastly/go-fastly/v17/fastly"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+type NestedModel struct {
+	Name             types.String `tfsdk:"name"`
+	Action           types.String `tfsdk:"action"`
+	BypassBusyWait   types.Bool   `tfsdk:"bypass_busy_wait"`
+	DefaultHost      types.String `tfsdk:"default_host"`
+	ForceMiss        types.Bool   `tfsdk:"force_miss"`
+	ForceSSL         types.Bool   `tfsdk:"force_ssl"`
+	HashKeys         types.String `tfsdk:"hash_keys"`
+	MaxStaleAge      types.Int64  `tfsdk:"max_stale_age"`
+	RequestCondition types.String `tfsdk:"request_condition"`
+	TimerSupport     types.Bool   `tfsdk:"timer_support"`
+	XFF              types.String `tfsdk:"xff"`
+}
+
+func (n NestedModel) ModelsEqual(other NestedModel) bool {
+	return service.StringValue(n.Name) == service.StringValue(other.Name) &&
+		service.StringValue(n.Action) == service.StringValue(other.Action) &&
+		service.BoolValue(n.BypassBusyWait) == service.BoolValue(other.BypassBusyWait) &&
+		service.StringValue(n.DefaultHost) == service.StringValue(other.DefaultHost) &&
+		service.BoolValue(n.ForceMiss) == service.BoolValue(other.ForceMiss) &&
+		service.BoolValue(n.ForceSSL) == service.BoolValue(other.ForceSSL) &&
+		service.StringValue(n.HashKeys) == service.StringValue(other.HashKeys) &&
+		service.Int64Value(n.MaxStaleAge) == service.Int64Value(other.MaxStaleAge) &&
+		service.StringValue(n.RequestCondition) == service.StringValue(other.RequestCondition) &&
+		service.BoolValue(n.TimerSupport) == service.BoolValue(other.TimerSupport) &&
+		service.StringValue(n.XFF) == service.StringValue(other.XFF)
+}
+
+func CommonAttributes() map[string]schema.Attribute {
+	return map[string]schema.Attribute{
+		"name": schema.StringAttribute{
+			Required:    true,
+			Description: "Unique name to refer to this Request Setting. Changing this attribute will delete and recreate the resource.",
+		},
+		"action": schema.StringAttribute{
+			Optional:    true,
+			Description: "Allows you to terminate request handling and immediately perform an action. When set it can be `lookup` or `pass` (ignore the cache completely).",
+			Validators: []validator.String{
+				stringvalidator.OneOfCaseInsensitive("lookup", "pass"),
+			},
+		},
+		"bypass_busy_wait": schema.BoolAttribute{
+			Optional:    true,
+			Computed:    true,
+			Default:     booldefault.StaticBool(false),
+			Description: "Disable collapsed forwarding, so you don't wait for other objects to origin. Default `false`.",
+		},
+		"default_host": schema.StringAttribute{
+			Optional:    true,
+			Computed:    true,
+			Default:     stringdefault.StaticString(""),
+			Description: "Sets the host header.",
+		},
+		"force_miss": schema.BoolAttribute{
+			Optional:    true,
+			Computed:    true,
+			Default:     booldefault.StaticBool(false),
+			Description: "Force a cache miss for the request. Default `false`.",
+		},
+		"force_ssl": schema.BoolAttribute{
+			Optional:    true,
+			Computed:    true,
+			Default:     booldefault.StaticBool(false),
+			Description: "Forces the request to use SSL (redirects a non-SSL request to SSL). Default `false`.",
+		},
+		"hash_keys": schema.StringAttribute{
+			Optional:    true,
+			Computed:    true,
+			Default:     stringdefault.StaticString(""),
+			Description: "Comma separated list of varnish request object fields that should be in the hash key.",
+		},
+		"max_stale_age": schema.Int64Attribute{
+			Optional:    true,
+			Computed:    true,
+			Default:     int64default.StaticInt64(0),
+			Description: "How old an object is allowed to be to serve `stale-if-error` or `stale-while-revalidate`, in seconds. Default `0`.",
+		},
+		"request_condition": schema.StringAttribute{
+			Optional:    true,
+			Computed:    true,
+			Default:     stringdefault.StaticString(""),
+			Description: "Name of already defined `condition` to determine if this request setting should be applied. Should be unique across multiple instances of `request_setting`, including any left unset (Fastly rejects more than one request setting sharing the same, or unset, `request_condition`).",
+		},
+		"timer_support": schema.BoolAttribute{
+			Optional:    true,
+			Computed:    true,
+			Default:     booldefault.StaticBool(false),
+			Description: "Injects the X-Timer info into the request for viewing origin fetch durations. Default `false`.",
+		},
+		"xff": schema.StringAttribute{
+			Optional:    true,
+			Description: "X-Forwarded-For, should be `clear`, `leave`, `append`, `append_all`, or `overwrite`.",
+			Validators: []validator.String{
+				stringvalidator.OneOfCaseInsensitive("clear", "leave", "append", "append_all", "overwrite"),
+			},
+		},
+	}
+}
+
+func NestedBlockSchema() schema.ListNestedBlock {
+	return schema.ListNestedBlock{
+		Description: "Request settings attached to this service.",
+		NestedObject: schema.NestedBlockObject{
+			Attributes: CommonAttributes(),
+		},
+	}
+}
+
+type ops struct{}
+
+func (o ops) List(ctx context.Context, client *fastly.Client, serviceID string, version int) ([]*fastly.RequestSetting, error) {
+	return client.ListRequestSettings(ctx, &fastly.ListRequestSettingsInput{
+		ServiceID:      serviceID,
+		ServiceVersion: version,
+	})
+}
+
+func (o ops) GetName(api *fastly.RequestSetting) string {
+	return fastly.ToValue(api.Name)
+}
+
+func (o ops) Delete(ctx context.Context, client *fastly.Client, serviceID string, version int, name string) error {
+	return client.DeleteRequestSetting(ctx, &fastly.DeleteRequestSettingInput{
+		ServiceID:      serviceID,
+		ServiceVersion: version,
+		Name:           name,
+	})
+}
+
+// Create omits Action/XFF entirely when unset, rather than sending an empty string, since
+// both are enums the Fastly API validates and may reject a blank value on creation. Update
+// (below) always sends both, since that's the only way to clear a previously configured
+// value back to unset.
+func (o ops) Create(ctx context.Context, client *fastly.Client, serviceID string, version int, desired NestedModel) (*fastly.RequestSetting, error) {
+	name := service.StringValue(desired.Name)
+	defaultHost := service.StringValue(desired.DefaultHost)
+	hashKeys := service.StringValue(desired.HashKeys)
+	maxStaleAge := int(service.Int64Value(desired.MaxStaleAge))
+	requestCondition := service.StringValue(desired.RequestCondition)
+	bypassBusyWait := fastly.Compatibool(service.BoolValue(desired.BypassBusyWait))
+	forceMiss := fastly.Compatibool(service.BoolValue(desired.ForceMiss))
+	forceSSL := fastly.Compatibool(service.BoolValue(desired.ForceSSL))
+	timerSupport := fastly.Compatibool(service.BoolValue(desired.TimerSupport))
+
+	return client.CreateRequestSetting(ctx, &fastly.CreateRequestSettingInput{
+		ServiceID:        serviceID,
+		ServiceVersion:   version,
+		Name:             &name,
+		Action:           actionPointer(desired.Action),
+		BypassBusyWait:   &bypassBusyWait,
+		DefaultHost:      &defaultHost,
+		ForceMiss:        &forceMiss,
+		ForceSSL:         &forceSSL,
+		HashKeys:         &hashKeys,
+		MaxStaleAge:      &maxStaleAge,
+		RequestCondition: &requestCondition,
+		TimerSupport:     &timerSupport,
+		XForwardedFor:    xffPointer(desired.XFF),
+	})
+}
+
+// actionPointer returns nil for a null/unknown/empty action, so Create omits the field
+// rather than sending an invalid empty string for an enum the Fastly API validates. The
+// value is lowercased since the validator accepts any case (e.g. LOOKUP) but the API expects
+// the lowercase enum value.
+func actionPointer(v types.String) *fastly.RequestSettingAction {
+	if v.IsNull() || v.IsUnknown() || v.ValueString() == "" {
+		return nil
+	}
+	action := fastly.RequestSettingAction(strings.ToLower(v.ValueString()))
+	return &action
+}
+
+// xffPointer returns nil for a null/unknown/empty value, so Create omits the field rather
+// than sending an invalid empty string for an enum the Fastly API validates.
+func xffPointer(v types.String) *fastly.RequestSettingXFF {
+	if v.IsNull() || v.IsUnknown() || v.ValueString() == "" {
+		return nil
+	}
+	xff := fastly.RequestSettingXFF(strings.ToLower(v.ValueString()))
+	return &xff
+}
+
+func (o ops) Equal(desired NestedModel, remote *fastly.RequestSetting) bool {
+	return desired.ModelsEqual(o.ToModel(remote))
+}
+
+func (o ops) Update(ctx context.Context, client *fastly.Client, serviceID string, version int, desired NestedModel) (*fastly.RequestSetting, error) {
+	action := fastly.RequestSettingAction(strings.ToLower(service.StringValue(desired.Action)))
+	xff := fastly.RequestSettingXFF(strings.ToLower(service.StringValue(desired.XFF)))
+	defaultHost := service.StringValue(desired.DefaultHost)
+	hashKeys := service.StringValue(desired.HashKeys)
+	maxStaleAge := int(service.Int64Value(desired.MaxStaleAge))
+	requestCondition := service.StringValue(desired.RequestCondition)
+	bypassBusyWait := fastly.Compatibool(service.BoolValue(desired.BypassBusyWait))
+	forceMiss := fastly.Compatibool(service.BoolValue(desired.ForceMiss))
+	forceSSL := fastly.Compatibool(service.BoolValue(desired.ForceSSL))
+	timerSupport := fastly.Compatibool(service.BoolValue(desired.TimerSupport))
+
+	return client.UpdateRequestSetting(ctx, &fastly.UpdateRequestSettingInput{
+		ServiceID:        serviceID,
+		ServiceVersion:   version,
+		Name:             service.StringValue(desired.Name),
+		Action:           &action,
+		BypassBusyWait:   &bypassBusyWait,
+		DefaultHost:      &defaultHost,
+		ForceMiss:        &forceMiss,
+		ForceSSL:         &forceSSL,
+		HashKeys:         &hashKeys,
+		MaxStaleAge:      &maxStaleAge,
+		RequestCondition: &requestCondition,
+		TimerSupport:     &timerSupport,
+		XForwardedFor:    &xff,
+	})
+}
+
+func (o ops) ToModel(api *fastly.RequestSetting) NestedModel {
+	model := NestedModel{
+		Name:             types.StringValue(fastly.ToValue(api.Name)),
+		BypassBusyWait:   types.BoolValue(fastly.ToValue(api.BypassBusyWait)),
+		DefaultHost:      types.StringValue(fastly.ToValue(api.DefaultHost)),
+		ForceMiss:        types.BoolValue(fastly.ToValue(api.ForceMiss)),
+		ForceSSL:         types.BoolValue(fastly.ToValue(api.ForceSSL)),
+		HashKeys:         types.StringValue(fastly.ToValue(api.HashKeys)),
+		MaxStaleAge:      types.Int64Value(int64(fastly.ToValue(api.MaxStaleAge))),
+		RequestCondition: types.StringValue(fastly.ToValue(api.RequestCondition)),
+		TimerSupport:     types.BoolValue(fastly.ToValue(api.TimerSupport)),
+	}
+	if api.Action != nil && *api.Action != "" {
+		model.Action = types.StringValue(string(*api.Action))
+	} else {
+		model.Action = types.StringNull()
+	}
+	if api.XForwardedFor != nil && *api.XForwardedFor != "" {
+		model.XFF = types.StringValue(string(*api.XForwardedFor))
+	} else {
+		model.XFF = types.StringNull()
+	}
+	return model
+}
+
+var reconciler = &reconcile.Resource[NestedModel, fastly.RequestSetting]{
+	Ops: ops{},
+	GetName: func(m NestedModel) string {
+		return service.StringValue(m.Name)
+	},
+	Sortable: true,
+}
+
+func ReadForVersion(ctx context.Context, client *fastly.Client, serviceID string, version int) ([]NestedModel, error) {
+	return reconciler.ReadForVersion(ctx, client, serviceID, version)
+}
+
+func Reconcile(ctx context.Context, client *fastly.Client, serviceID string, version int, desired []NestedModel) error {
+	return reconciler.Run(ctx, client, serviceID, version, desired)
+}
+
+func Equal(a, b []NestedModel) bool {
+	return reconcile.ModelsEqual(a, b, func(m NestedModel) string { return service.StringValue(m.Name) }, NestedModel.ModelsEqual, true)
+}
+
+func MatchOrder(items, order []NestedModel) []NestedModel {
+	return reconcile.MatchOrder(items, order, func(m NestedModel) string { return service.StringValue(m.Name) })
+}

--- a/internal/resources/servicecdnauto/resource.go
+++ b/internal/resources/servicecdnauto/resource.go
@@ -29,6 +29,7 @@ import (
 	"github.com/fastly/terraform-provider-fastly/internal/resources/loggingsplunk"
 	"github.com/fastly/terraform-provider-fastly/internal/resources/loggingsumologic"
 	"github.com/fastly/terraform-provider-fastly/internal/resources/ratelimiter"
+	"github.com/fastly/terraform-provider-fastly/internal/resources/requestsetting"
 	"github.com/fastly/terraform-provider-fastly/internal/resources/snippet"
 	"github.com/fastly/terraform-provider-fastly/internal/resources/vcl"
 	"github.com/fastly/terraform-provider-fastly/internal/service"
@@ -81,6 +82,7 @@ type Model struct {
 	Header                        []header.NestedModel                        `tfsdk:"header"`
 	Gzip                          []gzip.NestedModel                          `tfsdk:"gzip"`
 	CacheSetting                  []cachesetting.NestedModel                  `tfsdk:"cache_setting"`
+	RequestSetting                []requestsetting.NestedModel                `tfsdk:"request_setting"`
 	Dictionary                    []dictionary.NestedModel                    `tfsdk:"dictionary"`
 	RateLimiter                   []ratelimiter.NestedModel                   `tfsdk:"rate_limiter"`
 	LoggingBlobStorage            []loggingblobstorage.NestedModel            `tfsdk:"logging_blobstorage"`
@@ -155,6 +157,7 @@ func (r *Resource) Schema(_ context.Context, _ resource.SchemaRequest, resp *res
 			"header":                           header.NestedBlockSchema(),
 			"gzip":                             gzip.NestedBlockSchema(),
 			"cache_setting":                    cachesetting.NestedBlockSchema(),
+			"request_setting":                  requestsetting.NestedBlockSchema(),
 			"dictionary":                       dictionary.NestedBlockSchema(),
 			"rate_limiter":                     ratelimiter.NestedBlockSchema(),
 			"logging_blobstorage":              loggingblobstorage.NestedBlockSchema(),
@@ -330,10 +333,10 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 	}
 	plan.Domain = domain.MatchOrder(domains, plan.Domain)
 
-	// Conditions must be reconciled before backend/gzip/cache_setting/header: all four can
-	// reference a condition by name (request_condition, cache_condition, response_condition), and
-	// the Fastly API rejects a create that names a condition which doesn't exist yet in this
-	// version.
+	// Conditions must be reconciled before backend/gzip/cache_setting/request_setting/header: all
+	// five can reference a condition by name (request_condition, cache_condition,
+	// response_condition), and the Fastly API rejects a create that names a condition which
+	// doesn't exist yet in this version.
 	if err := condition.Reconcile(ctx, r.providerData.AutoClient(), serviceID, version, plan.Condition); err != nil {
 		resp.Diagnostics.AddError("Error reconciling conditions", err.Error())
 		return
@@ -435,6 +438,18 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 		return
 	}
 	plan.CacheSetting = cachesetting.MatchOrder(cacheSettings, plan.CacheSetting)
+
+	if err := requestsetting.Reconcile(ctx, r.providerData.AutoClient(), serviceID, version, plan.RequestSetting); err != nil {
+		resp.Diagnostics.AddError("Error reconciling request settings", err.Error())
+		return
+	}
+
+	requestSettings, err := requestsetting.ReadForVersion(ctx, r.providerData.AutoClient(), serviceID, version)
+	if err != nil {
+		resp.Diagnostics.AddError("Error reading service request settings", err.Error())
+		return
+	}
+	plan.RequestSetting = requestsetting.MatchOrder(requestSettings, plan.RequestSetting)
 
 	if err := dictionary.ReconcileWithPrevious(ctx, r.providerData.AutoClient(), serviceID, version, nil, plan.Dictionary); err != nil {
 		resp.Diagnostics.AddError("Error reconciling dictionaries", err.Error())
@@ -744,6 +759,11 @@ func (r *Resource) Read(ctx context.Context, req resource.ReadRequest, resp *res
 		resp.Diagnostics.AddError("Error reading service cache settings", err.Error())
 		return
 	}
+	requestSettings, err := requestsetting.ReadForVersion(ctx, r.providerData.AutoClient(), state.ID.ValueString(), readVersion)
+	if err != nil {
+		resp.Diagnostics.AddError("Error reading service request settings", err.Error())
+		return
+	}
 	dictionaries, err := dictionary.ReadForVersionWithPlan(ctx, r.providerData.AutoClient(), state.ID.ValueString(), readVersion, state.Dictionary)
 	if err != nil {
 		resp.Diagnostics.AddError("Error reading service dictionaries", err.Error())
@@ -813,6 +833,7 @@ func (r *Resource) Read(ctx context.Context, req resource.ReadRequest, resp *res
 	state.Header = header.MatchOrder(headers, state.Header)
 	state.Gzip = gzip.MatchOrder(gzips, state.Gzip)
 	state.CacheSetting = cachesetting.MatchOrder(cacheSettings, state.CacheSetting)
+	state.RequestSetting = requestsetting.MatchOrder(requestSettings, state.RequestSetting)
 	state.Dictionary = dictionary.MatchOrder(dictionaries, state.Dictionary)
 	state.RateLimiter = ratelimiter.MatchOrder(rateLimiters, state.RateLimiter)
 	state.LoggingBlobStorage = loggingblobstorage.MatchOrder(loggingBlobStorages, state.LoggingBlobStorage)
@@ -937,6 +958,7 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 		!header.Equal(plan.Header, state.Header) ||
 		!gzip.Equal(plan.Gzip, state.Gzip) ||
 		!cachesetting.Equal(plan.CacheSetting, state.CacheSetting) ||
+		!requestsetting.Equal(plan.RequestSetting, state.RequestSetting) ||
 		!dictionary.Equal(plan.Dictionary, state.Dictionary) ||
 		!ratelimiter.Equal(plan.RateLimiter, state.RateLimiter) ||
 		!loggingblobstorage.Equal(plan.LoggingBlobStorage, state.LoggingBlobStorage) ||
@@ -999,10 +1021,10 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 		}
 		plan.Domain = domain.MatchOrder(domains, plan.Domain)
 
-		// Conditions must be reconciled before backend/gzip/cache_setting/header: all four can
-		// reference a condition by name (request_condition, cache_condition, response_condition),
-		// and the Fastly API rejects a create that names a condition which doesn't exist yet in
-		// this version.
+		// Conditions must be reconciled before backend/gzip/cache_setting/request_setting/header:
+		// all five can reference a condition by name (request_condition, cache_condition,
+		// response_condition), and the Fastly API rejects a create that names a condition which
+		// doesn't exist yet in this version.
 		if err := condition.Reconcile(ctx, r.providerData.AutoClient(), serviceID, targetVersion, plan.Condition); err != nil {
 			resp.Diagnostics.AddError("Error reconciling conditions", err.Error())
 			return
@@ -1137,6 +1159,18 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 			return
 		}
 		plan.CacheSetting = cachesetting.MatchOrder(cacheSettings, plan.CacheSetting)
+
+		if err := requestsetting.Reconcile(ctx, r.providerData.AutoClient(), serviceID, targetVersion, plan.RequestSetting); err != nil {
+			resp.Diagnostics.AddError("Error reconciling request settings", err.Error())
+			return
+		}
+
+		requestSettings, err := requestsetting.ReadForVersion(ctx, r.providerData.AutoClient(), serviceID, targetVersion)
+		if err != nil {
+			resp.Diagnostics.AddError("Error reading service request settings", err.Error())
+			return
+		}
+		plan.RequestSetting = requestsetting.MatchOrder(requestSettings, plan.RequestSetting)
 
 		// Dictionaries and rate limiters are reconciled in three passes, not the usual single
 		// ReconcileWithPrevious + Reconcile pair, because uri_dictionary_name creates a
@@ -1377,6 +1411,7 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 		plan.Header = header.MatchOrder(state.Header, plan.Header)
 		plan.Gzip = gzip.MatchOrder(state.Gzip, plan.Gzip)
 		plan.CacheSetting = cachesetting.MatchOrder(state.CacheSetting, plan.CacheSetting)
+		plan.RequestSetting = requestsetting.MatchOrder(state.RequestSetting, plan.RequestSetting)
 		plan.Dictionary = dictionary.MatchOrder(state.Dictionary, plan.Dictionary)
 		plan.RateLimiter = ratelimiter.MatchOrder(state.RateLimiter, plan.RateLimiter)
 		plan.LoggingBlobStorage = loggingblobstorage.MatchOrder(state.LoggingBlobStorage, plan.LoggingBlobStorage)


### PR DESCRIPTION
### Change summary

Ports fastly/block_fastly_service_requestsetting.go from the legacy provider into a NestedModel package for the dual-model rewrite, wired into fastly_service_cdn_auto only (request settings are VCL-only, matching legacy registration). Includes unit tests, acceptance tests, and generated docs.

 All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/terraform-provider-fastly/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

* [x] Does your submission pass tests?
* [x] Post the output of your test runs
<img width="753" height="426" alt="Screenshot 2026-08-19 at 8 55 15 AM" src="https://github.com/user-attachments/assets/477cc8de-cb95-4797-8626-cc927cccaccd" />

