### PR TITLE
feat(user): add Next-Gen WAF roles to fastly_user

### DIFF
--- a/fastly/resource_fastly_user.go
+++ b/fastly/resource_fastly_user.go
@@ -38,7 +38,7 @@ func resourceUser() *schema.Resource {
 				Type:             schema.TypeString,
 				Optional:         true,
 				Default:          "user",
-				Description:      "The role of this user. Can be `user` (the default), `billing`, `engineer`, or `superuser`. For detailed information on the abilities granted to each role, see [Fastly's Documentation on User roles](https://docs.fastly.com/en/guides/configuring-user-roles-and-permissions#user-roles-and-what-they-can-do)",
+				Description:      "The role of this user. Can be `user` (the default), `billing`, `engineer`, `superuser`, `ngwaf_observer`, `ngwaf_user`, `ngwaf_admin`, or `ngwaf_owner`. For detailed information on the abilities granted to each role, see [Fastly's Documentation on User roles](https://docs.fastly.com/en/guides/configuring-user-roles-and-permissions#user-roles-and-what-they-can-do)",
 				ValidateDiagFunc: validateUserRole(),
 			},
 		},

--- a/fastly/validators.go
+++ b/fastly/validators.go
@@ -174,6 +174,10 @@ func validateUserRole() schema.SchemaValidateDiagFunc {
 			"billing",
 			"engineer",
 			"superuser",
+			"ngwaf_observer",
+			"ngwaf_user",
+			"ngwaf_admin",
+			"ngwaf_owner",
 		},
 		false,
 	))

--- a/fastly/validators_test.go
+++ b/fastly/validators_test.go
@@ -348,10 +348,15 @@ func TestValidateUserRole(t *testing.T) {
 		{"billing", 0, 0},
 		{"engineer", 0, 0},
 		{"superuser", 0, 0},
+		{"ngwaf_observer", 0, 0},
+		{"ngwaf_user", 0, 0},
+		{"ngwaf_admin", 0, 0},
+		{"ngwaf_owner", 0, 0},
 		{"USER", 0, 1},
 		{"BILLING", 0, 1},
 		{"ENGINEER", 0, 1},
 		{"SUPERUSER", 0, 1},
+		{"ngwaf_observer_imported", 0, 1},
 	} {
 		t.Run(testcase.value, func(t *testing.T) {
 			actualWarns, actualErrors := diagToWarnsAndErrs(validateUserRole()(testcase.value, cty.GetAttrPath("role")))


### PR DESCRIPTION
## Summary

The Fastly platform supports four Next-Gen WAF (NGWAF) roles for users — `ngwaf_observer`, `ngwaf_user`, `ngwaf_admin`, and `ngwaf_owner` — as documented in [Fastly's user roles guide](https://www.fastly.com/documentation/guides/account-info/user-and-account-management/about-user-roles-and-permissions/). However, `validateUserRole()` only accepted the four classic roles (`user`, `billing`, `engineer`, `superuser`), causing a plan-time error when attempting to manage users with NGWAF roles:

```
Error: expected role to be one of ["user" "billing" "engineer" "superuser"], got ngwaf_observer
```

## Changes

- **`fastly/validators.go`**: Added `ngwaf_observer`, `ngwaf_user`, `ngwaf_admin`, `ngwaf_owner` to `validateUserRole()`
- **`fastly/resource_fastly_user.go`**: Updated the `role` field description to document the new valid values
- **`fastly/validators_test.go`**: Added test cases for all four new roles (expect success) and `ngwaf_observer_imported` (expect failure — the `_imported` suffix is a Signal Sciences migration artifact and is not a valid role to assign)

## Test plan

- [ ] `go test ./fastly/ -run TestValidateUserRole` passes (verified locally — 13/13 cases pass)
- [ ] Existing acceptance tests unaffected

## Context

After the Signal Sciences → Fastly NGWAF migration, many accounts have users whose portal role is `ngwaf_observer_imported` (or similar). These users cannot be managed via `fastly_user` today because the validator rejects any NGWAF role string. This change allows operators to set the clean NGWAF roles (`ngwaf_observer` etc.) on users, giving them proper Terraform lifecycle management.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)