### PR TITLE
feat(tls/certificate): support allow_untrusted_root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### ENHANCEMENTS:
 
+- feat(tls/certificate): add `allow_untrusted_root` support to `fastly_tls_certificate` ([#1424](https://github.com/fastly/terraform-provider-fastly/pull/1424))
+
 ### BUG FIXES:
 
 ### Dependencies

--- a/docs/resources/tls_certificate.md
+++ b/docs/resources/tls_certificate.md
@@ -47,9 +47,10 @@ resource "fastly_tls_private_key" "key" {
 }
 
 resource "fastly_tls_certificate" "example" {
-  name = "tf-demo"
-  certificate_body = tls_self_signed_cert.cert.cert_pem
-  depends_on = [fastly_tls_private_key.key] // The private key has to be present before the certificate can be uploaded
+  allow_untrusted_root = true
+  name                 = "tf-demo"
+  certificate_body     = tls_self_signed_cert.cert.cert_pem
+  depends_on           = [fastly_tls_private_key.key] // The private key has to be present before the certificate can be uploaded
 }
 ```
 
@@ -82,6 +83,7 @@ $ terraform import fastly_tls_certificate.demo xxxxxxxxxxx
 
 ### Optional
 
+- `allow_untrusted_root` (Boolean) Allow a certificate whose chain is not signed by a trusted root. Useful for development purposes with self-signed CAs. Defaults to false. Write-only on create and update.
 - `name` (String) Human-readable name used to identify the certificate. Defaults to the certificate's Common Name or first Subject Alternative Name entry.
 
 ### Read-Only

--- a/examples/resources/tls_certificate_basic_usage.tf
+++ b/examples/resources/tls_certificate_basic_usage.tf
@@ -27,7 +27,8 @@ resource "fastly_tls_private_key" "key" {
 }
 
 resource "fastly_tls_certificate" "example" {
-  name = "tf-demo"
-  certificate_body = tls_self_signed_cert.cert.cert_pem
-  depends_on = [fastly_tls_private_key.key] // The private key has to be present before the certificate can be uploaded
+  allow_untrusted_root = true
+  name                 = "tf-demo"
+  certificate_body     = tls_self_signed_cert.cert.cert_pem
+  depends_on           = [fastly_tls_private_key.key] // The private key has to be present before the certificate can be uploaded
 }

--- a/fastly/resource_fastly_tls_certificate.go
+++ b/fastly/resource_fastly_tls_certificate.go
@@ -23,6 +23,12 @@ func resourceFastlyTLSCertificate() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 		Schema: map[string]*schema.Schema{
+			"allow_untrusted_root": {
+				Type:        schema.TypeBool,
+				Description: "Allow a certificate whose chain is not signed by a trusted root. Useful for development purposes with self-signed CAs. Defaults to false. Write-only on create and update.",
+				Optional:    true,
+				Default:     false,
+			},
 			"certificate_body": {
 				Type:             schema.TypeString,
 				Description:      "PEM-formatted certificate, optionally including any intermediary certificates.",
@@ -84,7 +90,8 @@ func resourceFastlyTLSCertificateCreate(ctx context.Context, d *schema.ResourceD
 	conn := meta.(*APIClient).conn
 
 	input := &fastly.CreateCustomTLSCertificateInput{
-		CertBlob: d.Get("certificate_body").(string),
+		AllowUntrustedRoot: d.Get("allow_untrusted_root").(bool),
+		CertBlob:           d.Get("certificate_body").(string),
 	}
 
 	if v, ok := d.GetOk("name"); ok {
@@ -162,8 +169,9 @@ func resourceFastlyTLSCertificateUpdate(ctx context.Context, d *schema.ResourceD
 	conn := meta.(*APIClient).conn
 
 	input := &fastly.UpdateCustomTLSCertificateInput{
-		ID:       d.Id(),
-		CertBlob: d.Get("certificate_body").(string),
+		AllowUntrustedRoot: d.Get("allow_untrusted_root").(bool),
+		ID:                 d.Id(),
+		CertBlob:           d.Get("certificate_body").(string),
 	}
 
 	if v, ok := d.GetOk("name"); ok {

--- a/fastly/resource_fastly_tls_certificate_test.go
+++ b/fastly/resource_fastly_tls_certificate_test.go
@@ -2,17 +2,112 @@ package fastly
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/stretchr/testify/require"
 
 	"github.com/fastly/go-fastly/v17/fastly"
 )
+
+func TestResourceFastlyTLSCertificateAllowUntrustedRoot(t *testing.T) {
+	testCases := []struct {
+		name   string
+		method string
+		allow  bool
+	}{
+		{name: "create with untrusted root", method: http.MethodPost, allow: true},
+		{name: "create with trusted root", method: http.MethodPost, allow: false},
+		{name: "update with untrusted root", method: http.MethodPatch, allow: true},
+		{name: "update with trusted root", method: http.MethodPatch, allow: false},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			type observedAttribute struct {
+				present bool
+				value   bool
+			}
+
+			observed := make(chan observedAttribute, 1)
+			certificateResponse := `{
+				"data": {
+					"type": "tls_certificate",
+					"id": "test-certificate",
+					"attributes": {
+						"created_at": "2026-09-05T00:00:00Z",
+						"issued_to": "example.com",
+						"issuer": "Test CA",
+						"name": "test-certificate",
+						"replace": false,
+						"serial_number": "1",
+						"signature_algorithm": "SHA256-RSA",
+						"updated_at": "2026-09-05T00:00:00Z"
+					},
+					"relationships": {
+						"tls_domains": {"data": []}
+					}
+				}
+			}`
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/vnd.api+json")
+				if r.Method == testCase.method {
+					var payload struct {
+						Data struct {
+							Attributes map[string]any `json:"attributes"`
+						} `json:"data"`
+					}
+					if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+						http.Error(w, err.Error(), http.StatusBadRequest)
+						return
+					}
+
+					value, present := payload.Data.Attributes["allow_untrusted_root"]
+					boolValue, _ := value.(bool)
+					observed <- observedAttribute{present: present, value: boolValue}
+				}
+				_, _ = w.Write([]byte(certificateResponse))
+			}))
+			defer server.Close()
+
+			conn, err := fastly.NewClientForEndpoint("test-key", server.URL)
+			require.NoError(t, err)
+			client := &APIClient{conn: conn}
+			d := schema.TestResourceDataRaw(t, resourceFastlyTLSCertificate().Schema, map[string]any{
+				"allow_untrusted_root": testCase.allow,
+				"certificate_body":     "test-certificate-body",
+				"name":                 "test-certificate",
+			})
+
+			var diagnostics diag.Diagnostics
+			if testCase.method == http.MethodPost {
+				diagnostics = resourceFastlyTLSCertificateCreate(context.Background(), d, client)
+			} else {
+				d.SetId("test-certificate")
+				diagnostics = resourceFastlyTLSCertificateUpdate(context.Background(), d, client)
+			}
+			require.False(t, diagnostics.HasError(), diagnostics)
+
+			attribute := <-observed
+			if testCase.allow {
+				require.True(t, attribute.present)
+				require.True(t, attribute.value)
+			} else {
+				require.False(t, attribute.present)
+			}
+		})
+	}
+}
 
 func init() {
 	resource.AddTestSweepers("fastly_tls_certificate", &resource.Sweeper{
@@ -41,6 +136,7 @@ func TestAccFastlyTLSCertificate_withName(t *testing.T) {
 			{
 				Config: testAccTLSCertificateWithName(name, key, name, cert),
 				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "allow_untrusted_root", "true"),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
 					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
 					resource.TestCheckResourceAttrSet(resourceName, "updated_at"),
@@ -55,13 +151,16 @@ func TestAccFastlyTLSCertificate_withName(t *testing.T) {
 			},
 			{
 				Config: testAccTLSCertificateWithName(name, key, updatedName, cert2),
-				Check:  resource.TestCheckResourceAttr(resourceName, "name", updatedName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "allow_untrusted_root", "true"),
+					resource.TestCheckResourceAttr(resourceName, "name", updatedName),
+				),
 			},
 			{
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"certificate_body"},
+				ImportStateVerifyIgnore: []string{"allow_untrusted_root", "certificate_body"},
 			},
 		},
 	})
@@ -85,6 +184,7 @@ func TestAccFastlyTLSCertificate_withoutName(t *testing.T) {
 			{
 				Config: testAccTLSCertificateWithoutName(name, key, cert),
 				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "allow_untrusted_root", "true"),
 					resource.TestCheckResourceAttr(resourceName, "name", domain),
 					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
 					resource.TestCheckResourceAttrSet(resourceName, "updated_at"),
@@ -130,6 +230,7 @@ EOF
 }
 
 resource "fastly_tls_certificate" "test" {
+  allow_untrusted_root = true
   name = "%[3]s"
   certificate_body = <<EOF
 %[4]s
@@ -149,6 +250,7 @@ EOF
 }
 
 resource "fastly_tls_certificate" "test" {
+  allow_untrusted_root = true
   certificate_body = <<EOF
 %[3]s
 EOF


### PR DESCRIPTION
## Motivation

The Fastly Custom TLS Certificate API accepts `allow_untrusted_root` on create and update requests. The `fastly_tls_certificate` resource does not expose that field, so Terraform cannot upload a certificate whose chain is not signed by a root trusted by Fastly, even when the caller explicitly wants the API to accept that chain.

## Changes

- Add the optional `allow_untrusted_root` argument to `fastly_tls_certificate`, defaulting to `false`.
- Pass the argument to both create and update API requests.
- Add unit coverage for create/update requests with both `true` and `false` values.
- Update the existing self-signed acceptance fixtures, example, generated resource documentation, and changelog.

Validation:

- `go test ./fastly -run '^TestResourceFastlyTLSCertificateAllowUntrustedRoot$' -count=1`
- `make test`
- `make tfproviderlintx`
- `make generate-docs`
- `git diff --check`

## Decisions

- Keep the argument write-only because the Fastly API client exposes it only on create/update inputs and does not return it when reading a certificate.
- Preserve the current API request shape when disabled: the Go client omits `false`, while Terraform records the explicit default.
- Reuse the existing self-signed certificate acceptance paths instead of adding a separate fixture. Acceptance tests were not run because they require Fastly credentials.
- `make validate-docs` currently reports legacy frontmatter errors across the existing generated documentation, and `make lint` is blocked by the repository-pinned golangci-lint v2.4.0 being built with Go 1.24 while this checkout targets Go 1.26.5; neither failure is introduced by this diff.